### PR TITLE
fix(npm): Fix install location on Windows

### DIFF
--- a/scripts/install.js
+++ b/scripts/install.js
@@ -70,7 +70,7 @@ function downloadBinary() {
   const platform = os.platform();
   const outputPath = path.resolve(
     __dirname,
-    platform === 'win32' ? 'sentry-cli.exe' : '../sentry-cli'
+    platform === 'win32' ? '../bin/sentry-cli.exe' : '../sentry-cli'
   );
 
   if (fs.existsSync(outputPath)) {


### PR DESCRIPTION
Compensates the script was moved from `bin/` to `scripts/`. Therefore, the path of `sentry-cli.exe` has to go back to the `bin/` directory.

Fixes #238 