### PR TITLE
feat: Added bash hook

### DIFF
--- a/src/bashsupport.sh
+++ b/src/bashsupport.sh
@@ -1,0 +1,55 @@
+_SENTRY_TRACEBACK_FILE="___SENTRY_TRACEBACK_FILE___"
+_SENTRY_LOG_FILE="___SENTRY_LOG_FILE___"
+
+trap _sentry_exit_trap EXIT
+trap _sentry_err_trap ERR
+
+_sentry_shown_traceback=0
+
+_sentry_exit_trap() {
+  local _exit_code="$?"
+  local _command="${BASH_COMMAND:-unknown}"
+  if [[ $_exit_code != 0 && "${_sentry_shown_traceback}" != 1 ]]; then
+    _sentry_err_trap "$_command" "$_exit_code"
+  fi
+  rm -f "$_SENTRY_TRACEBACK_FILE" "$_SENTRY_LOG_FILE"
+  exit $_exit_code
+}
+
+_sentry_err_trap() {
+  local _exit_code="$?"
+  local _command="${BASH_COMMAND:-unknown}"
+  if [ "x$1" != x ]; then
+    _command="$1"
+  fi
+  if [ "x$2" != x ]; then
+    _exit_code="$2"
+  fi
+  _sentry_traceback 1
+  echo "@command:${_command}" >> "$_SENTRY_TRACEBACK_FILE"
+  echo "@exit_code:${_exit_code}" >> "$_SENTRY_TRACEBACK_FILE"
+  export SENTRY_LAST_EVENT=$(___SENTRY_CLI___ bash-hook --send-event --traceback "$_SENTRY_TRACEBACK_FILE" --log "$_SENTRY_LOG_FILE")
+  rm -f "$_SENTRY_TRACEBACK_FILE" "$_SENTRY_LOG_FILE"
+}
+
+_sentry_traceback() {
+  _sentry_shown_traceback=1
+  local -i start=$(( ${1:-0} + 1 ))
+  local -i end=${#BASH_SOURCE[@]}
+  local -i i=0
+  local -i j=0
+
+  : > "$_SENTRY_TRACEBACK_FILE"
+  for ((i=${start}; i < ${end}; i++)); do
+    j=$(( $i - 1 ))
+    local function="${FUNCNAME[$i]}"
+    local file="${BASH_SOURCE[$i]}"
+    local line="${BASH_LINENO[$j]}"
+    echo "${function}:${file}:${line}" >> "$_SENTRY_TRACEBACK_FILE"
+  done
+}
+
+: > "$_SENTRY_LOG_FILE"
+exec \
+  1> >(tee >(awk '{ system(""); print strftime("%c"), "stdout:", $0; system(""); }' >> "$_SENTRY_LOG_FILE")) \
+  2> >(tee >(awk '{ system(""); print strftime("%c"), "stderr:", $0; system(""); }' >> "$_SENTRY_LOG_FILE") >&2)

--- a/src/commands/bash_hook.rs
+++ b/src/commands/bash_hook.rs
@@ -1,0 +1,163 @@
+//! Implements a command for showing infos from Sentry.
+use std::fs;
+use std::io::{BufRead, BufReader};
+use std::env;
+use std::cmp::min;
+use std::path::Path;
+use std::collections::HashMap;
+
+use clap::{App, Arg, ArgMatches};
+use uuid::{Uuid, UuidVersion};
+use regex::Regex;
+
+use prelude::*;
+use config::Config;
+use event::{Event, Exception, SingleException, Frame, Stacktrace};
+use api::Api;
+
+const BASH_SCRIPT: &'static str = include_str!("../bashsupport.sh");
+lazy_static! {
+    static ref FRAME_RE: Regex = Regex::new(
+        r#"^(.*?):(.*):(\d+)$"#).unwrap();
+}
+
+
+pub fn make_app<'a, 'b: 'a>(app: App<'a, 'b>) -> App<'a, 'b> {
+    app.about("Prints out a bash script that does error handling.")
+        .arg(Arg::with_name("no_exit")
+             .long("no-exit")
+             .help("Do not turn on -e (exit immediately) flag automatically"))
+        .arg(Arg::with_name("send_event")
+            .long("send-event")
+            .requires_all(&["traceback", "log"])
+            .hidden(true))
+        .arg(Arg::with_name("traceback")
+            .long("traceback")
+            .value_name("PATH")
+            .hidden(true))
+        .arg(Arg::with_name("log")
+            .long("log")
+            .value_name("PATH")
+            .hidden(true))
+}
+
+fn send_event(config: &Config, traceback: &str, logfile: &str) -> Result<()> {
+    let mut event = Event::new_prefilled()?;
+    event.detect_release();
+
+    let mut cmd = "unknown".to_string();
+    let mut exit_code = 1;
+    let mut frames = vec![];
+
+    if let Ok(f) = fs::File::open(traceback) {
+        let f = BufReader::new(f);
+        for line in f.lines() {
+            let line = line?;
+
+            // meta info
+            if line.starts_with("@") {
+                if line.starts_with("@command:") {
+                    cmd = line[9..].to_string();
+                } else if line.starts_with("@exit_code:") {
+                    exit_code = line[11..].parse().unwrap_or(exit_code);
+                } else {
+                    continue;
+                }
+            }
+
+            if let Some(cap) = FRAME_RE.captures(&line) {
+                match &cap[1] {
+                    "_sentry_err_trap" |
+                    "_sentry_exit_trap" |
+                    "_sentry_traceback" => continue,
+                    _ => {}
+                }
+                frames.push(Frame {
+                    filename: cap[2].to_string(),
+                    abs_path: Path::new(&cap[2])
+                        .canonicalize().map(|x| x.display().to_string()).ok(),
+                    function: cap[1].to_string(),
+                    lineno: cap[3].parse().ok(),
+                    ..Default::default()
+                });
+            }
+        }
+    }
+
+    let mut source_caches = HashMap::new();
+    for frame in frames.iter_mut() {
+        let lineno = match frame.lineno {
+            Some(lineno) => lineno as usize,
+            None => continue,
+        };
+        if !source_caches.contains_key(&frame.filename) {
+            if let Ok(f) = fs::File::open(&frame.filename) {
+                let lines: Vec<_> = BufReader::new(f)
+                    .lines()
+                    .map(|x| x.unwrap_or_else(|_| "".to_string()))
+                    .collect();
+                source_caches.insert(frame.filename.clone(), lines);
+            } else {
+                source_caches.insert(frame.filename.clone(), vec![]);
+            }
+        }
+        let source = source_caches.get(&frame.filename).unwrap();
+        frame.context_line = source.get(
+            lineno.saturating_sub(1)).map(|x| x.clone());
+        if let Some(slice) = source.get(
+            lineno.saturating_sub(5)..lineno.saturating_sub(1)) {
+            frame.pre_context = Some(slice.iter().map(|x| x.clone()).collect());
+        };
+        if let Some(slice) = source.get(
+            lineno..min(lineno + 5, source.len())) {
+            frame.post_context = Some(slice.iter().map(|x| x.clone()).collect());
+        };
+    }
+
+    event.attach_logfile(logfile, true)?;
+
+    frames.reverse();
+    let mut exception = SingleException {
+        ty: "BashError".into(),
+        value: format!("command {} exited with status {}", cmd, exit_code),
+        stacktrace: Some(Stacktrace {
+            frames: frames,
+        }),
+    };
+    event.exception = Some(Exception {
+        values: vec![exception],
+    });
+
+    let dsn = config.get_dsn()?;
+
+    // handle errors here locally so that we do not get the extra "use sentry-cli
+    // login" to sign in which would be in appropriate here.
+    if let Ok(event_id) = Api::new(config).send_event(&dsn, &event) {
+        println!("{}", event_id);
+    };
+
+    Ok(())
+}
+
+pub fn execute<'a>(matches: &ArgMatches<'a>, config: &Config) -> Result<()> {
+    if matches.is_present("send_event") {
+        return send_event(config,
+                          matches.value_of("traceback").unwrap(),
+                          matches.value_of("log").unwrap());
+    }
+
+    let path = env::temp_dir();
+    let log = path.join(&format!(
+        ".sentry-{}.out", Uuid::new(UuidVersion::Random).unwrap().hyphenated().to_string()));
+    let traceback = path.join(&format!(
+        ".sentry-{}.traceback", Uuid::new(UuidVersion::Random).unwrap().hyphenated().to_string()));
+    let mut script = BASH_SCRIPT
+        .replace("___SENTRY_TRACEBACK_FILE___", &traceback.display().to_string())
+        .replace("___SENTRY_LOG_FILE___", &log.display().to_string())
+        .replace("___SENTRY_CLI___", &env::current_exe().unwrap().display().to_string());
+    if !matches.is_present("no_exit") {
+        script.insert_str(0, "set -e\n\n");
+    }
+    println!("{}", script);
+    Ok(())
+}

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -34,6 +34,7 @@ macro_rules! each_subcommand {
         $mac!(send_event);
         $mac!(react_native);
         $mac!(difutil);
+        $mac!(bash_hook);
 
         // these here exist for legacy reasons only.  They were moved
         // to subcommands of the react-native command.  Note that
@@ -68,6 +69,7 @@ pub mod uninstall;
 pub mod info;
 pub mod login;
 pub mod send_event;
+pub mod bash_hook;
 
 pub mod react_native;
 #[cfg(target_os="macos")]

--- a/src/commands/send_event.rs
+++ b/src/commands/send_event.rs
@@ -1,24 +1,12 @@
 //! Implements a command for sending events to Sentry.
-use std::fs;
-use std::io::{BufRead, BufReader};
-use std::env;
-use std::collections::HashMap;
-
 use clap::{App, Arg, ArgMatches};
 use itertools::Itertools;
-use username::get_user_name;
-use hostname::get_hostname;
-#[cfg(not(windows))]
-use uname::uname;
 use serde_json::Value;
-use anylog::LogEntry;
 
 use prelude::*;
 use config::Config;
-use event::{Event, Message, Breadcrumb};
+use event::{Event, Message};
 use api::Api;
-use constants::{ARCH, PLATFORM};
-use utils::{get_model, get_family, detect_release_name};
 
 pub fn make_app<'a, 'b: 'a>(app: App<'a, 'b>) -> App<'a, 'b> {
     app.about("Send a manual event to Sentry.")
@@ -100,11 +88,12 @@ pub fn make_app<'a, 'b: 'a>(app: App<'a, 'b>) -> App<'a, 'b> {
 }
 
 pub fn execute<'a>(matches: &ArgMatches<'a>, config: &Config) -> Result<()> {
-    let mut event = Event::new();
+    let mut event = Event::new_prefilled()?;
     event.level = matches.value_of("level").unwrap_or("error").into();
-    event.release = matches.value_of("release").map(|x| x.into());
-    if event.release.is_none() {
-        event.release = detect_release_name().ok();
+    if let Some(release) = matches.value_of("release") {
+        event.release = Some(release.into());
+    } else {
+        event.detect_release();
     }
     event.dist = matches.value_of("dist").map(|x| x.into());
     event.platform = matches.value_of("platform").unwrap_or("other").into();
@@ -130,12 +119,9 @@ pub fn execute<'a>(matches: &ArgMatches<'a>, config: &Config) -> Result<()> {
         }
     }
 
-    if !matches.is_present("no-environ") {
-        event.extra.insert("environ".into(), Value::Object(env::vars().map(|(k, v)| {
-            (k, Value::String(v))
-        }).collect()));
+    if matches.is_present("no-environ") {
+        event.extra.remove("environ");
     }
-
     if let Some(extra) = matches.values_of("extra") {
         for pair in extra {
             let mut split = pair.splitn(2, ':');
@@ -146,65 +132,21 @@ pub fn execute<'a>(matches: &ArgMatches<'a>, config: &Config) -> Result<()> {
     }
 
     if let Some(user_data) = matches.values_of("user_data") {
+        event.user.remove("username");
         for pair in user_data {
             let mut split = pair.splitn(2, ':');
             let key = split.next().ok_or("missing user key")?;
             let value = split.next().ok_or("missing user value")?;
             event.user.insert(key.into(), value.into());
         }
-    } else {
-        event.user.insert("username".into(), get_user_name().unwrap_or("unknown".into()));
     }
-
-    let mut device = HashMap::new();
-    if let Some(hostname) = get_hostname() {
-        device.insert("name".into(), hostname);
-    }
-    if let Some(model) = get_model() {
-        device.insert("model".into(), model);
-    }
-    if let Some(family) = get_family() {
-        device.insert("family".into(), family);
-    }
-    device.insert("arch".into(), ARCH.into());
-    event.contexts.insert("device".into(), device);
-
-    let mut os = HashMap::new();
-    #[cfg(not(windows))] {
-        if let Ok(info) = uname() {
-            os.insert("name".into(), info.sysname);
-            os.insert("kernel_version".into(), info.version);
-            os.insert("version".into(), info.release);
-        }
-    }
-    if !os.contains_key("name") {
-        os.insert("name".into(), PLATFORM.into());
-    }
-    event.contexts.insert("os".into(), os);
 
     if let Some(fingerprint) = matches.values_of("fingerprint") {
         event.fingerprint = Some(fingerprint.map(|x| x.to_string()).collect());
     }
 
     if let Some(logfile) = matches.value_of("logfile") {
-        let f = fs::File::open(logfile)
-            .chain_err(|| "Could not open logfile")?;
-        let reader = BufReader::new(f);
-        for line in reader.lines() {
-            let line = line?;
-            let rec = LogEntry::parse(line.as_bytes());
-            event.breadcrumbs.push(Breadcrumb {
-                timestamp: rec.utc_timestamp().map(|x| x.timestamp() as f64),
-                message: rec.message().to_string(),
-                ty: "default".to_string(),
-                category: "log".to_string(),
-            })
-        }
-    }
-
-    if event.breadcrumbs.len() > 100 {
-        let skip = event.breadcrumbs.len() - 100;
-        event.breadcrumbs = event.breadcrumbs.into_iter().skip(skip).collect();
+        event.attach_logfile(logfile, false)?;
     }
 
     let dsn = config.get_dsn()?;


### PR DESCRIPTION
This adds basic support for automatically capturing failures in bash scripts:

## How to use

```
export SENTRY_DSN="..."
eval "$(sentry-cli bash-hook)"
```

What it does: it turns on `set -e` and captures failures on non 0 status codes and sends them to sentry.

## How it looks like

<img width="888" alt="screen shot 2017-11-22 at 01 45 39" src="https://user-images.githubusercontent.com/7396/33104139-e09d7dfc-cf26-11e7-93f2-8153fbdf6e9e.png">

(Known issue is that stderr and stdout can not interleave until buffer is full. This can only be fixed with emulating a tty which I am too lazy to do)