### PR TITLE
fix(react_native): Use cmd wrappers for appcenter on Windows

### DIFF
--- a/src/utils/appcenter.rs
+++ b/src/utils/appcenter.rs
@@ -15,8 +15,15 @@ use serde_json;
 use utils::releases::{get_xcode_release_name, infer_gradle_release_name};
 use utils::xcode::{InfoPlist, XcodeProjectInfo};
 
+#[cfg(not(windows))]
 static APPCENTER_BIN_PATH: &str = "appcenter";
+#[cfg(not(windows))]
 static APPCENTER_NPM_PATH: &str = "node_modules/.bin/appcenter";
+
+#[cfg(windows)]
+static APPCENTER_BIN_PATH: &str = "appcenter.cmd";
+#[cfg(windows)]
+static APPCENTER_NPM_PATH: &str = "node_modules/.bin/appcenter.cmd";
 
 static APPCENTER_NOT_FOUND: &str = "AppCenter CLI not found
 

--- a/src/utils/codepush.rs
+++ b/src/utils/codepush.rs
@@ -12,8 +12,15 @@ use serde_json;
 use utils::releases::{get_xcode_release_name, infer_gradle_release_name};
 use utils::xcode::{InfoPlist, XcodeProjectInfo};
 
+#[cfg(not(windows))]
 static CODEPUSH_BIN_PATH: &'static str = "code-push";
+#[cfg(not(windows))]
 static CODEPUSH_NPM_PATH: &'static str = "node_modules/.bin/code-push";
+
+#[cfg(windows)]
+static CODEPUSH_BIN_PATH: &'static str = "code-push.cmd";
+#[cfg(windows)]
+static CODEPUSH_NPM_PATH: &'static str = "node_modules/.bin/code-push.cmd";
 
 #[derive(Debug, Deserialize)]
 pub struct CodePushPackage {


### PR DESCRIPTION
Fixes https://github.com/getsentry/sentry-cli/issues/319