### PR TITLE
Get users IP address before sending event

### DIFF
--- a/src/event.rs
+++ b/src/event.rs
@@ -132,6 +132,7 @@ impl Event {
         }).collect()));
 
         event.user.insert("username".into(), get_user_name().unwrap_or("unknown".into()));
+        event.user.insert("ip_address".into(), String::from("{{auto}}"));
 
         let mut device = HashMap::new();
         if let Some(hostname) = get_hostname() {


### PR DESCRIPTION
This sends a `curl` request before logging events. 

I have compiled and tested _(on linux)_:

![untitled](https://user-images.githubusercontent.com/9503662/34229114-1d15ea04-e5a1-11e7-9b78-ea10dca69ec7.png)

This requires that user has `curl` installed. I know `libcurl` is a dependency that means `curl` should be available in bash right?

https://github.com/getsentry/sentry-cli/issues/191