### PR TITLE
Write Proguard mappings even if upload is disabled, create parent dir…

### DIFF
--- a/src/commands/upload_proguard.rs
+++ b/src/commands/upload_proguard.rs
@@ -174,6 +174,11 @@ pub fn execute<'a>(matches: &ArgMatches<'a>, config: &Config) -> Result<()> {
         }
     }
 
+    // write UUIDs into the mapping file.
+    if let Some(p) = matches.value_of("write_properties") {
+        let uuids: Vec<_> = mappings.iter().map(|x| x.uuid).collect();
+        dump_proguard_uuids_as_properties(p, &uuids)?;
+    }
 
     if matches.is_present("no_upload") {
         println!("{} skipping upload.", style(">").dim());
@@ -190,12 +195,6 @@ pub fn execute<'a>(matches: &ArgMatches<'a>, config: &Config) -> Result<()> {
         for df in rv {
             println!("  {}", style(&df.uuid).dim());
         }
-    }
-
-    // write UUIDs into the mapping file.
-    if let Some(p) = matches.value_of("write_properties") {
-        let uuids: Vec<_> = mappings.iter().map(|x| x.uuid).collect();
-        dump_proguard_uuids_as_properties(p, &uuids)?;
     }
 
     // update the uuids

--- a/src/utils/android.rs
+++ b/src/utils/android.rs
@@ -102,7 +102,9 @@ pub fn dump_proguard_uuids_as_properties<P: AsRef<Path>>(
         .map(|x| x.to_string())
         .join("|"));
 
-    p.as_ref().parent().map(|parent| fs::create_dir_all(parent));
+    if let Some(ref parent) = p.as_ref().parent() {
+        fs::create_dir_all(parent)?;
+    }
     let mut f = fs::File::create(p.as_ref())?;
     java_properties::write(&mut f, &props)
         .map_err(|_| Error::from("Could not persist proguard UUID in properties file"))?;

--- a/src/utils/android.rs
+++ b/src/utils/android.rs
@@ -102,6 +102,7 @@ pub fn dump_proguard_uuids_as_properties<P: AsRef<Path>>(
         .map(|x| x.to_string())
         .join("|"));
 
+    p.as_ref().parent().map(|parent| fs::create_dir_all(parent));
     let mut f = fs::File::create(p.as_ref())?;
     java_properties::write(&mut f, &props)
         .map_err(|_| Error::from("Could not persist proguard UUID in properties file"))?;


### PR DESCRIPTION
…ectories.

I'm sure my Rust sucks.

Anyway, we weren't writing properties if `--no-upload` was used. We also didn't create parent directories.