### PR TITLE
feat: Optionally include binaries when uploading dSYMs

### DIFF
--- a/src/utils/macho.rs
+++ b/src/utils/macho.rs
@@ -20,6 +20,7 @@ lazy_static! {
 
 
 const FAT_MAGIC: &'static [u8; 4] = b"\xca\xfe\xba\xbe";
+const FAT_CIGAM: &'static [u8; 4] = b"\xbe\xba\xfe\xca";
 const MAGIC: &'static [u8; 4] = b"\xfe\xed\xfa\xce";
 const MAGIC_CIGAM: &'static [u8; 4] = b"\xce\xfa\xed\xfe";
 const MAGIC_64: &'static [u8; 4] = b"\xfe\xed\xfa\xcf";
@@ -156,7 +157,7 @@ fn is_macho_file_as_result<R: Read>(mut rdr: R) -> Result<bool> {
     let mut magic: [u8; 4] = [0; 4];
     rdr.read_exact(&mut magic)?;
     Ok(match &magic {
-        FAT_MAGIC | MAGIC | MAGIC_CIGAM | MAGIC_64 | MAGIC_CIGAM64 => true,
+        FAT_MAGIC | FAT_CIGAM | MAGIC | MAGIC_CIGAM | MAGIC_64 | MAGIC_CIGAM64 => true,
         _ => false,
     })
 }

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -25,7 +25,7 @@ pub use self::formatting::{HumanDuration, Table, TableRow};
 pub use self::fs::{TempDir, TempFile, is_writable, set_executable_mode, is_zip_file,
                    get_sha1_checksum, SeekRead};
 pub use self::logging::Logger;
-pub use self::macho::MachoInfo;
+pub use self::macho::{MachoInfo, MachoFileType};
 pub use self::releases::detect_release_name;
 pub use self::sourcemaps::{SourceMapProcessor, get_sourcemap_reference_from_headers};
 pub use self::system::{propagate_exit_status, is_homebrew_install,


### PR DESCRIPTION
This adds support to include binaries in dSYM uploads to allow server-side
stackwalking. Binaries are either executables or dynamic libraries. The Sentry
server will then extract relevant information from the binaries and merge
them into the dSYMs.

The reasoning behind uploading complete binaries is to maintain flexibility
for further processing choices. For now, this does not require too much
processing on the client side and we can stabilize our processing pipeline
on the server side, first. Once the process is stable, we can start pulling
symbolic into sentry-cli and process / strip debug symbols on the client
side already.

The PR contains the following changes:

 - First, the `filetype` flag is read from MachO headers. In FAT files, the
   file type is only located in the architecture's MachoHeaders. This forces
   us to iterate over the entire list of architectures and verify that all
   types match. Otherwise a type `MachoFileType::Inconsistent` is returned.
   We will have to see, if this happens out in the wild, but for now we can
   assume, that only matching file types get merged into a universal binary.

 - The `upload-dsym` CLI has a new parameter `--binaries`, which enables the
   search for binaries. A binary is either `MachoFileType::Executable`
   (`MH_EXECUTE`) or `MachoFileType::Dylib` (`MH_DYLIB`).

 - The file walker does not only check for dwarf data anymore, but also
   whether the filetype is one of the binary types. Since these files do not
   contain the `__DWARF` section, the `has_dwarf_data()` check is omitted.

 - Found files are now consistently keyed by a tuple `(Uuid, MachoFileType)`.
   Duplicate detection now also considers the file type in addition to the
   uuid. As a result, the early exit condition `BatchIter::found_all` now
   considers binaries too, if the `--binaries` option is set.

Note that the Sentry server currently ignores these binaries. Thus, they
will be uploaded repeatedly until we start to handle them.