### PR TITLE
Add configuration values to the docs

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -115,6 +115,10 @@ value in the parentheses is the config key in the config file):
     disabled.  This was introduced in 1.17.  Versions before that did not
     include an update check.  The update check is also not enabled for npm
     based installations of sentry-cli at the moment.
+``DEVICE_FAMILY`` (`device.family`):
+    Device family value reported to Sentry.
+``DEVICE_Model`` (`device.model`):
+    Device model value reported to Sentry.
 
 Validating The Config
 ---------------------

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -117,7 +117,7 @@ value in the parentheses is the config key in the config file):
     based installations of sentry-cli at the moment.
 ``DEVICE_FAMILY`` (`device.family`):
     Device family value reported to Sentry.
-``DEVICE_Model`` (`device.model`):
+``DEVICE_MODEL`` (`device.model`):
     Device model value reported to Sentry.
 
 Validating The Config


### PR DESCRIPTION
This should have been included in the related commit.

But I noticed when I started this feature my original issue was with the docs repo.

https://github.com/getsentry/sentry-docs/issues/191

So with this I can close that one.