### PR TITLE
[WIP] feat: Use internal rcfile abstraction

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -3,20 +3,17 @@ use std::io;
 use std::fs;
 use std::env;
 use std::path::{Path, PathBuf};
-use std::fs::OpenOptions;
 use std::sync::Arc;
 
 use dotenv;
 use log;
-use java_properties;
 use clap::ArgMatches;
 use url::Url;
-use ini::Ini;
 use parking_lot::Mutex;
 
 use prelude::*;
 use constants::{DEFAULT_URL, VERSION, PROTOCOL_VERSION};
-use utils::Logger;
+use utils::{Logger, RcFile};
 
 /// Represents the auth information
 #[derive(Debug, Clone)]
@@ -104,9 +101,8 @@ lazy_static! {
 
 /// Represents the `sentry-cli` config.
 pub struct Config {
-    filename: PathBuf,
     process_bound: bool,
-    ini: Ini,
+    rcfile: RcFile,
     cached_auth: Option<Auth>,
     cached_base_url: String,
     cached_log_level: log::LogLevelFilter,
@@ -115,14 +111,13 @@ pub struct Config {
 impl Config {
     /// Loads the CLI config from the default location and returns it.
     pub fn from_cli_config() -> Result<Config> {
-        let (filename, ini) = load_cli_config()?;
+        let rcfile = load_cli_config()?;
         Ok(Config {
-            filename: filename,
             process_bound: false,
-            cached_auth: get_default_auth(&ini),
-            cached_base_url: get_default_url(&ini),
-            cached_log_level: get_default_log_level(&ini)?,
-            ini: ini,
+            cached_auth: get_default_auth(&rcfile),
+            cached_base_url: get_default_url(&rcfile),
+            cached_log_level: get_default_log_level(&rcfile)?,
+            rcfile: rcfile,
         })
     }
 
@@ -180,17 +175,12 @@ impl Config {
 
     /// Returns the config filename.
     pub fn get_filename(&self) -> &Path {
-        &self.filename
+        self.rcfile.filename().unwrap()
     }
 
     /// Write the current config state back into the file.
     pub fn save(&self) -> Result<()> {
-        let mut file = OpenOptions::new().write(true)
-            .truncate(true)
-            .create(true)
-            .open(&self.filename)?;
-        self.ini.write_to(&mut file)?;
-        Ok(())
+        self.rcfile.save()
     }
 
     /// Returns the auth info
@@ -202,14 +192,14 @@ impl Config {
     pub fn set_auth(&mut self, auth: Auth) {
         self.cached_auth = Some(auth);
 
-        self.ini.delete_from(Some("auth"), "api_key");
-        self.ini.delete_from(Some("auth"), "token");
+        self.rcfile.remove("auth.api_key");
+        self.rcfile.remove("auth.token");
         match self.cached_auth {
             Some(Auth::Token(ref val)) => {
-                self.ini.set_to(Some("auth"), "token".into(), val.to_string());
+                self.rcfile.set("auth.token", val);
             }
             Some(Auth::Key(ref val)) => {
-                self.ini.set_to(Some("auth"), "api_key".into(), val.to_string());
+                self.rcfile.set("auth.api_key", val);
             }
             None => {}
         }
@@ -218,7 +208,7 @@ impl Config {
     /// Sets the URL
     pub fn set_base_url(&mut self, url: &str) {
         self.cached_base_url = url.to_owned();
-        self.ini.set_to(Some("defaults"), "url".into(), self.cached_base_url.clone());
+        self.rcfile.set("defaults.url", &self.cached_base_url);
     }
 
     /// Returns the base url (without trailing slashes)
@@ -254,7 +244,7 @@ impl Config {
     /// mostly corresponds to an ini config but also has some sensible
     /// default handling.
     pub fn allow_keepalive(&self) -> bool {
-        let val = self.ini.get_from(Some("http"), "keepalive");
+        let val = self.rcfile.get("http.keepalive");
         match val {
             // keepalive is broken on our dev server.  Since this makes local development
             // quite frustrating we disable keepalive (handle reuse) when we connect to
@@ -266,17 +256,17 @@ impl Config {
 
     /// Returns the proxy URL if defined.
     fn get_proxy_url(&self) -> Option<&str> {
-        self.ini.get_from(Some("http"), "proxy_url")
+        self.rcfile.get("http.proxy_url")
     }
 
     /// Returns the proxy username if defined.
     pub fn get_proxy_username(&self) -> Option<&str> {
-        self.ini.get_from(Some("http"), "proxy_username")
+        self.rcfile.get("http.proxy_username")
     }
 
     /// Returns the proxy password if defined.
     pub fn get_proxy_password(&self) -> Option<&str> {
-        self.ini.get_from(Some("http"), "proxy_password")
+        self.rcfile.get("http.proxy_password")
     }
 
     /// Indicates if SSL is enabled or disabled for the server.
@@ -286,7 +276,7 @@ impl Config {
 
     /// Indicates whether SSL verification should be on or off.
     pub fn should_verify_ssl(&self) -> bool {
-        let val = self.ini.get_from(Some("http"), "verify_ssl");
+        let val = self.rcfile.get("http.verify_ssl");
         match val {
             None => true,
             Some(val) => val == "true",
@@ -296,7 +286,7 @@ impl Config {
     /// Controls the SSL revocation check on windows.  This can be used as a
     /// workaround for misconfigured local SSL proxies.
     pub fn disable_ssl_revocation_check(&self) -> bool {
-        let val = self.ini.get_from(Some("http"), "check_ssl_revoke");
+        let val = self.rcfile.get("http.check_ssl_revoke");
         match val {
             None => true,
             Some(val) => val == "true",
@@ -308,7 +298,7 @@ impl Config {
         Ok(matches.value_of("org")
                .map(|x| x.to_owned())
                .or_else(|| env::var("SENTRY_ORG").ok())
-               .or_else(|| self.ini.get_from(Some("defaults"), "org").map(|x| x.to_owned()))
+               .or_else(|| self.rcfile.get("defaults.org").map(|x| x.to_owned()))
                .ok_or("An organization slug is required (provide with --org)")?)
     }
 
@@ -328,7 +318,7 @@ impl Config {
     /// Return the default value for a project.
     pub fn get_project_default(&self) -> Result<String> {
         Ok(env::var("SENTRY_PROJECT").ok()
-            .or_else(|| self.ini.get_from(Some("defaults"), "project").map(|x| x.to_owned()))
+            .or_else(|| self.rcfile.get("defaults.project").map(|x| x.to_owned()))
             .ok_or("A project slug is required")?)
     }
 
@@ -336,22 +326,22 @@ impl Config {
     pub fn get_org_and_project_defaults(&self) -> (Option<String>, Option<String>) {
         (env::var("SENTRY_ORG")
              .ok()
-             .or_else(|| self.ini.get_from(Some("defaults"), "org").map(|x| x.to_owned())),
+             .or_else(|| self.rcfile.get("defaults.org").map(|x| x.to_owned())),
          env::var("SENTRY_PROJECT")
              .ok()
-             .or_else(|| self.ini.get_from(Some("defaults"), "project").map(|x| x.to_owned())))
+             .or_else(|| self.rcfile.get("defaults.project").map(|x| x.to_owned())))
     }
 
     /// Returns true if notifications should be displayed
     pub fn show_notifications(&self) -> Result<bool> {
-        Ok(self.ini.get_from(Some("ui"), "show_notifications")
+        Ok(self.rcfile.get("ui.show_notifications")
             .map(|x| x == "true")
             .unwrap_or(true))
     }
 
     /// Returns the maximum dsym upload size
     pub fn get_max_dsym_upload_size(&self) -> Result<u64> {
-        Ok(self.ini.get_from(Some("dsym"), "max_upload_size")
+        Ok(self.rcfile.get("dsym.max_upload_size")
             .and_then(|x| x.parse().ok())
             .unwrap_or(35 * 1024 * 1024))
     }
@@ -360,7 +350,7 @@ impl Config {
     pub fn get_dsn(&self) -> Result<Dsn> {
         if let Some(ref val) = env::var("SENTRY_DSN").ok() {
             Dsn::from_str(val)
-        } else if let Some(val) = self.ini.get_from(Some("auth"), "dsn") {
+        } else if let Some(val) = self.rcfile.get("auth.dsn") {
             Dsn::from_str(val)
         } else {
             fail!("No DSN provided");
@@ -371,7 +361,7 @@ impl Config {
     pub fn get_model(&self) -> Option<String> {
         if env::var_os("DEVICE_MODEL").is_some() {
             env::var("DEVICE_MODEL").ok()
-        } else if let Some(val) = self.ini.get_from(Some("device"), "model") {
+        } else if let Some(val) = self.rcfile.get("device.model") {
             Some(String::from(val))
         } else {
             None
@@ -382,7 +372,7 @@ impl Config {
     pub fn get_family(&self) -> Option<String> {
         if env::var_os("DEVICE_FAMILY").is_some() {
             env::var("DEVICE_FAMILY").ok()
-        } else if let Some(val) = self.ini.get_from(Some("device"), "family") {
+        } else if let Some(val) = self.rcfile.get("device.family") {
             Some(String::from(val))
         } else {
             None
@@ -394,7 +384,7 @@ impl Config {
         if let Ok(var) = env::var("SENTRY_DISABLE_UPDATE_CHECK") {
             &var == "1" || &var == "true"
         } else {
-            if let Some(val) = self.ini.get_from(Some("update"), "disable_check") {
+            if let Some(val) = self.rcfile.get("update.disable_check") {
                 val == "true"
             } else {
                 false
@@ -414,6 +404,10 @@ fn find_project_config_file() -> Option<PathBuf> {
             if path.exists() {
                 return Some(path);
             }
+            path.set_file_name("sentry.properties");
+            if path.exists() {
+                return Some(path);
+            }
             path.pop();
             if !path.pop() {
                 return None;
@@ -422,15 +416,15 @@ fn find_project_config_file() -> Option<PathBuf> {
     })
 }
 
-fn load_cli_config() -> Result<(PathBuf, Ini)> {
+fn load_cli_config() -> Result<RcFile> {
     let mut home_fn = env::home_dir().ok_or("Could not find home dir")?;
     home_fn.push(".sentryclirc");
 
     let mut rv = match fs::File::open(&home_fn) {
-        Ok(mut file) => Ini::read_from(&mut file)?,
+        Ok(mut file) => RcFile::open(&mut file)?,
         Err(err) => {
             if err.kind() == io::ErrorKind::NotFound {
-                Ini::new()
+                RcFile::new()
             } else {
                 return Err(err).chain_err(
                     || "Failed to load .sentryclirc file from the home folder.");
@@ -438,38 +432,24 @@ fn load_cli_config() -> Result<(PathBuf, Ini)> {
         }
     };
 
-    let (path, mut rv) = if let Some(project_config_path) = find_project_config_file() {
-        let mut f = fs::File::open(&project_config_path)
+    let path = if let Some(project_config_path) = find_project_config_file() {
+        let project_conf = RcFile::open_path(&project_config_path)
             .chain_err(|| format!("Failed to load .sentryclirc file from project path ({})",
                 project_config_path.display()))?;
-        let ini = Ini::read_from(&mut f)?;
-        for (section, props) in ini.iter() {
-            for (key, value) in props {
-                rv.set_to(section.clone(), key.clone(), value.to_owned());
-            }
-        }
-        (project_config_path, rv)
+        rv.update(&project_conf);
+        project_config_path
     } else {
-        (home_fn, rv)
+        home_fn
     };
+    rv.set_filename(Some(&path));
 
     if let Ok(prop_path) = env::var("SENTRY_PROPERTIES") {
         match fs::File::open(&prop_path) {
             Ok(f) => {
-                let props = match java_properties::read(f) {
-                    Ok(props) => props,
-                    Err(err) => {
-                        return Err(Error::from(format!(
-                            "Could not load java style properties file: {}", err)));
-                    }
-                };
-                for (key, value) in props {
-                    let mut iter = key.rsplitn(2, '.');
-                    if let Some(key) = iter.next() {
-                        let section = iter.next();
-                        rv.set_to(section, key.to_string(), value);
-                    }
-                }
+                let prop_conf = RcFile::open(f)
+                    .chain_err(|| format!("Failed to load java style properties file ({})",
+                        prop_path))?;
+                rv.update(&prop_conf);
             },
             Err(err) => {
                 if err.kind() != io::ErrorKind::NotFound {
@@ -481,15 +461,15 @@ fn load_cli_config() -> Result<(PathBuf, Ini)> {
         }
     }
 
-    Ok((path, rv))
+    println!("{:#?}", &rv);
+    Ok(rv)
 }
 
 impl Clone for Config {
     fn clone(&self) -> Config {
         Config {
-            filename: self.filename.clone(),
             process_bound: false,
-            ini: self.ini.clone(),
+            rcfile: self.rcfile.clone(),
             cached_auth: self.cached_auth.clone(),
             cached_base_url: self.cached_base_url.clone(),
             cached_log_level: self.cached_log_level.clone(),
@@ -497,38 +477,38 @@ impl Clone for Config {
     }
 }
 
-fn get_default_auth(ini: &Ini) -> Option<Auth> {
+fn get_default_auth(rcfile: &RcFile) -> Option<Auth> {
     if let Some(ref val) = env::var("SENTRY_AUTH_TOKEN").ok() {
         Some(Auth::Token(val.to_owned()))
     } else if let Some(ref val) = env::var("SENTRY_API_KEY").ok() {
         Some(Auth::Key(val.to_owned()))
-    } else if let Some(val) = ini.get_from(Some("auth"), "token") {
+    } else if let Some(val) = rcfile.get("auth.token") {
         Some(Auth::Token(val.to_owned()))
-    } else if let Some(val) = ini.get_from(Some("auth"), "api_key") {
+    } else if let Some(val) = rcfile.get("auth.api_key") {
         Some(Auth::Key(val.to_owned()))
     } else {
         None
     }
 }
 
-fn get_default_url(ini: &Ini) -> String {
+fn get_default_url(rcfile: &RcFile) -> String {
     if let Some(ref val) = env::var("SENTRY_URL").ok() {
         val.to_owned()
-    } else if let Some(val) = ini.get_from(Some("defaults"), "url") {
+    } else if let Some(val) = rcfile.get("defaults.url") {
         val.to_owned()
     } else {
         DEFAULT_URL.to_owned()
     }
 }
 
-fn get_default_log_level(ini: &Ini) -> Result<log::LogLevelFilter> {
+fn get_default_log_level(rcfile: &RcFile) -> Result<log::LogLevelFilter> {
     if let Ok(level_str) = env::var("SENTRY_LOG_LEVEL") {
         if let Ok(level) = level_str.parse() {
             return Ok(level);
         }
     }
 
-    if let Some(level_str) = ini.get_from(Some("log"), "level") {
+    if let Some(level_str) = rcfile.get("log.level") {
         if let Ok(level) = level_str.parse() {
             return Ok(level);
         }

--- a/src/config.rs
+++ b/src/config.rs
@@ -461,7 +461,6 @@ fn load_cli_config() -> Result<RcFile> {
         }
     }
 
-    println!("{:#?}", &rv);
     Ok(rv)
 }
 

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -12,6 +12,7 @@ mod sourcemaps;
 mod system;
 mod ui;
 mod update;
+mod rcfile;
 pub mod dif;
 pub mod vcs;
 pub mod xcode;
@@ -37,3 +38,4 @@ pub use self::ui::{prompt_to_continue, prompt, capitalize_string,
                    copy_with_progress, make_byte_progress_bar};
 pub use self::update::{can_update_sentrycli, get_latest_sentrycli_release,
                        run_sentrycli_update_nagger, SentryCliUpdateInfo};
+pub use self::rcfile::{RcFile, RcFileFormat};

--- a/src/utils/rcfile.rs
+++ b/src/utils/rcfile.rs
@@ -1,0 +1,150 @@
+use std::fs;
+use std::io::{Seek, SeekFrom, BufReader, Read, Write};
+use std::path::{Path, PathBuf};
+use std::collections::HashMap;
+
+use java_properties::{PropertiesIter, PropertiesWriter};
+use ini::Ini;
+use encoding::Encoding;
+use encoding::all::{UTF_8, ISO_8859_1};
+
+use prelude::*;
+
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub enum RcFileFormat {
+    Ini,
+    Properties,
+}
+
+
+pub struct RcFile {
+    filename: Option<PathBuf>,
+    format: RcFileFormat,
+    items: HashMap<String, String>,
+}
+
+fn load_props<R: Read + Seek>(mut rdr: R, encoding: &'static Encoding)
+    -> Result<HashMap<String, String>>
+{
+    let mut rv = HashMap::new();
+    rdr.seek(SeekFrom::Start(0))?;
+    PropertiesIter::new_with_encoding(rdr, encoding).read_into(|key, value| {
+        rv.insert(key, value);
+    }).map_err(|_| Error::from("bad property data"))?;
+    Ok(rv)
+}
+
+impl RcFile {
+    pub fn new() -> RcFile {
+        RcFile {
+            filename: None,
+            format: RcFileFormat::Ini,
+            items: HashMap::new(),
+        }
+    }
+
+    pub fn open<R: Read + Seek>(mut rdr: R) -> Result<RcFile> {
+        let format;
+        let mut items;
+
+        // try to load as utf-8 props first
+        if let Ok(rv) = load_props(&mut rdr, UTF_8) {
+            format = RcFileFormat::Properties;
+            items = rv;
+        } else if let Ok(rv) = load_props(&mut rdr, ISO_8859_1) {
+            format = RcFileFormat::Properties;
+            items = rv;
+        } else {
+            format = RcFileFormat::Ini;
+            items = HashMap::new();
+
+            let ini = Ini::read_from(&mut rdr)?;
+            for (section, props) in ini.iter() {
+                for (key, value) in props {
+                    items.insert(match *section {
+                        Some(ref section) => format!("{}.{}", section, key),
+                        None => key.to_owned()
+                    }, value.to_owned());
+                }
+            }
+        }
+
+        Ok(RcFile {
+            filename: None,
+            format: format,
+            items: items,
+        })
+    }
+
+    pub fn filename(&self) -> Option<&Path> {
+        self.filename.as_ref().map(|x| x.as_path())
+    }
+
+    pub fn set_filename<P: AsRef<Path>>(&mut self, path: Option<P>) {
+        self.filename = path.map(|x| x.as_ref().to_path_buf());
+    }
+
+    pub fn from_path<P: AsRef<Path>>(path: P) -> Result<RcFile> {
+        let f = BufReader::new(fs::File::open(path.as_ref())?);
+        let mut rv = RcFile::open(f)?;
+        rv.filename = Some(path.as_ref().to_path_buf());
+        Ok(rv)
+    }
+
+    pub fn save(&self) -> Result<()> {
+        let filename = self.filename.as_ref().expect("No filename set");
+        let file = fs::OpenOptions::new().write(true)
+            .truncate(true)
+            .create(true)
+            .open(filename)?;
+        self.to_writer(file)
+    }
+
+    pub fn to_writer<W: Write>(&self, mut writer: W) -> Result<()> {
+        let mut items: Vec<(&str, &str)> = self.items
+            .iter().map(|(a, b)| (a.as_str(), b.as_str())).collect();
+        items.sort();
+
+        match self.format {
+            RcFileFormat::Ini => {
+                let mut ini = Ini::new();
+                for &(key, value) in &items {
+                    let mut key_iter = key.splitn(2, '.');
+                    let (sect, key) = match (key_iter.next(), key_iter.next()) {
+                        (Some(sect), Some(key)) => (Some(sect), key),
+                        (Some(key), None) => (None, key),
+                        _ => continue
+                    };
+                    ini.set_to(sect, key.to_string(), value.to_string());
+                }
+                ini.write_to(&mut writer)?;
+                Ok(())
+            }
+            RcFileFormat::Properties => {
+                let mut w = PropertiesWriter::new(&mut writer);
+                for &(key, value) in &items {
+                    w.write(&key, &value)
+                        .map_err(|_| Error::from("could not write properties"))?;
+                }
+                Ok(())
+            }
+        }
+    }
+
+    pub fn format(&self) -> RcFileFormat {
+        self.format
+    }
+
+    pub fn set_format(&mut self, format: RcFileFormat) {
+        self.format = format;
+    }
+
+    pub fn get(&self, key: &str) -> Option<&str> {
+        self.items.get(key).map(|x| x.as_str())
+    }
+
+    pub fn contains(&self, key: &str) -> bool {
+        self.items.contains_key(key)
+    }
+}

--- a/src/utils/rcfile.rs
+++ b/src/utils/rcfile.rs
@@ -31,14 +31,13 @@ fn load_props<R: Read + Seek>(mut rdr: R, encoding: &'static Encoding)
     rdr.seek(SeekFrom::Start(0))?;
     let iter = PropertiesIter::new_with_encoding(rdr, encoding);
     for item_rv in iter {
-        match item_rv.map_err(|_| Error::from("invalid line"))?.consume_content() {
-            LineContent::KVPair(key, value) => {
-                if key.trim().starts_with('[') {
-                    return Err(Error::from("ini format in props"));
-                }
-                rv.insert(key, value);
+        if let LineContent::KVPair(key, value) = item_rv
+            .map_err(|_| Error::from("invalid line"))?.consume_content()
+        {
+            if key.trim().starts_with('[') {
+                return Err(Error::from("ini format in props"));
             }
-            LineContent::Comment(..) => {}
+            rv.insert(key, value);
         }
     }
     Ok(rv)


### PR DESCRIPTION
This changes the config handling to always use both .properties and .ini
for all files.  We now try to read `.sentryclirc`, then `sentrycli.ini` and
then `sentry.properties`.  All files can support all formats (both java
properties and ini, we switch on demand).

This needs better tests.