### PR TITLE
Add Debug Info File Utilities

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1151,6 +1151,7 @@ version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "rand 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "sha1 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ serde = "1.0"
 serde_json = "1.0"
 serde_derive = "1.0"
 url = "1.4"
-uuid = { version = "0.5", features = ["v4"] }
+uuid = { version = "0.5", features = ["v4", "serde"] }
 walkdir = "1.0"
 which = "1.0"
 zip = "0.2"

--- a/src/commands/difutil.rs
+++ b/src/commands/difutil.rs
@@ -8,6 +8,7 @@ use commands;
 macro_rules! each_subcommand {
     ($mac:ident) => {
         $mac!(difutil_find);
+        $mac!(difutil_check);
     }
 }
 

--- a/src/commands/difutil.rs
+++ b/src/commands/difutil.rs
@@ -1,0 +1,37 @@
+use clap::{App, ArgMatches};
+
+use prelude::*;
+use config::Config;
+
+use commands;
+
+macro_rules! each_subcommand {
+    ($mac:ident) => {
+        $mac!(difutil_find);
+    }
+}
+
+pub fn make_app<'a, 'b: 'a>(mut app: App<'a, 'b>) -> App<'a, 'b> {
+    macro_rules! add_subcommand {
+        ($name:ident) => {{
+            app = app.subcommand(commands::$name::make_app(
+                App::new(&stringify!($name)[8..])));
+        }}
+    }
+
+    app = app.about("provides utilities for debug information files.");
+    each_subcommand!(add_subcommand);
+    app
+}
+
+pub fn execute<'a>(matches: &ArgMatches<'a>, config: &Config) -> Result<()> {
+    macro_rules! execute_subcommand {
+        ($name:ident) => {{
+            if let Some(sub_matches) = matches.subcommand_matches(&stringify!($name)[8..]) {
+                return Ok(commands::$name::execute(&sub_matches, &config)?);
+            }
+        }}
+    }
+    each_subcommand!(execute_subcommand);
+    unreachable!();
+}

--- a/src/commands/difutil.rs
+++ b/src/commands/difutil.rs
@@ -1,4 +1,4 @@
-use clap::{App, ArgMatches};
+use clap::{App, ArgMatches, AppSettings};
 
 use prelude::*;
 use config::Config;
@@ -20,7 +20,9 @@ pub fn make_app<'a, 'b: 'a>(mut app: App<'a, 'b>) -> App<'a, 'b> {
         }}
     }
 
-    app = app.about("provides utilities for debug information files.");
+    app = app
+        .about("provides utilities for debug information files.")
+        .setting(AppSettings::SubcommandRequiredElseHelp);
     each_subcommand!(add_subcommand);
     app
 }

--- a/src/commands/difutil_check.rs
+++ b/src/commands/difutil_check.rs
@@ -2,13 +2,13 @@ use std::path::Path;
 use std::ffi::OsStr;
 
 use clap::{App, Arg, ArgMatches};
-use uuid::{Uuid, UuidVersion};
+use uuid::Uuid;
 use proguard;
 use console::style;
 
 use prelude::*;
 use config::Config;
-use utils::{validate_uuid, MachoInfo};
+use utils::MachoInfo;
 use commands::difutil_find::DifType;
 
 enum DifRepr {
@@ -43,8 +43,8 @@ impl DifRepr {
             None
         } else {
             Some(match self {
-                &DifRepr::Dsym(ref mi) => "missing DWARF debug info",
-                &DifRepr::Proguard(ref pg) => "missing line information",
+                &DifRepr::Dsym(..) => "missing DWARF debug info",
+                &DifRepr::Proguard(..) => "missing line information",
             })
         }
     }
@@ -80,7 +80,6 @@ pub fn execute<'a>(matches: &ArgMatches<'a>, _config: &Config) -> Result<()> {
     let repr = match ty {
         Some(DifType::Dsym) => DifRepr::Dsym(MachoInfo::open_path(&path)?),
         Some(DifType::Proguard) => DifRepr::Proguard(proguard::MappingView::from_path(&path)?),
-        Some(_) => unreachable!(),
         None => {
             if let Ok(mi) = MachoInfo::open_path(&path) {
                 DifRepr::Dsym(mi)

--- a/src/commands/difutil_check.rs
+++ b/src/commands/difutil_check.rs
@@ -1,0 +1,117 @@
+use std::path::Path;
+use std::ffi::OsStr;
+
+use clap::{App, Arg, ArgMatches};
+use uuid::{Uuid, UuidVersion};
+use proguard;
+use console::style;
+
+use prelude::*;
+use config::Config;
+use utils::{validate_uuid, MachoInfo};
+use commands::difutil_find::DifType;
+
+enum DifRepr {
+    Dsym(MachoInfo),
+    Proguard(proguard::MappingView<'static>),
+}
+
+impl DifRepr {
+    pub fn ty(&self) -> DifType {
+        match self {
+            &DifRepr::Dsym(..) => DifType::Dsym,
+            &DifRepr::Proguard(..) => DifType::Proguard,
+        }
+    }
+
+    pub fn uuids(&self) -> Vec<Uuid> {
+        match self {
+            &DifRepr::Dsym(ref mi) => mi.get_uuids(),
+            &DifRepr::Proguard(ref pg) => vec![pg.uuid()],
+        }
+    }
+
+    pub fn is_usable(&self) -> bool {
+        match self {
+            &DifRepr::Dsym(ref mi) => mi.has_debug_info(),
+            &DifRepr::Proguard(ref pg) => pg.has_line_info(),
+        }
+    }
+
+    pub fn get_problem(&self) -> Option<&str> {
+        if self.is_usable() {
+            None
+        } else {
+            Some(match self {
+                &DifRepr::Dsym(ref mi) => "missing DWARF debug info",
+                &DifRepr::Proguard(ref pg) => "missing line information",
+            })
+        }
+    }
+}
+
+pub fn make_app<'a, 'b: 'a>(app: App<'a, 'b>) -> App<'a, 'b> {
+    app
+        .about("given the path to a debug info file it checks it")
+        .arg(Arg::with_name("type")
+             .long("type")
+             .short("t")
+             .value_name("TYPE")
+             .possible_values(&["dsym", "proguard"])
+             .help("Explicitly sets the type of the debug info file."))
+        .arg(Arg::with_name("path")
+             .index(1)
+             .required(true)
+             .help("The path to the debug info file."))
+}
+
+pub fn execute<'a>(matches: &ArgMatches<'a>, _config: &Config) -> Result<()> {
+    let path = Path::new(matches.value_of("path").unwrap());
+
+    // which types should we consider?
+    let ty = matches.value_of("type").map(|t| {
+        match t {
+            "dsym" => DifType::Dsym,
+            "proguard" => DifType::Proguard,
+            _ => unreachable!()
+        }
+    });
+
+    let repr = match ty {
+        Some(DifType::Dsym) => DifRepr::Dsym(MachoInfo::open_path(&path)?),
+        Some(DifType::Proguard) => DifRepr::Proguard(proguard::MappingView::from_path(&path)?),
+        Some(_) => unreachable!(),
+        None => {
+            if let Ok(mi) = MachoInfo::open_path(&path) {
+                DifRepr::Dsym(mi)
+            } else {
+                match proguard::MappingView::from_path(&path) {
+                    Ok(pg) => {
+                        if path.extension() == Some(OsStr::new("txt")) ||
+                           pg.has_line_info() {
+                            DifRepr::Proguard(pg)
+                        } else {
+                            fail!("invalid debug info file");
+                        }
+                    }
+                    Err(err) => { return Err(err.into()) }
+                }
+            }
+        }
+    };
+
+    println!("{}", style("Debug Info File Check").dim().bold());
+    println!("  Type: {}", style(repr.ty()).cyan());
+    println!("  Contained UUIDs:");
+    for uuid in repr.uuids() {
+        println!("    > {}", style(uuid).dim());
+    }
+
+    if let Some(prob) = repr.get_problem() {
+        println!("  Usable: {} ({})", style("no").red(), prob);
+    } else {
+        println!("  Usable: {}", style("yes").green());
+    }
+
+    Ok(())
+}

--- a/src/commands/difutil_find.rs
+++ b/src/commands/difutil_find.rs
@@ -22,7 +22,7 @@ use utils::{validate_uuid, MachoInfo};
 const MAX_MAPPING_FILE: u64 = 32 * 1024 * 1024;
 
 #[derive(PartialEq, Eq, Debug, Hash, Copy, Clone, Serialize)]
-enum DifType {
+pub enum DifType {
     #[serde(rename="dsym")]
     Dsym,
     #[serde(rename="proguard")]

--- a/src/commands/difutil_find.rs
+++ b/src/commands/difutil_find.rs
@@ -1,0 +1,255 @@
+use std::io;
+use std::env;
+use std::fmt;
+use std::ffi::OsStr;
+use std::path::PathBuf;
+use std::collections::HashSet;
+
+use clap::{App, Arg, ArgMatches};
+use uuid::{Uuid, UuidVersion};
+use walkdir::WalkDir;
+use proguard;
+use indicatif::{ProgressBar, ProgressStyle, ProgressDrawTarget};
+use console::style;
+use serde_json;
+
+use prelude::*;
+use config::Config;
+use utils::{validate_uuid, MachoInfo};
+
+// text files larger than 32 megabytes are not considered to be
+// valid mapping files when scanning
+const MAX_MAPPING_FILE: u64 = 32 * 1024 * 1024;
+
+#[derive(PartialEq, Eq, Debug, Hash, Copy, Clone, Serialize)]
+enum DifType {
+    #[serde(rename="dsym")]
+    Dsym,
+    #[serde(rename="proguard")]
+    Proguard,
+}
+
+#[derive(Serialize, Debug)]
+struct DifMatch {
+    #[serde(rename="type")]
+    pub ty: DifType,
+    pub uuid: Uuid,
+    pub path: PathBuf,
+}
+
+impl fmt::Display for DifType {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{}", match self {
+            &DifType::Dsym => "dsym",
+            &DifType::Proguard => "proguard",
+        })
+    }
+}
+
+pub fn make_app<'a, 'b: 'a>(app: App<'a, 'b>) -> App<'a, 'b> {
+    app
+        .about("given UUIDs this locates debug information files")
+        .arg(Arg::with_name("types")
+             .long("type")
+             .short("t")
+             .value_name("TYPE")
+             .multiple(true)
+             .number_of_values(1)
+             .possible_values(&["dsym", "proguard"])
+             .help("Only consider debug information files of the given \
+                    type.  By default all types are considered."))
+        .arg(Arg::with_name("no_well_known")
+             .long("no-well-known")
+             .help("Do not look for debug symbols in well known locations."))
+        .arg(Arg::with_name("no_cwd")
+             .long("no-cwd")
+             .help("Do not look for debug symbols starting from the current \
+                    working directory."))
+        .arg(Arg::with_name("paths")
+             .long("path")
+             .short("p")
+             .multiple(true)
+             .number_of_values(1)
+             .help("Adds a starting point for searching for debug info files."))
+        .arg(Arg::with_name("json")
+             .long("json")
+             .help("Returns the results as JSON"))
+        .arg(Arg::with_name("uuids")
+             .index(1)
+             .value_name("UUID")
+             .help("Finds debug information files by UUID.")
+             .validator(validate_uuid)
+             .multiple(true)
+             .number_of_values(1))
+}
+
+fn find_uuids(paths: HashSet<PathBuf>,
+              types: HashSet<DifType>,
+              uuids: HashSet<Uuid>,
+              as_json: bool) -> Result<bool>
+{
+    let mut remaining = uuids.clone();
+    let mut proguard_uuids: HashSet<_> = uuids
+        .iter()
+        .filter(|&x| x.get_version() == Some(UuidVersion::Sha1))
+        .collect();
+
+    let iter = paths
+        .iter()
+        .flat_map(|p| WalkDir::new(p))
+        .filter_map(|e| e.ok())
+        .filter(|e| e.file_type().is_file());
+
+    let mut found_files = vec![];
+    let pb = ProgressBar::new_spinner();
+    pb.set_draw_target(ProgressDrawTarget::stdout());
+    pb.set_style(ProgressStyle::default_spinner()
+        .tick_chars("/|\\- ")
+        .template("{spinner} Looking for debug info files... {msg:.dim}\
+                   \n  debug info files found: {prefix:.yellow}"));
+
+    for dirent in iter {
+        if remaining.is_empty() {
+            break;
+        }
+
+        if let Some(p) = dirent.file_name().to_str() {
+            pb.set_message(&p);
+        }
+        pb.tick();
+        pb.set_prefix(&format!("{}", found_files.len()));
+
+        let mut found = vec![];
+
+        // specifically look for proguard files.  We only look for UUID5s
+        // and only if the file is a text file.
+        if_chain! {
+            if !proguard_uuids.is_empty();
+            if types.contains(&DifType::Proguard);
+            if dirent.path().extension() == Some(OsStr::new("txt"));
+            if let Ok(mapping) = proguard::MappingView::from_path(dirent.path());
+            if proguard_uuids.contains(&mapping.uuid());
+            then {
+                found.push((mapping.uuid(), DifType::Proguard));
+            }
+        }
+
+        // look for dsyms
+        if_chain! {
+            if types.contains(&DifType::Dsym);
+            // we regularly match on .class files but the will never be
+            // dsyms, so we can quickly skip them here
+            if dirent.path().extension() != Some(OsStr::new("class"));
+            if let Ok(md) = dirent.metadata();
+            if md.len() < MAX_MAPPING_FILE;
+            if let Ok(info) = MachoInfo::open_path(dirent.path());
+            if info.matches_any(&remaining);
+            then {
+                for uuid in info.get_uuids() {
+                    if remaining.contains(&uuid) {
+                        found.push((uuid, DifType::Dsym));
+                    }
+                }
+            }
+        }
+
+        for (uuid, ty) in found {
+            found_files.push(DifMatch {
+                ty: ty,
+                uuid: uuid,
+                path: dirent.path().to_path_buf(),
+            });
+            remaining.remove(&uuid);
+            proguard_uuids.remove(&uuid);
+        }
+    }
+
+    pb.finish_and_clear();
+
+    if as_json {
+        serde_json::to_writer_pretty(&mut io::stdout(), &found_files)?;
+        println!("");
+    } else {
+        for m in found_files {
+            println!("{} {} [{}]", style(m.uuid).dim(), m.path.display(), style(m.ty).yellow());
+        }
+        if !remaining.is_empty() {
+            println_stderr!("");
+            println_stderr!("missing debug information files:");
+            for uuid in &remaining {
+                println_stderr!("  {} ({})", uuid, match uuid.get_version() {
+                    Some(UuidVersion::Sha1) => "likely proguard",
+                    Some(UuidVersion::Md5) => "likely dsym",
+                    _ => "unknown",
+                });
+            }
+        }
+    }
+
+    Ok(remaining.is_empty())
+}
+
+pub fn execute<'a>(matches: &ArgMatches<'a>, _config: &Config) -> Result<()> {
+    let mut paths = HashSet::new();
+    let mut types = HashSet::new();
+    let mut uuids = HashSet::new();
+
+    // which types should we consider?
+    if let Some(t) = matches.values_of("types") {
+        for ty in t {
+            types.insert(match ty {
+                "dsym" => DifType::Dsym,
+                "proguard" => DifType::Proguard,
+                _ => unreachable!()
+            });
+        }
+    } else {
+        types.insert(DifType::Dsym);
+        types.insert(DifType::Proguard);
+    }
+
+    let with_well_known = !matches.is_present("no_well_known");
+    let with_cwd = !matches.is_present("no_cwd");
+
+    // start adding well known locations
+    if_chain! {
+        if with_well_known;
+        if types.contains(&DifType::Dsym);
+        if let Some(path) = env::home_dir().map(|x| x.join("Library/Developer/Xcode/DerivedData"));
+        if path.is_dir();
+        then {
+            paths.insert(path);
+        }
+    }
+
+    // current folder if wanted
+    if_chain! {
+        if with_cwd;
+        if let Ok(path) = env::current_dir();
+        then {
+            paths.insert(path);
+        }
+    }
+
+    // extra paths
+    if let Some(p) = matches.values_of("paths") {
+        for path in p {
+            paths.insert(PathBuf::from(path));
+        }
+    }
+
+    // which uuids are we looking for?
+    if let Some(u) = matches.values_of("uuids") {
+        for uuid in u {
+            uuids.insert(uuid.parse().unwrap());
+        }
+    } else {
+        return Ok(());
+    }
+
+    if !find_uuids(paths, types, uuids, matches.is_present("json"))? {
+        return Err(ErrorKind::QuietExit(1).into());
+    }
+
+    Ok(())
+}

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -66,6 +66,7 @@ pub mod react_native_codepush;
 
 pub mod difutil;
 pub mod difutil_find;
+pub mod difutil_check;
 
 fn preexecute_hooks() -> Result<bool> {
     return sentry_react_native_xcode_wrap();

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -33,6 +33,7 @@ macro_rules! each_subcommand {
         $mac!(login);
         $mac!(send_event);
         $mac!(react_native);
+        $mac!(difutil);
 
         // these here exist for legacy reasons only.  They were moved
         // to subcommands of the react-native command.  Note that
@@ -62,6 +63,9 @@ pub mod react_native;
 pub mod react_native_xcode;
 pub mod react_native_gradle;
 pub mod react_native_codepush;
+
+pub mod difutil;
+pub mod difutil_find;
 
 fn preexecute_hooks() -> Result<bool> {
     return sentry_react_native_xcode_wrap();

--- a/src/commands/react_native.rs
+++ b/src/commands/react_native.rs
@@ -1,4 +1,4 @@
-use clap::{App, ArgMatches};
+use clap::{App, ArgMatches, AppSettings};
 
 use prelude::*;
 use config::Config;
@@ -22,7 +22,9 @@ pub fn make_app<'a, 'b: 'a>(mut app: App<'a, 'b>) -> App<'a, 'b> {
         }}
     }
 
-    app = app.about("provides helpers for react-native.");
+    app = app
+        .about("provides helpers for react-native.")
+        .setting(AppSettings::SubcommandRequiredElseHelp);
     each_subcommand!(add_subcommand);
     app
 }

--- a/src/commands/upload_dsym.rs
+++ b/src/commands/upload_dsym.rs
@@ -274,7 +274,7 @@ fn find_missing_files(api: &mut Api,
 }
 
 fn zip_up_missing(refs: &[DSymRef]) -> Result<TempFile> {
-    println!("{} Compressing {} missing debug symbol files", style("[2/3]").dim(),
+    println!("{} Compressing {} missing debug symbol files", style(">").dim(),
              style(refs.len()).yellow());
     let total_bytes = refs.iter().map(|x| x.size).sum();
     let pb = make_byte_progress_bar(total_bytes);
@@ -293,7 +293,7 @@ fn upload_dsyms(api: &mut Api,
                 project: &str)
                 -> Result<Vec<DSymFile>> {
     let tf = zip_up_missing(refs)?;
-    println!("{} Uploading debug symbol files", style("[3/3]").dim());
+    println!("{} Uploading debug symbol files", style(">").dim());
     Ok(api.upload_dsyms(org, project, tf.path())?)
 }
 
@@ -411,12 +411,12 @@ pub fn execute<'a>(matches: &ArgMatches<'a>, config: &Config) -> Result<()> {
                     all_dsym_checksums.push(dsym_ref.checksum.clone());
                 }
                 println!("{} Found {} debug symbol files. Checking for missing symbols on server",
-                         style("[1/3]").dim(), style(batch.len()).yellow());
+                         style(">").dim(), style(batch.len()).yellow());
                 let missing = find_missing_files(&mut api, batch, &org, &project)?;
                 if missing.len() == 0 {
                     println!("{} Nothing to compress, all symbols are on the server",
-                             style("[2/3]").dim());
-                    println!("{} Nothing to upload", style("[3/3]").dim());
+                             style(">").dim());
+                    println!("{} Nothing to upload", style(">").dim());
                     continue;
                 }
                 let rv = upload_dsyms(&mut api, &missing, &org, &project)?;
@@ -459,10 +459,11 @@ pub fn execute<'a>(matches: &ArgMatches<'a>, config: &Config) -> Result<()> {
         // If wanted trigger reprocessing
         if !matches.is_present("no_reprocessing") {
             if !api.trigger_reprocessing(&org, &project)? {
-                println!("Server does not support reprocessing. Not triggering.");
+                println!("{} Server does not support reprocessing. Not triggering.",
+                         style(">").dim());
             }
         } else {
-            println!("Skipped reprocessing.");
+            println!("{} skipped reprocessing", style(">").dim());
         }
 
         // did we miss anything?

--- a/src/commands/upload_proguard.rs
+++ b/src/commands/upload_proguard.rs
@@ -1,7 +1,6 @@
 //! Implements a command for uploading proguard mapping files.
 use std::fs;
 use std::io;
-use std::io::Write;
 use std::path::PathBuf;
 
 use prelude::*;

--- a/src/commands/upload_proguard.rs
+++ b/src/commands/upload_proguard.rs
@@ -88,7 +88,6 @@ pub fn make_app<'a, 'b: 'a>(app: App<'a, 'b>) -> App<'a, 'b> {
 }
 
 pub fn execute<'a>(matches: &ArgMatches<'a>, config: &Config) -> Result<()> {
-    let (org, project) = config.get_org_and_project(matches)?;
     let api = Api::new(config);
 
     let paths: Vec<_> = match matches.values_of("paths") {
@@ -138,10 +137,12 @@ pub fn execute<'a>(matches: &ArgMatches<'a>, config: &Config) -> Result<()> {
     }
 
     if mappings.is_empty() && matches.is_present("require_one") {
-        fail!("found no mapping files to upload");
+        println!("");
+        println_stderr!("{}", style("error: found no mapping files to upload").red());
+        return Err(ErrorKind::QuietExit(1).into());
     }
 
-    println!("{} compressing mappings", style("[1/2]").dim());
+    println!("{} compressing mappings", style(">").dim());
     let tf = TempFile::new()?;
 
     // add a scope here so we will flush before uploading
@@ -156,19 +157,21 @@ pub fn execute<'a>(matches: &ArgMatches<'a>, config: &Config) -> Result<()> {
         }
     }
 
-    if !matches.is_present("no_upload") {
-        println!("{} uploading mappings", style("[2/2]").dim());
-        let rv = api.upload_dsyms(&org, &project, tf.path())?;
-        println!("Uploaded a total of {} new mapping files",
-                 style(rv.len()).yellow());
-        if rv.len() > 0 {
-            println!("Newly uploaded debug symbols:");
-            for df in rv {
-                println!("  {}", style(&df.uuid).dim());
-            }
+    if matches.is_present("no_upload") {
+        println!("{} skipping upload.", style(">").dim());
+        return Ok(());
+    }
+
+    println!("{} uploading mappings", style(">").dim());
+    let (org, project) = config.get_org_and_project(matches)?;
+    let rv = api.upload_dsyms(&org, &project, tf.path())?;
+    println!("{} Uploaded a total of {} new mapping files",
+             style(">").dim(), style(rv.len()).yellow());
+    if rv.len() > 0 {
+        println!("Newly uploaded debug symbols:");
+        for df in rv {
+            println!("  {}", style(&df.uuid).dim());
         }
-    } else {
-        println!("Skipping upload.");
     }
 
     // write UUIDs into the mapping file.
@@ -198,10 +201,11 @@ pub fn execute<'a>(matches: &ArgMatches<'a>, config: &Config) -> Result<()> {
     if !matches.is_present("no_reprocessing") &&
        !matches.is_present("no_upload") {
         if !api.trigger_reprocessing(&org, &project)? {
-            println!("Server does not support reprocessing. Not triggering.");
+            println!("{} Server does not support reprocessing. Not triggering.",
+                     style(">").dim());
         }
     } else {
-        println!("Skipped reprocessing.");
+        println!("{} skipped reprocessing", style(">").dim());
     }
 
     Ok(())

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -31,6 +31,7 @@ macro_rules! iter_try {
 
 macro_rules! println_stderr(
     ($($arg:tt)*) => { {
+        use std::io::Write;
         let r = writeln!(&mut ::std::io::stderr(), $($arg)*);
         r.expect("failed printing to stderr");
     } }

--- a/src/utils/macho.rs
+++ b/src/utils/macho.rs
@@ -103,8 +103,8 @@ impl MachoInfo {
         !self.uuids.is_disjoint(uuids)
     }
 
-    pub fn get_uuids(self) -> Vec<Uuid> {
-        self.uuids.into_iter().collect()
+    pub fn get_uuids(&self) -> Vec<Uuid> {
+        self.uuids.iter().map(|&x| x).collect()
     }
 }
 


### PR DESCRIPTION
This can check debug info files and find the if needed

Running against dsym files:

<img width="319" alt="screen shot 2017-06-21 at 02 43 45" src="https://user-images.githubusercontent.com/7396/27362003-7dfd7504-562b-11e7-8be5-5a41493ae3de.png">

Running against macho binaries without debug info:

<img width="315" alt="screen shot 2017-06-21 at 02 44 16" src="https://user-images.githubusercontent.com/7396/27362010-88af1ad4-562b-11e7-9ee6-c8847698a0b3.png">

Running against proguard files:

<img width="313" alt="screen shot 2017-06-21 at 02 44 35" src="https://user-images.githubusercontent.com/7396/27362021-94038bb8-562b-11e7-9629-d553a307cab4.png">

Scanning for specific files:

<img width="1046" alt="screen shot 2017-06-21 at 02 45 28" src="https://user-images.githubusercontent.com/7396/27362038-b60d1bc0-562b-11e7-9df8-dfbf5339bd74.png">
