### PR TITLE
Fix typo leading to --extra param being ignored in send-event command

### DIFF
--- a/src/commands/send_event.rs
+++ b/src/commands/send_event.rs
@@ -90,7 +90,7 @@ pub fn execute<'a>(matches: &ArgMatches<'a>, config: &Config) -> Result<()> {
         }
     }
 
-    if let Some(extra) = matches.values_of("tags") {
+    if let Some(extra) = matches.values_of("extra") {
         for pair in extra {
             let mut split = pair.splitn(2, ':');
             let key = split.next().ok_or("missing extra key")?;


### PR DESCRIPTION
When using --extra x:y or -e x:y, no extra information was sent. but when using --tag a:b, the pair a:b was sent as a tag AND as an extra information.