### PR TITLE
Call execute on helper module

### DIFF
--- a/js/index.js
+++ b/js/index.js
@@ -56,7 +56,7 @@ class SentryCli {
    * @returns {Promise.<string>} A promise that resolves to the standard output.
    */
   execute(args, live) {
-    return this.helper.execute(args, live);
+    return helper.execute(args, live);
   }
 }
 


### PR DESCRIPTION
Simple fix to get `SentryCli.execute` method working. It's unlikely this ever worked as their is no `helper` property on the `SentryCli` class.