### PR TITLE
fix: Flush sources before adding references

### DIFF
--- a/src/utils/sourcemaps.rs
+++ b/src/utils/sourcemaps.rs
@@ -433,6 +433,7 @@ impl SourceMapProcessor {
 
     /// Adds sourcemap references to all minified files
     pub fn add_sourcemap_references(&mut self) -> Result<()> {
+        self.flush_pending_sources()?;
         let sourcemaps = HashSet::from_iter(self.sources
             .iter()
             .map(|x| x.1)


### PR DESCRIPTION
This fixes #160

In the absence of this commit unless rewrite was passed the files were
never loaded so zero sourcemap references were resolved.