### PR TITLE
feat: Added basic cordova release name support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 ## sentry-cli 1.25.0
 
 * Do not run update nagger if the command is not connected to a terminal
+* Source map uploading now correctly determines sourcemap references even
+  if the rewrite flag is not passed.
 
 ## sentry-cli 1.24.1
 

--- a/src/commands/react_native_codepush.rs
+++ b/src/commands/react_native_codepush.rs
@@ -8,7 +8,8 @@ use console::style;
 use prelude::*;
 use api::{Api, NewRelease};
 use config::Config;
-use utils::{ArgExt, SourceMapProcessor, get_codepush_package, get_codepush_release};
+use utils::{ArgExt, SourceMapProcessor, get_codepush_package,
+            get_react_native_codepush_release};
 
 pub fn make_app<'a, 'b: 'a>(app: App<'a, 'b>) -> App<'a, 'b> {
     app.about("Upload react-native projects for CodePush.")
@@ -61,7 +62,8 @@ pub fn execute<'a>(matches: &ArgMatches<'a>, config: &Config) -> Result<()> {
     }
 
     let package = get_codepush_package(app, deployment)?;
-    let release = get_codepush_release(&package, platform, matches.value_of("bundle_id"))?;
+    let release = get_react_native_codepush_release(
+        &package, platform, matches.value_of("bundle_id"))?;
     if print_release_name {
         println!("{}", release);
         return Ok(());

--- a/src/utils/codepush.rs
+++ b/src/utils/codepush.rs
@@ -67,8 +67,8 @@ pub fn get_codepush_package(app: &str, deployment: &str)
     Err(format!("could not find deployment {} for {}", deployment, app).into())
 }
 
-pub fn get_codepush_release(package: &CodePushPackage, platform: &str,
-                            bundle_id_override: Option<&str>)
+pub fn get_react_native_codepush_release(package: &CodePushPackage, platform: &str,
+                                         bundle_id_override: Option<&str>)
     -> Result<String>
 {
     if let Some(bundle_id) = bundle_id_override {

--- a/src/utils/cordova.rs
+++ b/src/utils/cordova.rs
@@ -1,0 +1,41 @@
+use std::fs;
+use std::path::Path;
+use std::io::BufReader;
+
+use elementtree::{Element, QName};
+
+use prelude::*;
+
+
+pub struct CordovaConfig {
+    id: String,
+    version: String,
+}
+
+impl CordovaConfig {
+    pub fn load<P: AsRef<Path>>(p: P) -> Result<Option<CordovaConfig>> {
+        let mut f = fs::File::open(p)?;
+        let root = Element::from_reader(BufReader::new(f))?;
+        if root.tag() != &QName::from("{http://www.w3.org/ns/widgets}widget") {
+            return Ok(None);
+        }
+        Ok(Some(CordovaConfig {
+            id: match root.get_attr("id") {
+                Some(value) => value.to_string(),
+                None => { return Ok(None); }
+            },
+            version: match root.get_attr("version") {
+                Some(value) => value.to_string(),
+                None => { return Ok(None); }
+            },
+        }))
+    }
+
+    pub fn id(&self) -> &str {
+        &self.id
+    }
+
+    pub fn version(&self) -> &str {
+        &self.version
+    }
+}

--- a/src/utils/cordova.rs
+++ b/src/utils/cordova.rs
@@ -8,34 +8,61 @@ use prelude::*;
 
 
 pub struct CordovaConfig {
-    id: String,
-    version: String,
+    root: Element,
 }
 
 impl CordovaConfig {
     pub fn load<P: AsRef<Path>>(p: P) -> Result<Option<CordovaConfig>> {
-        let mut f = fs::File::open(p)?;
+        let f = fs::File::open(p)?;
         let root = Element::from_reader(BufReader::new(f))?;
         if root.tag() != &QName::from("{http://www.w3.org/ns/widgets}widget") {
             return Ok(None);
+        } else {
+            Ok(Some(CordovaConfig {
+                root: root,
+            }))
         }
-        Ok(Some(CordovaConfig {
-            id: match root.get_attr("id") {
-                Some(value) => value.to_string(),
-                None => { return Ok(None); }
-            },
-            version: match root.get_attr("version") {
-                Some(value) => value.to_string(),
-                None => { return Ok(None); }
-            },
-        }))
     }
 
     pub fn id(&self) -> &str {
-        &self.id
+        self.root.get_attr("id").unwrap_or("unknown")
     }
 
     pub fn version(&self) -> &str {
-        &self.version
+        self.root.get_attr("version").unwrap_or("0.0")
+    }
+
+    pub fn android_package(&self) -> &str {
+        self.root.get_attr("android-packageName")
+            .unwrap_or_else(|| self.id())
+    }
+
+    pub fn android_version_code(&self) -> u64 {
+        if let Some(version) = self.root.get_attr("android-versionCode").and_then(|x| x.parse().ok()) {
+            return version;
+        }
+        let mut iter = self.version().split('.');
+        let major: u64 = iter.next().and_then(|x| x.parse().ok()).unwrap_or(0);
+        let minor: u64 = iter.next().and_then(|x| x.parse().ok()).unwrap_or(0);
+        let patch: u64 = iter.next().and_then(|x| x.parse().ok()).unwrap_or(0);
+        major * 10000 + minor * 100 + patch
+    }
+
+    pub fn ios_bundle_identifier(&self) -> &str {
+        self.root.get_attr("ios-CFBundleIdentifier")
+            .unwrap_or_else(|| self.id())
+    }
+
+    pub fn ios_version(&self) -> &str {
+        self.root.get_attr("ios-CFBundleVersion")
+            .unwrap_or_else(|| self.version())
+    }
+
+    pub fn android_release_name(&self) -> String {
+        format!("{}-{}", self.android_package(), self.version())
+    }
+
+    pub fn ios_release_name(&self) -> String {
+        format!("{}-{}", self.ios_bundle_identifier(), self.ios_version())
     }
 }

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -15,6 +15,7 @@ mod update;
 pub mod dif;
 pub mod vcs;
 pub mod xcode;
+pub mod cordova;
 
 pub use self::android::{AndroidManifest, dump_proguard_uuids_as_properties};
 pub use self::args::{ArgExt, validate_uuid, validate_seconds, validate_timestamp,

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -20,7 +20,7 @@ pub mod cordova;
 pub use self::android::{AndroidManifest, dump_proguard_uuids_as_properties};
 pub use self::args::{ArgExt, validate_uuid, validate_seconds, validate_timestamp,
                      validate_project, get_timestamp};
-pub use self::codepush::{get_codepush_package, get_codepush_release};
+pub use self::codepush::{get_codepush_package, get_react_native_codepush_release};
 pub use self::enc::{decode_unknown_string};
 pub use self::formatting::{HumanDuration, Table, TableRow};
 pub use self::fs::{TempDir, TempFile, is_writable, set_executable_mode, is_zip_file,

--- a/src/utils/releases.rs
+++ b/src/utils/releases.rs
@@ -12,18 +12,33 @@ use regex::Regex;
 use prelude::*;
 
 
-pub fn get_cordova_release_name() -> Result<Option<String>> {
-    let here = env::current_dir()?;
-    let path = here.join("config.xml");
+pub fn get_cordova_release_name(path: Option<PathBuf>) -> Result<Option<String>> {
+    let here = path.map_or(env::current_dir()?, |p| p.into());
+    let platform = match here.file_name().and_then(|x| x.to_str()) {
+        Some("android") => "android",
+        Some("ios") => "ios",
+        _ => return Ok(None)
+    };
+    let base = match here.parent().and_then(|x| x.parent()) {
+        Some(path) => path,
+        None => return Ok(None)
+    };
+
+    let path = base.join("config.xml");
     if_chain! {
         if let Ok(md) = path.metadata();
         if md.is_file();
         if let Ok(Some(config)) = CordovaConfig::load(path);
         then {
-            return Ok(Some(format!("{}-{}", config.id(), config.version())));
+            match platform {
+                "android" => Ok(Some(config.android_release_name())),
+                "ios" => Ok(Some(config.ios_release_name())),
+                _ => unreachable!(),
+            }
+        } else {
+            Ok(None)
         }
     }
-    return Ok(None);
 }
 
 pub fn get_xcode_release_name(plist: Option<InfoPlist>) -> Result<Option<String>> {
@@ -72,7 +87,7 @@ pub fn infer_gradle_release_name(path: Option<PathBuf>) -> Result<Option<String>
 /// Detects the release name for the current working directory.
 pub fn detect_release_name() -> Result<String> {
     // cordova release detection first.
-    if let Some(release) = get_cordova_release_name()? {
+    if let Some(release) = get_cordova_release_name(None)? {
         return Ok(release);
     }
 

--- a/src/utils/releases.rs
+++ b/src/utils/releases.rs
@@ -52,7 +52,6 @@ pub fn get_xcode_release_name(plist: Option<InfoPlist>) -> Result<Option<String>
 }
 
 pub fn infer_gradle_release_name(path: Option<PathBuf>) -> Result<Option<String>> {
-    // this is similar to utils::codepush::get_codepush_release
     lazy_static! {
         static ref APP_ID_RE: Regex = Regex::new(
             r#"applicationId\s+["']([^"']*)["']"#).unwrap();


### PR DESCRIPTION
This pull request adds support for parsing version info from the
cordova config.  Separately we still need to drag out the version
code for when we upload artifacts later in a new command.