### PR TITLE
ref(npm): Update NPM download mirror and add docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ This is a Sentry command line client for some generic tasks. Right now this is
 primarily used to upload debug symbols to Sentry if you are not using the
 fastlane tools.
 
-* Binaries can be found under
+* Downloads can be found under
   [Releases](https://github.com/getsentry/sentry-cli/releases/)
 * Documentation can be found [here](https://docs.sentry.io/hosted/learn/cli/)
 
@@ -24,6 +24,8 @@ fastlane tools.
 The recommended way to install is with everybody's favorite curl to bash:
 
     curl -sL https://sentry.io/get-cli/ | bash
+
+### Node
 
 Additionally you can also install this binary via npm:
 
@@ -36,9 +38,36 @@ install as root:
 
     sudo npm install -g @sentry/cli --unsafe-perm
 
-Or homebrew:
+By default, this package will download sentry-cli from
+[releases](https://github.com/getsentry/sentry-cli/releases). This should work
+fine for most people. If you are experiencing issues with downloading from
+GitHub, you may need to use a different download mirror. To use a custom CDN,
+set the npm config property `sentrycli_cdnurl`. The downloader will append
+`"/<version>/sentry-cli-<dist>"`.
+
+```sh
+npm install @sentry/cli --sentrycli_cdnurl=https://mymirror.com/path
+```
+
+Or add property into your `.npmrc` file (https://www.npmjs.org/doc/files/npmrc.html)
+
+```rc
+sentrycli_cdnurl=https://mymirror.com/path
+```
+
+Another option is to use the environment variable `SENTRYCLI_CDNURL`.
+
+```sh
+SENTRYCLI_CDNURL=https://mymirror.com/path npm install @sentry/cli
+```
+
+### Homebrew
+
+A homebrew recipe is provided in the `getsentry/tools` tap:
 
     brew install getsentry/tools/sentry-cli
+
+### Docker
 
 As of version _1.25.0_, there is an official Docker image that comes with
 `sentry-cli` preinstalled. If you prefer a specific version, specify it as tag.

--- a/README.md
+++ b/README.md
@@ -46,19 +46,19 @@ set the npm config property `sentrycli_cdnurl`. The downloader will append
 `"/<version>/sentry-cli-<dist>"`.
 
 ```sh
-npm install @sentry/cli --sentrycli_cdnurl=https://mymirror.com/path
+npm install @sentry/cli --sentrycli_cdnurl=https://mymirror.local/path
 ```
 
 Or add property into your `.npmrc` file (https://www.npmjs.org/doc/files/npmrc.html)
 
 ```rc
-sentrycli_cdnurl=https://mymirror.com/path
+sentrycli_cdnurl=https://mymirror.local/path
 ```
 
 Another option is to use the environment variable `SENTRYCLI_CDNURL`.
 
 ```sh
-SENTRYCLI_CDNURL=https://mymirror.com/path npm install @sentry/cli
+SENTRYCLI_CDNURL=https://mymirror.local/path npm install @sentry/cli
 ```
 
 ### Homebrew

--- a/bin/install-sentry-cli
+++ b/bin/install-sentry-cli
@@ -14,7 +14,7 @@ var https = require('https');
 var arch = os.arch();
 var spawn = require('child_process').spawn;
 
-var DEFAULT_CDN = 'https://github.com/getsentry/sentry-cli/releases/download/';
+var DEFAULT_CDN = 'https://github.com/getsentry/sentry-cli/releases/download';
 
 // downloadUrl vars
 var server;
@@ -25,7 +25,7 @@ var releasesUrl =
   process.env.npm_config_sentrycli_cdnurl ||
   process.env.SENTRYCLI_CDNURL ||
   process.env.SENTRYCLI_LOCAL_CDNURL ||
-  DEFAULT_CDN + version;
+  DEFAULT_CDN;
 
 if (process.env.SENTRYCLI_LOCAL_CDNURL) {
   fetch = http;
@@ -47,7 +47,7 @@ var outputPath = path.resolve(
 );
 
 var downloadUrl = null;
-releasesUrl += binaryPrefix;
+releasesUrl += '/' + version + binaryPrefix;
 
 // macOS
 if (platform === 'darwin') {

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -61,15 +61,15 @@ You can then find it in the `.bin` folder::
     a custom CDN, set the npm config property `sentrycli_cdnurl`. The downloader
     will append ``"/<version>/sentry-cli-<dist>"``.
 
-        $ npm install @sentry/cli --sentrycli_cdnurl=https://mymirror.com/path
+        $ npm install @sentry/cli --sentrycli_cdnurl=https://mymirror.local/path
 
     Or add property into your `.npmrc` file (https://www.npmjs.org/doc/files/npmrc.html)
 
-        sentrycli_cdnurl=https://mymirror.com/path
+        sentrycli_cdnurl=https://mymirror.local/path
 
     Another option is to use the environment variable `SENTRYCLI_CDNURL`.
 
-        $ SENTRYCLI_CDNURL=https://mymirror.com/path npm install @sentry/cli
+        $ SENTRYCLI_CDNURL=https://mymirror.local/path npm install @sentry/cli
 
 Installation via Homebrew
 -------------------------

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -52,6 +52,25 @@ You can then find it in the `.bin` folder::
 
     This installation is not recommended however.
 
+.. admonition:: Downloading from a Custom Source
+
+    By default, this package will download sentry-cli from
+    `the github release page <https://github.com/getsentry/sentry-cli/releases/>`__.
+    This should work fine for most people. If you are experiencing issues with
+    downloading from GitHub, you may need to use a different download mirror. To use
+    a custom CDN, set the npm config property `sentrycli_cdnurl`. The downloader
+    will append ``"/<version>/sentry-cli-<dist>"``.
+
+        $ npm install @sentry/cli --sentrycli_cdnurl=https://mymirror.com/path
+
+    Or add property into your `.npmrc` file (https://www.npmjs.org/doc/files/npmrc.html)
+
+        sentrycli_cdnurl=https://mymirror.com/path
+
+    Another option is to use the environment variable `SENTRYCLI_CDNURL`.
+
+        $ SENTRYCLI_CDNURL=https://mymirror.com/path npm install @sentry/cli
+
 Installation via Homebrew
 -------------------------
 


### PR DESCRIPTION
This should help people use their own download source for the npm version of sentry-cli. Still, we could consider uploading the binaries to a second CDN (maybe even the Raven one?) as a fallback.

See #207 and #196