### PR TITLE
Add support for empty dsym associations

### DIFF
--- a/src/api.rs
+++ b/src/api.rs
@@ -584,6 +584,16 @@ impl<'a> Api<'a> {
     pub fn associate_dsyms(&self, org: &str, project: &str, data: &AssociateDsyms)
         -> ApiResult<Option<AssociateDsymsResponse>>
     {
+        // in case we have no checksums to send up the server does not actually
+        // let us associate anything.  This generally makes sense but means that
+        // from the client side we need to deal with this separately.  In this
+        // case we just pretend we did a request that did nothing.
+        if data.checksums.is_empty() {
+            return Ok(Some(AssociateDsymsResponse {
+                associated_dsyms: vec![],
+            }));
+        }
+
         let path = format!("/projects/{}/{}/files/dsyms/associate/",
                            PathArg(org),
                            PathArg(project));


### PR DESCRIPTION
Currently when an upload does not create any new dsyms the
association will fail because no checksums are returned.  We now
change the logic so that we just pretend we did an HTTP request
that did not do any assocations.

This way callers do not need to special case.

Fixes #83