### PR TITLE
feat(react_native): Add a command for appcenter-cli

### DIFF
--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -69,6 +69,7 @@ pub mod upload_dsym;
 pub mod upload_proguard;
 
 pub mod react_native;
+pub mod react_native_appcenter;
 pub mod react_native_codepush;
 pub mod react_native_gradle;
 #[cfg(target_os = "macos")]

--- a/src/commands/react_native.rs
+++ b/src/commands/react_native.rs
@@ -6,6 +6,7 @@ use commands;
 macro_rules! each_subcommand {
     ($mac:ident) => {
         $mac!(react_native_gradle);
+        $mac!(react_native_appcenter);
         $mac!(react_native_codepush);
         #[cfg(target_os = "macos")]
         $mac!(react_native_xcode);

--- a/src/commands/react_native_appcenter.rs
+++ b/src/commands/react_native_appcenter.rs
@@ -2,19 +2,18 @@ use std::env;
 use std::ffi::OsStr;
 use std::fs;
 
-use clap::{App, AppSettings, Arg, ArgMatches};
+use clap::{App, Arg, ArgMatches};
 use console::style;
 use failure::Error;
 
 use api::{Api, NewRelease};
 use config::Config;
+use utils::appcenter::{get_appcenter_package, get_react_native_appcenter_release};
 use utils::args::ArgExt;
-use utils::codepush::{get_codepush_package, get_react_native_codepush_release};
 use utils::sourcemaps::SourceMapProcessor;
 
 pub fn make_app<'a, 'b: 'a>(app: App<'a, 'b>) -> App<'a, 'b> {
-    app.about("DEPRECATED: Upload react-native projects for CodePush.")
-        .setting(AppSettings::Hidden)
+    app.about("Upload react-native projects for AppCenter.")
         .org_project_args()
         .arg(
             Arg::with_name("deployment")
@@ -44,14 +43,14 @@ pub fn make_app<'a, 'b: 'a>(app: App<'a, 'b>) -> App<'a, 'b> {
                 .value_name("APP_NAME")
                 .index(1)
                 .required(true)
-                .help("The name of the CodePush application."),
+                .help("The name of the AppCenter application."),
         )
         .arg(
             Arg::with_name("platform")
                 .value_name("PLATFORM")
                 .index(2)
                 .required(true)
-                .help("The name of the CodePush platform. [ios, android]"),
+                .help("The name of the app platform. [ios, android]"),
         )
         .arg(
             Arg::with_name("paths")
@@ -76,21 +75,21 @@ pub fn execute<'a>(matches: &ArgMatches<'a>) -> Result<(), Error> {
 
     if !print_release_name {
         println!(
-            "{} Fetching latest code-push package info",
+            "{} Fetching latest AppCenter deployment info",
             style(">").dim()
         );
     }
 
-    let package = get_codepush_package(app, deployment)?;
+    let package = get_appcenter_package(app, deployment)?;
     let release =
-        get_react_native_codepush_release(&package, platform, matches.value_of("bundle_id"))?;
+        get_react_native_appcenter_release(&package, platform, matches.value_of("bundle_id"))?;
     if print_release_name {
         println!("{}", release);
         return Ok(());
     }
 
     println!(
-        "{} Processing react-native code-push sourcemaps",
+        "{} Processing react-native AppCenter sourcemaps",
         style(">").dim()
     );
 

--- a/src/commands/upload_dsym.rs
+++ b/src/commands/upload_dsym.rs
@@ -6,7 +6,7 @@ use commands::upload_dif;
 use utils::args::{validate_uuid, ArgExt};
 
 pub fn make_app<'a, 'b: 'a>(app: App<'a, 'b>) -> App<'a, 'b> {
-    app.about("Upload Mac debug symbols to a project.")
+    app.about("DEPRECATED: Upload Mac debug symbols to a project.")
         .setting(AppSettings::Hidden)
         .org_project_args()
         .arg(

--- a/src/utils/appcenter.rs
+++ b/src/utils/appcenter.rs
@@ -1,0 +1,167 @@
+use std::env;
+use std::fmt;
+use std::io;
+use std::path::Path;
+use std::process::{Command, Output};
+use std::str;
+
+use console::strip_ansi_codes;
+use failure::{err_msg, Error};
+use glob::{glob_with, MatchOptions};
+// use serde::de::{Deserialize, Deserializer, Error as DeError};
+use serde::de;
+use serde_json;
+
+use utils::releases::{get_xcode_release_name, infer_gradle_release_name};
+use utils::xcode::{InfoPlist, XcodeProjectInfo};
+
+static APPCENTER_BIN_PATH: &str = "appcenter";
+static APPCENTER_NPM_PATH: &str = "node_modules/.bin/appcenter";
+
+static APPCENTER_NOT_FOUND: &str = "AppCenter CLI not found
+
+Install with `npm install -g appcenter-cli` and make sure it is on the PATH.";
+
+#[derive(Debug)]
+pub struct AppCenterPackage {
+    pub label: String,
+}
+
+impl<'de> de::Deserialize<'de> for AppCenterPackage {
+    fn deserialize<D: de::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        struct PackageVisitor;
+
+        impl<'de> de::Visitor<'de> for PackageVisitor {
+            type Value = AppCenterPackage;
+
+            fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+                formatter.write_str("a deployment history entry")
+            }
+
+            fn visit_seq<S: de::SeqAccess<'de>>(
+                self,
+                mut seq: S,
+            ) -> Result<AppCenterPackage, S::Error> {
+                // Since we only need the package label, we can deserialize the JSON string very
+                // efficiently by only looking at the first element.
+                let label = seq.next_element()?
+                    .ok_or_else(|| de::Error::custom("missing package label"))?;
+
+                // Drain the sequence, ignoring all other values.
+                while seq.next_element::<de::IgnoredAny>()?.is_some() {}
+
+                Ok(AppCenterPackage { label })
+            }
+        }
+
+        deserializer.deserialize_seq(PackageVisitor)
+    }
+}
+
+pub fn get_appcenter_error(output: Output) -> Error {
+    let message = match str::from_utf8(&output.stdout) {
+        Ok(message) => message,
+        Err(_) => "Unknown AppCenter error".into(),
+    };
+
+    let stripped = strip_ansi_codes(message);
+    let cause = if stripped.starts_with("Error: ") {
+        &stripped[7..]
+    } else {
+        &stripped
+    }.to_string();
+
+    err_msg(cause)
+}
+
+pub fn get_appcenter_deployment_history(
+    app: &str,
+    deployment: &str,
+) -> Result<Vec<AppCenterPackage>, Error> {
+    let appcenter_bin = if Path::new(APPCENTER_NPM_PATH).exists() {
+        APPCENTER_NPM_PATH
+    } else {
+        APPCENTER_BIN_PATH
+    };
+
+    let output = Command::new(appcenter_bin)
+        .arg("codepush")
+        .arg("deployment")
+        .arg("history")
+        .arg(deployment)
+        .arg("--app")
+        .arg(app)
+        .arg("--output")
+        .arg("json")
+        .output()
+        .map_err(|e| match e.kind() {
+            io::ErrorKind::NotFound => APPCENTER_NOT_FOUND.into(),
+            _ => Error::from(e).context("Failed to run AppCenter CLI"),
+        })?;
+
+    if output.status.success() {
+        Ok(serde_json::from_slice(&output.stdout)?)
+    } else {
+        Err(get_appcenter_error(output)
+            .context("Failed to load AppCenter deployment history")
+            .into())
+    }
+}
+
+pub fn get_appcenter_package(app: &str, deployment: &str) -> Result<AppCenterPackage, Error> {
+    let history = get_appcenter_deployment_history(app, deployment)?;
+    if let Some(latest) = history.into_iter().last() {
+        Ok(latest)
+    } else {
+        bail!("Could not find deployment {} for {}", deployment, app);
+    }
+}
+
+pub fn get_react_native_appcenter_release(
+    package: &AppCenterPackage,
+    platform: &str,
+    bundle_id_override: Option<&str>,
+) -> Result<String, Error> {
+    if let Some(bundle_id) = bundle_id_override {
+        return Ok(format!("{}-codepush:{}", bundle_id, package.label));
+    }
+
+    if platform == "ios" {
+        if !cfg!(target_os = "macos") {
+            bail!("AppCenter codepush releases for iOS require macOS if no bundle ID is specified");
+        }
+
+        let mut opts = MatchOptions::new();
+        opts.case_sensitive = false;
+
+        for entry_rv in glob_with("ios/*.xcodeproj", &opts)? {
+            if let Ok(entry) = entry_rv {
+                let pi = XcodeProjectInfo::from_path(&entry)?;
+                if let Some(ipl) = InfoPlist::from_project_info(&pi)? {
+                    if let Some(release_name) = get_xcode_release_name(Some(ipl))? {
+                        return Ok(format!("{}-codepush:{}", release_name, package.label));
+                    }
+                }
+            }
+        }
+
+        bail!("Could not find plist");
+    } else if platform == "android" {
+        if_chain! {
+            if let Ok(here) = env::current_dir();
+            if let Ok(android_folder) = here.join("android").metadata();
+            if android_folder.is_dir();
+            then {
+                if let Some(release_name) = infer_gradle_release_name(Some(here.join("android")))? {
+                    return Ok(format!("{}-codepush:{}", release_name, package.label));
+                } else {
+                    bail!("Could not parse app id from build.gradle");
+                }
+            }
+        }
+
+        bail!("Could not find AndroidManifest.xml");
+    }
+
+    bail!("Unsupported platform '{}'", platform);
+}

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -1,5 +1,6 @@
 //! Various utility functionality.
 pub mod android;
+pub mod appcenter;
 pub mod args;
 pub mod batch;
 pub mod codepush;


### PR DESCRIPTION
Introduces the command `sentry-cli react-native appcenter` to manager codepush deployments with AppCenter CLI. It uses `appcenter codepush deployment history` to get a history of recent releases and fetches the package label from the last entry in the history.

This also deprecates the `sentry-cli react-native codepush` command and hides it in the command overview. However, it will still work as expected.

The appcenter command is a simple copy/paste from the old codepush command with changed strings and better help messages. Apart from `get_appcenter_package`, the code is identical.

Since we only require a deployment's package label, I've implemented a custom visitor that discards all other values returned by AppCenter CLI. This theoretically also makes us more robust against changes in the output format, if more parameters are added in the future. We could switch to tuple deserialization if we need to extract more info in the future.

Ref https://github.com/getsentry/sentry-cli/issues/218