### PR TITLE
ref: Remove explicit AsciiExt usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,11 +55,10 @@ docker run --rm -it -v $(pwd):/work getsentry/sentry-cli sentry-cli --help
 In case you want to compile this yourself, you need to install at minimum the
 following dependencies:
 
-* C and C++ 11 compiler
-* Make and CMake
-* OpenSSL 1.0.2j with development headers
+* Rust 1.23 and Cargo
+* Make, CMake and a C compiler
+* OpenSSL 1.0.2n with development headers
 * Curl 7.50 with development headers
-* Rust 1.20 and Cargo
 
 Use cargo to compile:
 

--- a/src/api.rs
+++ b/src/api.rs
@@ -13,7 +13,6 @@ use std::thread;
 use std::sync::Arc;
 use std::cell::{RefMut, RefCell};
 use std::path::Path;
-use std::ascii::AsciiExt;
 use std::collections::{HashSet, HashMap};
 use std::borrow::Cow;
 use std::rc::Rc;

--- a/src/utils/ui.rs
+++ b/src/utils/ui.rs
@@ -38,7 +38,6 @@ pub fn prompt(message: &str) -> io::Result<String> {
 
 /// Capitalizes a string and returns it.
 pub fn capitalize_string(s: &str) -> String {
-    use std::ascii::AsciiExt;
     let mut bytes = s.as_bytes().to_vec();
     bytes.make_ascii_lowercase();
     bytes[0] = bytes[0].to_ascii_uppercase();


### PR DESCRIPTION
Since rust 1.23.0 this is no longer necessary and there's not really a point in supporting old rust versions for `sentry-cli`.