### PR TITLE
docs: Improve bundle ID docs for codepush.  Refs #143

### DIFF
--- a/src/commands/react_native_codepush.rs
+++ b/src/commands/react_native_codepush.rs
@@ -22,7 +22,9 @@ pub fn make_app<'a, 'b: 'a>(app: App<'a, 'b>) -> App<'a, 'b> {
             .long("bundle-id")
             .help("Explicitly provide the bundle ID instead of \
                    parsing the source projects.  This allows you to push \
-                   codepush releases for iOS on platforms without Xcode."))
+                   codepush releases for iOS on platforms without Xcode or \
+                   codepush releases for Android when you use different \
+                   bundle IDs for release and debug etc."))
         .arg(Arg::with_name("print_release_name")
             .long("print-release-name")
             .help("Print the release name instead."))


### PR DESCRIPTION
This points out that bundle IDs are also necessary for other cases than just xcode builds on non macs.