### PR TITLE
feat: Add --ignore and --ignore-file to releases files upload-sourcemaps

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,15 @@
+root = true
+
+[*]
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+charset = utf-8
+
+[*.{rs,json}]
+indent_style = space
+indent_size = 4
+
+[.travis.yml]
+indent_style = space
+indent_size = 2

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,8 @@
+{
+    // See http://go.microsoft.com/fwlink/?LinkId=827846
+    // for the documentation about the extensions.json format
+    "recommendations": [
+        "EditorConfig.editorconfig",
+        "rust-lang.rust"
+    ]
+}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,6 +18,7 @@ dependencies = [
  "glob 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "humansize 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "if_chain 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ignore 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "indicatif 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "itertools 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "java-properties 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -262,6 +263,11 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam"
+version = "0.2.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "csv"
 version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -438,6 +444,11 @@ dependencies = [
 ]
 
 [[package]]
+name = "fnv"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "fs2"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -469,6 +480,18 @@ version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "globset"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "aho-corasick 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fnv 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "memchr 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "humansize"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -487,6 +510,21 @@ dependencies = [
 name = "if_chain"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "ignore"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "crossbeam 0.2.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "globset 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "memchr 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "thread_local 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "walkdir 1.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "indicatif"
@@ -1365,6 +1403,7 @@ dependencies = [
 "checksum cmake 0.1.26 (registry+https://github.com/rust-lang/crates.io-index)" = "357c07e7a1fc95732793c1edb5901e1a1f305cfcf63a90eb12dbd22bdb6b789d"
 "checksum console 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "21d6020031c1b7b2b1aa3f9c35568735c46270c6b0e9b338aae6e4a062301711"
 "checksum conv 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "78ff10625fd0ac447827aa30ea8b861fead473bb60aeb73af6c1c58caf0d1299"
+"checksum crossbeam 0.2.10 (registry+https://github.com/rust-lang/crates.io-index)" = "0c5ea215664ca264da8a9d9c3be80d2eaf30923c259d03e870388eb927508f97"
 "checksum csv 0.15.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7ef22b37c7a51c564a365892c012dc0271221fdcc64c69b19ba4d6fa8bd96d9c"
 "checksum curl 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)" = "7034c534a1d7d22f7971d6088aa9d281d219ef724026c3428092500f41ae9c2c"
 "checksum curl-sys 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)" = "4bee31aa3a079d5f3ff9579ea4dcfb1b1a17a40886f5f467436d383e78134b55"
@@ -1386,13 +1425,16 @@ dependencies = [
 "checksum encoding_index_tests 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "a246d82be1c9d791c5dfde9a2bd045fc3cbba3fa2b11ad558f27d01712f00569"
 "checksum error-chain 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d9435d864e017c3c6afeac1654189b06cdb491cf2ff73dbf0d73b0f292f42ff8"
 "checksum flate2 0.2.20 (registry+https://github.com/rust-lang/crates.io-index)" = "e6234dd4468ae5d1e2dbb06fe2b058696fdc50a339c68a393aefbf00bc81e423"
+"checksum fnv 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)" = "6cc484842f1e2884faf56f529f960cc12ad8c71ce96cc7abba0a067c98fee344"
 "checksum fs2 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "9ab76cfd2aaa59b7bf6688ad9ba15bbae64bff97f04ea02144cfd3443e5c2866"
 "checksum gcc 0.3.54 (registry+https://github.com/rust-lang/crates.io-index)" = "5e33ec290da0d127825013597dbdfc28bee4964690c7ce1166cbc2a7bd08b1bb"
 "checksum git2 0.6.8 (registry+https://github.com/rust-lang/crates.io-index)" = "0c1c0203d653f4140241da0c1375a404f0a397249ec818cd2076c6280c50f6fa"
 "checksum glob 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)" = "8be18de09a56b60ed0edf84bc9df007e30040691af7acd1c41874faac5895bfb"
+"checksum globset 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "feeb1b6840809ef5efcf7a4a990bc4e1b7ee3df8cf9e2379a75aeb2ba42ac9c3"
 "checksum humansize 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "92d211e6e70b05749dce515b47684f29a3c8c38bbbb21c50b30aff9eca1b0bd3"
 "checksum idna 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "014b298351066f1512874135335d62a789ffe78a9974f94b43ed5621951eaf7d"
 "checksum if_chain 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "61bb90bdd39e3af69b0172dfc6130f6cd6332bf040fbb9bdd4401d37adbd48b8"
+"checksum ignore 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "b3fcaf2365eb14b28ec7603c98c06cc531f19de9eb283d89a3dff8417c8c99f5"
 "checksum indicatif 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3ba24d01b1bc8bb67a28f71935c7545f2dff16e6c6a2b0b20af1514b6c9f096a"
 "checksum itertools 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)" = "22c285d60139cf413244894189ca52debcfd70b57966feed060da76802e415a0"
 "checksum itoa 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "8324a32baf01e2ae060e9de58ed0bc2320c9a2833491ee36cd3b4c414de4db8c"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ git2 = { version = "0.6.4", default-features = false }
 glob = "0.2.11"
 humansize = "1.0"
 if_chain = "0.1.2"
+ignore = "0.2"
 indicatif = "0.7"
 itertools = "0.6"
 java-properties = "1.0"

--- a/docs/releases.rst
+++ b/docs/releases.rst
@@ -212,6 +212,21 @@ The following options exist to change the behavior of the upload command:
     file by the file contents (eg: sources, minified sources, and
     source maps) and act appropriately.
 
+``--ignore``
+    Specifies one or more patterns of ignored files and folders.  Overrides
+    patterns specified in the ignore file. See ``--ignore-file`` for more
+    information.  Note that unlike ``--ignore-file``, this argument is
+    interpreted relative to the specified path argument.
+
+``--ignore-file``
+    Specifies a file containing patterns of files and folders to ignore
+    during the scan.  Ignore patterns follow the gitignore_ rules and are
+    evaluated relative to the location of the ignore file.  The file is
+    assumed in the current working directory or any of its parent
+    directories.
+
+.. _gitignore: https://git-scm.com/docs/gitignore#_pattern_format
+
 Some example usages::
 
     $ sentry-cli releases files 0.1 upload-sourcemaps /path/to/sourcemaps
@@ -219,6 +234,8 @@ Some example usages::
         --url-prefix '~/static/js`
     $ sentry-cli releases files 0.1 upload-sourcemaps /path/to/sourcemaps \
         --url-prefix '~/static/js` --rewrite --strip-common-prefix
+    $ sentry-cli releases files 0.1 upload-sourcemaps /path/to/sourcemaps \
+        --ignore-file .sentryignore
 
 List Files
 ``````````

--- a/src/commands/releases.rs
+++ b/src/commands/releases.rs
@@ -239,7 +239,7 @@ pub fn make_app<'a, 'b: 'a>(app: App<'a, 'b>) -> App<'a, 'b> {
                     .short("I")
                     .value_name("IGNORE_FILE")
                     .help("Ignores all fiels and folders specified in the given \
-                            ignore file, e.g. .gitignore. Defaults to .sentryignore"))
+                            ignore file, e.g. .gitignore."))
                 // legacy parameter
                 .arg(Arg::with_name("verbose")
                     .long("verbose")

--- a/src/commands/upload_dsym.rs
+++ b/src/commands/upload_dsym.rs
@@ -284,7 +284,7 @@ impl<'a> Iterator for BatchIter<'a> {
 
             if self.open_zip_index != !0 {
                 let mut archive_ptr = self.open_zip.borrow_mut();
-                let mut archive = archive_ptr.as_mut().unwrap();
+                let archive = archive_ptr.as_mut().unwrap();
                 if show_zip_continue {
                     show_zip_continue = false;
                 }
@@ -433,7 +433,7 @@ fn resolve_bcsymbolmaps(refs: &mut [DSymRef],
 
         let pb = ProgressBar::new(hidden_symbols.len() as u64);
         for idx in hidden_symbols.into_iter() {
-            let mut r = &mut refs[idx];
+            let r = &mut refs[idx];
             pb.inc(1);
             r.resolve_bcsymbolmaps(symbol_map_path)?;
         }

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -4,6 +4,7 @@ use std::string;
 use ini::ini;
 use clap;
 use glob;
+use ignore;
 use serde_json;
 use url;
 use walkdir;
@@ -33,6 +34,7 @@ error_chain! {
 
     foreign_links {
         Io(io::Error);
+        Ignore(ignore::Error);
         Zip(zip::result::ZipError);
         WalkDir(walkdir::Error);
         UrlParse(url::ParseError);

--- a/src/main.rs
+++ b/src/main.rs
@@ -63,6 +63,7 @@ extern crate mac_process_info;
 extern crate app_dirs;
 extern crate uchardet;
 extern crate encoding;
+extern crate ignore;
 
 mod macros;
 


### PR DESCRIPTION
This PR adds two flags to the releases:files:upload-sourcemaps command:

 - `-i` or `--ignore`: Ignore a certain glob **relative to the cwd**.
   This allows to, for instance, exclude `node_modules/`.
 - `-I` or `--ignore-file`: Set a file containing one more more ignore
   patterns **relative to the file's path**. Any file that is a valid
   gitignore file can also be used here. This also includes overrides
   in the form of `!pattern`. If the specified file is not found in the
   cwd, sentry-cli traverses up the directory tree until it finds the
   file.

Both options can be used together, with the patterns declared in `--ignore`
taking precedence. There is no default ignore file configured, but it would
be easy to default to something like `.sentryignore`.

Along with these changes, file extension matching has been rewritten
to use the `ignore` crate. Command line options and defaults remain
the same.

Fixes #126