### PR TITLE
fix: Resolve awk compatibility issue in bash hooks

### DIFF
--- a/docs/send-event.rst
+++ b/docs/send-event.rst
@@ -39,7 +39,7 @@ Sending Breadcrumbs
 -------------------
 
 You can also pass a logfile to the ``send-event`` command which will be
-parsed and sent along as breadcrumbs.  The last 100 items will be sent:
+parsed and sent along as breadcrumbs.  The last 100 items will be sent::
 
     $ sentry-cli send-event -m "task failed" --logfile error.log
 

--- a/src/bashsupport.sh
+++ b/src/bashsupport.sh
@@ -50,6 +50,13 @@ _sentry_traceback() {
 }
 
 : > "$_SENTRY_LOG_FILE"
-exec \
-  1> >(tee >(awk '{ system(""); print strftime("%Y-%m-%d %H:%M:%S %z:"), "stdout:", $0; system(""); }' >> "$_SENTRY_LOG_FILE")) \
-  2> >(tee >(awk '{ system(""); print strftime("%Y-%m-%d %H:%M:%S %z:"), "stderr:", $0; system(""); }' >> "$_SENTRY_LOG_FILE") >&2)
+
+if command -v perl >/dev/null; then
+  exec \
+    1> >(tee >(perl '-MPOSIX' -ne '$|++; print strftime("%Y-%m-%d %H:%M:%S %z: ", localtime()), "stdout: ", $_;' >> "$_SENTRY_LOG_FILE")) \
+    2> >(tee >(perl '-MPOSIX' -ne '$|++; print strftime("%Y-%m-%d %H:%M:%S %z: ", localtime()), "stderr: ", $_;' >> "$_SENTRY_LOG_FILE") >&2)
+else
+  exec \
+    1> >(tee >(awk '{ system(""); print strftime("%Y-%m-%d %H:%M:%S %z:"), "stdout:", $0; system(""); }' >> "$_SENTRY_LOG_FILE")) \
+    2> >(tee >(awk '{ system(""); print strftime("%Y-%m-%d %H:%M:%S %z:"), "stderr:", $0; system(""); }' >> "$_SENTRY_LOG_FILE") >&2)
+fi


### PR DESCRIPTION
`strftime` is not available in some versions of `awk`. 
Let's use Perl whenever possible :)

Fixes #357.