### PR TITLE
fix(docker): Include CA certificates in our docker container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,5 +16,6 @@ RUN touch src/main.rs && cargo build --release --features managed
 FROM alpine:3.6
 WORKDIR /work
 
+RUN apk add --no-cache ca-certificates
 COPY --from=sentry-build /work/target/x86_64-unknown-linux-musl/release/sentry-cli /bin
 CMD ["/bin/sentry-cli"]


### PR DESCRIPTION
Installs the required `ca-certificates` package in our docker container, which was removed with the new musl builds. Previously, it was a transitive dependency of `libcurl`. 

Ref #223
