### PR TITLE
Wait for binary download file to close before resolving `downloadBinary`

### DIFF
--- a/scripts/install.js
+++ b/scripts/install.js
@@ -105,7 +105,7 @@ function downloadBinary() {
         .on('data', chunk => progressBar.tick(chunk.length))
         .pipe(fs.createWriteStream(outputPath, { mode: '0755' }))
         .on('error', e => reject(e))
-        .on('finish', () => resolve());
+        .on('close', () => resolve());
     });
   });
 }


### PR DESCRIPTION
The finish event informs listeners that `stream.end` has been called and all
data has been flushed to disk, however the file may still be open. In some cases
this may cause an ETXTBSY error to be thrown when the file is subsequently
executed to check its version.