### PR TITLE
ref: Streamline utils and DIFs

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -3,7 +3,6 @@ use std::fs::File;
 use std::io::Write;
 use std::path::Path;
 
-
 fn main() {
     let out_dir = env::var("OUT_DIR").unwrap();
     let dest_path = Path::new(&out_dir).join("constants.gen.rs");

--- a/src/api.rs
+++ b/src/api.rs
@@ -644,7 +644,7 @@ impl Api {
     }
 
     /// Uploads a dsym file from the given path.
-    pub fn upload_dsyms(&self, org: &str, project: &str, file: &Path) -> ApiResult<Vec<DSymFile>> {
+    pub fn upload_dsyms(&self, org: &str, project: &str, file: &Path) -> ApiResult<Vec<DebugInfoFile>> {
         let path = format!(
             "/projects/{}/{}/files/dsyms/",
             PathArg(org),
@@ -1388,9 +1388,10 @@ struct EventInfo {
     id: String,
 }
 
-/// Structure of DSym files.
+/// Debug information files as processed and stored on the server.
+/// Can be dSYMs, ELF debug infos, Breakpad symbols, etc...
 #[derive(Debug, Deserialize)]
-pub struct DSymFile {
+pub struct DebugInfoFile {
     pub uuid: String,
     #[serde(rename = "objectName")]
     pub object_name: String,
@@ -1400,7 +1401,7 @@ pub struct DSymFile {
     pub checksum: String,
 }
 
-impl DSymFile {
+impl DebugInfoFile {
     pub fn uuid(&self) -> Uuid {
         Uuid::parse_str(&self.uuid).unwrap()
     }
@@ -1470,7 +1471,7 @@ impl IssueFilter {
 #[derive(Deserialize)]
 pub struct AssociateDsymsResponse {
     #[serde(rename = "associatedDsymFiles")]
-    pub associated_dsyms: Vec<DSymFile>,
+    pub associated_dsyms: Vec<DebugInfoFile>,
 }
 
 #[derive(Deserialize, Debug)]
@@ -1578,7 +1579,7 @@ pub struct ChunkedDifResponse {
     #[serde(rename = "error")]
     pub error: Option<String>,
     #[serde(rename = "dif")]
-    pub dif: Option<DSymFile>,
+    pub dif: Option<DebugInfoFile>,
 }
 
 pub type AssembleDifsRequest<'a> = HashMap<Digest, ChunkedDifRequest<'a>>;

--- a/src/api.rs
+++ b/src/api.rs
@@ -28,11 +28,13 @@ use regex::{Captures, Regex};
 use sha1::Digest;
 use uuid::Uuid;
 
-use utils;
-use utils::xcode::InfoPlist;
-use event::Event;
 use config::{Auth, Config, Dsn};
 use constants::{ARCH, EXT, PLATFORM, VERSION};
+use event::Event;
+use utils::android::AndroidManifest;
+use utils::sourcemaps::get_sourcemap_reference_from_headers;
+use utils::ui::{capitalize_string, make_byte_progress_bar};
+use utils::xcode::InfoPlist;
 
 /// Wrapper that escapes arguments for URL path segments.
 pub struct PathArg<A: fmt::Display>(A);
@@ -589,12 +591,7 @@ impl Api {
     /// Finds the latest release for sentry-cli on GitHub.
     pub fn get_latest_sentrycli_release(&self) -> ApiResult<Option<SentryCliRelease>> {
         let resp = self.get("https://api.github.com/repos/getsentry/sentry-cli/releases/latest")?;
-        let ref_name = format!(
-            "sentry-cli-{}-{}{}",
-            utils::capitalize_string(PLATFORM),
-            ARCH,
-            EXT
-        );
+        let ref_name = format!("sentry-cli-{}-{}{}", capitalize_string(PLATFORM), ARCH, EXT);
         info!("Looking for file named: {}", ref_name);
 
         if resp.status() == 404 {
@@ -644,7 +641,12 @@ impl Api {
     }
 
     /// Uploads a dsym file from the given path.
-    pub fn upload_dsyms(&self, org: &str, project: &str, file: &Path) -> ApiResult<Vec<DebugInfoFile>> {
+    pub fn upload_dsyms(
+        &self,
+        org: &str,
+        project: &str,
+        file: &Path,
+    ) -> ApiResult<Vec<DebugInfoFile>> {
         let path = format!(
             "/projects/{}/{}/files/dsyms/",
             PathArg(org),
@@ -758,7 +760,7 @@ impl Api {
         &self,
         org: &str,
         project: &str,
-        manifest: &utils::AndroidManifest,
+        manifest: &AndroidManifest,
         checksums: Vec<String>,
     ) -> ApiResult<Option<AssociateDsymsResponse>> {
         self.associate_dsyms(
@@ -905,7 +907,7 @@ fn handle_req<W: Write>(
                 if up_len > 0 && progress_bar_mode.request() {
                     if up_pos < up_len {
                         if pb.is_none() {
-                            *pb = Some(utils::make_byte_progress_bar(up_len));
+                            *pb = Some(make_byte_progress_bar(up_len));
                         }
                         pb.as_ref().unwrap().set_position(up_pos);
                     } else if pb.is_some() {
@@ -915,7 +917,7 @@ fn handle_req<W: Write>(
                 if down_len > 0 && progress_bar_mode.response() {
                     if down_pos < down_len {
                         if pb.is_none() {
-                            *pb = Some(utils::make_byte_progress_bar(down_len));
+                            *pb = Some(make_byte_progress_bar(down_len));
                         }
                         pb.as_ref().unwrap().set_position(down_pos);
                     } else if pb.is_some() {
@@ -1307,7 +1309,7 @@ impl Artifact {
     }
 
     pub fn get_sourcemap_reference(&self) -> Option<&str> {
-        utils::get_sourcemap_reference_from_headers(self.headers.iter())
+        get_sourcemap_reference_from_headers(self.headers.iter())
     }
 }
 

--- a/src/api.rs
+++ b/src/api.rs
@@ -612,9 +612,9 @@ impl Api {
         }
     }
 
-    /// Given a list of checksums for Dsym files this returns a list of those
+    /// Given a list of checksums for DIFs, this returns a list of those
     /// that do not exist for the project yet.
-    pub fn find_missing_dsym_checksums<I>(
+    pub fn find_missing_dif_checksums<I>(
         &self,
         org: &str,
         project: &str,
@@ -640,8 +640,8 @@ impl Api {
         Ok(state.missing)
     }
 
-    /// Uploads a dsym file from the given path.
-    pub fn upload_dsyms(
+    /// Uploads a ZIP archive containing DIFs from the given path.
+    pub fn upload_dif_archive(
         &self,
         org: &str,
         project: &str,

--- a/src/commands/bash_hook.rs
+++ b/src/commands/bash_hook.rs
@@ -10,10 +10,10 @@ use clap::{App, Arg, ArgMatches};
 use uuid::{Uuid, UuidVersion};
 use regex::Regex;
 
-use prelude::*;
+use api::Api;
 use config::Config;
 use event::{Event, Exception, SingleException, Frame, Stacktrace};
-use api::Api;
+use prelude::*;
 
 const BASH_SCRIPT: &'static str = include_str!("../bashsupport.sh");
 lazy_static! {

--- a/src/commands/bash_hook.rs
+++ b/src/commands/bash_hook.rs
@@ -12,8 +12,8 @@ use regex::Regex;
 
 use api::Api;
 use config::Config;
+use errors::Result;
 use event::{Event, Exception, SingleException, Frame, Stacktrace};
-use prelude::*;
 
 const BASH_SCRIPT: &'static str = include_str!("../bashsupport.sh");
 lazy_static! {

--- a/src/commands/difutil.rs
+++ b/src/commands/difutil.rs
@@ -1,7 +1,7 @@
 use clap::{App, ArgMatches, AppSettings};
 
 use commands;
-use prelude::*;
+use errors::Result;
 
 macro_rules! each_subcommand {
     ($mac:ident) => {

--- a/src/commands/difutil.rs
+++ b/src/commands/difutil.rs
@@ -1,8 +1,7 @@
 use clap::{App, ArgMatches, AppSettings};
 
-use prelude::*;
-
 use commands;
+use prelude::*;
 
 macro_rules! each_subcommand {
     ($mac:ident) => {

--- a/src/commands/difutil_check.rs
+++ b/src/commands/difutil_check.rs
@@ -6,7 +6,7 @@ use console::style;
 use serde_json;
 
 use prelude::*;
-use utils::dif;
+use utils::dif::DifFile;
 
 pub fn make_app<'a, 'b: 'a>(app: App<'a, 'b>) -> App<'a, 'b> {
     app
@@ -32,7 +32,7 @@ pub fn execute<'a>(matches: &ArgMatches<'a>) -> Result<()> {
 
     // which types should we consider?
     let ty = matches.value_of("type").map(|t| t.parse().unwrap());
-    let f = dif::DifFile::open_path(path, ty)?;
+    let f = DifFile::open_path(path, ty)?;
 
     if matches.is_present("json") {
         serde_json::to_writer_pretty(&mut io::stdout(), &f)?;

--- a/src/commands/difutil_check.rs
+++ b/src/commands/difutil_check.rs
@@ -5,7 +5,7 @@ use clap::{App, Arg, ArgMatches};
 use console::style;
 use serde_json;
 
-use prelude::*;
+use errors::{ErrorKind, Result};
 use utils::dif::DifFile;
 
 pub fn make_app<'a, 'b: 'a>(app: App<'a, 'b>) -> App<'a, 'b> {

--- a/src/commands/difutil_find.rs
+++ b/src/commands/difutil_find.rs
@@ -14,7 +14,7 @@ use symbolic_common::ByteView;
 use symbolic_proguard::ProguardMappingView;
 
 use prelude::*;
-use utils::{validate_uuid};
+use utils::args::validate_uuid;
 use utils::dif::{DifType, DifFile};
 
 // text files larger than 32 megabytes are not considered to be

--- a/src/commands/difutil_find.rs
+++ b/src/commands/difutil_find.rs
@@ -13,7 +13,7 @@ use serde_json;
 use symbolic_common::ByteView;
 use symbolic_proguard::ProguardMappingView;
 
-use prelude::*;
+use errors::{ErrorKind, Result};
 use utils::args::validate_uuid;
 use utils::dif::{DifType, DifFile};
 

--- a/src/commands/difutil_uuid.rs
+++ b/src/commands/difutil_uuid.rs
@@ -5,7 +5,7 @@ use clap::{App, Arg, ArgMatches};
 use serde_json;
 
 use prelude::*;
-use utils::dif;
+use utils::dif::DifFile;
 
 pub fn make_app<'a, 'b: 'a>(app: App<'a, 'b>) -> App<'a, 'b> {
     app
@@ -31,7 +31,7 @@ pub fn execute<'a>(matches: &ArgMatches<'a>) -> Result<()> {
 
     // which types should we consider?
     let ty = matches.value_of("type").map(|t| t.parse().unwrap());
-    let f = dif::DifFile::open_path(path, ty)?;
+    let f = DifFile::open_path(path, ty)?;
 
     if !f.is_usable() {
         println_stderr!("error: debug info file is not usable: {}",

--- a/src/commands/difutil_uuid.rs
+++ b/src/commands/difutil_uuid.rs
@@ -4,7 +4,7 @@ use std::path::Path;
 use clap::{App, Arg, ArgMatches};
 use serde_json;
 
-use prelude::*;
+use errors::{ErrorKind, Result};
 use utils::dif::DifFile;
 
 pub fn make_app<'a, 'b: 'a>(app: App<'a, 'b>) -> App<'a, 'b> {

--- a/src/commands/info.rs
+++ b/src/commands/info.rs
@@ -7,7 +7,7 @@ use serde_json;
 
 use api::Api;
 use config::{Auth, Config};
-use prelude::*;
+use errors::{ErrorKind, Result};
 
 #[derive(Serialize, Default)]
 pub struct AuthStatus {

--- a/src/commands/info.rs
+++ b/src/commands/info.rs
@@ -5,9 +5,9 @@ use std::collections::HashMap;
 use clap::{App, Arg, ArgMatches};
 use serde_json;
 
-use prelude::*;
 use api::Api;
 use config::{Auth, Config};
+use prelude::*;
 
 #[derive(Serialize, Default)]
 pub struct AuthStatus {

--- a/src/commands/issues.rs
+++ b/src/commands/issues.rs
@@ -3,7 +3,7 @@ use clap::{App, AppSettings, Arg, ArgMatches};
 
 use api::{Api, IssueFilter, IssueChanges};
 use config::Config;
-use prelude::*;
+use errors::{Result, ResultExt};
 use utils::args::ArgExt;
 
 pub fn make_app<'a, 'b: 'a>(app: App<'a, 'b>) -> App<'a, 'b> {

--- a/src/commands/issues.rs
+++ b/src/commands/issues.rs
@@ -1,11 +1,10 @@
 //! Implements a command for issue management.
 use clap::{App, AppSettings, Arg, ArgMatches};
 
-use prelude::*;
 use api::{Api, IssueFilter, IssueChanges};
 use config::Config;
-use utils::ArgExt;
-
+use prelude::*;
+use utils::args::ArgExt;
 
 pub fn make_app<'a, 'b: 'a>(app: App<'a, 'b>) -> App<'a, 'b> {
     app.about("Manage issues in Sentry.")

--- a/src/commands/login.rs
+++ b/src/commands/login.rs
@@ -5,7 +5,7 @@ use url::Url;
 
 use api::Api;
 use config::{Config, Auth};
-use prelude::*;
+use errors::Result;
 use utils::ui::{prompt, prompt_to_continue};
 
 pub fn make_app<'a, 'b: 'a>(app: App<'a, 'b>) -> App<'a, 'b> {

--- a/src/commands/login.rs
+++ b/src/commands/login.rs
@@ -3,10 +3,10 @@ use clap::{App, ArgMatches};
 use open;
 use url::Url;
 
-use prelude::*;
-use config::{Config, Auth};
-use utils::{prompt, prompt_to_continue};
 use api::Api;
+use config::{Config, Auth};
+use prelude::*;
+use utils::ui::{prompt, prompt_to_continue};
 
 pub fn make_app<'a, 'b: 'a>(app: App<'a, 'b>) -> App<'a, 'b> {
     app.about("Authenticate with the Sentry server.")

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -5,10 +5,11 @@ use std::process;
 
 use clap::{Arg, App, AppSettings};
 
-use prelude::*;
+use config::{prepare_environment, Auth, Config};
 use constants::VERSION;
-use utils::{print_error, run_sentrycli_update_nagger};
-use config::{Config, Auth, prepare_environment};
+use prelude::*;
+use utils::system::print_error;
+use utils::update::run_sentrycli_update_nagger;
 
 const ABOUT: &'static str = "
 Command line utility for Sentry.
@@ -16,7 +17,6 @@ Command line utility for Sentry.
 This tool helps you managing remote resources on a Sentry server like
 sourcemaps, debug symbols or releases.  Use `--help` on the subcommands
 to learn more about them.";
-
 
 macro_rules! each_subcommand {
     ($mac:ident) => {

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -7,7 +7,7 @@ use clap::{Arg, App, AppSettings};
 
 use config::{prepare_environment, Auth, Config};
 use constants::VERSION;
-use prelude::*;
+use errors::{ErrorKind, Result};
 use utils::system::print_error;
 use utils::update::run_sentrycli_update_nagger;
 

--- a/src/commands/projects.rs
+++ b/src/commands/projects.rs
@@ -1,11 +1,11 @@
 //! Implements a command for managing projects.
 use clap::{App, AppSettings, ArgMatches};
 
-use prelude::*;
-use config::Config;
-use utils::{ArgExt, Table};
 use api::Api;
-
+use config::Config;
+use prelude::*;
+use utils::args::ArgExt;
+use utils::formatting::Table;
 
 pub fn make_app<'a, 'b: 'a>(app: App<'a, 'b>) -> App<'a, 'b> {
     app.about("Manage projects on Sentry.")

--- a/src/commands/projects.rs
+++ b/src/commands/projects.rs
@@ -3,7 +3,7 @@ use clap::{App, AppSettings, ArgMatches};
 
 use api::Api;
 use config::Config;
-use prelude::*;
+use errors::Result;
 use utils::args::ArgExt;
 use utils::formatting::Table;
 

--- a/src/commands/react_native.rs
+++ b/src/commands/react_native.rs
@@ -1,7 +1,7 @@
 use clap::{App, ArgMatches, AppSettings};
 
 use commands;
-use prelude::*;
+use errors::Result;
 
 macro_rules! each_subcommand {
     ($mac:ident) => {

--- a/src/commands/react_native.rs
+++ b/src/commands/react_native.rs
@@ -1,8 +1,7 @@
 use clap::{App, ArgMatches, AppSettings};
 
-use prelude::*;
-
 use commands;
+use prelude::*;
 
 macro_rules! each_subcommand {
     ($mac:ident) => {

--- a/src/commands/react_native_codepush.rs
+++ b/src/commands/react_native_codepush.rs
@@ -5,11 +5,12 @@ use std::ffi::OsStr;
 use clap::{App, Arg, ArgMatches};
 use console::style;
 
-use prelude::*;
 use api::{Api, NewRelease};
 use config::Config;
-use utils::{ArgExt, SourceMapProcessor, get_codepush_package,
-            get_react_native_codepush_release};
+use prelude::*;
+use utils::args::ArgExt;
+use utils::codepush::{get_codepush_package, get_react_native_codepush_release};
+use utils::sourcemaps::SourceMapProcessor;
 
 pub fn make_app<'a, 'b: 'a>(app: App<'a, 'b>) -> App<'a, 'b> {
     app.about("Upload react-native projects for CodePush.")

--- a/src/commands/react_native_codepush.rs
+++ b/src/commands/react_native_codepush.rs
@@ -7,7 +7,7 @@ use console::style;
 
 use api::{Api, NewRelease};
 use config::Config;
-use prelude::*;
+use errors::Result;
 use utils::args::ArgExt;
 use utils::codepush::{get_codepush_package, get_react_native_codepush_release};
 use utils::sourcemaps::SourceMapProcessor;

--- a/src/commands/react_native_gradle.rs
+++ b/src/commands/react_native_gradle.rs
@@ -3,11 +3,11 @@ use std::path::PathBuf;
 
 use clap::{App, Arg, ArgMatches};
 
-use prelude::*;
-use config::Config;
-use utils::{ArgExt, SourceMapProcessor};
 use api::{Api, NewRelease};
-
+use config::Config;
+use prelude::*;
+use utils::args::ArgExt;
+use utils::sourcemaps::SourceMapProcessor;
 
 pub fn make_app<'a, 'b: 'a>(app: App<'a, 'b>) -> App<'a, 'b> {
     app.about("Upload react-native projects in a gradle build step.")

--- a/src/commands/react_native_gradle.rs
+++ b/src/commands/react_native_gradle.rs
@@ -5,7 +5,7 @@ use clap::{App, Arg, ArgMatches};
 
 use api::{Api, NewRelease};
 use config::Config;
-use prelude::*;
+use errors::Result;
 use utils::args::ArgExt;
 use utils::sourcemaps::SourceMapProcessor;
 

--- a/src/commands/react_native_xcode.rs
+++ b/src/commands/react_native_xcode.rs
@@ -8,10 +8,14 @@ use clap::{App, Arg, ArgMatches};
 use serde_json;
 use chrono::Duration;
 
-use prelude::*;
 use api::{Api, NewRelease};
 use config::Config;
-use utils::{ArgExt, TempFile, propagate_exit_status, SourceMapProcessor, xcode};
+use prelude::*;
+use utils::args::ArgExt;
+use utils::fs::TempFile;
+use utils::sourcemaps::SourceMapProcessor;
+use utils::system::propagate_exit_status;
+use utils::xcode::{InfoPlist, MayDetach};
 
 #[derive(Serialize, Deserialize, Default, Debug)]
 struct SourceMapReport {
@@ -116,7 +120,7 @@ pub fn execute<'a>(matches: &ArgMatches<'a>) -> Result<()> {
     }
 
     info!("Parsing Info.plist");
-    let plist = match xcode::InfoPlist::discover_from_env()? {
+    let plist = match InfoPlist::discover_from_env()? {
         Some(plist) => plist,
         None => { return Err("Could not find info.plist".into()); }
     };
@@ -125,7 +129,7 @@ pub fn execute<'a>(matches: &ArgMatches<'a>) -> Result<()> {
     let node = find_node();
     info!("Using node interpreter '{}'", &node);
 
-    xcode::MayDetach::wrap("React native symbol handling", |md| {
+    MayDetach::wrap("React native symbol handling", |md| {
         let bundle_path;
         let sourcemap_path;
         let bundle_url;

--- a/src/commands/react_native_xcode.rs
+++ b/src/commands/react_native_xcode.rs
@@ -10,7 +10,7 @@ use chrono::Duration;
 
 use api::{Api, NewRelease};
 use config::Config;
-use prelude::*;
+use errors::Result;
 use utils::args::ArgExt;
 use utils::fs::TempFile;
 use utils::sourcemaps::SourceMapProcessor;

--- a/src/commands/releases.rs
+++ b/src/commands/releases.rs
@@ -12,7 +12,7 @@ use regex::Regex;
 
 use api::{Api, Deploy, FileContents, NewRelease, UpdatedRelease};
 use config::Config;
-use prelude::*;
+use errors::{Error, ErrorKind, Result};
 use utils::args::{get_timestamp, validate_project, validate_seconds, validate_timestamp, ArgExt};
 use utils::formatting::{HumanDuration, Table};
 use utils::releases::detect_release_name;

--- a/src/commands/repos.rs
+++ b/src/commands/repos.rs
@@ -3,7 +3,7 @@ use clap::{App, AppSettings, ArgMatches};
 
 use api::Api;
 use config::Config;
-use prelude::*;
+use errors::Result;
 use utils::args::ArgExt;
 use utils::formatting::Table;
 

--- a/src/commands/repos.rs
+++ b/src/commands/repos.rs
@@ -1,11 +1,11 @@
 //! Implements a command for managing repos.
 use clap::{App, AppSettings, ArgMatches};
 
-use prelude::*;
-use config::Config;
-use utils::{ArgExt, Table};
 use api::Api;
-
+use config::Config;
+use prelude::*;
+use utils::args::ArgExt;
+use utils::formatting::Table;
 
 pub fn make_app<'a, 'b: 'a>(app: App<'a, 'b>) -> App<'a, 'b> {
     app.about("Manage repositories on Sentry.")

--- a/src/commands/send_event.rs
+++ b/src/commands/send_event.rs
@@ -5,8 +5,8 @@ use serde_json::Value;
 
 use api::Api;
 use config::Config;
+use errors::{ErrorKind, Result};
 use event::{Event, Message};
-use prelude::*;
 
 pub fn make_app<'a, 'b: 'a>(app: App<'a, 'b>) -> App<'a, 'b> {
     app.about("Send a manual event to Sentry.")

--- a/src/commands/send_event.rs
+++ b/src/commands/send_event.rs
@@ -3,10 +3,10 @@ use clap::{App, Arg, ArgMatches};
 use itertools::Itertools;
 use serde_json::Value;
 
-use prelude::*;
+use api::Api;
 use config::Config;
 use event::{Event, Message};
-use api::Api;
+use prelude::*;
 
 pub fn make_app<'a, 'b: 'a>(app: App<'a, 'b>) -> App<'a, 'b> {
     app.about("Send a manual event to Sentry.")

--- a/src/commands/uninstall.rs
+++ b/src/commands/uninstall.rs
@@ -6,7 +6,7 @@ use clap::{App, ArgMatches, AppSettings};
 use console::style;
 use runas;
 
-use prelude::*;
+use errors::{ErrorKind, Result};
 use utils::fs::is_writable;
 use utils::system::{is_homebrew_install, is_npm_install};
 use utils::ui::prompt_to_continue;

--- a/src/commands/uninstall.rs
+++ b/src/commands/uninstall.rs
@@ -1,11 +1,15 @@
 //! Implements a command for uninstalling `sentry-cli`
 use std::env;
+use std::fs;
 
 use clap::{App, ArgMatches, AppSettings};
 use console::style;
+use runas;
 
 use prelude::*;
-use utils::{is_homebrew_install, is_npm_install};
+use utils::fs::is_writable;
+use utils::system::{is_homebrew_install, is_npm_install};
+use utils::ui::prompt_to_continue;
 
 fn is_hidden() -> bool {
     cfg!(windows) || is_homebrew_install() || is_npm_install()
@@ -21,10 +25,6 @@ pub fn make_app<'a, 'b: 'a>(app: App<'a, 'b>) -> App<'a, 'b> {
 }
 
 pub fn execute<'a>(_matches: &ArgMatches<'a>) -> Result<()> {
-    use std::fs;
-    use runas;
-    use utils;
-
     let exe = env::current_exe()?;
 
     if is_homebrew_install() {
@@ -46,12 +46,12 @@ pub fn execute<'a>(_matches: &ArgMatches<'a>) -> Result<()> {
         return Err(ErrorKind::QuietExit(1).into());
     }
 
-    if !utils::prompt_to_continue("Do you really want to uninstall sentry-cli?")? {
+    if !prompt_to_continue("Do you really want to uninstall sentry-cli?")? {
         println!("Aborted!");
         return Ok(());
     }
 
-    if !utils::is_writable(&exe) {
+    if !is_writable(&exe) {
         println!("Need to sudo to uninstall {}", exe.display());
         runas::Command::new("rm").arg("-f")
             .arg(&exe)

--- a/src/commands/update.rs
+++ b/src/commands/update.rs
@@ -4,7 +4,7 @@ use std::env;
 use clap::{App, Arg, ArgMatches, AppSettings};
 
 use prelude::*;
-use utils::{get_latest_sentrycli_release, can_update_sentrycli};
+use utils::update::{get_latest_sentrycli_release, can_update_sentrycli};
 
 pub fn make_app<'a, 'b: 'a>(app: App<'a, 'b>) -> App<'a, 'b> {
     app.about("Update the sentry-cli executable.")

--- a/src/commands/update.rs
+++ b/src/commands/update.rs
@@ -3,7 +3,7 @@ use std::env;
 
 use clap::{App, Arg, ArgMatches, AppSettings};
 
-use prelude::*;
+use errors::Result;
 use utils::update::{get_latest_sentrycli_release, can_update_sentrycli};
 
 pub fn make_app<'a, 'b: 'a>(app: App<'a, 'b>) -> App<'a, 'b> {

--- a/src/commands/upload_breakpad.rs
+++ b/src/commands/upload_breakpad.rs
@@ -8,7 +8,7 @@ use uuid::Uuid;
 use api::Api;
 use config::Config;
 use errors::{ErrorKind, Result};
-use utils::{validate_uuid, ArgExt};
+use utils::args::{validate_uuid, ArgExt};
 use utils::dif_upload::DifUpload;
 
 pub fn make_app<'a, 'b: 'a>(app: App<'a, 'b>) -> App<'a, 'b> {

--- a/src/commands/upload_dbg.rs
+++ b/src/commands/upload_dbg.rs
@@ -8,7 +8,7 @@ use uuid::Uuid;
 use api::Api;
 use config::Config;
 use errors::{ErrorKind, Result};
-use utils::{validate_uuid, ArgExt};
+use utils::args::{validate_uuid, ArgExt};
 use utils::dif_upload::DifUpload;
 
 pub fn make_app<'a, 'b: 'a>(app: App<'a, 'b>) -> App<'a, 'b> {

--- a/src/commands/upload_dsym.rs
+++ b/src/commands/upload_dsym.rs
@@ -12,7 +12,7 @@ use uuid::Uuid;
 use api::Api;
 use config::Config;
 use errors::{ErrorKind, Result};
-use utils::{validate_uuid, ArgExt};
+use utils::args::{validate_uuid, ArgExt};
 use utils::dif_upload::DifUpload;
 use utils::xcode::{InfoPlist, MayDetach};
 

--- a/src/commands/upload_dsym.rs
+++ b/src/commands/upload_dsym.rs
@@ -1,4 +1,4 @@
-//! Implements a command for uploading dsym files.
+//! Implements a command for uploading dSYM files.
 use std::collections::BTreeSet;
 use std::env;
 use std::str;

--- a/src/commands/upload_proguard.rs
+++ b/src/commands/upload_proguard.rs
@@ -12,7 +12,7 @@ use zip;
 
 use api::{Api, AssociateDsyms};
 use config::Config;
-use prelude::*;
+use errors::{Error, ErrorKind, Result, ResultExt};
 use utils::android::{dump_proguard_uuids_as_properties, AndroidManifest};
 use utils::args::{validate_uuid, ArgExt};
 use utils::fs::{TempFile, get_sha1_checksum};

--- a/src/commands/upload_proguard.rs
+++ b/src/commands/upload_proguard.rs
@@ -188,7 +188,7 @@ pub fn execute<'a>(matches: &ArgMatches<'a>) -> Result<()> {
     println!("{} uploading mappings", style(">").dim());
     let config = Config::get_current();
     let (org, project) = config.get_org_and_project(matches)?;
-    let rv = api.upload_dsyms(&org, &project, tf.path())?;
+    let rv = api.upload_dif_archive(&org, &project, tf.path())?;
     println!("{} Uploaded a total of {} new mapping files",
              style(">").dim(), style(rv.len()).yellow());
     if rv.len() > 0 {

--- a/src/commands/upload_proguard.rs
+++ b/src/commands/upload_proguard.rs
@@ -3,19 +3,20 @@ use std::fs;
 use std::io;
 use std::path::PathBuf;
 
-use prelude::*;
-use utils::{ArgExt, TempFile, copy_with_progress, make_byte_progress_bar,
-            get_sha1_checksum, AndroidManifest, dump_proguard_uuids_as_properties,
-            validate_uuid};
-use config::Config;
-use api::{Api, AssociateDsyms};
-
 use clap::{App, Arg, ArgMatches};
 use console::style;
 use symbolic_common::ByteView;
 use symbolic_proguard::ProguardMappingView;
 use uuid::Uuid;
 use zip;
+
+use api::{Api, AssociateDsyms};
+use config::Config;
+use prelude::*;
+use utils::android::{dump_proguard_uuids_as_properties, AndroidManifest};
+use utils::args::{validate_uuid, ArgExt};
+use utils::fs::{TempFile, get_sha1_checksum};
+use utils::ui::{copy_with_progress, make_byte_progress_bar};
 
 #[derive(Debug)]
 struct MappingRef {

--- a/src/config.rs
+++ b/src/config.rs
@@ -14,9 +14,9 @@ use url::Url;
 use ini::Ini;
 use parking_lot::Mutex;
 
-use prelude::*;
 use constants::{DEFAULT_URL, VERSION, PROTOCOL_VERSION};
-use utils::Logger;
+use prelude::*;
+use utils::logging::Logger;
 
 static LOGGER: Logger = Logger;
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -358,8 +358,8 @@ impl Config {
             .unwrap_or(true))
     }
 
-    /// Returns the maximum dsym upload size
-    pub fn get_max_dsym_upload_size(&self) -> Result<u64> {
+    /// Returns the maximum DIF upload size
+    pub fn get_max_dif_archive_size(&self) -> Result<u64> {
         Ok(self.ini.get_from(Some("dsym"), "max_upload_size")
             .and_then(|x| x.parse().ok())
             .unwrap_or(35 * 1024 * 1024))

--- a/src/config.rs
+++ b/src/config.rs
@@ -15,7 +15,7 @@ use ini::Ini;
 use parking_lot::Mutex;
 
 use constants::{DEFAULT_URL, VERSION, PROTOCOL_VERSION};
-use prelude::*;
+use errors::{Error, Result, ResultExt};
 use utils::logging::Logger;
 
 static LOGGER: Logger = Logger;

--- a/src/event.rs
+++ b/src/event.rs
@@ -15,7 +15,7 @@ use anylog::LogEntry;
 use regex::Regex;
 
 use constants::{ARCH, PLATFORM};
-use prelude::*;
+use errors::{Result, ResultExt};
 use utils::releases::detect_release_name;
 use utils::system::{to_timestamp, get_model, get_family};
 
@@ -23,7 +23,6 @@ lazy_static! {
     static ref COMPONENT_RE: Regex = Regex::new(
         r#"^([^:]+): (.*)$"#).unwrap();
 }
-
 
 #[derive(Serialize)]
 pub struct Message {

--- a/src/event.rs
+++ b/src/event.rs
@@ -14,9 +14,10 @@ use hostname::get_hostname;
 use anylog::LogEntry;
 use regex::Regex;
 
-use prelude::*;
 use constants::{ARCH, PLATFORM};
-use utils::{to_timestamp, get_model, get_family, detect_release_name};
+use prelude::*;
+use utils::releases::detect_release_name;
+use utils::system::{to_timestamp, get_model, get_family};
 
 lazy_static! {
     static ref COMPONENT_RE: Regex = Regex::new(

--- a/src/main.rs
+++ b/src/main.rs
@@ -93,6 +93,6 @@ pub fn main() {
     {
         dotenv::dotenv().ok();
     }
-    utils::init_backtrace();
-    utils::run_or_interrupt(commands::main);
+    utils::system::init_backtrace();
+    utils::system::run_or_interrupt(commands::main);
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -82,7 +82,6 @@ pub mod config;
 pub mod constants;
 pub mod errors;
 pub mod event;
-pub mod prelude;
 pub mod utils;
 
 /// Executes the command line application and exits the process.

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -1,1 +1,0 @@
-pub use errors::{Result, Error, ErrorKind, ResultExt};

--- a/src/utils/android.rs
+++ b/src/utils/android.rs
@@ -4,12 +4,12 @@ use std::fmt;
 use std::path::{Path, PathBuf};
 use std::collections::HashMap;
 
-use prelude::*;
-
-use uuid::Uuid;
 use elementtree::Element;
 use itertools::Itertools;
 use java_properties;
+use uuid::Uuid;
+
+use prelude::*;
 
 pub struct AndroidManifest {
     path: PathBuf,

--- a/src/utils/android.rs
+++ b/src/utils/android.rs
@@ -9,7 +9,7 @@ use itertools::Itertools;
 use java_properties;
 use uuid::Uuid;
 
-use prelude::*;
+use errors::{Error, Result};
 
 pub struct AndroidManifest {
     path: PathBuf,

--- a/src/utils/args.rs
+++ b/src/utils/args.rs
@@ -1,11 +1,10 @@
 use std::result::Result as StdResult;
 
-use uuid::Uuid;
 use clap;
+use uuid::Uuid;
 use chrono::{DateTime, Utc, TimeZone};
 
 use prelude::*;
-
 
 fn validate_org(v: String) -> StdResult<(), String> {
     if v.contains("/") || &v == "." || &v == ".." || v.contains(' ') {

--- a/src/utils/args.rs
+++ b/src/utils/args.rs
@@ -4,7 +4,7 @@ use clap;
 use uuid::Uuid;
 use chrono::{DateTime, Utc, TimeZone};
 
-use prelude::*;
+use errors::{Error, Result};
 
 fn validate_org(v: String) -> StdResult<(), String> {
     if v.contains("/") || &v == "." || &v == ".." || v.contains(' ') {

--- a/src/utils/batch.rs
+++ b/src/utils/batch.rs
@@ -96,7 +96,7 @@ pub trait BatchedSliceExt<T: ItemSize> {
     /// `max_size`) and at most `max_items`. Items must implement `ItemSize`.
     ///
     /// ```
-    /// use utils::dif_upload::{BatchedSliceExt, ItemSize};
+    /// use utils::batch::{BatchedSliceExt, ItemSize};
     ///
     /// let slice = &[5, 10, 1, 1, 1, 1];
     /// let mut batches = slice.batches(5, 3);

--- a/src/utils/codepush.rs
+++ b/src/utils/codepush.rs
@@ -4,13 +4,13 @@ use std::path::Path;
 use std::process;
 use std::str;
 
-use serde_json;
 use console::strip_ansi_codes;
 use glob::{glob_with, MatchOptions};
+use serde_json;
 
 use prelude::*;
-use utils::xcode::{InfoPlist, XcodeProjectInfo};
 use utils::releases::{get_xcode_release_name, infer_gradle_release_name};
+use utils::xcode::{InfoPlist, XcodeProjectInfo};
 
 static CODEPUSH_BIN_PATH: &'static str = "code-push";
 static CODEPUSH_NPM_PATH: &'static str = "node_modules/.bin/code-push";

--- a/src/utils/codepush.rs
+++ b/src/utils/codepush.rs
@@ -8,7 +8,7 @@ use console::strip_ansi_codes;
 use glob::{glob_with, MatchOptions};
 use serde_json;
 
-use prelude::*;
+use errors::{Error, Result, ResultExt};
 use utils::releases::{get_xcode_release_name, infer_gradle_release_name};
 use utils::xcode::{InfoPlist, XcodeProjectInfo};
 

--- a/src/utils/cordova.rs
+++ b/src/utils/cordova.rs
@@ -6,7 +6,6 @@ use elementtree::{Element, QName};
 
 use prelude::*;
 
-
 pub struct CordovaConfig {
     root: Element,
 }

--- a/src/utils/cordova.rs
+++ b/src/utils/cordova.rs
@@ -4,7 +4,7 @@ use std::io::BufReader;
 
 use elementtree::{Element, QName};
 
-use prelude::*;
+use errors::Result;
 
 pub struct CordovaConfig {
     root: Element,

--- a/src/utils/dif.rs
+++ b/src/utils/dif.rs
@@ -10,7 +10,7 @@ use symbolic_common::{ByteView, ObjectKind};
 use symbolic_debuginfo::{FatObject, SymbolTable};
 use symbolic_proguard::ProguardMappingView;
 
-use prelude::*;
+use errors::{Error, Result};
 
 #[derive(PartialEq, Eq, Debug, Hash, Copy, Clone, Serialize)]
 pub enum DifType {

--- a/src/utils/dif_upload.rs
+++ b/src/utils/dif_upload.rs
@@ -32,7 +32,7 @@ use config::Config;
 use errors::Result;
 use utils::batch::{BatchedSliceExt, ItemSize};
 use utils::dif::has_hidden_symbols;
-use utils::fs::{get_sha1_checksum, get_sha1_checksums, TempDir, TempFile};
+use utils::fs::{TempDir, TempFile, get_sha1_checksum, get_sha1_checksums};
 use utils::ui::{copy_with_progress, make_byte_progress_bar};
 
 /// A debug info file on the server.
@@ -1016,7 +1016,7 @@ fn get_missing_difs<'data>(
 
     let missing_checksums = {
         let checksums = objects.iter().map(|s| s.checksum());
-        api.find_missing_dsym_checksums(&options.org, &options.project, checksums)?
+        api.find_missing_dif_checksums(&options.org, &options.project, checksums)?
     };
 
     let missing = objects
@@ -1064,7 +1064,7 @@ fn upload_in_batches(
         let archive = create_batch_archive(&batch)?;
 
         println!("{} Uploading debug symbol files", style(">").dim());
-        dsyms.extend(api.upload_dsyms(&options.org, &options.project, archive.path())?);
+        dsyms.extend(api.upload_dif_archive(&options.org, &options.project, archive.path())?);
     }
 
     Ok(dsyms)

--- a/src/utils/dif_upload.rs
+++ b/src/utils/dif_upload.rs
@@ -30,10 +30,10 @@ use zip::write::FileOptions;
 use api::{Api, ChunkUploadOptions, ChunkedDifRequest, ChunkedFileState, ProgressBarMode};
 use config::Config;
 use errors::Result;
-use utils::{copy_with_progress, make_byte_progress_bar, TempDir, TempFile, get_sha1_checksum,
-            get_sha1_checksums};
 use utils::batch::{BatchedSliceExt, ItemSize};
 use utils::dif::has_hidden_symbols;
+use utils::fs::{get_sha1_checksum, get_sha1_checksums, TempDir, TempFile};
+use utils::ui::{copy_with_progress, make_byte_progress_bar};
 
 /// A debug info file on the server.
 pub use api::DebugInfoFile;

--- a/src/utils/dif_upload.rs
+++ b/src/utils/dif_upload.rs
@@ -1050,7 +1050,7 @@ fn upload_in_batches(
     objects: Vec<HashedDifMatch>,
     options: &DifUpload,
 ) -> Result<Vec<DebugInfoFile>> {
-    let max_size = Config::get_current().get_max_dsym_upload_size()?;
+    let max_size = Config::get_current().get_max_dif_archive_size()?;
     let mut dsyms = Vec::new();
 
     for (i, (batch, _)) in objects.batches(max_size, MAX_CHUNKS).enumerate() {

--- a/src/utils/dif_upload.rs
+++ b/src/utils/dif_upload.rs
@@ -35,11 +35,11 @@ use utils::{copy_with_progress, make_byte_progress_bar, TempDir, TempFile, get_s
 use utils::batch::{BatchedSliceExt, ItemSize};
 use utils::dif::has_hidden_symbols;
 
+/// A debug info file on the server.
+pub use api::DebugInfoFile;
+
 /// Fallback maximum number of chunks in a batch for the legacy upload.
 static MAX_CHUNKS: u64 = 64;
-
-/// A debug info file on the server.
-pub type DebugInfoFile = api::DSymFile;
 
 /// A single chunk of a debug information file returned by
 /// `ChunkedDifMatch::chunks`. It carries the binary data slice and a SHA1

--- a/src/utils/enc.rs
+++ b/src/utils/enc.rs
@@ -5,7 +5,7 @@ use chardet::detect;
 use encoding::DecoderTrap;
 use encoding::label::encoding_from_whatwg_label;
 
-use prelude::*;
+use errors::{ErrorKind, Result};
 
 // Decodes bytes from an unknown encoding
 pub fn decode_unknown_string(bytes: &[u8]) -> Result<Cow<str>> {

--- a/src/utils/enc.rs
+++ b/src/utils/enc.rs
@@ -7,7 +7,6 @@ use encoding::label::encoding_from_whatwg_label;
 
 use prelude::*;
 
-
 // Decodes bytes from an unknown encoding
 pub fn decode_unknown_string(bytes: &[u8]) -> Result<Cow<str>> {
     if let Ok(s) = str::from_utf8(bytes) {

--- a/src/utils/fs.rs
+++ b/src/utils/fs.rs
@@ -8,7 +8,7 @@ use std::io::{Read, Seek, SeekFrom};
 use sha1::{Sha1, Digest};
 use uuid::{Uuid, UuidVersion};
 
-use prelude::*;
+use errors::Result;
 
 pub trait SeekRead: Seek + Read {}
 impl<T: Seek + Read> SeekRead for T {}

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -1,40 +1,20 @@
 //! Various utility functionality.
-mod android;
-mod args;
-mod codepush;
-mod enc;
-mod formatting;
-mod fs;
-mod iter;
-mod logging;
-mod releases;
-mod sourcemaps;
-mod system;
-mod ui;
-mod update;
+pub mod android;
+pub mod args;
 pub mod batch;
+pub mod codepush;
 pub mod cordova;
 pub mod dif;
 pub mod dif_upload;
+pub mod enc;
+pub mod formatting;
+pub mod fs;
+pub mod iter;
+pub mod logging;
+pub mod releases;
+pub mod sourcemaps;
+pub mod system;
+pub mod ui;
+pub mod update;
 pub mod vcs;
 pub mod xcode;
-
-pub use self::android::{dump_proguard_uuids_as_properties, AndroidManifest};
-pub use self::args::{get_timestamp, validate_project, validate_seconds, validate_timestamp,
-                     validate_uuid, ArgExt};
-pub use self::codepush::{get_codepush_package, get_react_native_codepush_release};
-pub use self::enc::decode_unknown_string;
-pub use self::formatting::{HumanDuration, Table, TableRow};
-pub use self::fs::{is_writable, is_zip_file, set_executable_mode, SeekRead, TempDir, TempFile,
-                   get_sha1_checksum, get_sha1_checksums};
-pub use self::iter::invert_result;
-pub use self::logging::Logger;
-pub use self::releases::detect_release_name;
-pub use self::sourcemaps::{get_sourcemap_reference_from_headers, SourceMapProcessor};
-pub use self::system::{expand_envvars, expand_vars, get_family, get_model, init_backtrace,
-                       is_homebrew_install, is_npm_install, print_error, propagate_exit_status,
-                       run_or_interrupt, to_timestamp};
-pub use self::ui::{capitalize_string, copy_with_progress, make_byte_progress_bar, prompt,
-                   prompt_to_continue};
-pub use self::update::{can_update_sentrycli, get_latest_sentrycli_release,
-                       run_sentrycli_update_nagger, SentryCliUpdateInfo};

--- a/src/utils/releases.rs
+++ b/src/utils/releases.rs
@@ -3,14 +3,12 @@ use std::io::Read;
 use std::env;
 use std::path::PathBuf;
 
-use utils::vcs;
-use utils::xcode::InfoPlist;
-use utils::cordova::CordovaConfig;
-
 use regex::Regex;
 
 use prelude::*;
-
+use utils::vcs;
+use utils::xcode::InfoPlist;
+use utils::cordova::CordovaConfig;
 
 pub fn get_cordova_release_name(path: Option<PathBuf>) -> Result<Option<String>> {
     let here = path.map_or(env::current_dir()?, |p| p.into());

--- a/src/utils/releases.rs
+++ b/src/utils/releases.rs
@@ -5,7 +5,7 @@ use std::path::PathBuf;
 
 use regex::Regex;
 
-use prelude::*;
+use errors::Result;
 use utils::vcs;
 use utils::xcode::InfoPlist;
 use utils::cordova::CordovaConfig;

--- a/src/utils/sourcemaps.rs
+++ b/src/utils/sourcemaps.rs
@@ -15,7 +15,7 @@ use sourcemap;
 use url::Url;
 
 use api::{Api, FileContents};
-use prelude::*;
+use errors::Result;
 use utils::enc::decode_unknown_string;
 
 fn make_progress_bar(len: u64) -> ProgressBar {

--- a/src/utils/sourcemaps.rs
+++ b/src/utils/sourcemaps.rs
@@ -8,16 +8,15 @@ use std::collections::{HashSet, HashMap};
 use std::iter::FromIterator;
 use std::path::{Path, PathBuf};
 
-use sourcemap;
-use might_be_minified;
-use indicatif::{ProgressBar, ProgressStyle, ProgressDrawTarget};
 use console::{Term, style};
-
-use prelude::*;
+use indicatif::{ProgressBar, ProgressStyle, ProgressDrawTarget};
+use might_be_minified;
+use sourcemap;
 use url::Url;
-use api::{Api, FileContents};
-use utils::decode_unknown_string;
 
+use api::{Api, FileContents};
+use prelude::*;
+use utils::enc::decode_unknown_string;
 
 fn make_progress_bar(len: u64) -> ProgressBar {
     let pb = ProgressBar::new(len);

--- a/src/utils/system.rs
+++ b/src/utils/system.rs
@@ -6,13 +6,12 @@ use std::borrow::Cow;
 
 use config::Config;
 
-use regex::{Regex, Captures};
-use chrono::{DateTime, Utc};
-
 #[cfg(not(windows))]
 use chan_signal::{notify, Signal};
+use chrono::{DateTime, Utc};
+use regex::{Captures, Regex};
 
-use prelude::*;
+use errors::{Error, ErrorKind, Result};
 
 #[cfg(not(windows))]
 pub fn run_or_interrupt<F>(f: F)

--- a/src/utils/update.rs
+++ b/src/utils/update.rs
@@ -10,12 +10,12 @@ use app_dirs;
 use serde_json;
 use chrono::{Utc, DateTime, Duration};
 
-use config::Config;
 use api::{Api, SentryCliRelease};
+use config::Config;
 use constants::{APP_INFO, VERSION};
-use utils::{is_homebrew_install, is_npm_install, set_executable_mode, is_writable};
 use prelude::*;
-
+use utils::fs::{set_executable_mode, is_writable};
+use utils::system::{is_homebrew_install, is_npm_install};
 
 #[cfg(windows)]
 fn rename_exe(exe: &Path, downloaded_path: &Path, elevate: bool) -> Result<()> {

--- a/src/utils/update.rs
+++ b/src/utils/update.rs
@@ -13,7 +13,7 @@ use chrono::{Utc, DateTime, Duration};
 use api::{Api, SentryCliRelease};
 use config::Config;
 use constants::{APP_INFO, VERSION};
-use prelude::*;
+use errors::{Error, ErrorKind, Result, ResultExt};
 use utils::fs::{set_executable_mode, is_writable};
 use utils::system::{is_homebrew_install, is_npm_install};
 

--- a/src/utils/vcs.rs
+++ b/src/utils/vcs.rs
@@ -5,7 +5,7 @@ use git2;
 use regex::Regex;
 
 use api::{Repo, Ref};
-use prelude::*;
+use errors::{Error, Result};
 
 #[derive(Copy, Clone)]
 pub enum GitReference<'a> {

--- a/src/utils/vcs.rs
+++ b/src/utils/vcs.rs
@@ -4,9 +4,8 @@ use std::path::PathBuf;
 use git2;
 use regex::Regex;
 
-use prelude::*;
 use api::{Repo, Ref};
-
+use prelude::*;
 
 #[derive(Copy, Clone)]
 pub enum GitReference<'a> {

--- a/src/utils/xcode.rs
+++ b/src/utils/xcode.rs
@@ -18,10 +18,10 @@ use unix_daemonize::{daemonize_redirect, ChdirMode};
 use mac_process_info;
 use regex::Regex;
 
-use prelude::*;
 use config::Config;
-use utils::{TempFile, expand_vars, SeekRead};
-
+use prelude::*;
+use utils::fs::{TempFile, SeekRead};
+use utils::system::{expand_vars, print_error};
 
 #[derive(Deserialize, Debug)]
 pub struct InfoPlist {
@@ -345,7 +345,6 @@ impl<'a> MayDetach<'a> {
         use std::time::Duration;
         use std::thread;
         use open;
-        use utils::print_error;
 
         let mut md = MayDetach::new(task_name);
         match f(&mut md) {

--- a/src/utils/xcode.rs
+++ b/src/utils/xcode.rs
@@ -19,7 +19,7 @@ use mac_process_info;
 use regex::Regex;
 
 use config::Config;
-use prelude::*;
+use errors::{Error, Result, ResultExt};
 use utils::fs::{TempFile, SeekRead};
 use utils::system::{expand_vars, print_error};
 


### PR DESCRIPTION
This PR consists of cleanup, mainly:

 - Make `utils::*` submodules opague and import them explicitly
 - Kill `prelude` as it was basically an alias to `errors` and deglob imports
 - Internally rename everything that's called `/dsym/i` but actually refers to DIFs.