### PR TITLE
fix: Also disable SSL peer certificate verification with flag

### DIFF
--- a/src/api.rs
+++ b/src/api.rs
@@ -174,6 +174,7 @@ impl<'a> Api<'a> {
             handle.proxy_password(proxy_password)?;
         }
         handle.ssl_verify_host(self.config.should_verify_ssl())?;
+        handle.ssl_verify_peer(self.config.should_verify_ssl())?;
 
         ApiRequest::new(handle, method, &url, auth)
     }


### PR DESCRIPTION
The configuration option `http.verify_ssl` should disable verification of the SSL certificate. Right now, it only disables host name verification ([`CURLOPT_SSL_VERIFYHOST`](https://curl.haxx.se/libcurl/c/CURLOPT_SSL_VERIFYHOST.html)) but it should also/instead disable certificate verification ([`CURLOPT_SSL_VERIFYPEER`](https://curl.haxx.se/libcurl/c/CURLOPT_SSL_VERIFYPEER.html)).

I'd argue that we should **only** disable peer certificate validation and leave host validation in place to support self-signed certificates.

Fixes #178