### PR TITLE
docs(js): Add JSDoc comments to all methods

### DIFF
--- a/js/helper.js
+++ b/js/helper.js
@@ -4,42 +4,86 @@ const os = require('os');
 const path = require('path');
 const childProcess = require('child_process');
 
+/**
+ * Absolute path to the sentry-cli binary (platform dependant).
+ * @type {string}
+ */
 const binaryPath =
   os.platform() === 'win32'
     ? path.resolve(__dirname, '..\\bin\\sentry-cli.exe')
     : path.resolve(__dirname, '../sentry-cli');
 
+/**
+ * Converts the given option into a command line args array.
+ *
+ * The value can either be an array of values or a single value. The value(s) will be
+ * converted to string. If an array is given, the option name is repeated for each value.
+ *
+ * @example
+ * expect(transformOption('--foo', 'a'))
+ *   .toEqual(['--foo', 'a'])
+ *
+ * @example
+ * expect(transformOption('--foo', ['a', 'b']))
+ *   .toEqual(['--foo', 'a', '--foo', 'b']);
+ *
+ * @param {string} option The literal name of the option, including dashes.
+ * @param {any[]|any} values One or more values for this option.
+ * @returns {string[]} An arguments array that can be passed via command line.
+ */
 function transformOption(option, values) {
   if (Array.isArray(values)) {
-    return values.reduce((acc, value) => acc.concat([option.param, value]), []);
+    return values.reduce((acc, value) => acc.concat([option.param, String(value)]), []);
   }
 
-  return [option.param, values];
+  return [option.param, String(values)];
 }
 
-function normalizeOptions(commandOptions, options) {
-  return Object.keys(commandOptions).reduce((newOptions, sourceMapOption) => {
-    const paramValue = options[sourceMapOption];
+/**
+ * The javascript type of a command line option.
+ * @typedef {'array'|'string'|'boolean'|'inverted-boolean'} OptionType
+ */
+
+/**
+ * Schema definition of a command line option.
+ * @typedef {object} OptionSchema
+ * @prop {string} param The flag of the command line option including dashes.
+ * @prop {OptionType} type The value type of the command line option.
+ */
+
+/**
+ * Schema definition for a command.
+ * @typedef {Object.<string, OptionSchema>} OptionsSchema
+ */
+
+/**
+ * Serializes command line options into an arguments array.
+ *
+ * @param {OptionsSchema} schema An options schema required by the command.
+ * @param {object} options An options object according to the schema.
+ * @returns {string[]} An arguments array that can be passed via command line.
+ */
+function serializeOptions(schema, options) {
+  return Object.keys(schema).reduce((newOptions, option) => {
+    const paramValue = options[option];
     if (paramValue === undefined) {
       return newOptions;
     }
 
-    const paramType = commandOptions[sourceMapOption].type;
-    const paramName = commandOptions[sourceMapOption].param;
+    const paramType = schema[option].type;
+    const paramName = schema[option].param;
 
     if (paramType === 'array') {
       if (!Array.isArray(paramValue)) {
-        throw new Error(`${sourceMapOption} should be an array`);
+        throw new Error(`${option} should be an array`);
       }
 
-      return newOptions.concat(
-        transformOption(commandOptions[sourceMapOption], paramValue)
-      );
+      return newOptions.concat(transformOption(schema[option], paramValue));
     }
 
     if (paramType === 'boolean' || paramType === 'inverted-boolean') {
       if (typeof paramValue !== 'boolean') {
-        throw new Error(`${sourceMapOption} should be a bool`);
+        throw new Error(`${option} should be a bool`);
       }
 
       if (paramType === 'boolean' && paramValue) {
@@ -57,10 +101,22 @@ function normalizeOptions(commandOptions, options) {
   }, []);
 }
 
-function prepareCommand(command, commandOptions, options) {
-  return command.concat(normalizeOptions(commandOptions || {}, options || {}));
+/**
+ * Serializes the command and its options into an arguments array.
+ *
+ * @param {string} command The literal name of the command.
+ * @param {OptionsSchema} [schema] An options schema required by the command.
+ * @param {object} [options] An options object according to the schema.
+ * @returns {string[]} An arguments array that can be passed via command line.
+ */
+function prepareCommand(command, schema, options) {
+  return command.concat(serializeOptions(schema || {}, options || {}));
 }
 
+/**
+ * Returns the absolute path to the `sentry-cli` binary.
+ * @returns {string}
+ */
 function getPath() {
   if (process.env.NODE_ENV === 'test') {
     return path.resolve(__dirname, '__mocks__/sentry-cli');
@@ -69,6 +125,26 @@ function getPath() {
   return binaryPath;
 }
 
+/**
+ * Runs `sentry-cli` with the given command line arguments.
+ *
+ * Use {@link prepareCommand} to specify the command and add arguments for command-
+ * specific options. For top-level options, use {@link serializeOptions} directly.
+ *
+ * The returned promise resolves with the standard output of the command invocation
+ * including all newlines. In order to parse this output, be sure to trim the output
+ * first.
+ *
+ * If the command failed to execute, the Promise rejects with the error returned by the
+ * CLI. This error includes a `code` property with the process exit status.
+ *
+ * @example
+ * const output = await execute(['--version']);
+ * expect(output.trim()).toBe('sentry-cli x.y.z');
+ *
+ * @param {string[]} args Command line arguments passed to `sentry-cli`.
+ * @returns {Promise.<string>} A promise that resolves to the standard output.
+ */
 function execute(args) {
   const env = Object.assign({}, process.env);
   return new Promise((resolve, reject) => {
@@ -83,7 +159,7 @@ function execute(args) {
 }
 
 module.exports = {
-  normalizeOptions,
+  serializeOptions,
   prepareCommand,
   getPath,
   execute,

--- a/js/index.js
+++ b/js/index.js
@@ -3,17 +3,48 @@
 const pkgInfo = require('../package.json');
 const helper = require('./helper');
 
+/**
+ * Interface to and wrapper around the `sentry-cli` executable.
+ *
+ * Commands are grouped into namespaces. See the respective namespaces for more
+ * documentation. To use this wrapper, simply create an instance and call methods:
+ *
+ * @example
+ * const cli = new SentryCli();
+ * console.log(cli.getVersion());
+ *
+ * @example
+ * const cli = new SentryCli('path/to/custom/sentry.properties');
+ * console.log(cli.getVersion());
+ */
 class SentryCli {
+  /**
+   * Creates a new `SentryCli` instance.
+   *
+   * If the `configFile` parameter is specified, configuration located in the default
+   * location and the value specified in the `SENTRY_PROPERTIES` environment variable is
+   * overridden.
+   *
+   * @param {string} [configFile] Relative or absolute path to the configuration file.
+   */
   constructor(configFile) {
     if (typeof configFile === 'string') {
       process.env.SENTRY_PROPERTIES = configFile;
     }
   }
 
+  /**
+   * Returns the version of the installed `sentry-cli` binary.
+   * @returns {string}
+   */
   static getVersion() {
     return pkgInfo.version;
   }
 
+  /**
+   * Returns an absolute path to the `sentry-cli` binary.
+   * @returns {string}
+   */
   static getPath() {
     return helper.getPath();
   }

--- a/js/releases/index.js
+++ b/js/releases/index.js
@@ -53,7 +53,9 @@ module.exports = {
    * @memberof SentryReleases
    */
   proposeVersion() {
-    return helper.execute(['releases', 'propose-version']);
+    return helper
+      .execute(['releases', 'propose-version'])
+      .then(version => version && version.trim());
   },
 
   /**

--- a/js/releases/index.js
+++ b/js/releases/index.js
@@ -2,38 +2,105 @@
 
 const helper = require('../helper');
 
+/**
+ * Default arguments for the `--ignore` option.
+ * @type {string[]}
+ */
 const DEFAULT_IGNORE = ['node_modules'];
-const SOURCEMAPS_OPTIONS = require('./options/uploadSourcemaps');
 
+/**
+ * Schema for the `upload-sourcemaps` command.
+ * @type {OptionsSchema}
+ */
+const SOURCEMAPS_SCHEMA = require('./options/uploadSourcemaps');
+
+/**
+ * Manages releases and release artifacts on Sentry.
+ * @namespace SentryReleases
+ */
 module.exports = {
+  /**
+   * Registers a new release with sentry.
+   *
+   * The given release name should be unique and deterministic. It can later be used to
+   * upload artifacts, such as source maps.
+   *
+   * @param {string} release Unique name of the new release.
+   * @returns {Promise} A promise that resolves when the release has been created.
+   * @memberof SentryReleases
+   */
   new(release) {
     return helper.execute(['releases', 'new', release]);
   },
 
+  /**
+   * Marks this release as complete. This should be called once all artifacts has been
+   * uploaded.
+   *
+   * @param {string} release Unique name of the release.
+   * @returns {Promise} A promise that resolves when the release has been finalized.
+   * @memberof SentryReleases
+   */
   finalize(release) {
     return helper.execute(['releases', 'finalize', release]);
   },
 
+  /**
+   * Creates a unique, deterministic version identifier based on the project type and
+   * source files. This identifier can be used as release name.
+   *
+   * @returns {Promise.<string>} A promise that resolves to the version string.
+   * @memberof SentryReleases
+   */
   proposeVersion() {
     return helper.execute(['releases', 'propose-version']);
   },
 
+  /**
+   * Scans the given include folders for JavaScript source maps and uploads them to the
+   * specified release for processing.
+   *
+   * The options require an `include` array, which is a list of directories to scan.
+   * Additionally, it supports to ignore certain files, validate and preprocess source
+   * maps and define a URL prefix.
+   *
+   * @example
+   * await cli.releases.uploadSourceMaps(cli.releases.proposeVersion(), {
+   *   // required options:
+   *   include: ['build'],
+   *
+   *   // default options:
+   *   ignore: ['node_modules'],  // globs for files to ignore
+   *   ignoreFile: null,          // path to a file with ignore rules
+   *   rewrite: false,            // preprocess sourcemaps before uploading
+   *   sourceMapReference: true,  // add a source map reference to source files
+   *   stripPrefix: [],           // remove certain prefices from filenames
+   *   stripCommonPrefix: false,  // guess common prefices to remove from filenames
+   *   validate: false,           // validate source maps and cancel the upload on error
+   *   urlPrefix: '',             // add a prefix source map urls after stripping them
+   *   ext: ['js', 'map', 'jsbundle', 'bundle'],  // override file extensions to scan for
+   * });
+   *
+   * @param {string} release Unique name of the release.
+   * @param {object} options Options to configure the source map upload.
+   * @returns {Promise} A promise that resolves when the upload has completed successfully.
+   * @memberof SentryReleases
+   */
   uploadSourceMaps(release, options) {
     if (!options || !options.include) {
       throw new Error('options.include must be a vaild path(s)');
     }
 
-    return Promise.all(
-      options.include.map(sourcemapPath => {
-        const args = ['releases', 'files', release, 'upload-sourcemaps', sourcemapPath];
-        const newOptions = Object.assign({}, options);
+    const uploads = options.include.map(sourcemapPath => {
+      const newOptions = Object.assign({}, options);
+      if (!newOptions.ignoreFile && !newOptions.ignore) {
+        newOptions.ignore = DEFAULT_IGNORE;
+      }
 
-        if (!newOptions.ignoreFile && !newOptions.ignore) {
-          newOptions.ignore = DEFAULT_IGNORE;
-        }
+      const args = ['releases', 'files', release, 'upload-sourcemaps', sourcemapPath];
+      return helper.execute(helper.prepareCommand(args, SOURCEMAPS_SCHEMA, options));
+    });
 
-        return helper.execute(helper.prepareCommand(args, SOURCEMAPS_OPTIONS, options));
-      })
-    );
+    return Promise.all(uploads);
   },
 };

--- a/js/releases/options/uploadSourcemaps.js
+++ b/js/releases/options/uploadSourcemaps.js
@@ -21,7 +21,7 @@ module.exports = {
   },
   stripCommonPrefix: {
     param: '--strip-common-prefix',
-    type: 'array',
+    type: 'boolean',
   },
   validate: {
     param: '--validate',
@@ -33,6 +33,6 @@ module.exports = {
   },
   ext: {
     param: '--ext',
-    type: 'string',
+    type: 'array',
   },
 };


### PR DESCRIPTION
Adds JSDoc comments everywhere. Also renames some internal functions and variables.

I tried to make types as strict as possible everywhere, but was too lazy to type out the options for `releases.uploadSourceMaps`. Please let me know, if you'd prefer a `@typedef` instead.

Also note the comments below.