### PR TITLE
ref: New Config System

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1098,6 +1098,7 @@ dependencies = [
  "open 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "openssl-probe 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "osascript 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "parking_lot 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "plist 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "prettytable-rs 0.6.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,6 +52,7 @@ uuid = { version = "0.5.1", features = ["v4", "serde"] }
 walkdir = "2.0.1"
 which = "1.0.3"
 zip = "0.2.6"
+parking_lot = "0.5.3"
 
 [profile.dev]
 codegen-units = 2

--- a/src/api.rs
+++ b/src/api.rs
@@ -129,10 +129,15 @@ pub struct ApiResponse {
 }
 
 impl<'a> Api<'a> {
-    /// Creates a new API access helper for the given config.  For as long
-    /// as it lives HTTP keepalive can be used.  When the object is recreated
-    /// new connections will be established.
-    pub fn new(config: &'a Config) -> Api<'a> {
+    /// Creates a new API access helper.  For as long as it lives HTTP
+    /// keepalive can be used.  When the object is recreated new
+    /// connections will be established.
+    pub fn new() -> Api<'a> {
+        Api::with_config(Config::get_current())
+    }
+
+    /// Similar to `new` but uses a specific config.
+    pub fn with_config(config: &'a Config) -> Api<'a> {
         Api {
             config: config,
             shared_handle: RefCell::new(curl::easy::Easy::new()),

--- a/src/api.rs
+++ b/src/api.rs
@@ -10,6 +10,7 @@ use std::io::{Read, Write};
 use std::fmt;
 use std::error;
 use std::thread;
+use std::sync::Arc;
 use std::cell::{RefMut, RefCell};
 use std::path::Path;
 use std::ascii::AsciiExt;
@@ -61,8 +62,8 @@ pub enum ProgressBarMode {
 }
 
 /// Helper for the API access.
-pub struct Api<'a> {
-    config: &'a Config,
+pub struct Api {
+    config: Arc<Config>,
     shared_handle: RefCell<curl::easy::Easy>,
 }
 
@@ -128,16 +129,16 @@ pub struct ApiResponse {
     body: Option<Vec<u8>>,
 }
 
-impl<'a> Api<'a> {
+impl Api {
     /// Creates a new API access helper.  For as long as it lives HTTP
     /// keepalive can be used.  When the object is recreated new
     /// connections will be established.
-    pub fn new() -> Api<'a> {
+    pub fn new() -> Api {
         Api::with_config(Config::get_current())
     }
 
     /// Similar to `new` but uses a specific config.
-    pub fn with_config(config: &'a Config) -> Api<'a> {
+    pub fn with_config(config: Arc<Config>) -> Api {
         Api {
             config: config,
             shared_handle: RefCell::new(curl::easy::Easy::new()),
@@ -149,7 +150,7 @@ impl<'a> Api<'a> {
     /// Create a new `ApiRequest` for the given HTTP method and URL.  If the
     /// URL is just a path then it's relative to the configured API host
     /// and authentication is automatically enabled.
-    pub fn request(&'a self, method: Method, url: &str) -> ApiResult<ApiRequest<'a>> {
+    pub fn request<'a>(&'a self, method: Method, url: &str) -> ApiResult<ApiRequest<'a>> {
         let mut handle = self.shared_handle.borrow_mut();
         if !self.config.allow_keepalive() {
             handle.forbid_reuse(true).ok();

--- a/src/api.rs
+++ b/src/api.rs
@@ -163,7 +163,7 @@ impl<'a> Api<'a> {
                 Err(err) => {
                     return Err(Error::BadApiUrl(err.to_string()));
                 }
-            }), self.config.auth.as_ref())
+            }), self.config.get_auth())
         };
 
         // the proxy url is discovered from the http_proxy envvar.

--- a/src/commands/bash_hook.rs
+++ b/src/commands/bash_hook.rs
@@ -41,7 +41,8 @@ pub fn make_app<'a, 'b: 'a>(app: App<'a, 'b>) -> App<'a, 'b> {
             .hidden(true))
 }
 
-fn send_event(config: &Config, traceback: &str, logfile: &str) -> Result<()> {
+fn send_event(traceback: &str, logfile: &str) -> Result<()> {
+    let config = Config::get_current();
     let mut event = Event::new_prefilled()?;
     event.detect_release();
 
@@ -131,17 +132,16 @@ fn send_event(config: &Config, traceback: &str, logfile: &str) -> Result<()> {
 
     // handle errors here locally so that we do not get the extra "use sentry-cli
     // login" to sign in which would be in appropriate here.
-    if let Ok(event_id) = Api::new(config).send_event(&dsn, &event) {
+    if let Ok(event_id) = Api::new().send_event(&dsn, &event) {
         println!("{}", event_id);
     };
 
     Ok(())
 }
 
-pub fn execute<'a>(matches: &ArgMatches<'a>, config: &Config) -> Result<()> {
+pub fn execute<'a>(matches: &ArgMatches<'a>) -> Result<()> {
     if matches.is_present("send_event") {
-        return send_event(config,
-                          matches.value_of("traceback").unwrap(),
+        return send_event(matches.value_of("traceback").unwrap(),
                           matches.value_of("log").unwrap());
     }
 

--- a/src/commands/difutil.rs
+++ b/src/commands/difutil.rs
@@ -1,7 +1,6 @@
 use clap::{App, ArgMatches, AppSettings};
 
 use prelude::*;
-use config::Config;
 
 use commands;
 
@@ -28,11 +27,11 @@ pub fn make_app<'a, 'b: 'a>(mut app: App<'a, 'b>) -> App<'a, 'b> {
     app
 }
 
-pub fn execute<'a>(matches: &ArgMatches<'a>, config: &Config) -> Result<()> {
+pub fn execute<'a>(matches: &ArgMatches<'a>) -> Result<()> {
     macro_rules! execute_subcommand {
         ($name:ident) => {{
             if let Some(sub_matches) = matches.subcommand_matches(&stringify!($name)[8..]) {
-                return Ok(commands::$name::execute(&sub_matches, &config)?);
+                return Ok(commands::$name::execute(&sub_matches)?);
             }
         }}
     }

--- a/src/commands/difutil_check.rs
+++ b/src/commands/difutil_check.rs
@@ -6,7 +6,6 @@ use console::style;
 use serde_json;
 
 use prelude::*;
-use config::Config;
 use utils::dif;
 
 pub fn make_app<'a, 'b: 'a>(app: App<'a, 'b>) -> App<'a, 'b> {
@@ -28,7 +27,7 @@ pub fn make_app<'a, 'b: 'a>(app: App<'a, 'b>) -> App<'a, 'b> {
              .help("The path to the debug info file."))
 }
 
-pub fn execute<'a>(matches: &ArgMatches<'a>, _config: &Config) -> Result<()> {
+pub fn execute<'a>(matches: &ArgMatches<'a>) -> Result<()> {
     let path = Path::new(matches.value_of("path").unwrap());
 
     // which types should we consider?

--- a/src/commands/difutil_find.rs
+++ b/src/commands/difutil_find.rs
@@ -14,7 +14,6 @@ use symbolic_common::ByteView;
 use symbolic_proguard::ProguardMappingView;
 
 use prelude::*;
-use config::Config;
 use utils::{validate_uuid};
 use utils::dif::{DifType, DifFile};
 
@@ -186,7 +185,7 @@ fn find_uuids(paths: HashSet<PathBuf>,
     Ok(remaining.is_empty())
 }
 
-pub fn execute<'a>(matches: &ArgMatches<'a>, _config: &Config) -> Result<()> {
+pub fn execute<'a>(matches: &ArgMatches<'a>) -> Result<()> {
     let mut paths = HashSet::new();
     let mut types = HashSet::new();
     let mut uuids = HashSet::new();

--- a/src/commands/difutil_uuid.rs
+++ b/src/commands/difutil_uuid.rs
@@ -5,7 +5,6 @@ use clap::{App, Arg, ArgMatches};
 use serde_json;
 
 use prelude::*;
-use config::Config;
 use utils::dif;
 
 pub fn make_app<'a, 'b: 'a>(app: App<'a, 'b>) -> App<'a, 'b> {
@@ -27,7 +26,7 @@ pub fn make_app<'a, 'b: 'a>(app: App<'a, 'b>) -> App<'a, 'b> {
              .help("The path to the debug info file."))
 }
 
-pub fn execute<'a>(matches: &ArgMatches<'a>, _config: &Config) -> Result<()> {
+pub fn execute<'a>(matches: &ArgMatches<'a>) -> Result<()> {
     let path = Path::new(matches.value_of("path").unwrap());
 
     // which types should we consider?

--- a/src/commands/info.rs
+++ b/src/commands/info.rs
@@ -46,7 +46,8 @@ fn describe_auth(auth: Option<&Auth>) -> &str {
     }
 }
 
-fn get_config_status_json(config: &Config) -> Result<()> {
+fn get_config_status_json() -> Result<()> {
+    let config = Config::get_current();
     let mut rv = ConfigStatus::default();
 
     let (org, project) = config.get_org_and_project_defaults();
@@ -58,7 +59,7 @@ fn get_config_status_json(config: &Config) -> Result<()> {
         &Auth::Token(_) => "token".into(),
         &Auth::Key(_) => "api_key".into(),
     });
-    rv.auth.successful = config.get_auth().is_some() && Api::new(config).get_auth_info().is_ok();
+    rv.auth.successful = config.get_auth().is_some() && Api::new().get_auth_info().is_ok();
     rv.have_dsn = config.get_dsn().is_ok();
 
     serde_json::to_writer_pretty(&mut io::stdout(), &rv)?;
@@ -66,13 +67,14 @@ fn get_config_status_json(config: &Config) -> Result<()> {
     Ok(())
 }
 
-pub fn execute<'a>(matches: &ArgMatches<'a>, config: &Config) -> Result<()> {
+pub fn execute<'a>(matches: &ArgMatches<'a>) -> Result<()> {
     if matches.is_present("config_status_json") {
-        return get_config_status_json(config);
+        return get_config_status_json();
     }
 
+    let config = Config::get_current();
     let (org, project) = config.get_org_and_project_defaults();
-    let info_rv = Api::new(config).get_auth_info();
+    let info_rv = Api::new().get_auth_info();
     let errors = project.is_none() || org.is_none() || config.get_auth().is_none() || info_rv.is_err();
 
     if !matches.is_present("quiet") {

--- a/src/commands/info.rs
+++ b/src/commands/info.rs
@@ -52,13 +52,13 @@ fn get_config_status_json(config: &Config) -> Result<()> {
     let (org, project) = config.get_org_and_project_defaults();
     rv.config.insert("org".into(), org);
     rv.config.insert("project".into(), project);
-    rv.config.insert("url".into(), Some(config.url.clone()));
+    rv.config.insert("url".into(), Some(config.get_base_url()?.to_string()));
 
-    rv.auth.auth_type = config.auth.as_ref().map(|val| match val {
+    rv.auth.auth_type = config.get_auth().map(|val| match val {
         &Auth::Token(_) => "token".into(),
         &Auth::Key(_) => "api_key".into(),
     });
-    rv.auth.successful = config.auth.is_some() && Api::new(config).get_auth_info().is_ok();
+    rv.auth.successful = config.get_auth().is_some() && Api::new(config).get_auth_info().is_ok();
     rv.have_dsn = config.get_dsn().is_ok();
 
     serde_json::to_writer_pretty(&mut io::stdout(), &rv)?;
@@ -73,17 +73,17 @@ pub fn execute<'a>(matches: &ArgMatches<'a>, config: &Config) -> Result<()> {
 
     let (org, project) = config.get_org_and_project_defaults();
     let info_rv = Api::new(config).get_auth_info();
-    let errors = project.is_none() || org.is_none() || config.auth.is_none() || info_rv.is_err();
+    let errors = project.is_none() || org.is_none() || config.get_auth().is_none() || info_rv.is_err();
 
     if !matches.is_present("quiet") {
-        println!("Sentry Server: {}", config.url);
+        println!("Sentry Server: {}", config.get_base_url().unwrap_or("-"));
         println!("Default Organization: {}", org.unwrap_or("-".into()));
         println!("Default Project: {}", project.unwrap_or("-".into()));
 
-        if config.auth.is_some() {
+        if config.get_auth().is_some() {
             println!("");
             println!("Authentication Info:");
-            println!("  Method: {}", describe_auth(config.auth.as_ref()));
+            println!("  Method: {}", describe_auth(config.get_auth()));
             match info_rv {
                 Ok(info) => {
                     if let Some(ref user) = info.user {

--- a/src/commands/issues.rs
+++ b/src/commands/issues.rs
@@ -58,13 +58,12 @@ fn get_filter_from_matches<'a>(matches: &ArgMatches<'a>) -> Result<IssueFilter> 
     }
 }
 
-fn execute_change(config: &Config,
-                  org: &str,
+fn execute_change(org: &str,
                   project: &str,
                   filter: &IssueFilter,
                   changes: &IssueChanges)
                   -> Result<()> {
-    if Api::new(config).bulk_update_issue(org, project, filter, changes)? {
+    if Api::new().bulk_update_issue(org, project, filter, changes)? {
         println!("Updated matching issues.");
         if let Some(status) = changes.new_status.as_ref() {
             println!("  new status: {}", status);
@@ -75,7 +74,8 @@ fn execute_change(config: &Config,
     Ok(())
 }
 
-pub fn execute<'a>(matches: &ArgMatches<'a>, config: &Config) -> Result<()> {
+pub fn execute<'a>(matches: &ArgMatches<'a>) -> Result<()> {
+    let config = Config::get_current();
     let (org, project) = config.get_org_and_project(matches)?;
     let filter = get_filter_from_matches(matches)?;
     let mut changes: IssueChanges = Default::default();
@@ -92,5 +92,5 @@ pub fn execute<'a>(matches: &ArgMatches<'a>, config: &Config) -> Result<()> {
         changes.new_status = Some("unresolved".into());
     }
 
-    return execute_change(config, &org, &project, &filter, &changes);
+    return execute_change(&org, &project, &filter, &changes);
 }

--- a/src/commands/login.rs
+++ b/src/commands/login.rs
@@ -1,4 +1,6 @@
 //! Implements a command for signing in.
+use std::sync::Arc;
+
 use clap::{App, ArgMatches};
 use open;
 use url::Url;
@@ -42,9 +44,9 @@ pub fn execute<'a>(_matches: &ArgMatches<'a>) -> Result<()> {
     loop {
         token = prompt("Enter your token")?;
 
-        let mut test_cfg = config.clone();
+        let mut test_cfg = (*config).clone();
         test_cfg.set_auth(Auth::Token(token.to_string()));
-        match Api::with_config(&test_cfg).get_auth_info() {
+        match Api::with_config(Arc::new(test_cfg)).get_auth_info() {
             Ok(info) => {
                 // we can unwrap here somewhat safely because we do not permit
                 // signing in with legacy non user bound api keys here.

--- a/src/commands/login.rs
+++ b/src/commands/login.rs
@@ -15,7 +15,7 @@ pub fn make_app<'a, 'b: 'a>(app: App<'a, 'b>) -> App<'a, 'b> {
 fn update_config(config: &Config, token: &str) -> Result<()> {
     let mut new_cfg = config.clone();
     new_cfg.set_auth(Auth::Token(token.to_string()));
-    new_cfg.write_back()?;
+    new_cfg.save()?;
     Ok(())
 }
 

--- a/src/commands/login.rs
+++ b/src/commands/login.rs
@@ -1,6 +1,4 @@
 //! Implements a command for signing in.
-use std::sync::Arc;
-
 use clap::{App, ArgMatches};
 use open;
 use url::Url;
@@ -44,9 +42,11 @@ pub fn execute<'a>(_matches: &ArgMatches<'a>) -> Result<()> {
     loop {
         token = prompt("Enter your token")?;
 
-        let mut test_cfg = (*config).clone();
-        test_cfg.set_auth(Auth::Token(token.to_string()));
-        match Api::with_config(Arc::new(test_cfg)).get_auth_info() {
+        let test_cfg = config.make_copy(|cfg| {
+            cfg.set_auth(Auth::Token(token.to_string()));
+            Ok(())
+        })?;
+        match Api::with_config(test_cfg).get_auth_info() {
             Ok(info) => {
                 // we can unwrap here somewhat safely because we do not permit
                 // signing in with legacy non user bound api keys here.

--- a/src/commands/login.rs
+++ b/src/commands/login.rs
@@ -19,7 +19,8 @@ fn update_config(config: &Config, token: &str) -> Result<()> {
     Ok(())
 }
 
-pub fn execute<'a>(_matches: &ArgMatches<'a>, config: &Config) -> Result<()> {
+pub fn execute<'a>(_matches: &ArgMatches<'a>) -> Result<()> {
+    let config = Config::get_current();
     let token_url = format!("{}/api/", config.get_base_url()?);
 
     println!("This helps you signing in your sentry-cli with an authentication token.");
@@ -43,7 +44,7 @@ pub fn execute<'a>(_matches: &ArgMatches<'a>, config: &Config) -> Result<()> {
 
         let mut test_cfg = config.clone();
         test_cfg.set_auth(Auth::Token(token.to_string()));
-        match Api::new(&test_cfg).get_auth_info() {
+        match Api::with_config(&test_cfg).get_auth_info() {
             Ok(info) => {
                 // we can unwrap here somewhat safely because we do not permit
                 // signing in with legacy non user bound api keys here.

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -3,12 +3,11 @@
 use std::env;
 use std::process;
 
-use log;
 use clap::{Arg, App, AppSettings};
 
 use prelude::*;
 use constants::VERSION;
-use utils::{Logger, print_error, run_sentrycli_update_nagger};
+use utils::{print_error, run_sentrycli_update_nagger};
 use config::{Config, Auth, prepare_environment};
 
 const ABOUT: &'static str = "
@@ -109,7 +108,9 @@ fn preexecute_hooks() -> Result<bool> {
 
 /// Given an argument vector and a `Config` this executes the
 /// command line and returns the result.
-pub fn execute(args: Vec<String>, config: &mut Config) -> Result<()> {
+pub fn execute(args: Vec<String>) -> Result<()> {
+    let mut config = Config::from_cli_config()?;
+
     // special case for the xcode integration for react native.  For more
     // information see commands/react_native_xcode.rs
     if preexecute_hooks()? {
@@ -180,20 +181,16 @@ pub fn execute(args: Vec<String>, config: &mut Config) -> Result<()> {
         }
     }
 
-    log::set_logger(|max_log_level| {
-        max_log_level.set(config.get_log_level());
-        Box::new(Logger)
-    }).ok();
-
-    config.configure_environment();
+    // bind the config to the process and fetch an immutable reference to it
+    config.bind_to_process();
 
     macro_rules! execute_subcommand {
         ($name:ident) => {{
             let cmd = stringify!($name).replace("_", "-");
             if let Some(sub_matches) = matches.subcommand_matches(&cmd) {
-                let rv = $name::execute(&sub_matches, &config)?;
+                let rv = $name::execute(&sub_matches)?;
                 if UPDATE_NAGGER_CMDS.iter().any(|x| x == &cmd) {
-                    run_sentrycli_update_nagger(&config);
+                    run_sentrycli_update_nagger();
                 }
                 return Ok(rv);
             }
@@ -205,14 +202,13 @@ pub fn execute(args: Vec<String>, config: &mut Config) -> Result<()> {
 
 fn run() -> Result<()> {
     prepare_environment();
-    let mut cfg = Config::from_cli_config()?;
-    match execute(env::args().collect(), &mut cfg) {
+    match execute(env::args().collect()) {
         Ok(()) => Ok(()),
         Err(err) => {
             // if the user hit an error, it might be time to run the update
             // nagger because maybe they tried to do something only newer
             // versions support.
-            run_sentrycli_update_nagger(&cfg);
+            run_sentrycli_update_nagger();
             Err(err)
         }
     }

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -161,18 +161,18 @@ pub fn execute(args: Vec<String>, config: &mut Config) -> Result<()> {
     let matches = app.get_matches_from_safe(args)?;
 
     if let Some(url) = matches.value_of("url") {
-        config.url = url.to_owned();
+        config.set_base_url(url);
     }
     if let Some(api_key) = matches.value_of("api_key") {
-        config.auth = Some(Auth::Key(api_key.to_owned()));
+        config.set_auth(Auth::Key(api_key.to_owned()));
     }
     if let Some(auth_token) = matches.value_of("auth_token") {
-        config.auth = Some(Auth::Token(auth_token.to_owned()));
+        config.set_auth(Auth::Token(auth_token.to_owned()));
     }
     if let Some(level_str) = matches.value_of("log_level") {
         match level_str.parse() {
             Ok(level) => {
-                config.log_level = level;
+                config.set_log_level(level);
             }
             Err(_) => {
                 fail!("Unknown log level: {}", level_str);
@@ -181,7 +181,7 @@ pub fn execute(args: Vec<String>, config: &mut Config) -> Result<()> {
     }
 
     log::set_logger(|max_log_level| {
-        max_log_level.set(config.log_level);
+        max_log_level.set(config.get_log_level());
         Box::new(Logger)
     }).ok();
 

--- a/src/commands/projects.rs
+++ b/src/commands/projects.rs
@@ -15,9 +15,9 @@ pub fn make_app<'a, 'b: 'a>(app: App<'a, 'b>) -> App<'a, 'b> {
             .about("List all projects for an organization."))
 }
 
-pub fn execute<'a>(matches: &ArgMatches<'a>, config: &Config) -> Result<()> {
-    let api = Api::new(config);
-
+pub fn execute<'a>(matches: &ArgMatches<'a>) -> Result<()> {
+    let config = Config::get_current();
+    let api = Api::new();
     let org = config.get_org(matches)?;
     let mut projects = api.list_organization_projects(&org)?;
     projects.sort_by_key(|p| (p.team.name.clone(), p.name.clone()));

--- a/src/commands/react_native.rs
+++ b/src/commands/react_native.rs
@@ -1,7 +1,6 @@
 use clap::{App, ArgMatches, AppSettings};
 
 use prelude::*;
-use config::Config;
 
 use commands;
 
@@ -29,11 +28,11 @@ pub fn make_app<'a, 'b: 'a>(mut app: App<'a, 'b>) -> App<'a, 'b> {
     app
 }
 
-pub fn execute<'a>(matches: &ArgMatches<'a>, config: &Config) -> Result<()> {
+pub fn execute<'a>(matches: &ArgMatches<'a>) -> Result<()> {
     macro_rules! execute_subcommand {
         ($name:ident) => {{
             if let Some(sub_matches) = matches.subcommand_matches(&stringify!($name)[13..]) {
-                return Ok(commands::$name::execute(&sub_matches, &config)?);
+                return Ok(commands::$name::execute(&sub_matches)?);
             }
         }}
     }

--- a/src/commands/react_native_codepush.rs
+++ b/src/commands/react_native_codepush.rs
@@ -47,14 +47,15 @@ pub fn make_app<'a, 'b: 'a>(app: App<'a, 'b>) -> App<'a, 'b> {
             .help("A list of folders with assets that should be processed."))
 }
 
-pub fn execute<'a>(matches: &ArgMatches<'a>, config: &Config) -> Result<()> {
+pub fn execute<'a>(matches: &ArgMatches<'a>) -> Result<()> {
+    let config = Config::get_current();
     let here = env::current_dir()?;
     let here_str: &str = &here.to_string_lossy();
     let (org, project) = config.get_org_and_project(matches)?;
     let app = matches.value_of("app_name").unwrap();
     let platform = matches.value_of("platform").unwrap();
     let deployment = matches.value_of("deployment").unwrap_or("Staging");
-    let api = Api::new(config);
+    let api = Api::new();
     let print_release_name = matches.is_present("print_release_name");
 
     if !print_release_name {

--- a/src/commands/react_native_gradle.rs
+++ b/src/commands/react_native_gradle.rs
@@ -36,9 +36,10 @@ pub fn make_app<'a, 'b: 'a>(app: App<'a, 'b>) -> App<'a, 'b> {
              .help("The names of the distributions to publish. Can be supplied multiple times."))
 }
 
-pub fn execute<'a>(matches: &ArgMatches<'a>, config: &Config) -> Result<()> {
+pub fn execute<'a>(matches: &ArgMatches<'a>) -> Result<()> {
+    let config = Config::get_current();
     let (org, project) = config.get_org_and_project(matches)?;
-    let api = Api::new(config);
+    let api = Api::new();
     let base = env::current_dir()?;
 
     let sourcemap_path = PathBuf::from(matches.value_of("sourcemap").unwrap());

--- a/src/commands/react_native_xcode.rs
+++ b/src/commands/react_native_xcode.rs
@@ -74,9 +74,10 @@ fn find_node() -> String {
     "node".into()
 }
 
-pub fn execute<'a>(matches: &ArgMatches<'a>, config: &Config) -> Result<()> {
+pub fn execute<'a>(matches: &ArgMatches<'a>) -> Result<()> {
+    let config = Config::get_current();
     let (org, project) = config.get_org_and_project(matches)?;
-    let api = Api::new(config);
+    let api = Api::new();
     let should_wrap = matches.is_present("force") || match env::var("CONFIGURATION") {
         Ok(config) => &config != "Debug",
         Err(_) => { return Err("Need to run this from Xcode".into()); }
@@ -124,7 +125,7 @@ pub fn execute<'a>(matches: &ArgMatches<'a>, config: &Config) -> Result<()> {
     let node = find_node();
     info!("Using node interpreter '{}'", &node);
 
-    xcode::MayDetach::wrap(config, "React native symbol handling", |md| {
+    xcode::MayDetach::wrap("React native symbol handling", |md| {
         let bundle_path;
         let sourcemap_path;
         let bundle_url;

--- a/src/commands/releases.rs
+++ b/src/commands/releases.rs
@@ -20,7 +20,6 @@ use utils::{ArgExt, Table, HumanDuration, validate_timestamp,
 
 struct ReleaseContext<'a> {
     pub api: Api<'a>,
-    pub config: &'a Config,
     pub org: String,
     pub project_default: Option<&'a str>,
 }
@@ -34,7 +33,8 @@ impl<'a> ReleaseContext<'a> {
         if let Some(ref proj) = self.project_default {
             Ok(proj.to_string())
         } else {
-            Ok(self.config.get_project_default()?)
+            let config = Config::get_current();
+            Ok(config.get_project_default()?)
         }
     }
 
@@ -44,7 +44,8 @@ impl<'a> ReleaseContext<'a> {
         } else if let Some(project) = self.project_default {
             Ok(vec![project.to_string()])
         } else {
-            Ok(vec![self.config.get_project_default()?])
+            let config = Config::get_current();
+            Ok(vec![config.get_project_default()?])
         }
     }
 }
@@ -843,15 +844,15 @@ fn execute_deploys<'a>(ctx: &ReleaseContext,
     unreachable!();
 }
 
-pub fn execute<'a>(matches: &ArgMatches<'a>, config: &Config) -> Result<()> {
+pub fn execute<'a>(matches: &ArgMatches<'a>) -> Result<()> {
     // this one does not need a context or org
     if let Some(_sub_matches) = matches.subcommand_matches("propose-version") {
         return execute_propose_version();
     }
 
+    let config = Config::get_current();
     let ctx = ReleaseContext {
-        api: Api::new(config),
-        config: config,
+        api: Api::new(),
         org: config.get_org(matches)?,
         project_default: matches.value_of("project"),
     };

--- a/src/commands/releases.rs
+++ b/src/commands/releases.rs
@@ -19,7 +19,7 @@ use utils::{ArgExt, Table, HumanDuration, validate_timestamp,
 
 
 struct ReleaseContext<'a> {
-    pub api: Api<'a>,
+    pub api: Api,
     pub org: String,
     pub project_default: Option<&'a str>,
 }

--- a/src/commands/repos.rs
+++ b/src/commands/repos.rs
@@ -15,9 +15,10 @@ pub fn make_app<'a, 'b: 'a>(app: App<'a, 'b>) -> App<'a, 'b> {
             .about("List all repositories in your organization."))
 }
 
-pub fn execute<'a>(matches: &ArgMatches<'a>, config: &Config) -> Result<()> {
-    let api = Api::new(config);
+pub fn execute<'a>(matches: &ArgMatches<'a>) -> Result<()> {
+    let api = Api::new();
 
+    let config = Config::get_current();
     let org = config.get_org(matches)?;
     let repos = api.list_organization_repos(&org)?;
 

--- a/src/commands/send_event.rs
+++ b/src/commands/send_event.rs
@@ -87,7 +87,8 @@ pub fn make_app<'a, 'b: 'a>(app: App<'a, 'b>) -> App<'a, 'b> {
             .help("Send a logfile as breadcrumbs with the event (last 100 records)"))
 }
 
-pub fn execute<'a>(matches: &ArgMatches<'a>, config: &Config) -> Result<()> {
+pub fn execute<'a>(matches: &ArgMatches<'a>) -> Result<()> {
+    let config = Config::get_current();
     let mut event = Event::new_prefilled()?;
     event.level = matches.value_of("level").unwrap_or("error").into();
     if let Some(release) = matches.value_of("release") {
@@ -153,7 +154,7 @@ pub fn execute<'a>(matches: &ArgMatches<'a>, config: &Config) -> Result<()> {
 
     // handle errors here locally so that we do not get the extra "use sentry-cli
     // login" to sign in which would be in appropriate here.
-    match Api::new(config).send_event(&dsn, &event) {
+    match Api::new().send_event(&dsn, &event) {
         Ok(event_id) => {
             println!("Event sent: {}", event_id);
         }

--- a/src/commands/uninstall.rs
+++ b/src/commands/uninstall.rs
@@ -5,7 +5,6 @@ use clap::{App, ArgMatches, AppSettings};
 use console::style;
 
 use prelude::*;
-use config::Config;
 use utils::{is_homebrew_install, is_npm_install};
 
 fn is_hidden() -> bool {
@@ -21,7 +20,7 @@ pub fn make_app<'a, 'b: 'a>(app: App<'a, 'b>) -> App<'a, 'b> {
         })
 }
 
-pub fn execute<'a>(_matches: &ArgMatches<'a>, _config: &Config) -> Result<()> {
+pub fn execute<'a>(_matches: &ArgMatches<'a>) -> Result<()> {
     use std::fs;
     use runas;
     use utils;

--- a/src/commands/update.rs
+++ b/src/commands/update.rs
@@ -4,7 +4,6 @@ use std::env;
 use clap::{App, Arg, ArgMatches, AppSettings};
 
 use prelude::*;
-use config::Config;
 use utils::{get_latest_sentrycli_release, can_update_sentrycli};
 
 pub fn make_app<'a, 'b: 'a>(app: App<'a, 'b>) -> App<'a, 'b> {
@@ -20,9 +19,9 @@ pub fn make_app<'a, 'b: 'a>(app: App<'a, 'b>) -> App<'a, 'b> {
             .help("Force the update even if the latest version is already installed."))
 }
 
-pub fn execute<'a>(matches: &ArgMatches<'a>, config: &Config) -> Result<()> {
+pub fn execute<'a>(matches: &ArgMatches<'a>) -> Result<()> {
     let exe = env::current_exe()?;
-    let update = get_latest_sentrycli_release(config)?;
+    let update = get_latest_sentrycli_release()?;
 
     // aborts with an error if this installation is not updatable.
     update.assert_updatable()?;

--- a/src/commands/upload_breakpad.rs
+++ b/src/commands/upload_breakpad.rs
@@ -45,14 +45,14 @@ pub fn make_app<'a, 'b: 'a>(app: App<'a, 'b>) -> App<'a, 'b> {
              .help("Do not trigger reprocessing after uploading."))
 }
 
-struct ProjectContext<'a> {
-    api: Api<'a>,
+struct ProjectContext {
+    api: Api,
     org: String,
     project: String,
 }
 
-impl<'a> ProjectContext<'a> {
-    pub fn from_cli(matches: &ArgMatches) -> Result<ProjectContext<'a>> {
+impl ProjectContext {
+    pub fn from_cli(matches: &ArgMatches) -> Result<ProjectContext> {
         let config = Config::get_current();
         let (org, project) = config.get_org_and_project(matches)?;
 

--- a/src/commands/upload_breakpad.rs
+++ b/src/commands/upload_breakpad.rs
@@ -52,11 +52,12 @@ struct ProjectContext<'a> {
 }
 
 impl<'a> ProjectContext<'a> {
-    pub fn from_cli(matches: &ArgMatches, config: &'a Config) -> Result<ProjectContext<'a>> {
+    pub fn from_cli(matches: &ArgMatches) -> Result<ProjectContext<'a>> {
+        let config = Config::get_current();
         let (org, project) = config.get_org_and_project(matches)?;
 
         Ok(ProjectContext {
-            api: Api::new(config),
+            api: Api::new(),
             org: org,
             project: project,
         })
@@ -275,7 +276,7 @@ fn process_batch(batch: Batch, context: &mut ProjectContext) -> Result<usize> {
     Ok(uploaded.len())
 }
 
-pub fn execute<'a>(matches: &ArgMatches<'a>, config: &Config) -> Result<()> {
+pub fn execute<'a>(matches: &ArgMatches<'a>) -> Result<()> {
     let paths = match matches.values_of("paths") {
         Some(paths) => paths.map(|path| PathBuf::from(path)).collect(),
         None => vec![],
@@ -291,7 +292,8 @@ pub fn execute<'a>(matches: &ArgMatches<'a>, config: &Config) -> Result<()> {
         uuids.map(|s| Uuid::parse_str(s).unwrap()).collect()
     });
 
-    let mut context = ProjectContext::from_cli(matches, config)?;
+    let config = Config::get_current();
+    let mut context = ProjectContext::from_cli(matches)?;
     let max_size = config.get_max_dsym_upload_size()?;
     let mut total_uploaded = 0;
 

--- a/src/commands/upload_dsym.rs
+++ b/src/commands/upload_dsym.rs
@@ -547,7 +547,7 @@ pub fn make_app<'a, 'b: 'a>(app: App<'a, 'b>) -> App<'a, 'b> {
                     will be shown in the Xcode build output."))
 }
 
-pub fn execute<'a>(matches: &ArgMatches<'a>, config: &Config) -> Result<()> {
+pub fn execute<'a>(matches: &ArgMatches<'a>) -> Result<()> {
     let zips = !matches.is_present("no_zips");
     let mut paths = match matches.values_of("paths") {
         Some(paths) => paths.map(|x| PathBuf::from(x)).collect(),
@@ -583,12 +583,13 @@ pub fn execute<'a>(matches: &ArgMatches<'a>, config: &Config) -> Result<()> {
         println!("Warning: no paths were provided.");
     }
 
+    let config = Config::get_current();
     let (org, project) = config.get_org_and_project(matches)?;
     let max_size = config.get_max_dsym_upload_size()?;
-    let mut api = Api::new(config);
+    let mut api = Api::new();
     let mut total_uploaded = 0;
 
-    xcode::MayDetach::wrap(config, "Debug symbol upload", |md| {
+    xcode::MayDetach::wrap("Debug symbol upload", |md| {
         // Optionally detach if run from xcode
         if !matches.is_present("force_foreground") {
             md.may_detach()?;

--- a/src/commands/upload_proguard.rs
+++ b/src/commands/upload_proguard.rs
@@ -97,8 +97,8 @@ pub fn make_app<'a, 'b: 'a>(app: App<'a, 'b>) -> App<'a, 'b> {
                     a file with a forced UUID you can only upload a single proguard file."))
 }
 
-pub fn execute<'a>(matches: &ArgMatches<'a>, config: &Config) -> Result<()> {
-    let api = Api::new(config);
+pub fn execute<'a>(matches: &ArgMatches<'a>) -> Result<()> {
+    let api = Api::new();
 
     let paths: Vec<_> = match matches.values_of("paths") {
         Some(paths) => paths.collect(),
@@ -185,6 +185,7 @@ pub fn execute<'a>(matches: &ArgMatches<'a>, config: &Config) -> Result<()> {
     }
 
     println!("{} uploading mappings", style(">").dim());
+    let config = Config::get_current();
     let (org, project) = config.get_org_and_project(matches)?;
     let rv = api.upload_dsyms(&org, &project, tf.path())?;
     println!("{} Uploaded a total of {} new mapping files",

--- a/src/config.rs
+++ b/src/config.rs
@@ -124,7 +124,7 @@ impl Config {
     }
 
     /// Write the current config state back into the file.
-    pub fn write_back(&self) -> Result<()> {
+    pub fn save(&self) -> Result<()> {
         let mut file = OpenOptions::new().write(true)
             .truncate(true)
             .create(true)

--- a/src/config.rs
+++ b/src/config.rs
@@ -128,7 +128,7 @@ impl Config {
         self.process_bound = true;
         self.apply_to_process();
         unsafe {
-            if CONFIG.is_none() {
+            if CONFIG.is_some() {
                 panic!("Can only bind a single config");
             }
             CONFIG = Some(self);

--- a/src/config.rs
+++ b/src/config.rs
@@ -148,6 +148,15 @@ impl Config {
         Config::get_current_opt().expect("Config not bound yet")
     }
 
+    /// Makes a copy of the config in a closure and boxes it.
+    pub fn make_copy<F: FnOnce(&mut Config) -> Result<()>>(&self, cb: F)
+        -> Result<Arc<Config>>
+    {
+        let mut new_config = self.clone();
+        cb(&mut new_config)?;
+        Ok(Arc::new(new_config))
+    }
+
     fn apply_to_process(&self) {
         // this can only apply to the process if we are a process config.
         if !self.process_bound { 

--- a/src/main.rs
+++ b/src/main.rs
@@ -72,6 +72,7 @@ extern crate uuid;
 extern crate walkdir;
 extern crate which;
 extern crate zip;
+extern crate parking_lot;
 
 mod macros;
 

--- a/src/utils/system.rs
+++ b/src/utils/system.rs
@@ -221,11 +221,11 @@ pub fn get_family() -> Option<String> {
 }
 
 #[cfg(not(target_os="macos"))]
-pub fn get_model(config: &Config) -> Option<String> {
-    config.get_model()
+pub fn get_model() -> Option<String> {
+    Config::get_current().get_model()
 }
 
 #[cfg(not(target_os="macos"))]
-pub fn get_family(config: &Config) -> Option<String> {
-    config.get_family()
+pub fn get_family() -> Option<String> {
+    Config::get_current().get_family()
 }

--- a/src/utils/system.rs
+++ b/src/utils/system.rs
@@ -176,46 +176,44 @@ pub fn init_backtrace() {
 
 #[cfg(target_os="macos")]
 pub fn get_model() -> Option<String> {
-    let config = Config::get_current();
-    if config.get_model().is_some() {
-        config.get_model()
-    } else {
-        use std::ptr;
-        use libc;
-        use libc::c_void;
+    if let Some(model) = Config::get_current().get_model() {
+        return Some(model);
+    }
 
-        unsafe {
-            let mut size = 0;
-            libc::sysctlbyname("hw.model\x00".as_ptr() as *const i8,
-                ptr::null_mut(), &mut size, ptr::null_mut(), 0);
-            let mut buf = vec![0u8; size as usize];
-            libc::sysctlbyname("hw.model\x00".as_ptr() as *const i8,
-                buf.as_mut_ptr() as *mut c_void, &mut size, ptr::null_mut(), 0);
-            Some(String::from_utf8_lossy(&buf).to_string())
-        }
+    use std::ptr;
+    use libc;
+    use libc::c_void;
+
+    unsafe {
+        let mut size = 0;
+        libc::sysctlbyname("hw.model\x00".as_ptr() as *const i8,
+            ptr::null_mut(), &mut size, ptr::null_mut(), 0);
+        let mut buf = vec![0u8; size as usize];
+        libc::sysctlbyname("hw.model\x00".as_ptr() as *const i8,
+            buf.as_mut_ptr() as *mut c_void, &mut size, ptr::null_mut(), 0);
+        Some(String::from_utf8_lossy(&buf).to_string())
     }
 }
 
 #[cfg(target_os="macos")]
 pub fn get_family() -> Option<String> {
-    let config = Config::get_current();
-    if config.get_family().is_some() {
-        config.get_family()
-    } else {
-        use regex::Regex;
-        lazy_static! {
-            static ref FAMILY_RE: Regex = Regex::new(r#"([a-zA-Z]+)\d"#).unwrap();
-        }
+    if let Some(family) = Config::get_current().get_family() {
+        return Some(family);
+    }
 
-        if_chain! {
-            if let Some(model) = get_model();
-            if let Some(m) = FAMILY_RE.captures(&model);
-            if let Some(group) = m.get(1);
-            then {
-                Some(group.as_str().to_string())
-            } else {
-                None
-            }
+    use regex::Regex;
+    lazy_static! {
+        static ref FAMILY_RE: Regex = Regex::new(r#"([a-zA-Z]+)\d"#).unwrap();
+    }
+
+    if_chain! {
+        if let Some(model) = get_model();
+        if let Some(m) = FAMILY_RE.captures(&model);
+        if let Some(group) = m.get(1);
+        then {
+            Some(group.as_str().to_string())
+        } else {
+            None
         }
     }
 }

--- a/src/utils/xcode.rs
+++ b/src/utils/xcode.rs
@@ -293,17 +293,14 @@ impl InfoPlist {
 /// the xcode console and continue in the background.  This becomes
 /// a dummy shim for non xcode runs or platforms.
 pub struct MayDetach<'a> {
-    #[allow(dead_code)]
-    config: &'a Config,
     output_file: Option<TempFile>,
     #[allow(dead_code)]
     task_name: &'a str,
 }
 
 impl<'a> MayDetach<'a> {
-    fn new(config: &'a Config, task_name: &'a str) -> MayDetach<'a> {
+    fn new(task_name: &'a str) -> MayDetach<'a> {
         MayDetach {
-            config: config,
             output_file: None,
             task_name: task_name,
         }
@@ -324,7 +321,7 @@ impl<'a> MayDetach<'a> {
         }
 
         println!("Continuing in background.");
-        show_notification(self.config, "Sentry", &format!("{} starting", self.task_name))?;
+        show_notification("Sentry", &format!("{} starting", self.task_name))?;
         let output_file = TempFile::new()?;
         daemonize_redirect(Some(output_file.path()),
                            Some(output_file.path()),
@@ -343,14 +340,14 @@ impl<'a> MayDetach<'a> {
     /// calls into `may_detach`.
     #[cfg(target_os="macos")]
     pub fn wrap<T, F: FnOnce(&mut MayDetach) -> Result<T>>(
-        config: &Config, task_name: &'a str, f: F) -> Result<T>
+        task_name: &'a str, f: F) -> Result<T>
     {
         use std::time::Duration;
         use std::thread;
         use open;
         use utils::print_error;
 
-        let mut md = MayDetach::new(config, task_name);
+        let mut md = MayDetach::new(task_name);
         match f(&mut md) {
             Ok(x) => {
                 md.show_done()?;
@@ -372,8 +369,8 @@ impl<'a> MayDetach<'a> {
     /// Dummy wrap call that never detaches for non mac platforms.
     #[cfg(not(target_os="macos"))]
     pub fn wrap<T, F: FnOnce(&mut MayDetach) -> Result<T>>(
-        config: &Config, task_name: &'a str, f: F) -> Result<T> {
-        f(&mut MayDetach::new(config, task_name))
+        task_name: &'a str, f: F) -> Result<T> {
+        f(&mut MayDetach::new(task_name))
     }
 
     #[cfg(target_os="macos")]
@@ -389,7 +386,7 @@ impl<'a> MayDetach<'a> {
     #[cfg(target_os="macos")]
     fn show_done(&self) -> Result<()> {
         if self.is_detached() {
-            show_notification(self.config, "Sentry", &format!("{} finished", self.task_name))?;
+            show_notification("Sentry", &format!("{} finished", self.task_name))?;
         }
         Ok(())
     }
@@ -457,7 +454,7 @@ pub fn show_critical_info(title: &str, msg: &str) -> Result<bool> {
 
 /// Shows a notification in xcode
 #[cfg(target_os="macos")]
-pub fn show_notification(config: &Config, title: &str, msg: &str) -> Result<()> {
+pub fn show_notification(title: &str, msg: &str) -> Result<()> {
     lazy_static! {
         static ref SCRIPT: osascript::JavaScript = osascript::JavaScript::new("
             var App = Application.currentApplication();
@@ -468,6 +465,7 @@ pub fn show_notification(config: &Config, title: &str, msg: &str) -> Result<()> 
         ");
     }
 
+    let config = Config::get_current();
     if !config.show_notifications()? {
         return Ok(());
     }


### PR DESCRIPTION
This refactors the internal config system to no longer require explicit
passing of the config.  This also changes the config object to no longer
expose the internal fields.

The hope is that with this we can restructure the config loading greatly
to then also affect how (and when) we load .env and other information.

This is the first work needed to get workspaces in place.