### PR TITLE
feat(api): Add a more descriptive project rename error message

### DIFF
--- a/src/api.rs
+++ b/src/api.rs
@@ -175,7 +175,7 @@ pub struct ApiError {
 
 #[derive(Clone, Debug, Fail)]
 #[fail(
-    display = "project was renamed to '{}'\n\nPlease update the project slug in your .sentryclirc or sentry.properties",
+    display = "project was renamed to '{}'\n\nPlease use this slug in your .sentryclirc or sentry.properties or for the --project parameter",
     _0
 )]
 pub struct ProjectRenamedError(String);

--- a/src/api.rs
+++ b/src/api.rs
@@ -174,7 +174,10 @@ pub struct ApiError {
 }
 
 #[derive(Clone, Debug, Fail)]
-#[fail(display = "project was renamed to '{}'", _0)]
+#[fail(
+    display = "project was renamed to '{}'\n\nPlease update the project slug in your .sentryclirc or sentry.properties",
+    _0
+)]
 pub struct ProjectRenamedError(String);
 
 impl Fail for ApiError {


### PR DESCRIPTION
New error message:

```
$ sentry-cli releases list
error: project not found
  caused by: project was renamed to 'rust'

Please update the project slug in your .sentryclirc or sentry.properties
```