### PR TITLE
feat(releases): Detect HEROKU_SLUG_COMMIT in propose-version

### DIFF
--- a/src/utils/releases.rs
+++ b/src/utils/releases.rs
@@ -88,6 +88,13 @@ pub fn detect_release_name() -> Result<String, Error> {
         return Ok(release);
     }
 
+    // try heroku: https://docs.sentry.io/integrations/heroku/#configure-releases
+    if let Ok(release) = env::var("HEROKU_SLUG_COMMIT") {
+        if !release.is_empty() {
+            return Ok(release);
+        }
+    }
+
     // for now only execute this on macs.  The reason is that this uses
     // xcodebuild which does not exist anywhere but there.
     if_chain! {


### PR DESCRIPTION
This detects `HEROKU_SLUG_COMMIT` in `sentry-cli releases propose-version`,
as users would expect: https://docs.sentry.io/integrations/heroku/#configure-releases

Fixes #289