### PR TITLE
ref(codepush): Improve codepush error messages

### DIFF
--- a/src/utils/codepush.rs
+++ b/src/utils/codepush.rs
@@ -24,13 +24,21 @@ pub struct CodePushDeployment {
 pub fn get_codepush_deployments(app: &str)
     -> Result<Vec<CodePushDeployment>>
 {
-    let p = process::Command::new("code-push")
+    let result = process::Command::new("code-push")
         .arg("deployment")
         .arg("ls")
         .arg(app)
         .arg("--format")
         .arg("json")
-        .output()?;
+        .output();
+
+    let p = match result {
+        Ok(p) => p,
+        Err(e) => {
+            return Err(Error::from(e).chain_err(|| "Could not run codepush. Is it on the PATH?"))
+        }
+    };
+
     if !p.status.success() {
         let msgstr;
         let detail = if let Ok(msg) = str::from_utf8(&p.stderr) {


### PR DESCRIPTION
Also looks for codepush in `<cwd>/node_modules/.bin` and improves error messages if something goes wrong (using error chains 🎉 ):

 - If codepush is missing entirely:
```
> Fetching latest code-push package info
error: Codepush not found. Is it installed and on the PATH?
```

- If codepush cannot be executed:
```
> Fetching latest code-push package info
error: Failed to run codepush
  caused by: Permission denied (os error 13)
```

- If codepush encounters an error:
```
> Fetching latest code-push package info
error: Failed to get codepush deployments
  caused by: You are not currently logged in. Run the 'code-push login' command to authenticate with the CodePush server.
```

Fixes #218 