### PR TITLE
fix(js): Only use the mocked binary in tests

### DIFF
--- a/js/__tests__/helper.test.js
+++ b/js/__tests__/helper.test.js
@@ -1,10 +1,15 @@
 /* eslint-env jest */
 
+const path = require('path');
 const helper = require('../helper');
 
 const SOURCEMAPS_OPTIONS = require('../releases/options/uploadSourcemaps');
 
 describe('SentryCli helper', () => {
+  beforeEach(() => {
+    helper.mockBinaryPath(path.resolve(__dirname, '../__mocks__/sentry-cli'));
+  });
+
   test('call sentry-cli --version', () => {
     expect.assertions(1);
     return helper

--- a/js/__tests__/index.test.js
+++ b/js/__tests__/index.test.js
@@ -1,9 +1,11 @@
 /* eslint-env jest */
 
+const os = require('os');
 const SentryCli = require('../');
 
 describe('SentryCli', () => {
   test('call getPath', () => {
-    expect(SentryCli.getPath()).toContain('sentry-cli');
+    const pattern = os.platform() === 'win32' ? /sentry-cli.exe$/ : /sentry-cli$/;
+    expect(SentryCli.getPath()).toMatch(pattern);
   });
 });

--- a/js/helper.js
+++ b/js/helper.js
@@ -8,10 +8,19 @@ const childProcess = require('child_process');
  * Absolute path to the sentry-cli binary (platform dependant).
  * @type {string}
  */
-const binaryPath =
+let binaryPath =
   os.platform() === 'win32'
     ? path.resolve(__dirname, '..\\bin\\sentry-cli.exe')
     : path.resolve(__dirname, '../sentry-cli');
+
+/**
+ * Overrides the default binary path with a mock value, useful for testing.
+ *
+ * @param {string} mockPath The new path to the mock sentry-cli binary
+ */
+function mockBinaryPath(mockPath) {
+  binaryPath = mockPath;
+}
 
 /**
  * Converts the given option into a command line args array.
@@ -118,10 +127,6 @@ function prepareCommand(command, schema, options) {
  * @returns {string}
  */
 function getPath() {
-  if (process.env.NODE_ENV === 'test') {
-    return path.resolve(__dirname, '__mocks__/sentry-cli');
-  }
-
   return binaryPath;
 }
 
@@ -159,6 +164,7 @@ function execute(args) {
 }
 
 module.exports = {
+  mockBinaryPath,
   serializeOptions,
   prepareCommand,
   getPath,

--- a/js/helper.js
+++ b/js/helper.js
@@ -8,6 +8,7 @@ const childProcess = require('child_process');
  * Absolute path to the sentry-cli binary (platform dependant).
  * @type {string}
  */
+// istanbul ignore next
 let binaryPath =
   os.platform() === 'win32'
     ? path.resolve(__dirname, '..\\bin\\sentry-cli.exe')
@@ -20,32 +21,6 @@ let binaryPath =
  */
 function mockBinaryPath(mockPath) {
   binaryPath = mockPath;
-}
-
-/**
- * Converts the given option into a command line args array.
- *
- * The value can either be an array of values or a single value. The value(s) will be
- * converted to string. If an array is given, the option name is repeated for each value.
- *
- * @example
- * expect(transformOption('--foo', 'a'))
- *   .toEqual(['--foo', 'a'])
- *
- * @example
- * expect(transformOption('--foo', ['a', 'b']))
- *   .toEqual(['--foo', 'a', '--foo', 'b']);
- *
- * @param {string} option The literal name of the option, including dashes.
- * @param {any[]|any} values One or more values for this option.
- * @returns {string[]} An arguments array that can be passed via command line.
- */
-function transformOption(option, values) {
-  if (Array.isArray(values)) {
-    return values.reduce((acc, value) => acc.concat([option.param, String(value)]), []);
-  }
-
-  return [option.param, String(values)];
 }
 
 /**
@@ -87,7 +62,9 @@ function serializeOptions(schema, options) {
         throw new Error(`${option} should be an array`);
       }
 
-      return newOptions.concat(transformOption(schema[option], paramValue));
+      return newOptions.concat(
+        paramValue.reduce((acc, value) => acc.concat([paramName, String(value)]), [])
+      );
     }
 
     if (paramType === 'boolean' || paramType === 'inverted-boolean') {


### PR DESCRIPTION
Fixes #251