### PR TITLE
fix: Safely reset handles only if the config managed to initialize

### DIFF
--- a/src/api.rs
+++ b/src/api.rs
@@ -291,6 +291,16 @@ impl Api {
         API.with(|api| api.clone())
     }
 
+    /// Returns the current api for the thread if bound.
+    pub fn get_current_opt() -> Option<Rc<Api>> {
+        // `Api::get_current` fails if there is no config yet.
+        if Config::get_current_opt().is_some() {
+            Some(Api::get_current())
+        } else {
+            None
+        }
+    }
+
     /// Similar to `new` but uses a specific config.
     pub fn with_config(config: Arc<Config>) -> Api {
         Api {

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -247,7 +247,10 @@ fn setup() {
 pub fn main() {
     setup();
     let result = run();
-    Api::get_current().reset();
+
+    if let Some(api) = Api::get_current_opt() {
+        api.reset();
+    }
 
     match result {
         Ok(()) => process::exit(0),

--- a/src/utils/system.rs
+++ b/src/utils/system.rs
@@ -119,7 +119,7 @@ pub fn print_error(err: &Error) {
         clap_err.exit();
     }
 
-    for (idx, cause) in err.causes().enumerate() {
+    for (idx, cause) in err.iter_chain().enumerate() {
         if idx == 0 {
             writeln!(&mut io::stderr(), "error: {}", cause).ok();
         } else {


### PR DESCRIPTION
This resolves

```
thread 'unnamed' panicked at 'Config not bound yet': libcore/option.rs:960

stack backtrace:
   0:        0x10f037a6e - backtrace::backtrace::trace::h514d75a2770f3a20
   1:        0x10f036c2c - <backtrace::capture::Backtrace as core::default::Default>::default::hd67a7078af019b2d
   2:        0x10f036cad - backtrace::capture::Backtrace::new::h5baec8c77729d101
   3:        0x10eb18021 - sentry_cli::utils::system::init_backtrace::{{closure}}::hb329223ccdd28415
   4:        0x10f0e828e - std::panicking::rust_panic_with_hook::h81c4f3add25e6667
   5:        0x10f0e800e - std::panicking::continue_panic_fmt::hfa057b7c1de88179
   6:        0x10f0e7c98 - _rust_begin_unwind
   7:        0x10f12bc71 - core::panicking::panic_fmt::h4c82aa4e615d52a2
   8:        0x10f11dfb8 - core::option::expect_failed::h05d35beb9d2793c7
   9:        0x10ea5f093 - sentry_cli::config::Config::get_current::h845d19fcf13f44bc
  10:        0x10ea4b11f - sentry_cli::api::API::__init::h4084e8cb0f707f74
  11:        0x10ea510b4 - <std::thread::local::LocalKey<T>>::with::h8419641dab2c31de
  12:        0x10eb63465 - sentry_cli::commands::main::hd1cb43f646c19c76
  13:        0x10ea4ebce - std::sys_common::backtrace::__rust_begin_short_backtrace::hb16bb4bd11617aad
  14:        0x10f0f444e - ___rust_maybe_catch_panic
  15:        0x10ea562f9 - <F as alloc::boxed::FnBox<A>>::call_box::h71b3c444d492e00d
  16:        0x10f0e70e7 - std::sys_common::thread::start_thread::h78b1dd404be976ad
  17:        0x10f0ca248 - std::sys::unix::thread::Thread::new::thread_start::h27c6becca8cf44e0
  18:     0x7fff5a9c4660 - __pthread_body
  19:     0x7fff5a9c450c - __pthread_start
```