### PR TITLE
New PList Loading (Preprocessor Support)

### DIFF
--- a/src/commands/upload_dsym.rs
+++ b/src/commands/upload_dsym.rs
@@ -501,7 +501,8 @@ pub fn make_app<'a, 'b: 'a>(app: App<'a, 'b>) -> App<'a, 'b> {
              .help("Optional path to the Info.plist.  We will try to find this \
                     automatically if run from xcode.  Providing this information \
                     will associate the debug symbols with a specific ITC application \
-                    and build in Sentry."))
+                    and build in Sentry.  Note that if you provide the plist
+                    explicitly it must already be processed."))
         .arg(Arg::with_name("no_reprocessing")
              .long("no-reprocessing")
              .help("Does not trigger reprocessing after upload"))

--- a/src/utils/codepush.rs
+++ b/src/utils/codepush.rs
@@ -9,7 +9,7 @@ use glob::{glob, glob_with, MatchOptions};
 use regex::Regex;
 
 use prelude::*;
-use utils::xcode::XcodeProjectInfo;
+use utils::xcode::{InfoPlist, XcodeProjectInfo};
 
 
 #[derive(Debug, Deserialize)]
@@ -93,15 +93,8 @@ pub fn get_codepush_release(package: &CodePushPackage, platform: &str,
         for entry_rv in glob_with("ios/*.xcodeproj", &opts)? {
             if let Ok(entry) = entry_rv {
                 let pi = XcodeProjectInfo::from_path(&entry)?;
-                if_chain! {
-                    if let Some(config) = pi.get_configuration("release")
-                        .or_else(|| pi.get_configuration("debug"));
-                    if let Some(target) = pi.get_first_target();
-                    then {
-                        return Ok(pi.get_release_name(
-                            target, config,
-                            Some(&format!("codepush:{}", package.label)))?);
-                    }
+                if let Some(ipl) = InfoPlist::from_project_info(&pi)? {
+                    return Ok(ipl.get_release_name());
                 }
             }
         }

--- a/src/utils/fs.rs
+++ b/src/utils/fs.rs
@@ -11,6 +11,9 @@ use uuid::{Uuid, UuidVersion};
 use prelude::*;
 
 
+pub trait SeekRead: Seek + Read {}
+impl<T: Seek + Read> SeekRead for T {}
+
 /// Helper for temporary dicts
 #[derive(Debug)]
 pub struct TempDir {

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -21,7 +21,7 @@ pub use self::args::{ArgExt, validate_uuid, validate_seconds, validate_timestamp
 pub use self::codepush::{get_codepush_package, get_codepush_release};
 pub use self::formatting::{HumanDuration, Table, TableRow};
 pub use self::fs::{TempDir, TempFile, is_writable, set_executable_mode, is_zip_file,
-                   get_sha1_checksum};
+                   get_sha1_checksum, SeekRead};
 pub use self::logging::Logger;
 pub use self::macho::MachoInfo;
 pub use self::releases::detect_release_name;

--- a/src/utils/xcode.rs
+++ b/src/utils/xcode.rs
@@ -230,7 +230,7 @@ impl InfoPlist {
             }
             c.arg(path.as_ref());
             let p = c.output()?;
-            InfoPlist::from_reader(&mut Cursor::new(&p.stderr[..]))?
+            InfoPlist::from_reader(&mut Cursor::new(&p.stdout[..]))?
         } else {
             InfoPlist::from_path(path)?
         };

--- a/src/utils/xcode.rs
+++ b/src/utils/xcode.rs
@@ -171,6 +171,8 @@ impl InfoPlist {
 
     /// Loads a processed plist file.
     pub fn discover_from_env() -> Result<Option<InfoPlist>> {
+        // if we are loaded directly from xcode we can trust the os environment
+        // and pass those variables to the processor.
         if env::var("XCODE_VERSION_ACTUAL").is_ok() {
             let vars: HashMap<_, _> = env::vars().collect();
             if let Some(filename) = vars.get("INFOPLIST_FILE") {
@@ -178,6 +180,10 @@ impl InfoPlist {
             } else {
                 Ok(None)
             }
+
+        // otherwise, we discover the project info from the current path and
+        // invoke xcodebuild to give us the project settings for the first
+        // target.
         } else {
             if_chain! {
                 if let Ok(here) = env::current_dir();


### PR DESCRIPTION
There are some issues with plist loading, in particular we do not have a
consistent path for it right now and variable expansion is kinda hacky.

This PR adds preprocessor support and go through consistent paths
for dealing with plist files.