### PR TITLE
Fix npm install on Windows

### DIFF
--- a/bin/install-sentry-cli
+++ b/bin/install-sentry-cli
@@ -21,9 +21,8 @@ var archSuffix64bit = '-x86_64';
 var windowsFileExt = '.exe';
 
 // output vars
-var outputDir = './bin';
 var outputName = 'sentry-cli';
-var outputPath = path.join(outputDir, outputName);
+var outputPath = path.join(__dirname, outputName) + (platform === 'win32' ? windowsFileExt : '');
 
 var src = '';
 if (platform === 'darwin') { //OSX
@@ -56,7 +55,7 @@ if (src === '') {
 // Download the binary from the response
 function downloadBinary(res) {
   var download = fs.createWriteStream(outputPath, {
-    mode: Number.parseInt('0755', 8) // - rwxr-xr-x 
+    mode: Number.parseInt('0755', 8) // - rwxr-xr-x
   });
   res.pipe(download);
   download.on('error', function (err) {
@@ -72,6 +71,12 @@ function downloadBinary(res) {
       } else {
         if (stdout.trim() !== outputName + ' ' + version) {
           console.error('Warning! Unexpected ' + outputName + ' version: ' + stdout.trim().split(' ')[1] + ', expected ' + version + '!');
+        }
+        // On windows also create a symlink from `sentry-cli.exe` to `sentry-cli`
+        // because this is the executable expected in package.json bin.
+        if (platform === 'win32') {
+          var linkPath = outputPath.replace(windowsFileExt, '');
+          fs.linkSync(outputPath, linkPath);
         }
         process.exit(0);
       }

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "A command line utility to work with Sentry. https://docs.sentry.io/hosted/learn/cli/",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
-    "preinstall": "./bin/install-sentry-cli"
+    "preinstall": "node ./bin/install-sentry-cli"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
There were a few issues when trying to install sentry cli using the npm package on Windows

1. Running `./bin/install-sentry-cli` doesn't work so I changed to calling the node executable.
2. The output binary must have an extension otherwise it cannot be run so I added .exe on windows.
3. Use absolute paths with __dirname
4. Symlink sentry-cli.exe to sentry-cli on windows so the package.json bin works.

Tested that npm install runs successfully and the cli works on both mac and windows.