### PR TITLE
ref(js): Use ES6 language level

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -6,10 +6,10 @@ insert_final_newline = true
 trim_trailing_whitespace = true
 charset = utf-8
 
-[*.{rs,json}]
+[*.rs]
 indent_style = space
 indent_size = 4
 
-[.travis.yml]
+[*.{js,json,yml}]
 indent_style = space
 indent_size = 2

--- a/.eslintrc
+++ b/.eslintrc
@@ -1,8 +1,7 @@
 {
-    "extends": ["es5", "prettier"],
-    "rules": {
-        "no-console": "off",
-        "no-process-exit": "off",
-        "func-names": "off"
-    }
+  "extends": ["airbnb-base", "prettier"],
+  "rules": {
+    "prefer-destructuring": "off",
+    "strict": "off"
+  }
 }

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,4 +1,5 @@
 {
     "singleQuote": true,
+    "trailingComma": "es5",
     "printWidth": 90
 }

--- a/bin/sentry-cli
+++ b/bin/sentry-cli
@@ -1,25 +1,26 @@
 #!/usr/bin/env node
-/*
- * a wrapper script
- */
-var cli = require('../js');
-var child = require('child_process').spawn(cli.getPath(), process.argv.slice(2), {
-  stdio: 'inherit'
+/* eslint-disable no-console */
+
+'use strict';
+
+const cli = require('../js');
+const child = require('child_process').spawn(cli.getPath(), process.argv.slice(2), {
+  stdio: 'inherit',
 });
 
-child.on('error', function(err) {
+child.on('error', err => {
   console.error('error: failed to invoke sentry-cli');
   console.error(err.stack);
 });
 
-child.on('exit', function(code) {
+child.on('exit', code => {
   process.exit(code);
 });
 
-process.on('SIGTERM', function() {
+process.on('SIGTERM', () => {
   child.kill('SIGTERM');
 });
 
-process.on('SIGINT', function() {
+process.on('SIGINT', () => {
   child.kill('SIGINT');
 });

--- a/js/__tests__/helper.test.js
+++ b/js/__tests__/helper.test.js
@@ -1,38 +1,38 @@
 /* eslint-env jest */
 
-var helper = require('../helper');
+const helper = require('../helper');
 
-var SOURCEMAPS_OPTIONS = require('../releases/options/uploadSourcemaps');
+const SOURCEMAPS_OPTIONS = require('../releases/options/uploadSourcemaps');
 
-describe('SentryCli helper', function() {
-  test('call sentry-cli --version', function() {
+describe('SentryCli helper', () => {
+  test('call sentry-cli --version', () => {
     expect.assertions(1);
-    return helper.execute(['--version']).then(function() {
-      expect(true).toBe(true);
-    });
+    return helper
+      .execute(['--version'])
+      .then(version => expect(version.trim()).toBe('sentry-cli DEV'));
   });
 
-  test('call sentry-cli with wrong command', function() {
+  test('call sentry-cli with wrong command', () => {
     expect.assertions(1);
-    return helper.execute(['fail']).catch(function(e) {
-      expect(e.message).toMatch('Command failed:');
-    });
+    return helper
+      .execute(['fail'])
+      .catch(e => expect(e.message).toMatch('Command failed:'));
   });
 
-  test('call prepare command add default ignore', function() {
-    var command = ['releases', 'files', 'release', 'upload-sourcemaps', '/dev/null'];
+  test('call prepare command add default ignore', () => {
+    const command = ['releases', 'files', 'release', 'upload-sourcemaps', '/dev/null'];
 
     expect(helper.prepareCommand(command)).toEqual([
       'releases',
       'files',
       'release',
       'upload-sourcemaps',
-      '/dev/null'
+      '/dev/null',
     ]);
   });
 
-  test('call prepare command with array option', function() {
-    var command = ['releases', 'files', 'release', 'upload-sourcemaps', '/dev/null'];
+  test('call prepare command with array option', () => {
+    const command = ['releases', 'files', 'release', 'upload-sourcemaps', '/dev/null'];
 
     expect(
       helper.prepareCommand(command, SOURCEMAPS_OPTIONS, { stripPrefix: ['node', 'app'] })
@@ -45,17 +45,17 @@ describe('SentryCli helper', function() {
       '--strip-prefix',
       'node',
       '--strip-prefix',
-      'app'
+      'app',
     ]);
 
     // Should throw since it is no array
-    expect(function() {
+    expect(() => {
       helper.prepareCommand(command, SOURCEMAPS_OPTIONS, { stripPrefix: 'node' });
     }).toThrow();
   });
 
-  test('call prepare command with boolean option', function() {
-    var command = ['releases', 'files', 'release', 'upload-sourcemaps', '/dev/null'];
+  test('call prepare command with boolean option', () => {
+    const command = ['releases', 'files', 'release', 'upload-sourcemaps', '/dev/null'];
 
     expect(
       helper.prepareCommand(command, SOURCEMAPS_OPTIONS, { sourceMapReference: false })
@@ -65,7 +65,7 @@ describe('SentryCli helper', function() {
       'release',
       'upload-sourcemaps',
       '/dev/null',
-      '--no-sourcemap-reference'
+      '--no-sourcemap-reference',
     ]);
 
     expect(
@@ -76,13 +76,13 @@ describe('SentryCli helper', function() {
       ['releases', 'files', 'release', 'upload-sourcemaps', '/dev/null', '--rewrite']
     );
 
-    expect(function() {
+    expect(() => {
       helper.prepareCommand(command, SOURCEMAPS_OPTIONS, { sourceMapReference: 'node' });
     }).toThrow();
   });
 
-  test('call prepare command with string option', function() {
-    var command = ['releases', 'files', 'release', 'upload-sourcemaps', '/dev/null'];
+  test('call prepare command with string option', () => {
+    const command = ['releases', 'files', 'release', 'upload-sourcemaps', '/dev/null'];
 
     expect(helper.prepareCommand(command, SOURCEMAPS_OPTIONS, { ext: 'js' })).toEqual([
       'releases',
@@ -91,7 +91,7 @@ describe('SentryCli helper', function() {
       'upload-sourcemaps',
       '/dev/null',
       '--ext',
-      'js'
+      'js',
     ]);
 
     expect(
@@ -103,7 +103,7 @@ describe('SentryCli helper', function() {
       'upload-sourcemaps',
       '/dev/null',
       '--url-prefix',
-      '~/'
+      '~/',
     ]);
 
     expect(
@@ -115,7 +115,7 @@ describe('SentryCli helper', function() {
       'upload-sourcemaps',
       '/dev/null',
       '--ignore-file',
-      '/js.ignore'
+      '/js.ignore',
     ]);
   });
 });

--- a/js/__tests__/index.test.js
+++ b/js/__tests__/index.test.js
@@ -1,9 +1,9 @@
 /* eslint-env jest */
 
-var SentryCli = require('../');
+const SentryCli = require('../');
 
-describe('SentryCli', function() {
-  test('call getPath', function() {
+describe('SentryCli', () => {
+  test('call getPath', () => {
     expect(SentryCli.getPath()).toContain('sentry-cli');
   });
 });

--- a/js/helper.js
+++ b/js/helper.js
@@ -1,84 +1,90 @@
 'use strict';
 
-/* global Promise */
+const os = require('os');
+const path = require('path');
+const childProcess = require('child_process');
 
-var os = require('os');
-var path = require('path');
-var childProcess = require('child_process');
-
-function transformOption(option, values) {
-  if (Array.isArray(values)) {
-    return values
-      .map(function(value) {
-        return [option.param, value];
-      })
-      .reduce(function(acc, value) {
-        return acc.concat(value);
-      }, []);
-  }
-  return [option.param, values];
-}
-
-var binaryPath =
+const binaryPath =
   os.platform() === 'win32'
     ? path.resolve(__dirname, '..\\bin\\sentry-cli.exe')
     : path.resolve(__dirname, '../sentry-cli');
 
-module.exports = {
-  normalizeOptions: function(commandOptions, options) {
-    return Object.keys(commandOptions).reduce(function(newOptions, sourceMapOption) {
-      var paramValue = options[sourceMapOption];
-      if (typeof paramValue === 'undefined') {
-        return newOptions;
-      }
-
-      var paramType = commandOptions[sourceMapOption].type;
-      var paramName = commandOptions[sourceMapOption].param;
-
-      if (paramType === 'array') {
-        if (!Array.isArray(paramValue)) {
-          throw new Error(sourceMapOption + ' should be an array');
-        }
-        return newOptions.concat(
-          transformOption(commandOptions[sourceMapOption], paramValue)
-        );
-      } else if (paramType === 'boolean' || paramType === 'inverted-boolean') {
-        if (typeof paramValue !== 'boolean') {
-          throw new Error(sourceMapOption + ' should be a bool');
-        }
-        if (paramType === 'boolean' && paramValue) {
-          return newOptions.concat([paramName]);
-        } else if (paramType === 'inverted-boolean' && paramValue === false) {
-          return newOptions.concat([paramName]);
-        }
-        return newOptions;
-      }
-      return newOptions.concat(paramName, paramValue);
-    }, []);
-  },
-
-  prepareCommand: function(command, commandOptions, options) {
-    return command.concat(this.normalizeOptions(commandOptions || {}, options || {}));
-  },
-
-  getPath: function() {
-    if (process.env.NODE_ENV === 'test') {
-      return path.resolve(__dirname, '__mocks__/sentry-cli');
-    }
-    return binaryPath;
-  },
-
-  execute: function(args) {
-    var env = Object.assign({}, process.env);
-    var that = this;
-    return new Promise(function(resolve, reject) {
-      childProcess.execFile(that.getPath(), args, { env: env }, function(err, stdout) {
-        if (err) {
-          reject(err);
-        } else {
-          resolve(stdout);
-        }
-      });
-    });
+function transformOption(option, values) {
+  if (Array.isArray(values)) {
+    return values.reduce((acc, value) => acc.concat([option.param, value]), []);
   }
+
+  return [option.param, values];
+}
+
+function normalizeOptions(commandOptions, options) {
+  return Object.keys(commandOptions).reduce((newOptions, sourceMapOption) => {
+    const paramValue = options[sourceMapOption];
+    if (paramValue === undefined) {
+      return newOptions;
+    }
+
+    const paramType = commandOptions[sourceMapOption].type;
+    const paramName = commandOptions[sourceMapOption].param;
+
+    if (paramType === 'array') {
+      if (!Array.isArray(paramValue)) {
+        throw new Error(`${sourceMapOption} should be an array`);
+      }
+
+      return newOptions.concat(
+        transformOption(commandOptions[sourceMapOption], paramValue)
+      );
+    }
+
+    if (paramType === 'boolean' || paramType === 'inverted-boolean') {
+      if (typeof paramValue !== 'boolean') {
+        throw new Error(`${sourceMapOption} should be a bool`);
+      }
+
+      if (paramType === 'boolean' && paramValue) {
+        return newOptions.concat([paramName]);
+      }
+
+      if (paramType === 'inverted-boolean' && paramValue === false) {
+        return newOptions.concat([paramName]);
+      }
+
+      return newOptions;
+    }
+
+    return newOptions.concat(paramName, paramValue);
+  }, []);
+}
+
+function prepareCommand(command, commandOptions, options) {
+  return command.concat(normalizeOptions(commandOptions || {}, options || {}));
+}
+
+function getPath() {
+  if (process.env.NODE_ENV === 'test') {
+    return path.resolve(__dirname, '__mocks__/sentry-cli');
+  }
+
+  return binaryPath;
+}
+
+function execute(args) {
+  const env = Object.assign({}, process.env);
+  return new Promise((resolve, reject) => {
+    childProcess.execFile(getPath(), args, { env }, (err, stdout) => {
+      if (err) {
+        reject(err);
+      } else {
+        resolve(stdout);
+      }
+    });
+  });
+}
+
+module.exports = {
+  normalizeOptions,
+  prepareCommand,
+  getPath,
+  execute,
 };

--- a/js/index.js
+++ b/js/index.js
@@ -1,23 +1,23 @@
 'use strict';
 
-var pkgInfo = require('../package.json');
-var helper = require('./helper');
+const pkgInfo = require('../package.json');
+const helper = require('./helper');
 
-function SentryCli(configFile) {
-  if (typeof configFile === 'string') process.env.SENTRY_PROPERTIES = configFile;
+class SentryCli {
+  constructor(configFile) {
+    if (typeof configFile === 'string') {
+      process.env.SENTRY_PROPERTIES = configFile;
+    }
+  }
+
+  static getVersion() {
+    return pkgInfo.version;
+  }
+
+  static getPath() {
+    return helper.getPath();
+  }
 }
-
-SentryCli.prototype.getConfigStatus = function() {
-  return helper.execute(['info', '--config-status-json']);
-};
-
-SentryCli.getVersion = function() {
-  return pkgInfo.version;
-};
-
-SentryCli.getPath = function() {
-  return helper.getPath();
-};
 
 SentryCli.prototype.releases = require('./releases');
 

--- a/js/releases/__tests__/index.test.js
+++ b/js/releases/__tests__/index.test.js
@@ -1,22 +1,19 @@
 /* eslint-env jest */
 
-var SentryCli = require('../../');
+const SentryCli = require('../../');
 
-describe('SentryCli releases', function() {
-  test('call sentry-cli releases propose-version', function() {
+describe('SentryCli releases', () => {
+  test('call sentry-cli releases propose-version', () => {
     expect.assertions(1);
-    var cli = new SentryCli();
-    return cli.releases.proposeVersion().then(function(version) {
-      expect(version).toBeTruthy();
-    });
+    const cli = new SentryCli();
+    return cli.releases.proposeVersion().then(version => expect(version).toBeTruthy());
   });
-  test('call sentry-cli releases upload-sourcemaps', function() {
+
+  test('call sentry-cli releases upload-sourcemaps', () => {
     expect.assertions(1);
-    var cli = new SentryCli();
+    const cli = new SentryCli();
     return cli.releases
       .uploadSourceMaps('#abc', { include: ['hello'] })
-      .then(function(version) {
-        expect(version).toBeTruthy();
-      });
+      .then(version => expect(version).toBeTruthy());
   });
 });

--- a/js/releases/index.js
+++ b/js/releases/index.js
@@ -1,39 +1,39 @@
 'use strict';
 
-/* global Promise */
+const helper = require('../helper');
 
-var helper = require('../helper');
-
-var DEFAULT_IGNORE = ['node_modules'];
-var SOURCEMAPS_OPTIONS = require('./options/uploadSourcemaps');
+const DEFAULT_IGNORE = ['node_modules'];
+const SOURCEMAPS_OPTIONS = require('./options/uploadSourcemaps');
 
 module.exports = {
-  new: function(release) {
+  new(release) {
     return helper.execute(['releases', 'new', release]);
   },
-  finalize: function(release) {
+
+  finalize(release) {
     return helper.execute(['releases', 'finalize', release]);
   },
-  proposeVersion: function() {
+
+  proposeVersion() {
     return helper.execute(['releases', 'propose-version']);
   },
-  uploadSourceMaps: function(release, options) {
-    if (typeof options === 'undefined' || typeof options.include === 'undefined') {
+
+  uploadSourceMaps(release, options) {
+    if (!options || !options.include) {
       throw new Error('options.include must be a vaild path(s)');
     }
+
     return Promise.all(
-      options.include.map(function(sourcemapPath) {
-        var command = ['releases', 'files', release, 'upload-sourcemaps', sourcemapPath];
-        var newOptions = Object.assign({}, options);
+      options.include.map(sourcemapPath => {
+        const args = ['releases', 'files', release, 'upload-sourcemaps', sourcemapPath];
+        const newOptions = Object.assign({}, options);
 
         if (!newOptions.ignoreFile && !newOptions.ignore) {
           newOptions.ignore = DEFAULT_IGNORE;
         }
 
-        return helper.execute(
-          helper.prepareCommand(command, SOURCEMAPS_OPTIONS, options)
-        );
-      }, this)
+        return helper.execute(helper.prepareCommand(args, SOURCEMAPS_OPTIONS, options));
+      })
     );
-  }
+  },
 };

--- a/js/releases/options/uploadSourcemaps.js
+++ b/js/releases/options/uploadSourcemaps.js
@@ -1,38 +1,38 @@
 module.exports = {
   ignore: {
     param: '--ignore',
-    type: 'array'
+    type: 'array',
   },
   ignoreFile: {
     param: '--ignore-file',
-    type: 'string'
+    type: 'string',
   },
   rewrite: {
     param: '--rewrite',
-    type: 'boolean'
+    type: 'boolean',
   },
   sourceMapReference: {
     param: '--no-sourcemap-reference',
-    type: 'inverted-boolean'
+    type: 'inverted-boolean',
   },
   stripPrefix: {
     param: '--strip-prefix',
-    type: 'array'
+    type: 'array',
   },
   stripCommonPrefix: {
     param: '--strip-common-prefix',
-    type: 'array'
+    type: 'array',
   },
   validate: {
     param: '--validate',
-    type: 'boolean'
+    type: 'boolean',
   },
   urlPrefix: {
     param: '--url-prefix',
-    type: 'string'
+    type: 'string',
   },
   ext: {
     param: '--ext',
-    type: 'string'
-  }
+    type: 'string',
+  },
 };

--- a/package.json
+++ b/package.json
@@ -8,8 +8,8 @@
     "fix:prettier": "prettier --write 'bin/*' 'js/**/*.js'",
     "fix": "npm-run-all fix:eslint fix:prettier",
     "test:jest": "jest",
-    "test:eslint": "eslint 'bin/*' js",
-    "test:prettier": "prettier-check 'bin/*' 'js/**/*.js'",
+    "test:eslint": "eslint bin scripts js",
+    "test:prettier": "prettier-check 'bin/*' 'scripts/*.js' 'js/**/*.js'",
     "test": "npm-run-all test:jest test:eslint test:prettier",
     "test:watch": "jest --watch --notify"
   },
@@ -38,12 +38,13 @@
   "homepage": "https://docs.sentry.io/hosted/learn/cli/",
   "license": "BSD-3-Clause",
   "devDependencies": {
-    "eslint": "^4.12.1",
-    "eslint-config-es5": "^0.5.0",
+    "eslint": "^4.16.0",
+    "eslint-config-airbnb-base": "^12.1.0",
     "eslint-config-prettier": "^2.9.0",
+    "eslint-plugin-import": "^2.8.0",
     "jest": "^21.2.1",
     "npm-run-all": "^4.1.2",
-    "prettier": "^1.9.0",
+    "prettier": "^1.10.2",
     "prettier-check": "^2.0.0"
   },
   "engines": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -415,7 +415,7 @@ bser@^2.0.0:
   dependencies:
     node-int64 "^0.4.0"
 
-builtin-modules@^1.0.0:
+builtin-modules@^1.0.0, builtin-modules@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/builtin-modules/-/builtin-modules-1.1.1.tgz#270f076c5a72c02f5b65a47df94c5fe3a278892f"
 
@@ -548,6 +548,10 @@ console-control-strings@^1.0.0, console-control-strings@~1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/console-control-strings/-/console-control-strings-1.1.0.tgz#3d7cf4464db6446ea644bf4b39507f9851008e8e"
 
+contains-path@^0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/contains-path/-/contains-path-0.1.0.tgz#fe8cf184ff6670b6baef01a9d4861a5cbec4120a"
+
 content-type-parser@^1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/content-type-parser/-/content-type-parser-1.0.2.tgz#caabe80623e63638b2502fd4c7f12ff4ce2352e7"
@@ -600,13 +604,13 @@ dashdash@^1.12.0:
   dependencies:
     assert-plus "^1.0.0"
 
-debug@^2.2.0, debug@^2.6.8:
+debug@^2.2.0, debug@^2.6.8, debug@^2.6.9:
   version "2.6.9"
   resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.9.tgz#5d128515df134ff327e90a4c93f4e077a536341f"
   dependencies:
     ms "2.0.0"
 
-debug@^3.0.1, debug@^3.1.0:
+debug@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/debug/-/debug-3.1.0.tgz#5bb5a0672628b64149566ba16819e61518c67261"
   dependencies:
@@ -671,9 +675,16 @@ diff@^3.2.0:
   version "3.4.0"
   resolved "https://registry.yarnpkg.com/diff/-/diff-3.4.0.tgz#b1d85507daf3964828de54b37d0d73ba67dda56c"
 
-doctrine@^2.0.2:
-  version "2.0.2"
-  resolved "https://registry.yarnpkg.com/doctrine/-/doctrine-2.0.2.tgz#68f96ce8efc56cc42651f1faadb4f175273b0075"
+doctrine@1.5.0:
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/doctrine/-/doctrine-1.5.0.tgz#379dce730f6166f76cefa4e6707a159b02c5a6fa"
+  dependencies:
+    esutils "^2.0.2"
+    isarray "^1.0.0"
+
+doctrine@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/doctrine/-/doctrine-2.1.0.tgz#5cd01fc101621b42c4cd7f5d1a66243716d3f39d"
   dependencies:
     esutils "^2.0.2"
 
@@ -748,15 +759,50 @@ escodegen@^1.6.1:
   optionalDependencies:
     source-map "~0.5.6"
 
-eslint-config-es5@^0.5.0:
-  version "0.5.0"
-  resolved "https://registry.yarnpkg.com/eslint-config-es5/-/eslint-config-es5-0.5.0.tgz#ac300f5f75c456993adabcb5ccb4d28ccf00e175"
+eslint-config-airbnb-base@^12.1.0:
+  version "12.1.0"
+  resolved "https://registry.yarnpkg.com/eslint-config-airbnb-base/-/eslint-config-airbnb-base-12.1.0.tgz#386441e54a12ccd957b0a92564a4bafebd747944"
+  dependencies:
+    eslint-restricted-globals "^0.1.1"
 
 eslint-config-prettier@^2.9.0:
   version "2.9.0"
   resolved "https://registry.yarnpkg.com/eslint-config-prettier/-/eslint-config-prettier-2.9.0.tgz#5ecd65174d486c22dff389fe036febf502d468a3"
   dependencies:
     get-stdin "^5.0.1"
+
+eslint-import-resolver-node@^0.3.1:
+  version "0.3.2"
+  resolved "https://registry.yarnpkg.com/eslint-import-resolver-node/-/eslint-import-resolver-node-0.3.2.tgz#58f15fb839b8d0576ca980413476aab2472db66a"
+  dependencies:
+    debug "^2.6.9"
+    resolve "^1.5.0"
+
+eslint-module-utils@^2.1.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/eslint-module-utils/-/eslint-module-utils-2.1.1.tgz#abaec824177613b8a95b299639e1b6facf473449"
+  dependencies:
+    debug "^2.6.8"
+    pkg-dir "^1.0.0"
+
+eslint-plugin-import@^2.8.0:
+  version "2.8.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-import/-/eslint-plugin-import-2.8.0.tgz#fa1b6ef31fcb3c501c09859c1b86f1fc5b986894"
+  dependencies:
+    builtin-modules "^1.1.1"
+    contains-path "^0.1.0"
+    debug "^2.6.8"
+    doctrine "1.5.0"
+    eslint-import-resolver-node "^0.3.1"
+    eslint-module-utils "^2.1.1"
+    has "^1.0.1"
+    lodash.cond "^4.3.0"
+    minimatch "^3.0.3"
+    read-pkg-up "^2.0.0"
+
+eslint-restricted-globals@^0.1.1:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/eslint-restricted-globals/-/eslint-restricted-globals-0.1.1.tgz#35f0d5cbc64c2e3ed62e93b4b1a7af05ba7ed4d7"
 
 eslint-scope@^3.7.1:
   version "3.7.1"
@@ -765,21 +811,25 @@ eslint-scope@^3.7.1:
     esrecurse "^4.1.0"
     estraverse "^4.1.1"
 
-eslint@^4.12.1:
-  version "4.12.1"
-  resolved "https://registry.yarnpkg.com/eslint/-/eslint-4.12.1.tgz#5ec1973822b4a066b353770c3c6d69a2a188e880"
+eslint-visitor-keys@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/eslint-visitor-keys/-/eslint-visitor-keys-1.0.0.tgz#3f3180fb2e291017716acb4c9d6d5b5c34a6a81d"
+
+eslint@^4.16.0:
+  version "4.16.0"
+  resolved "https://registry.yarnpkg.com/eslint/-/eslint-4.16.0.tgz#934ada9e98715e1d7bbfd6f6f0519ed2fab35cc1"
   dependencies:
     ajv "^5.3.0"
     babel-code-frame "^6.22.0"
     chalk "^2.1.0"
     concat-stream "^1.6.0"
     cross-spawn "^5.1.0"
-    debug "^3.0.1"
-    doctrine "^2.0.2"
+    debug "^3.1.0"
+    doctrine "^2.1.0"
     eslint-scope "^3.7.1"
+    eslint-visitor-keys "^1.0.0"
     espree "^3.5.2"
     esquery "^1.0.0"
-    estraverse "^4.2.0"
     esutils "^2.0.2"
     file-entry-cache "^2.0.0"
     functional-red-black-tree "^1.0.1"
@@ -1478,7 +1528,7 @@ is-utf8@^0.2.0:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/is-utf8/-/is-utf8-0.2.1.tgz#4b0da1442104d1b336340e80797e865cf39f7d72"
 
-isarray@1.0.0, isarray@~1.0.0:
+isarray@1.0.0, isarray@^1.0.0, isarray@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/isarray/-/isarray-1.0.0.tgz#bb935d48582cba168c06834957a54a3e07124f11"
 
@@ -1938,6 +1988,10 @@ locate-path@^2.0.0:
     p-locate "^2.0.0"
     path-exists "^3.0.0"
 
+lodash.cond@^4.3.0:
+  version "4.5.2"
+  resolved "https://registry.yarnpkg.com/lodash.cond/-/lodash.cond-4.5.2.tgz#f471a1da486be60f6ab955d17115523dd1d255d5"
+
 lodash@^4.14.0, lodash@^4.17.4, lodash@^4.3.0:
   version "4.17.4"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.4.tgz#78203a4d1c328ae1d86dca6460e369b57f4055ae"
@@ -2344,6 +2398,12 @@ pinkie@^2.0.0:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/pinkie/-/pinkie-2.0.4.tgz#72556b80cfa0d48a974e80e77248e80ed4f7f870"
 
+pkg-dir@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/pkg-dir/-/pkg-dir-1.0.0.tgz#7a4b508a8d5bb2d629d447056ff4e9c9314cf3d4"
+  dependencies:
+    find-up "^1.0.0"
+
 pluralize@^7.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/pluralize/-/pluralize-7.0.0.tgz#298b89df8b93b0221dbf421ad2b1b1ea23fc6777"
@@ -2362,9 +2422,9 @@ prettier-check@^2.0.0:
   dependencies:
     execa "^0.6.0"
 
-prettier@^1.9.0:
-  version "1.9.0"
-  resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.9.0.tgz#1a7205bdb6126b30cf8c0a7b2b86997162e1ee3e"
+prettier@^1.10.2:
+  version "1.10.2"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.10.2.tgz#1af8356d1842276a99a5b5529c82dd9e9ad3cc93"
 
 pretty-format@^21.2.1:
   version "21.2.1"
@@ -2585,6 +2645,12 @@ resolve-from@^1.0.0:
 resolve@1.1.7:
   version "1.1.7"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.1.7.tgz#203114d82ad2c5ed9e8e0411b3932875e889e97b"
+
+resolve@^1.5.0:
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.5.0.tgz#1f09acce796c9a762579f31b2c1cc4c3cddf9f36"
+  dependencies:
+    path-parse "^1.0.5"
 
 restore-cursor@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
Since we dropped support for Node 0.12 recently, we can now use a considerable subset of the ES6 spec. This PR updates the linter and formatter and applies the new style to all files.

Most of the changeset was generated automatically. See comments below for exceptions.