### PR TITLE
feat: Expose execute to be able to run all commands

### DIFF
--- a/js/helper.js
+++ b/js/helper.js
@@ -136,7 +136,7 @@ function execute(args, live) {
         env,
         stdio: 'inherit',
       });
-      pid.on('exit', code => {
+      pid.on('exit', () => {
         resolve();
       });
     } else {

--- a/js/helper.js
+++ b/js/helper.js
@@ -125,18 +125,29 @@ function getPath() {
  * expect(output.trim()).toBe('sentry-cli x.y.z');
  *
  * @param {string[]} args Command line arguments passed to `sentry-cli`.
+ * @param {boolean} live We inherit stdio to display `sentry-cli` output directly.
  * @returns {Promise.<string>} A promise that resolves to the standard output.
  */
-function execute(args) {
+function execute(args, live) {
   const env = Object.assign({}, process.env);
   return new Promise((resolve, reject) => {
-    childProcess.execFile(getPath(), args, { env }, (err, stdout) => {
-      if (err) {
-        reject(err);
-      } else {
-        resolve(stdout);
-      }
-    });
+    if (live === true) {
+      const pid = childProcess.spawn(getPath(), args, {
+        env,
+        stdio: 'inherit',
+      });
+      pid.on('exit', code => {
+        resolve();
+      });
+    } else {
+      childProcess.execFile(getPath(), args, { env }, (err, stdout) => {
+        if (err) {
+          reject(err);
+        } else {
+          resolve(stdout);
+        }
+      });
+    }
   });
 }
 

--- a/js/index.js
+++ b/js/index.js
@@ -52,10 +52,11 @@ class SentryCli {
   /**
    * See {helper.execute} docs.
    * @param {string[]} args Command line arguments passed to `sentry-cli`.
+   * @param {boolean} live We inherit stdio to display `sentry-cli` output directly.
    * @returns {Promise.<string>} A promise that resolves to the standard output.
    */
-  execute(args) {
-    return helper.execute(args);
+  execute(args, live) {
+    return helper.execute(args, live);
   }
 }
 

--- a/js/index.js
+++ b/js/index.js
@@ -48,6 +48,15 @@ class SentryCli {
   static getPath() {
     return helper.getPath();
   }
+
+  /**
+   * See {helper.execute} docs.
+   * @param {string[]} args Command line arguments passed to `sentry-cli`.
+   * @returns {Promise.<string>} A promise that resolves to the standard output.
+   */
+  execute(args) {
+    return helper.execute(args);
+  }
 }
 
 SentryCli.prototype.releases = require('./releases');

--- a/js/index.js
+++ b/js/index.js
@@ -56,7 +56,7 @@ class SentryCli {
    * @returns {Promise.<string>} A promise that resolves to the standard output.
    */
   execute(args, live) {
-    return helper.execute(args, live);
+    return this.helper.execute(args, live);
   }
 }
 


### PR DESCRIPTION
Since I am very lazy, lets expose `execute` so we can call `upload-dif` for electron without writing a lot of code.