### PR TITLE
feat: implement tls api and concurrent uploads

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1046,6 +1046,11 @@ dependencies = [
 ]
 
 [[package]]
+name = "scoped_threadpool"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "scroll"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1117,6 +1122,7 @@ dependencies = [
  "regex 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "runas 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "rust-ini 0.10.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "scoped_threadpool 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.27 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.27 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.9 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1731,6 +1737,7 @@ dependencies = [
 "checksum safemem 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e27a8b19b835f7aea908818e871f5cc3a5a186550c30773be987e155e8163d8f"
 "checksum same-file 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "cfb6eded0b06a0b512c8ddbcf04089138c9b4362c2f696f3c3d76039d68f3637"
 "checksum schannel 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)" = "acece75e0f987c48863a6c792ec8b7d6c4177d4a027f8ccc72f849794f437016"
+"checksum scoped_threadpool 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)" = "4ea459fe3ceff01e09534847c49860891d3ff1c12b4eb7731b67f2778fb60190"
 "checksum scroll 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b13864e1e0b3ed661d7206d512b8d1c4970f7fd9de23ae4e9b4331f0c25559e8"
 "checksum scroll_derive 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "2a67086db2a44e94311fc4c02ec3f4751bda0fca9d87fd4e1bfe1cef55e9411d"
 "checksum semver 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7a3186ec9e65071a2095434b1f5bb24838d4e8e130f584c790f6033c79943537"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,15 +9,12 @@ anylog = "0.2.0"
 app_dirs = "1.1.1"
 backtrace = "0.3.5"
 chardet = "0.2.4"
-chrono = { version = "0.4.0", features = ["serde"] }
-clap = { version = "2.29.4", default-features = false, features = ["suggestions", "wrap_help"] }
 console = "0.6.1"
 curl = "0.4.11"
 dotenv = "0.10.1"
 elementtree = "0.5.0"
 encoding = "0.2.33"
 error-chain = "0.11.0"
-git2 = { version = "0.6.11", default-features = false }
 glob = "0.2.11"
 hostname = "0.1.4"
 humansize = "1.1.0"
@@ -38,31 +35,57 @@ prettytable-rs = "0.6.7"
 regex = "0.2.6"
 runas = "0.1.4"
 rust-ini = "0.10.2"
+scoped_threadpool = "0.1.8"
 serde = "1.0.27"
 serde_derive = "1.0.27"
 serde_json = "1.0.9"
-sha1 = { version = "0.5.0", features = ["serde"] }
 sourcemap = "2.2.0"
 symbolic-common = "2.0.6"
 symbolic-debuginfo = "2.0.6"
 symbolic-proguard = "2.0.6"
 url = "1.6.0"
 username = "0.2.0"
-uuid = { version = "0.5.1", features = ["v4", "serde"] }
 walkdir = "2.1.3"
 which = "1.0.3"
 zip = "0.3.0"
 
-[target.'cfg(unix)'.dependencies]
-chan = "0.1.21"
-chan-signal = "0.3.1"
-openssl-probe = "0.1.2"
-uname = "0.1.1"
+[dependencies.chrono]
+features = ["serde"]
+version = "0.4.0"
 
-[target.'cfg(target_os = "macos")'.dependencies]
+[dependencies.clap]
+default-features = false
+features = ["suggestions", "wrap_help"]
+version = "2.29.4"
+
+[dependencies.git2]
+default-features = false
+version = "0.6.11"
+
+[dependencies.sha1]
+features = ["serde"]
+version = "0.5.0"
+
+[dependencies.uuid]
+features = ["v4", "serde"]
+version = "0.5.1"
+
+[features]
+managed = []
+
+[target]
+
+[target."cfg(target_os = \"macos\")"]
+
+[target."cfg(target_os = \"macos\")".dependencies]
 mac-process-info = "0.1.0"
 osascript = "0.3.0"
 unix-daemonize = "0.1.2"
 
-[features]
-managed = []
+[target."cfg(unix)"]
+
+[target."cfg(unix)".dependencies]
+chan = "0.1.21"
+chan-signal = "0.3.1"
+openssl-probe = "0.1.2"
+uname = "0.1.1"

--- a/src/api.rs
+++ b/src/api.rs
@@ -39,6 +39,10 @@ use utils::xcode::InfoPlist;
 /// Wrapper that escapes arguments for URL path segments.
 pub struct PathArg<A: fmt::Display>(A);
 
+thread_local! {
+    static API: Rc<Api> = Rc::new(Api::new());
+}
+
 impl<A: fmt::Display> fmt::Display for PathArg<A> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         // if we put values into the path we need to url encode them.  However
@@ -163,6 +167,11 @@ impl Api {
     /// connections will be established.
     pub fn new() -> Api {
         Api::with_config(Config::get_current())
+    }
+
+    /// Returns the current api for the thread.
+    pub fn get_current() -> Rc<Api> {
+        API.with(|api| api.clone())
     }
 
     /// Similar to `new` but uses a specific config.

--- a/src/commands/bash_hook.rs
+++ b/src/commands/bash_hook.rs
@@ -132,7 +132,7 @@ fn send_event(traceback: &str, logfile: &str) -> Result<()> {
 
     // handle errors here locally so that we do not get the extra "use sentry-cli
     // login" to sign in which would be in appropriate here.
-    if let Ok(event_id) = Api::new().send_event(&dsn, &event) {
+    if let Ok(event_id) = Api::get_current().send_event(&dsn, &event) {
         println!("{}", event_id);
     };
 

--- a/src/commands/info.rs
+++ b/src/commands/info.rs
@@ -59,7 +59,7 @@ fn get_config_status_json() -> Result<()> {
         &Auth::Token(_) => "token".into(),
         &Auth::Key(_) => "api_key".into(),
     });
-    rv.auth.successful = config.get_auth().is_some() && Api::new().get_auth_info().is_ok();
+    rv.auth.successful = config.get_auth().is_some() && Api::get_current().get_auth_info().is_ok();
     rv.have_dsn = config.get_dsn().is_ok();
 
     serde_json::to_writer_pretty(&mut io::stdout(), &rv)?;
@@ -74,7 +74,7 @@ pub fn execute<'a>(matches: &ArgMatches<'a>) -> Result<()> {
 
     let config = Config::get_current();
     let (org, project) = config.get_org_and_project_defaults();
-    let info_rv = Api::new().get_auth_info();
+    let info_rv = Api::get_current().get_auth_info();
     let errors = project.is_none() || org.is_none() || config.get_auth().is_none() || info_rv.is_err();
 
     if !matches.is_present("quiet") {

--- a/src/commands/issues.rs
+++ b/src/commands/issues.rs
@@ -62,7 +62,7 @@ fn execute_change(org: &str,
                   filter: &IssueFilter,
                   changes: &IssueChanges)
                   -> Result<()> {
-    if Api::new().bulk_update_issue(org, project, filter, changes)? {
+    if Api::get_current().bulk_update_issue(org, project, filter, changes)? {
         println!("Updated matching issues.");
         if let Some(status) = changes.new_status.as_ref() {
             println!("  new status: {}", status);

--- a/src/commands/projects.rs
+++ b/src/commands/projects.rs
@@ -17,7 +17,7 @@ pub fn make_app<'a, 'b: 'a>(app: App<'a, 'b>) -> App<'a, 'b> {
 
 pub fn execute<'a>(matches: &ArgMatches<'a>) -> Result<()> {
     let config = Config::get_current();
-    let api = Api::new();
+    let api = Api::get_current();
     let org = config.get_org(matches)?;
     let mut projects = api.list_organization_projects(&org)?;
     projects.sort_by_key(|p| (p.team.name.clone(), p.name.clone()));

--- a/src/commands/react_native_codepush.rs
+++ b/src/commands/react_native_codepush.rs
@@ -56,7 +56,7 @@ pub fn execute<'a>(matches: &ArgMatches<'a>) -> Result<()> {
     let app = matches.value_of("app_name").unwrap();
     let platform = matches.value_of("platform").unwrap();
     let deployment = matches.value_of("deployment").unwrap_or("Staging");
-    let api = Api::new();
+    let api = Api::get_current();
     let print_release_name = matches.is_present("print_release_name");
 
     if !print_release_name {

--- a/src/commands/react_native_gradle.rs
+++ b/src/commands/react_native_gradle.rs
@@ -39,7 +39,7 @@ pub fn make_app<'a, 'b: 'a>(app: App<'a, 'b>) -> App<'a, 'b> {
 pub fn execute<'a>(matches: &ArgMatches<'a>) -> Result<()> {
     let config = Config::get_current();
     let (org, project) = config.get_org_and_project(matches)?;
-    let api = Api::new();
+    let api = Api::get_current();
     let base = env::current_dir()?;
 
     let sourcemap_path = PathBuf::from(matches.value_of("sourcemap").unwrap());

--- a/src/commands/react_native_xcode.rs
+++ b/src/commands/react_native_xcode.rs
@@ -81,7 +81,7 @@ fn find_node() -> String {
 pub fn execute<'a>(matches: &ArgMatches<'a>) -> Result<()> {
     let config = Config::get_current();
     let (org, project) = config.get_org_and_project(matches)?;
-    let api = Api::new();
+    let api = Api::get_current();
     let should_wrap = matches.is_present("force") || match env::var("CONFIGURATION") {
         Ok(config) => &config != "Debug",
         Err(_) => { return Err("Need to run this from Xcode".into()); }

--- a/src/commands/releases.rs
+++ b/src/commands/releases.rs
@@ -1,5 +1,6 @@
 //! Implements a command for managing releases.
 use std::path::Path;
+use std::rc::Rc;
 use std::collections::HashSet;
 
 use clap::{App, AppSettings, Arg, ArgMatches};
@@ -20,7 +21,7 @@ use utils::sourcemaps::SourceMapProcessor;
 use utils::vcs::{find_heads, CommitSpec};
 
 struct ReleaseContext<'a> {
-    pub api: Api,
+    pub api: Rc<Api>,
     pub org: String,
     pub project_default: Option<&'a str>,
 }
@@ -861,7 +862,7 @@ pub fn execute<'a>(matches: &ArgMatches<'a>) -> Result<()> {
 
     let config = Config::get_current();
     let ctx = ReleaseContext {
-        api: Api::new(),
+        api: Api::get_current(),
         org: config.get_org(matches)?,
         project_default: matches.value_of("project"),
     };

--- a/src/commands/repos.rs
+++ b/src/commands/repos.rs
@@ -16,7 +16,7 @@ pub fn make_app<'a, 'b: 'a>(app: App<'a, 'b>) -> App<'a, 'b> {
 }
 
 pub fn execute<'a>(matches: &ArgMatches<'a>) -> Result<()> {
-    let api = Api::new();
+    let api = Api::get_current();
 
     let config = Config::get_current();
     let org = config.get_org(matches)?;

--- a/src/commands/send_event.rs
+++ b/src/commands/send_event.rs
@@ -154,7 +154,7 @@ pub fn execute<'a>(matches: &ArgMatches<'a>) -> Result<()> {
 
     // handle errors here locally so that we do not get the extra "use sentry-cli
     // login" to sign in which would be in appropriate here.
-    match Api::new().send_event(&dsn, &event) {
+    match Api::get_current().send_event(&dsn, &event) {
         Ok(event_id) => {
             println!("Event sent: {}", event_id);
         }

--- a/src/commands/upload_breakpad.rs
+++ b/src/commands/upload_breakpad.rs
@@ -55,7 +55,7 @@ pub fn execute<'a>(matches: &ArgMatches<'a>) -> Result<()> {
         .filter_kind(ObjectKind::Breakpad)
         .filter_ids(uuids)
         .allow_zips(!matches.is_present("no_zips"))
-        .upload_with(&api)?;
+        .upload()?;
 
     // Trigger reprocessing only if requested by user
     if matches.is_present("no_reprocessing") {

--- a/src/commands/upload_breakpad.rs
+++ b/src/commands/upload_breakpad.rs
@@ -40,7 +40,7 @@ pub fn make_app<'a, 'b: 'a>(app: App<'a, 'b>) -> App<'a, 'b> {
 }
 
 pub fn execute<'a>(matches: &ArgMatches<'a>) -> Result<()> {
-    let api = Api::new();
+    let api = Api::get_current();
     let config = Config::get_current();
     let (org, project) = config.get_org_and_project(matches)?;
 

--- a/src/commands/upload_dbg.rs
+++ b/src/commands/upload_dbg.rs
@@ -47,7 +47,7 @@ pub fn make_app<'a, 'b: 'a>(app: App<'a, 'b>) -> App<'a, 'b> {
 }
 
 pub fn execute<'a>(matches: &ArgMatches<'a>) -> Result<()> {
-    let api = Api::new();
+    let api = Api::get_current();
     let config = Config::get_current();
     let (org, project) = config.get_org_and_project(matches)?;
 

--- a/src/commands/upload_dbg.rs
+++ b/src/commands/upload_dbg.rs
@@ -75,7 +75,7 @@ pub fn execute<'a>(matches: &ArgMatches<'a>) -> Result<()> {
     }
 
     // Execute the upload
-    let uploaded = upload.upload_with(&api)?;
+    let uploaded = upload.upload()?;
 
     // Trigger reprocessing only if requested by user
     if matches.is_present("no_reprocessing") {

--- a/src/commands/upload_dsym.rs
+++ b/src/commands/upload_dsym.rs
@@ -119,7 +119,7 @@ pub fn execute<'a>(matches: &ArgMatches<'a>) -> Result<()> {
         }
 
         // Execute the upload
-        let uploaded = upload.upload_with(&api)?;
+        let uploaded = upload.upload()?;
 
         // Associate the dSYMs with the Info.plist data, if available
         if let Some(ref info_plist) = info_plist {

--- a/src/commands/upload_dsym.rs
+++ b/src/commands/upload_dsym.rs
@@ -71,7 +71,7 @@ pub fn make_app<'a, 'b: 'a>(app: App<'a, 'b>) -> App<'a, 'b> {
 }
 
 pub fn execute<'a>(matches: &ArgMatches<'a>) -> Result<()> {
-    let api = Api::new();
+    let api = Api::get_current();
     let config = Config::get_current();
     let (org, project) = config.get_org_and_project(matches)?;
 

--- a/src/commands/upload_proguard.rs
+++ b/src/commands/upload_proguard.rs
@@ -99,7 +99,7 @@ pub fn make_app<'a, 'b: 'a>(app: App<'a, 'b>) -> App<'a, 'b> {
 }
 
 pub fn execute<'a>(matches: &ArgMatches<'a>) -> Result<()> {
-    let api = Api::new();
+    let api = Api::get_current();
 
     let paths: Vec<_> = match matches.values_of("paths") {
         Some(paths) => paths.collect(),

--- a/src/main.rs
+++ b/src/main.rs
@@ -69,6 +69,7 @@ extern crate unix_daemonize;
 extern crate url;
 extern crate username;
 extern crate uuid;
+extern crate scoped_threadpool;
 extern crate walkdir;
 extern crate which;
 extern crate zip;

--- a/src/utils/dif_upload.rs
+++ b/src/utils/dif_upload.rs
@@ -837,7 +837,6 @@ fn try_assemble_difs<'data>(
 fn upload_missing_chunks(
     api: &Api,
     missing_info: &MissingDifsInfo,
-    difs: &[ChunkedDifMatch],
     chunk_options: &ChunkUploadOptions,
 ) -> Result<()> {
     let progress_style = ProgressStyle::default_bar().template(
@@ -989,7 +988,7 @@ fn upload_difs_chunked(
     // Upload until all chunks are present on the server
     let mut initially_missing = None;
     while let Some(missing_info) = try_assemble_difs(api, &chunked, options)? {
-        upload_missing_chunks(api, &missing_info, &chunked, chunk_options)?;
+        upload_missing_chunks(api, &missing_info, chunk_options)?;
         initially_missing.get_or_insert(missing_info);
     }
 
@@ -1330,7 +1329,7 @@ impl DifUpload {
     /// use api::Api;
     /// use utils::dif_upload::DifUpload;
     ///
-    /// let api = Api::new();
+    /// let api = Api::get_current();
     /// DifUpload::new("org", "project")
     ///     .search_path(".")
     ///     .upload_with(&api)?;
@@ -1358,7 +1357,7 @@ impl DifUpload {
     ///     .upload()?;
     /// ```
     pub fn upload(&mut self) -> Result<Vec<DebugInfoFile>> {
-        self.upload_with(&Api::new())
+        self.upload_with(&Api::get_current())
     }
 
     /// Determines if this `ObjectId` matches the search criteria.

--- a/src/utils/update.rs
+++ b/src/utils/update.rs
@@ -168,7 +168,7 @@ impl SentryCliUpdateInfo {
             exe.parent().unwrap().join(".sentry-cli.part")
         };
         let mut f = fs::File::create(&tmp_path)?;
-        let api = Api::new();
+        let api = Api::get_current();
         match api.download_with_progress(self.download_url()?, &mut f) {
             Ok(_) => {}
             Err(err) => {
@@ -184,7 +184,7 @@ impl SentryCliUpdateInfo {
 }
 
 pub fn get_latest_sentrycli_release() -> Result<SentryCliUpdateInfo> {
-    let api = Api::new();
+    let api = Api::get_current();
     Ok(SentryCliUpdateInfo {
         latest_release: if let Ok(release) = api.get_latest_sentrycli_release() {
             release


### PR DESCRIPTION
This spawns up to `concurrency` threads that all upload. It also changes the API to have a TLS backing so each thread in the pool automatically gets its own API.