### PR TITLE
feat: Improve send-event and add docs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1,3 +1,61 @@
+[root]
+name = "sentry-cli"
+version = "1.23.0"
+dependencies = [
+ "anylog 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "app_dirs 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "backtrace 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "chan 0.1.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "chan-signal 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "chrono 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "clap 2.27.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "console 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "curl 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "dotenv 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "elementtree 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "encoding 0.2.33 (registry+https://github.com/rust-lang/crates.io-index)",
+ "error-chain 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "git2 0.6.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "glob 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hostname 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "humansize 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "if_chain 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ignore 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "indicatif 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "itertools 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "java-properties 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.33 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "mac-process-info 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "mach_object 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "memmap 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "might-be-minified 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "open 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "openssl-probe 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "osascript 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "plist 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "prettytable-rs 0.6.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proguard 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "runas 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rust-ini 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.21 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_derive 1.0.21 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sha1 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sourcemap 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "uchardet 2.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "uname 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "unix-daemonize 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "url 1.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "username 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "uuid 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "walkdir 1.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "which 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "zip 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
 [[package]]
 name = "advapi32-sys"
 version = "0.1.2"
@@ -22,6 +80,16 @@ version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "memchr 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "anylog"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "chrono 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -162,7 +230,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bit-set 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "chan 0.1.19 (registry+https://github.com/rust-lang/crates.io-index)",
- "lazy_static 0.2.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.33 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -194,7 +262,7 @@ version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "lazy_static 0.2.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.33 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -214,9 +282,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "clicolors-control 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "lazy_static 0.2.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.33 (registry+https://github.com/rust-lang/crates.io-index)",
- "parking_lot 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "parking_lot 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "termios 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicode-width 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -246,7 +314,7 @@ dependencies = [
  "curl-sys 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.33 (registry+https://github.com/rust-lang/crates.io-index)",
  "openssl-probe 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "openssl-sys 0.9.20 (registry+https://github.com/rust-lang/crates.io-index)",
+ "openssl-sys 0.9.21 (registry+https://github.com/rust-lang/crates.io-index)",
  "socket2 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -259,7 +327,7 @@ dependencies = [
  "cc 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.33 (registry+https://github.com/rust-lang/crates.io-index)",
  "libz-sys 1.0.18 (registry+https://github.com/rust-lang/crates.io-index)",
- "openssl-sys 0.9.20 (registry+https://github.com/rust-lang/crates.io-index)",
+ "openssl-sys 0.9.21 (registry+https://github.com/rust-lang/crates.io-index)",
  "pkg-config 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "vcpkg 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -507,7 +575,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "crossbeam 0.2.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "globset 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "lazy_static 0.2.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "memchr 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -521,8 +589,8 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "console 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "lazy_static 0.2.10 (registry+https://github.com/rust-lang/crates.io-index)",
- "parking_lot 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "parking_lot 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -573,7 +641,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "lazy_static"
-version = "0.2.10"
+version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -624,7 +692,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bitflags 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "lazy_static 0.2.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.33 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.38 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -744,7 +812,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.20"
+version = "0.9.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "cc 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -773,7 +841,7 @@ dependencies = [
 
 [[package]]
 name = "parking_lot"
-version = "0.5.0"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "owning_ref 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -849,7 +917,7 @@ dependencies = [
  "atty 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "csv 0.15.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "encode_unicode 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "lazy_static 0.2.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "term 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicode-width 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -859,7 +927,7 @@ name = "proguard"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "lazy_static 0.2.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "memmap 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "uuid 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -969,63 +1037,6 @@ dependencies = [
 name = "semver-parser"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
-name = "sentry-cli"
-version = "1.23.0"
-dependencies = [
- "app_dirs 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "backtrace 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "chan 0.1.19 (registry+https://github.com/rust-lang/crates.io-index)",
- "chan-signal 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "chrono 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "clap 2.27.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "console 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "curl 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "dotenv 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "elementtree 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "encoding 0.2.33 (registry+https://github.com/rust-lang/crates.io-index)",
- "error-chain 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "git2 0.6.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "glob 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
- "hostname 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "humansize 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "if_chain 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "ignore 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "indicatif 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "itertools 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "java-properties 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "lazy_static 0.2.10 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.33 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "mac-process-info 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "mach_object 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "memmap 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "might-be-minified 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "open 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "openssl-probe 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "osascript 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "plist 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "prettytable-rs 0.6.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "proguard 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "regex 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "runas 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "rust-ini 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.21 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_derive 1.0.21 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_json 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "sha1 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "sourcemap 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "uchardet 2.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "uname 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "unix-daemonize 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "url 1.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "username 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "uuid 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "walkdir 1.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "which 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "zip 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
-]
 
 [[package]]
 name = "serde"
@@ -1139,7 +1150,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "base64 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "if_chain 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "lazy_static 0.2.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc_version 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 0.9.15 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1159,7 +1170,7 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "debug_unreachable 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "lazy_static 0.2.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "phf_shared 0.7.21 (registry+https://github.com/rust-lang/crates.io-index)",
  "precomputed-hash 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.21 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1257,7 +1268,7 @@ name = "thread_local"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "lazy_static 0.2.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "unreachable 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -1475,6 +1486,7 @@ dependencies = [
 "checksum advapi32-sys 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "307c92332867e586720c0222ee9d890bbe8431711efed8a1b06bc5b40fc66bd7"
 "checksum advapi32-sys 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e06588080cb19d0acb6739808aafa5f26bfb2ca015b2b6370028b44cf7cb8a9a"
 "checksum aho-corasick 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)" = "500909c4f87a9e52355b26626d890833e9e1d53ac566db76c36faa984b889699"
+"checksum anylog 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "6eac724c1c3bb9257ae15c2fd83dc3f2f5c9f0ff9a403df4f11861eedaf0b28b"
 "checksum app_dirs 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "b7d1c0d48a81bbb13043847f957971f4d87c81542d80ece5e84ba3cba4058fd4"
 "checksum atty 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "21e50800ec991574876040fff8ee46b136a53e985286fbe6a3bdfe6421b78860"
 "checksum backtrace 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "8709cc7ec06f6f0ae6c2c7e12f6ed41540781f72b488d83734978295ceae182e"
@@ -1540,7 +1552,7 @@ dependencies = [
 "checksum kernel32-sys 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "e014dab1082fd9d80ea1fa6fcb261b47ed3eb511612a14198bb507701add083e"
 "checksum kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7507624b29483431c0ba2d82aece8ca6cdba9382bff4ddd0f7490560c056098d"
 "checksum lazy_static 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)" = "cf186d1a8aa5f5bee5fd662bc9c1b949e0259e1bcc379d1f006847b0080c7417"
-"checksum lazy_static 0.2.10 (registry+https://github.com/rust-lang/crates.io-index)" = "236eb37a62591d4a41a89b7763d7de3e06ca02d5ab2815446a8bae5d2f8c2d57"
+"checksum lazy_static 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)" = "76f033c7ad61445c5b347c7382dd1237847eb1bce590fe50365dcb33d546be73"
 "checksum libc 0.2.33 (registry+https://github.com/rust-lang/crates.io-index)" = "5ba3df4dcb460b9dfbd070d41c94c19209620c191b0340b929ce748a2bcd42d2"
 "checksum libgit2-sys 0.6.16 (registry+https://github.com/rust-lang/crates.io-index)" = "6f74b4959cef96898f5123148724fc7dee043b9a6b99f219d948851bfbe53cb2"
 "checksum libz-sys 1.0.18 (registry+https://github.com/rust-lang/crates.io-index)" = "87f737ad6cc6fd6eefe3d9dc5412f1573865bded441300904d2f42269e140f16"
@@ -1561,10 +1573,10 @@ dependencies = [
 "checksum ole32-sys 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5d2c49021782e5233cd243168edfa8037574afed4eba4bbaf538b3d8d1789d8c"
 "checksum open 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "c281318d992e4432cfa799969467003d05921582a7489a8325e37f8a450d5113"
 "checksum openssl-probe 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "d98df0270d404ccd3c050a41d579c52d1db15375168bb3471e04ec0f5f378daf"
-"checksum openssl-sys 0.9.20 (registry+https://github.com/rust-lang/crates.io-index)" = "0ad395f1cee51b64a8d07cc8063498dc7554db62d5f3ca87a67f4eed2791d0c8"
+"checksum openssl-sys 0.9.21 (registry+https://github.com/rust-lang/crates.io-index)" = "92867746af30eea7a89feade385f7f5366776f1c52ec6f0de81360373fa88363"
 "checksum osascript 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "38731fa859ef679f1aec66ca9562165926b442f298467f76f5990f431efe87dc"
 "checksum owning_ref 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "cdf84f41639e037b484f93433aa3897863b561ed65c6e59c7073d7c561710f37"
-"checksum parking_lot 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "9517dca2f725f6fdefc25bbd08837f76f525fb513eeb2383d643bed8339053ed"
+"checksum parking_lot 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "aaa05f44da976a971a70edfc7e560ab4ef7c0cbe786fc9a83f706bbb22144e46"
 "checksum parking_lot_core 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)" = "4f610cb9664da38e417ea3225f23051f589851999535290e077939838ab7a595"
 "checksum percent-encoding 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "31010dd2e1ac33d5b46a5b413495239882813e0369f8ed8a5e266f173602f831"
 "checksum phf_generator 0.7.21 (registry+https://github.com/rust-lang/crates.io-index)" = "6b07ffcc532ccc85e3afc45865469bf5d9e4ef5bfcf9622e3cfe80c2d275ec03"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1,4 +1,22 @@
 [[package]]
+name = "advapi32-sys"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi-build 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "advapi32-sys"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi-build 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -454,6 +472,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "hostname"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "libc 0.2.33 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winutil 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "humansize"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -519,6 +546,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "encoding 0.2.33 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "kernel32-sys"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi-build 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -952,6 +988,7 @@ dependencies = [
  "error-chain 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "git2 0.6.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "glob 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hostname 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "humansize 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "if_chain 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "ignore 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -980,8 +1017,10 @@ dependencies = [
  "sha1 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "sourcemap 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "uchardet 2.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "uname 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "unix-daemonize 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 1.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "username 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "uuid 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "walkdir 1.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "which 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1254,6 +1293,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "uname"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "libc 0.2.33 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "unicode-bidi"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1311,6 +1358,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "username"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "advapi32-sys 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "utf8-ranges"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1364,6 +1420,16 @@ version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "winutil"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "advapi32-sys 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "kernel32-sys 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "ws2_32-sys"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1406,6 +1472,8 @@ dependencies = [
 ]
 
 [metadata]
+"checksum advapi32-sys 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "307c92332867e586720c0222ee9d890bbe8431711efed8a1b06bc5b40fc66bd7"
+"checksum advapi32-sys 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e06588080cb19d0acb6739808aafa5f26bfb2ca015b2b6370028b44cf7cb8a9a"
 "checksum aho-corasick 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)" = "500909c4f87a9e52355b26626d890833e9e1d53ac566db76c36faa984b889699"
 "checksum app_dirs 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "b7d1c0d48a81bbb13043847f957971f4d87c81542d80ece5e84ba3cba4058fd4"
 "checksum atty 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "21e50800ec991574876040fff8ee46b136a53e985286fbe6a3bdfe6421b78860"
@@ -1460,6 +1528,7 @@ dependencies = [
 "checksum git2 0.6.8 (registry+https://github.com/rust-lang/crates.io-index)" = "0c1c0203d653f4140241da0c1375a404f0a397249ec818cd2076c6280c50f6fa"
 "checksum glob 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)" = "8be18de09a56b60ed0edf84bc9df007e30040691af7acd1c41874faac5895bfb"
 "checksum globset 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "464627f948c3190ae3d04b1bc6d7dca2f785bda0ac01278e6db129ad383dbeb6"
+"checksum hostname 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "d865f01509e69c001c31b8c341607d93caef4ecf6836ffee39a1702430147943"
 "checksum humansize 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "92d211e6e70b05749dce515b47684f29a3c8c38bbbb21c50b30aff9eca1b0bd3"
 "checksum idna 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "014b298351066f1512874135335d62a789ffe78a9974f94b43ed5621951eaf7d"
 "checksum if_chain 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "61bb90bdd39e3af69b0172dfc6130f6cd6332bf040fbb9bdd4401d37adbd48b8"
@@ -1468,6 +1537,7 @@ dependencies = [
 "checksum itertools 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)" = "d3f2be4da1690a039e9ae5fd575f706a63ad5a2120f161b1d653c9da3930dd21"
 "checksum itoa 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "8324a32baf01e2ae060e9de58ed0bc2320c9a2833491ee36cd3b4c414de4db8c"
 "checksum java-properties 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "0330c8386cfee98c0755a596e2adc312c20a0137aed78f988cdb29a321882480"
+"checksum kernel32-sys 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "e014dab1082fd9d80ea1fa6fcb261b47ed3eb511612a14198bb507701add083e"
 "checksum kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7507624b29483431c0ba2d82aece8ca6cdba9382bff4ddd0f7490560c056098d"
 "checksum lazy_static 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)" = "cf186d1a8aa5f5bee5fd662bc9c1b949e0259e1bcc379d1f006847b0080c7417"
 "checksum lazy_static 0.2.10 (registry+https://github.com/rust-lang/crates.io-index)" = "236eb37a62591d4a41a89b7763d7de3e06ca02d5ab2815446a8bae5d2f8c2d57"
@@ -1550,6 +1620,7 @@ dependencies = [
 "checksum time 0.1.38 (registry+https://github.com/rust-lang/crates.io-index)" = "d5d788d3aa77bc0ef3e9621256885555368b47bd495c13dd2e7413c89f845520"
 "checksum uchardet 2.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "a496d0db4c292beb5bf5291a02d5913ec97b6f1a6cb1d10a8e8852b08616949c"
 "checksum uchardet-sys 2.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "d904e4160dceaff13d2f09859f3d2a375c8044826c7c7bb6a56249be5e3268a1"
+"checksum uname 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "b72f89f0ca32e4db1c04e2a72f5345d59796d4866a1ee0609084569f73683dc8"
 "checksum unicode-bidi 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "49f2bd0c6468a8230e1db229cff8029217cf623c767ea5d60bfbd42729ea54d5"
 "checksum unicode-normalization 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "51ccda9ef9efa3f7ef5d91e8f9b83bbe6955f9bf86aec89d5cce2c874625920f"
 "checksum unicode-width 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "bf3a113775714a22dcb774d8ea3655c53a32debae63a063acc00a91cc586245f"
@@ -1558,6 +1629,7 @@ dependencies = [
 "checksum unreachable 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "1f2ae5ddb18e1c92664717616dd9549dde73f539f01bd7b77c2edb2446bdff91"
 "checksum unreachable 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "382810877fe448991dfc7f0dd6e3ae5d58088fd0ea5e35189655f84e6814fa56"
 "checksum url 1.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "fa35e768d4daf1d85733418a49fb42e10d7f633e394fccab4ab7aba897053fe2"
+"checksum username 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "92e425df6527f7bc1adc7eb3b829ecaec746fbbc0b05e42133ff84afef3b1a09"
 "checksum utf8-ranges 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "662fab6525a98beff2921d7f61a39e7d59e0b425ebc7d0d9e66d316e55124122"
 "checksum uuid 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "bcc7e3b898aa6f6c08e5295b6c89258d1331e9ac578cc992fb818759951bdc22"
 "checksum vcpkg 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "9e0a7d8bed3178a8fb112199d466eeca9ed09a14ba8ad67718179b4fd5487d0b"
@@ -1566,6 +1638,7 @@ dependencies = [
 "checksum which 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "4be6cfa54dab45266e98b5d7be2f8ce959ddd49abd141a05d52dce4b07f803bb"
 "checksum winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)" = "167dc9d6949a9b857f3451275e911c3f44255842c1f7a76f33c55103a909087a"
 "checksum winapi-build 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "2d315eee3b34aca4797b2da6b13ed88266e6d612562a0c46390af8299fc699bc"
+"checksum winutil 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "9486f81d058e5faff87ed37e6f476505f2c0fae341d46d53fddc73a88a26fec5"
 "checksum ws2_32-sys 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "d59cefebd0c892fa2dd6de581e937301d8552cb44489cdff035c6187cb63fa5e"
 "checksum xdg 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a66b7c2281ebde13cf4391d70d4c7e5946c3c25e72a7b859ca8f677dcd0b0c61"
 "checksum xml-rs 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)" = "e1945e12e16b951721d7976520b0832496ef79c31602c7a29d950de79ba74621"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,6 +49,7 @@ which = "1.0"
 zip = "0.2"
 username = "0.2.0"
 hostname = "0.1.3"
+anylog = "0.2.0"
 
 [profile]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,6 +47,8 @@ uuid = { version = "0.5", features = ["v4", "serde"] }
 walkdir = "1.0"
 which = "1.0"
 zip = "0.2"
+username = "0.2.0"
+hostname = "0.1.3"
 
 [profile]
 
@@ -64,6 +66,7 @@ codegen-units = 2
 chan = "0.1"
 chan-signal = "0.3"
 openssl-probe = "0.1.0"
+uname = "0.1.1"
 
 [target."cfg(target_os=\"macos\")"]
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -17,3 +17,4 @@ platforms.
    dif
    dsym
    proguard
+   send-event

--- a/docs/send-event.rst
+++ b/docs/send-event.rst
@@ -2,7 +2,7 @@ Sending Events
 ==============
 
 The ``sentry-cli`` tool can also be used for sending events.  If you want to
-use it you need to export the ``SENTRY_DSN`` environment variable and
+use it, you need to export the ``SENTRY_DSN`` environment variable and
 point it to the DSN of a project of yours::
 
     $ export SENTRY_DSN=___DSN___
@@ -13,13 +13,13 @@ command.
 Basic Events
 ------------
 
-For basic message events you just need to provide the ``--message`` or
+For basic message events, you just need to provide the ``--message`` or
 ``-m`` parameter to send a message::
 
     $ sentry-cli send-event -m "Hello from Sentry"
 
 This will send a single message to sentry and record it as an event.
-Along with that event it sends basic information about the machine you are
+Along with that event, it sends basic information about the machine you are
 running ``sentry-cli`` on.  You can provide ``-m`` multiple times to send
 multiple lines::
 
@@ -28,9 +28,9 @@ multiple lines::
 Events with Parameters
 ----------------------
 
-In addition you can use ``%s`` a placeholder in a message and fill it in
-with the ``-a`` parameter.  This helps grouping as all messages will be
-grouped the same automatically::
+In addition you can use ``%s`` as placeholder in a message and fill it in
+with the ``-a`` parameter.  This helps reviewing them, as all messages will
+be grouped together automatically::
 
     $ sentry-cli send-event -m "Hello %s!" -a "Joe"
     $ sentry-cli send-event -m "Hello %s!" -a "Peter"
@@ -39,7 +39,7 @@ Sending Breadcrumbs
 -------------------
 
 You can also pass a logfile to the ``send-event`` command which will be
-parsed and send along as breadcrumbs.  The last 100 items will be sent:
+parsed and sent along as breadcrumbs.  The last 100 items will be sent:
 
     $ sentry-cli send-event -m "task failed" --logfile error.log
 
@@ -54,17 +54,17 @@ you can do something along those lines::
 Extra Data
 ----------
 
-Extra data can be sent along with the ``-e`` parameter as ``KEY:VALUE``.
-For instance you can send some key value pairs like this::
+Extra data can be attached with the ``-e`` parameter as ``KEY:VALUE``.
+For instance, you can send some key value pairs like this::
 
     $ sentry-cli send-event -m "a failure" -e task:create-user -e object:42
 
-Likewise tags can be sent with ``-t`` in the same format::
+Likewise, tags can be sent with ``-t`` using the same format::
 
     $ sentry-cli send-event -m "a failure" -t task:create-user
 
-Sending Releases
-----------------
+Specifying Releases
+-------------------
 
 Releases can be sent with the ``--release`` parameter.  A default release
 is picked up automatically if you are using sentry-cli from within a git

--- a/docs/send-event.rst
+++ b/docs/send-event.rst
@@ -1,0 +1,71 @@
+Sending Events
+==============
+
+The ``sentry-cli`` tool can also be used for sending events.  If you want to
+use it you need to export the ``SENTRY_DSN`` environment variable and
+point it to the DSN of a project of yours::
+
+    $ export SENTRY_DSN=___DSN___
+
+Once that is done, you can start using the ``sentry-cli send-event``
+command.
+
+Basic Events
+------------
+
+For basic message events you just need to provide the ``--message`` or
+``-m`` parameter to send a message::
+
+    $ sentry-cli send-event -m "Hello from Sentry"
+
+This will send a single message to sentry and record it as an event.
+Along with that event it sends basic information about the machine you are
+running ``sentry-cli`` on.  You can provide ``-m`` multiple times to send
+multiple lines::
+
+    $ sentry-cli send-event -m "Hello from Sentry" -m "This is more text"
+
+Events with Parameters
+----------------------
+
+In addition you can use ``%s`` a placeholder in a message and fill it in
+with the ``-a`` parameter.  This helps grouping as all messages will be
+grouped the same automatically::
+
+    $ sentry-cli send-event -m "Hello %s!" -a "Joe"
+    $ sentry-cli send-event -m "Hello %s!" -a "Peter"
+
+Sending Breadcrumbs
+-------------------
+
+You can also pass a logfile to the ``send-event`` command which will be
+parsed and send along as breadcrumbs.  The last 100 items will be sent:
+
+    $ sentry-cli send-event -m "task failed" --logfile error.log
+
+The logfile can be in various formats.  If you want to create one yourself
+you can do something along those lines::
+
+    $ echo "$(date +%c) This is a log record" >> output.log
+    $ echo "$(date +%c) This is another record" >> output.log
+    $ sentry-cli send-event -m "Demo Event" --logfile output.log
+    $ rm output.log
+
+Extra Data
+----------
+
+Extra data can be sent along with the ``-e`` parameter as ``KEY:VALUE``.
+For instance you can send some key value pairs like this::
+
+    $ sentry-cli send-event -m "a failure" -e task:create-user -e object:42
+
+Likewise tags can be sent with ``-t`` in the same format::
+
+    $ sentry-cli send-event -m "a failure" -t task:create-user
+
+Sending Releases
+----------------
+
+Releases can be sent with the ``--release`` parameter.  A default release
+is picked up automatically if you are using sentry-cli from within a git
+repository.

--- a/src/commands/send_event.rs
+++ b/src/commands/send_event.rs
@@ -199,6 +199,11 @@ pub fn execute<'a>(matches: &ArgMatches<'a>, config: &Config) -> Result<()> {
         }
     }
 
+    if event.breadcrumbs.len() > 100 {
+        let skip = event.breadcrumbs.len() - 100;
+        event.breadcrumbs = event.breadcrumbs.into_iter().skip(skip).collect();
+    }
+
     let dsn = config.get_dsn()?;
 
     // handle errors here locally so that we do not get the extra "use sentry-cli

--- a/src/commands/send_event.rs
+++ b/src/commands/send_event.rs
@@ -18,7 +18,7 @@ use config::Config;
 use event::{Event, Message, Breadcrumb};
 use api::Api;
 use constants::{ARCH, PLATFORM};
-use utils::{get_model, get_family};
+use utils::{get_model, get_family, detect_release_name};
 
 pub fn make_app<'a, 'b: 'a>(app: App<'a, 'b>) -> App<'a, 'b> {
     app.about("Send a manual event to Sentry.")
@@ -103,6 +103,9 @@ pub fn execute<'a>(matches: &ArgMatches<'a>, config: &Config) -> Result<()> {
     let mut event = Event::new();
     event.level = matches.value_of("level").unwrap_or("error").into();
     event.release = matches.value_of("release").map(|x| x.into());
+    if event.release.is_none() {
+        event.release = detect_release_name().ok();
+    }
     event.dist = matches.value_of("dist").map(|x| x.into());
     event.platform = matches.value_of("platform").unwrap_or("other").into();
     event.environment = matches.value_of("environment").map(|x| x.into());

--- a/src/event.rs
+++ b/src/event.rs
@@ -8,12 +8,20 @@ use chrono::Utc;
 use serde_json::Value;
 
 
-// Represents a parameterized message.
 #[derive(Serialize)]
 pub struct Message {
     pub message: String,
     #[serde(skip_serializing_if="Vec::is_empty")]
     pub params: Vec<String>,
+}
+
+#[derive(Serialize)]
+pub struct Breadcrumb {
+    pub timestamp: Option<f64>,
+    #[serde(rename="type")]
+    pub ty: String,
+    pub message: String,
+    pub category: String,
 }
 
 /// Represents a Sentry event.
@@ -40,6 +48,8 @@ pub struct Event {
     pub user: HashMap<String, String>,
     #[serde(skip_serializing_if="HashMap::is_empty")]
     pub contexts: HashMap<String, HashMap<String, String>>,
+    #[serde(skip_serializing_if="Vec::is_empty")]
+    pub breadcrumbs: Vec<Breadcrumb>,
 }
 
 fn get_server_name() -> Result<String> {
@@ -63,6 +73,7 @@ impl Event {
             environment: None,
             user: HashMap::new(),
             contexts: HashMap::new(),
+            breadcrumbs: Vec::new(),
         }
     }
 }

--- a/src/event.rs
+++ b/src/event.rs
@@ -5,18 +5,27 @@ use std::process::Command;
 use prelude::*;
 use utils::to_timestamp;
 use chrono::Utc;
+use serde_json::Value;
 
+
+// Represents a parameterized message.
+#[derive(Serialize)]
+pub struct Message {
+    pub message: String,
+    #[serde(skip_serializing_if="Vec::is_empty")]
+    pub params: Vec<String>,
+}
 
 /// Represents a Sentry event.
 #[derive(Serialize)]
 pub struct Event {
     pub tags: HashMap<String, String>,
-    pub extra: HashMap<String, String>,
+    pub extra: HashMap<String, Value>,
     pub level: String,
     #[serde(skip_serializing_if="Option::is_none")]
     pub fingerprint: Option<Vec<String>>,
-    #[serde(skip_serializing_if="Option::is_none")]
-    pub message: Option<String>,
+    #[serde(skip_serializing_if="Option::is_none", rename="sentry.interfaces.Message")]
+    pub message: Option<Message>,
     pub platform: String,
     pub timestamp: f64,
     #[serde(skip_serializing_if="Option::is_none")]
@@ -29,6 +38,8 @@ pub struct Event {
     pub environment: Option<String>,
     #[serde(skip_serializing_if="HashMap::is_empty")]
     pub user: HashMap<String, String>,
+    #[serde(skip_serializing_if="HashMap::is_empty")]
+    pub contexts: HashMap<String, HashMap<String, String>>,
 }
 
 fn get_server_name() -> Result<String> {
@@ -51,6 +62,7 @@ impl Event {
             dist: None,
             environment: None,
             user: HashMap::new(),
+            contexts: HashMap::new(),
         }
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -70,6 +70,7 @@ extern crate username;
 extern crate hostname;
 #[cfg(not(windows))]
 extern crate uname;
+extern crate anylog;
 
 mod macros;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -66,6 +66,10 @@ extern crate uuid;
 extern crate walkdir;
 extern crate which;
 extern crate zip;
+extern crate username;
+extern crate hostname;
+#[cfg(not(windows))]
+extern crate uname;
 
 mod macros;
 

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -31,7 +31,7 @@ pub use self::sourcemaps::{SourceMapProcessor, get_sourcemap_reference_from_head
 pub use self::system::{propagate_exit_status, is_homebrew_install,
                        is_npm_install, expand_envvars, expand_vars,
                        print_error, to_timestamp,
-                       run_or_interrupt, init_backtrace};
+                       run_or_interrupt, init_backtrace, get_model, get_family};
 pub use self::ui::{prompt_to_continue, prompt, capitalize_string,
                    copy_with_progress, make_byte_progress_bar};
 pub use self::update::{can_update_sentrycli, get_latest_sentrycli_release,

--- a/src/utils/system.rs
+++ b/src/utils/system.rs
@@ -171,3 +171,49 @@ pub fn init_backtrace() {
         }
     }));
 }
+
+#[cfg(target_os="macos")]
+pub fn get_model() -> Option<String> {
+    use std::ptr;
+    use libc;
+    use libc::c_void;
+
+    unsafe {
+        let mut size = 0;
+        libc::sysctlbyname("hw.model\x00".as_ptr() as *const i8,
+            ptr::null_mut(), &mut size, ptr::null_mut(), 0);
+        let mut buf = vec![0u8; size as usize];
+        libc::sysctlbyname("hw.model\x00".as_ptr() as *const i8,
+            buf.as_mut_ptr() as *mut c_void, &mut size, ptr::null_mut(), 0);
+        Some(String::from_utf8_lossy(&buf).to_string())
+    }
+}
+
+#[cfg(target_os="macos")]
+pub fn get_family() -> Option<String> {
+    use regex::Regex;
+    lazy_static! {
+        static ref FAMILY_RE: Regex = Regex::new(r#"([a-zA-Z]+)\d"#).unwrap();
+    }
+
+    if_chain! {
+        if let Some(model) = get_model();
+        if let Some(m) = FAMILY_RE.captures(&model);
+        if let Some(group) = m.get(1);
+        then {
+            Some(group.as_str().to_string())
+        } else {
+            None
+        }
+    }
+}
+
+#[cfg(not(target_os="macos"))]
+pub fn get_model() -> Option<String> {
+    None
+}
+
+#[cfg(not(target_os="macos"))]
+pub fn get_family() -> Option<String> {
+    None
+}


### PR DESCRIPTION
This makes send-event actually useful.  In particular it supports basic
breadcrumbs by attaching log files and a few things more like user info
and basic device info as well as environment variables.

## Sending Events

<img width="740" alt="screen shot 2017-11-21 at 00 58 38" src="https://user-images.githubusercontent.com/7396/33047649-23587f50-ce57-11e7-9b72-a6559a1e4725.png">

## How the look like

<img width="845" alt="screen shot 2017-11-21 at 00 58 06" src="https://user-images.githubusercontent.com/7396/33047655-2a1d7b38-ce57-11e7-9b64-9ed33b737098.png">