### PR TITLE
fix: Refactor and fix release name for android codepush command

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,37 @@
+{
+    // See https://go.microsoft.com/fwlink/?LinkId=733558
+    // for the documentation about the tasks.json format
+    "version": "2.0.0",
+    "presentation": {
+        "reveal": "always",
+        "panel": "shared"
+    },
+    "tasks": [
+        {
+            "type": "shell",
+            "taskName": "cargo build",
+            "command": "cargo",
+            "args": [
+                "build"
+            ],
+            "problemMatcher": "$rustc",
+            "group": {
+                "kind": "build",
+                "isDefault": true
+            }
+        },
+        {
+            "type": "shell",
+            "taskName": "cargo test",
+            "command": "cargo",
+            "args": [
+                "test"
+            ],
+            "problemMatcher": "$rustc",
+            "group": {
+                "kind": "test",
+                "isDefault": true
+            }
+        }
+    ]
+}

--- a/src/utils/codepush.rs
+++ b/src/utils/codepush.rs
@@ -5,7 +5,6 @@ use std::process;
 use serde_json;
 use console::strip_ansi_codes;
 use glob::{glob_with, MatchOptions};
-use regex::Regex;
 
 use prelude::*;
 use utils::xcode::{InfoPlist, XcodeProjectInfo};

--- a/src/utils/codepush.rs
+++ b/src/utils/codepush.rs
@@ -1,16 +1,15 @@
-use std::fs;
-use std::io::Read;
+use std::env;
 use std::str;
 use std::process;
 
 use serde_json;
 use console::strip_ansi_codes;
-use glob::{glob, glob_with, MatchOptions};
+use glob::{glob_with, MatchOptions};
 use regex::Regex;
 
 use prelude::*;
 use utils::xcode::{InfoPlist, XcodeProjectInfo};
-
+use utils::releases::{get_xcode_release_name, infer_gradle_release_name};
 
 #[derive(Debug, Deserialize)]
 pub struct CodePushPackage {
@@ -73,12 +72,6 @@ pub fn get_codepush_release(package: &CodePushPackage, platform: &str,
                             bundle_id_override: Option<&str>)
     -> Result<String>
 {
-    // this is similar to utils::releases::infer_gradle_release_name
-    lazy_static! {
-        static ref APP_ID_RE: Regex = Regex::new(
-            r#"applicationId\s+["']([^"']*)["']"#).unwrap();
-    }
-
     if let Some(bundle_id) = bundle_id_override {
         return Ok(format!("{}-codepush:{}", bundle_id, package.label));
     }
@@ -94,26 +87,23 @@ pub fn get_codepush_release(package: &CodePushPackage, platform: &str,
             if let Ok(entry) = entry_rv {
                 let pi = XcodeProjectInfo::from_path(&entry)?;
                 if let Some(ipl) = InfoPlist::from_project_info(&pi)? {
-                    return Ok(format!("{}-codepush:{}", ipl.get_release_name(), package.label));
+                    if let Some(release_name) = get_xcode_release_name(Some(ipl))? {
+                        return Ok(format!("{}-codepush:{}", release_name, package.label));
+                    }
                 }
             }
         }
         return Err("Could not find plist".into());
     } else if platform == "android" {
-        for entry_rv in glob("android/app/build.gradle")? {
-            let mut s = String::new();
-            if_chain! {
-                if let Ok(entry) = entry_rv;
-                if let Ok(md) = entry.metadata();
-                if md.is_file();
-                if let Ok(mut f) = fs::File::open(entry);
-                if f.read_to_string(&mut s).is_ok();
-                then {
-                    return if let Some(app_id_caps) = APP_ID_RE.captures(&s) {
-                        Ok(format!("{}-codepush:{}", &app_id_caps[1], package.label))
-                    } else {
-                        Err("Could not parse app id from build.gradle".into())
-                    };
+        if_chain! {
+            if let Ok(here) = env::current_dir();
+            if let Ok(android_folder) = here.join("android").metadata();
+            if android_folder.is_dir();
+            then {
+                return if let Some(release_name) = infer_gradle_release_name(Some(here.join("android")))? {
+                    Ok(format!("{}-codepush:{}", release_name, package.label))
+                } else {
+                    Err("Could not parse app id from build.gradle".into())
                 }
             }
         }

--- a/src/utils/releases.rs
+++ b/src/utils/releases.rs
@@ -1,26 +1,25 @@
 use std::fs;
 use std::io::Read;
 use std::env;
+use std::path::PathBuf;
 
 use utils::vcs;
 use utils::xcode::InfoPlist;
 
-use regex::Regex;
-
 use prelude::*;
 
 
-fn get_xcode_release_name() -> Result<Option<String>> {
+pub fn get_xcode_release_name(plist: Option<InfoPlist>) -> Result<Option<String>> {
     // if we are executed from within xcode, then we can use the environment
     // based discovery to get a release name without any interpolation.
-    if let Some(plist) = InfoPlist::discover_from_env()? {
+    if let Some(plist) = plist.or(InfoPlist::discover_from_env()?) {
         return Ok(Some(plist.get_release_name()));
     }
 
     Ok(None)
 }
 
-fn infer_gradle_release_name() -> Result<Option<String>> {
+pub fn infer_gradle_release_name(path: Option<PathBuf>) -> Result<Option<String>> {
     // this is similar to utils::codepush::get_codepush_release
     lazy_static! {
         static ref APP_ID_RE: Regex = Regex::new(
@@ -30,24 +29,23 @@ fn infer_gradle_release_name() -> Result<Option<String>> {
     }
 
     let mut contents = String::new();
-    if let Ok(mut here) = env::current_dir() {
-        loop {
-            if_chain! {
-                if let Ok(build_md) = here.join("build.gradle").metadata();
-                if build_md.is_file();
-                if let Ok(app_md) = here.join("app/build.gradle").metadata();
-                if app_md.is_file();
-                if let Ok(mut f) = fs::File::open(here.join("app/build.gradle"));
-                if f.read_to_string(&mut contents).is_ok();
-                if let Some(app_id_caps) = APP_ID_RE.captures(&contents);
-                if let Some(version_caps) = VERSION_NAME_RE.captures(&contents);
-                then {
-                    return Ok(Some(format!("{}-{}", &app_id_caps[1], &version_caps[1])));
-                }
+    let mut here = path.map_or(env::current_dir()?, |p| p.into());
+    loop {
+        if_chain! {
+            if let Ok(build_md) = here.join("build.gradle").metadata();
+            if build_md.is_file();
+            if let Ok(app_md) = here.join("app/build.gradle").metadata();
+            if app_md.is_file();
+            if let Ok(mut f) = fs::File::open(here.join("app/build.gradle"));
+            if f.read_to_string(&mut contents).is_ok();
+            if let Some(app_id_caps) = APP_ID_RE.captures(&contents);
+            if let Some(version_caps) = VERSION_NAME_RE.captures(&contents);
+            then {
+                return Ok(Some(format!("{}-{}", &app_id_caps[1], &version_caps[1])));
             }
-            if !here.pop() {
-                break;
-            }
+        }
+        if !here.pop() {
+            break;
         }
     }
 
@@ -60,7 +58,7 @@ pub fn detect_release_name() -> Result<String> {
     // xcodebuild which does not exist anywhere but there.
     if_chain! {
         if cfg!(target_os="macos");
-        if let Some(release) = get_xcode_release_name()?;
+        if let Some(release) = get_xcode_release_name(None)?;
         then {
             return Ok(release)
         }
@@ -69,7 +67,7 @@ pub fn detect_release_name() -> Result<String> {
     // For android we badly parse gradle files.  We do this because most of the
     // time now people set the ids and versions in the gradle files instead of
     // the xml manifests.
-    if let Some(release) = infer_gradle_release_name()? {
+    if let Some(release) = infer_gradle_release_name(None)? {
         return Ok(release);
     }
 

--- a/src/utils/releases.rs
+++ b/src/utils/releases.rs
@@ -6,6 +6,8 @@ use std::path::PathBuf;
 use utils::vcs;
 use utils::xcode::InfoPlist;
 
+use regex::Regex;
+
 use prelude::*;
 
 


### PR DESCRIPTION
Releases with Codepush had a problem that they did not include the VersionCode in the release itself.
This PR fixes this by using already existing functionality from `infer_gradle_release_name`