### PR TITLE
Add support for automatic sourcemap headers on upload

### DIFF
--- a/src/api.rs
+++ b/src/api.rs
@@ -214,7 +214,7 @@ impl<'a> Api<'a> {
     /// system and uploaded as `name`.
     pub fn upload_release_file(&self, org: &str, project: &str,
                                version: &str, contents: FileContents, name: &str,
-                               headers: Option<&[(&str, &str)]>)
+                               headers: Option<&[(String, String)]>)
         -> ApiResult<Option<Artifact>>
     {
         let path = format!("/projects/{}/{}/releases/{}/files/",
@@ -234,7 +234,7 @@ impl<'a> Api<'a> {
         form.part("name").contents(name.as_bytes()).add()?;
 
         if let Some(headers) = headers {
-            for &(key, value) in headers {
+            for &(ref key, ref value) in headers {
                 form.part("header").contents(
                     format!("{}:{}", key, value).as_bytes()).add()?;
             }

--- a/src/api.rs
+++ b/src/api.rs
@@ -213,7 +213,8 @@ impl<'a> Api<'a> {
     /// Uploads a new release file.  The file is loaded directly from the file
     /// system and uploaded as `name`.
     pub fn upload_release_file(&self, org: &str, project: &str,
-                               version: &str, contents: FileContents, name: &str)
+                               version: &str, contents: FileContents, name: &str,
+                               headers: Option<&[(&str, &str)]>)
         -> ApiResult<Option<Artifact>>
     {
         let path = format!("/projects/{}/{}/releases/{}/files/",
@@ -231,6 +232,13 @@ impl<'a> Api<'a> {
             }
         }
         form.part("name").contents(name.as_bytes()).add()?;
+
+        if let Some(headers) = headers {
+            for &(key, value) in headers {
+                form.part("header").contents(
+                    format!("{}:{}", key, value).as_bytes()).add()?;
+            }
+        }
 
         let resp = self.request(Method::Post, &path)?.with_form_data(form)?.send()?;
         if resp.status() == 409 {

--- a/src/commands/releases.rs
+++ b/src/commands/releases.rs
@@ -208,7 +208,7 @@ fn execute_files_upload<'a>(matches: &ArgMatches<'a>, config: &Config,
             .and_then(|x| x.to_str()).ok_or("No filename provided.")?,
     };
     if let Some(artifact) = Api::new(config).upload_release_file(
-        org, project, &version, FileContents::FromPath(&path), &name)? {
+        org, project, &version, FileContents::FromPath(&path), &name, None)? {
         println!("A {}  ({} bytes)", artifact.sha1, artifact.size);
     } else {
         fail!("File already present!");

--- a/src/commands/releases.rs
+++ b/src/commands/releases.rs
@@ -100,6 +100,13 @@ pub fn make_app<'a, 'b: 'a>(app: App<'a, 'b>) -> App<'a, 'b>
                 .arg(Arg::with_name("validate")
                      .long("validate")
                      .help("Enable basic sourcemap validation"))
+                .arg(Arg::with_name("no_sourcemap_reference")
+                     .long("no-sourcemap-reference")
+                     .help("Disables the emitting of automatic sourcemap references. \
+                            By default the tool will store a 'Sourcemap' header with \
+                            minified files so that sourcemaps are located automatically \
+                            if the tool can detect a link. If this causes issues it can \
+                            be disabled."))
                 .arg(Arg::with_name("rewrite")
                      .long("rewrite")
                      .help("Enables rewriting of matching sourcemaps \
@@ -265,6 +272,10 @@ fn execute_files_upload_sourcemaps<'a>(matches: &ArgMatches<'a>, config: &Config
             prefixes.push("~");
         }
         processor.rewrite(&prefixes)?;
+    }
+
+    if !matches.is_present("no_sourcemap_reference") {
+        processor.add_sourcemap_references()?;
     }
 
     println!("Uploading sourcemaps for release {}", release.version);

--- a/src/sourcemaputils.rs
+++ b/src/sourcemaputils.rs
@@ -353,7 +353,7 @@ impl SourceMapProcessor {
             if let Some(artifact) = api.upload_release_file(
                 org, project, &release, FileContents::FromBytes(
                     source.contents.as_bytes()),
-                &source.url)? {
+                &source.url, None)? {
                 println!("  {}  ({} bytes)", artifact.sha1, artifact.size);
             } else {
                 println!("  already present");


### PR DESCRIPTION
This PR adds support for automatic emitting of sourcemap headers on upload.

This will help greatly with react-native and some other situations where the references contained in the minified files are wrong/misleading or absent.