### PR TITLE
Add debug logging to all responses for body/headers

### DIFF
--- a/src/api.rs
+++ b/src/api.rs
@@ -527,6 +527,15 @@ impl ApiResponse {
     /// Converts the API response into a result object.  This also converts
     /// non okay response codes into errors.
     pub fn to_result(self) -> ApiResult<ApiResponse> {
+        let mut headers_out = String::from("");
+        for header in self.headers() {
+            headers_out.push_str(&header.0);
+            headers_out.push_str(&header.1);
+        }
+        debug!("headers:\n{}", headers_out);
+        if let Some(ref body) = self.body {
+            debug!("body: {}", String::from_utf8_lossy(body));
+        }
         if self.ok() {
             return Ok(self);
         }

--- a/src/api.rs
+++ b/src/api.rs
@@ -410,8 +410,8 @@ impl<'a> Iterator for Headers<'a> {
         self.lines.get(self.idx).map(|line| {
             self.idx += 1;
             match line.find(':') {
-                Some(i) => (&line[..i], line[i..].trim_left_matches(' ')),
-                None => (&line[..], "")
+                Some(i) => (&line[..i], line[i+1..].trim()),
+                None => (line[..].trim(), "")
             }
         })
     }
@@ -528,9 +528,14 @@ impl ApiResponse {
     /// non okay response codes into errors.
     pub fn to_result(self) -> ApiResult<ApiResponse> {
         let mut headers_out = String::from("");
-        for header in self.headers() {
-            headers_out.push_str(&header.0);
-            headers_out.push_str(&header.1);
+        for (header_key, header_value) in self.headers() {
+            if header_key.len() > 0 {
+                if header_value.len() > 0 {
+                    headers_out.push_str(&format!("{}: {}\n", header_key, header_value));
+                } else {
+                    headers_out.push_str(&format!("{}\n", header_key))
+                }
+            }
         }
         debug!("headers:\n{}", headers_out);
         if let Some(ref body) = self.body {

--- a/src/commands/releases.rs
+++ b/src/commands/releases.rs
@@ -222,6 +222,7 @@ fn execute_files_upload_sourcemaps<'a>(matches: &ArgMatches<'a>, config: &Config
                     continue;
                 }
             }
+            debug!("found: {} ({} bytes)", dent.path().display(), dent.metadata().unwrap().len());
             let local_path = dent.path().strip_prefix(&base_path).unwrap();
             let url = format!("{}/{}", url_prefix, local_path.display());
             to_process.push((url, local_path.to_path_buf(),


### PR DESCRIPTION
Feel free to tell me this is terrible way to do this, but this seemed best I could come up with.

Example logs:

```
[INFO] sentry_cli::api request GET https://sentry.io/api/0/projects/burn-it-all-down/lol-gonna-get-burnt/releases/abc/
[INFO] sentry_cli::api using token authentication
[INFO] sentry_cli::api response: 200
[DEBUG] sentry_cli::api headers:
HTTP/1.1 200 OK
Server: nginx
Date: Mon, 14 Nov 2016 23:39:20 GMT
Content-Type: application/json
Content-Length: 235
Connection: close
X-XSS-Protection: 1; mode=block
Content-Language: en
X-Content-Type-Options: nosniff
Vary: Accept-Language, Cookie
Allow: GET, PUT, DELETE, HEAD, OPTIONS
X-Frame-Options: deny
X-Served-By: web-7
Strict-Transport-Security: max-age=31536000; includeSubDomains; preload


[DEBUG] sentry_cli::api body: {"dateReleased": null, "lastEvent": null, "url": null, "ref": null, "dateCreated": "2016-11-14T21:35:37.164Z", "owner": null, "version": "abc", "firstEvent": null, "shortVersion": "abc", "dateStarted": null, "newGroups": 0, "data": {}}
[DEBUG] sentry_cli::commands::releases found: /tmp/assets/file-40m.js.map (41943040 bytes)
Uploading sourcemaps for release abc
file-40m.js -> ~/file-40m.js
[INFO] sentry_cli::api request POST https://sentry.io/api/0/projects/burn-it-all-down/lol-gonna-get-burnt/releases/abc/files/
[INFO] sentry_cli::api using token authentication
[INFO] sentry_cli::api sending form data
[INFO] sentry_cli::api response: 413
[DEBUG] sentry_cli::api headers:
HTTP/1.1 413 Request Entity Too Large
Server: nginx
Date: Mon, 14 Nov 2016 23:28:28 GMT
Content-Type: text/plain
Content-Length: 29
Connection: close
ETag: "57d897eb-1d"
Access-Control-Allow-Origin: *
Strict-Transport-Security: max-age=31536000; includeSubDomains; preload


[DEBUG] sentry_cli::api body: 413 Request Entity Too Large

error: http error: generic error (413)
```