### PR TITLE
Use Info.plist from build with xcode

### DIFF
--- a/src/utils/xcode.rs
+++ b/src/utils/xcode.rs
@@ -179,13 +179,16 @@ impl InfoPlist {
         // if we are loaded directly from xcode we can trust the os environment
         // and pass those variables to the processor.
         if env::var("XCODE_VERSION_ACTUAL").is_ok() {
-            let vars: HashMap<_, _> = env::vars().collect();
-            if let Some(filename) = vars.get("INFOPLIST_FILE") {
-                let base = vars.get("PROJECT_DIR").map(|x| x.as_str()).unwrap_or(".");
-                let path = env::current_dir().unwrap().join(base).join(filename);
-                Ok(Some(InfoPlist::load_and_process(&path, &vars)?))
-            } else {
-                Ok(None)
+            match (
+                env::var("BUILT_PRODUCTS_DIR"),
+                env::var("INFOPLIST_PATH")
+            ) {
+                (Ok(dir), Ok(filepath)) => {
+                    let path: PathBuf = [dir, filepath].iter().collect();
+                    let vars: HashMap<_, _> = env::vars().collect();
+                    Ok(Some(InfoPlist::load_and_process(&path, &vars)?))
+                }
+                _ => Ok(None)
             }
 
         // otherwise, we discover the project info from the current path and

--- a/src/utils/xcode.rs
+++ b/src/utils/xcode.rs
@@ -180,7 +180,7 @@ impl InfoPlist {
         // and pass those variables to the processor.
         if env::var("XCODE_VERSION_ACTUAL").is_ok() {
             match (
-                env::var("BUILT_PRODUCTS_DIR"),
+                env::var("TARGET_BUILD_DIR"),
                 env::var("INFOPLIST_PATH")
             ) {
                 (Ok(dir), Ok(filepath)) => {


### PR DESCRIPTION
Fixes #198 

Tested for the use case described in the issue. I have every reason to believe this doesn't affect the existing functionality since xcode copies all files to the build directory, but didn't test this. I believe this is the recommended way to look at `Info.plist` during build. See e.g. https://github.com/facebook/react-native/blob/master/scripts/react-native-xcode.sh#L99 (but they use another variable to get the directory 🤔).

Also never touched rust before so feel free to make it more rusty 😉