### PR TITLE
Switch strftime to common log format

### DIFF
--- a/src/bashsupport.sh
+++ b/src/bashsupport.sh
@@ -51,5 +51,5 @@ _sentry_traceback() {
 
 : > "$_SENTRY_LOG_FILE"
 exec \
-  1> >(tee >(awk '{ system(""); print strftime("%c"), "stdout:", $0; system(""); }' >> "$_SENTRY_LOG_FILE")) \
-  2> >(tee >(awk '{ system(""); print strftime("%c"), "stderr:", $0; system(""); }' >> "$_SENTRY_LOG_FILE") >&2)
+  1> >(tee >(awk '{ system(""); print strftime("%Y-%m-%d %H:%M:%S %z:"), "stdout:", $0; system(""); }' >> "$_SENTRY_LOG_FILE")) \
+  2> >(tee >(awk '{ system(""); print strftime("%Y-%m-%d %H:%M:%S %z:"), "stderr:", $0; system(""); }' >> "$_SENTRY_LOG_FILE") >&2)


### PR DESCRIPTION
First of all - thanks for adding this feature, it's useful being able to track errors in even more places than before!

One problem I'm having is that the logfile doesn't get parsed into breadcrumbs by my default locale:

```console
$ echo $LANG $LANGUAGE
en_GB.UTF-8 en_GB:en
$ awk '{ system(""); print strftime("%c"), "stdout:", $0; system(""); }'
hello world
Tue 28 Nov 2017 22:49:56 GMT stdout: hello world
```

And without:

```console
$ awk '{ system(""); print strftime("%c"), "stdout:", $0; system(""); }'
hello world
Tue Nov 28 22:56:19 2017 stdout: hello world
```

In the first case, no breadcrumbs get added to the sentry issue - as rust-anylog can't parse it. Other languages would probably face plenty of other problems, as the day and month names won't match either.

This PR should change it to a format which is consistent regardless of environment variables, and [supported by rust-anylog](https://github.com/mitsuhiko/rust-anylog/blob/1568326005e007ce58ef886cbbc22f6058e8427f/src/parser.rs#L296):

```console
$ awk '{ system(""); print strftime("%Y-%m-%d %H:%M:%S %z:"), "stdout:", $0; system(""); }'
hello world
2017-11-28 23:10:12 +0000: stdout: hello world
$ LANG=de_DE.UTF-8 awk '{ system(""); print strftime("%Y-%m-%d %H:%M:%S %z:"), "stdout:", $0; system(""); }'
hello world
2017-11-28 23:20:41 +0000: stdout: hello world
```