### PR TITLE
fix(node): Inherit process environment

### DIFF
--- a/js/index.js
+++ b/js/index.js
@@ -103,7 +103,7 @@ function SentryCli(configFile) {
 }
 
 SentryCli.prototype.execute = function(args) {
-  var env = this.env;
+  var env = Object.assign({}, process.env, this.env);
   return new Promise(function(resolve, reject) {
     childProcess.execFile(SentryCli.getPath(), args, { env: env }, function(err, stdout) {
       if (err) return reject(err);


### PR DESCRIPTION
I think the linked issue has a fair point.
Do you see any reason not to do this, @kamilogorek @HazAT ?

Fixes getsentry/sentry-webpack-plugin#7