### PR TITLE
fix(dif_upload): Also show errors from previous uploads

### DIFF
--- a/src/api.rs
+++ b/src/api.rs
@@ -538,7 +538,8 @@ impl Api {
             }
         }
 
-        let resp = self.request(Method::Post, &path)?
+        let resp = self
+            .request(Method::Post, &path)?
             .with_form_data(form)?
             .progress_bar_mode(ProgressBarMode::Request)?
             .send()?;
@@ -813,7 +814,8 @@ impl Api {
     /// Get the server configuration for chunked file uploads.
     pub fn get_chunk_upload_options(&self, org: &str) -> ApiResult<Option<ChunkUploadOptions>> {
         let url = format!("/organizations/{}/chunk-upload/", org);
-        match self.get(&url)?
+        match self
+            .get(&url)?
             .convert_rnf(ApiErrorKind::ChunkUploadNotSupported)
         {
             Ok(options) => Ok(Some(options)),
@@ -888,7 +890,8 @@ impl Api {
             form.part(name).buffer(&checksum, buffer).add()?
         }
 
-        let request = self.request(Method::Post, url)?
+        let request = self
+            .request(Method::Post, url)?
             .with_form_data(form)?
             .progress_bar_mode(progress_bar_mode)?;
 
@@ -971,7 +974,8 @@ impl Api {
             PathArg(org),
             PathArg(project)
         );
-        let resp = self.request(Method::Post, &path)?
+        let resp = self
+            .request(Method::Post, &path)?
             .with_json_body(data)?
             .send()?;
         if resp.status() == 404 {

--- a/src/commands/difutil.rs
+++ b/src/commands/difutil.rs
@@ -18,7 +18,8 @@ pub fn make_app<'a, 'b: 'a>(mut app: App<'a, 'b>) -> App<'a, 'b> {
         }};
     }
 
-    app = app.about("Locate or analyze debug information files.")
+    app = app
+        .about("Locate or analyze debug information files.")
         .setting(AppSettings::SubcommandRequiredElseHelp);
     each_subcommand!(add_subcommand);
     app

--- a/src/commands/difutil_find.rs
+++ b/src/commands/difutil_find.rs
@@ -100,7 +100,8 @@ fn find_ids(
     as_json: bool,
 ) -> Result<bool, Error> {
     let mut remaining = ids.clone();
-    let mut proguard_uuids: HashSet<_> = ids.iter()
+    let mut proguard_uuids: HashSet<_> = ids
+        .iter()
         .map(|x| x.uuid())
         .filter(|&x| x.get_version() == Some(UuidVersion::Sha1))
         .collect();

--- a/src/commands/react_native.rs
+++ b/src/commands/react_native.rs
@@ -22,7 +22,8 @@ pub fn make_app<'a, 'b: 'a>(mut app: App<'a, 'b>) -> App<'a, 'b> {
         }};
     }
 
-    app = app.about("Upload build artifacts for react-native projects.")
+    app = app
+        .about("Upload build artifacts for react-native projects.")
         .setting(AppSettings::SubcommandRequiredElseHelp);
     each_subcommand!(add_subcommand);
     app

--- a/src/commands/releases.rs
+++ b/src/commands/releases.rs
@@ -498,7 +498,8 @@ fn execute_delete<'a>(ctx: &ReleaseContext, matches: &ArgMatches<'a>) -> Result<
 
 fn execute_list<'a>(ctx: &ReleaseContext, matches: &ArgMatches<'a>) -> Result<(), Error> {
     let project = ctx.get_project_default().ok();
-    let releases = ctx.api
+    let releases = ctx
+        .api
         .list_releases(ctx.get_org()?, project.as_ref().map(|x| x.as_str()))?;
     let abbrev = !matches.is_present("no_abbrev");
     let mut table = Table::new();
@@ -541,7 +542,8 @@ fn execute_info<'a>(ctx: &ReleaseContext, matches: &ArgMatches<'a>) -> Result<()
     let version = matches.value_of("version").unwrap();
     let org = ctx.get_org()?;
     let project = ctx.get_project_default().ok();
-    let release = ctx.api
+    let release = ctx
+        .api
         .get_release(org, project.as_ref().map(|x| x.as_str()), &version)?;
 
     // quiet mode just exists
@@ -586,7 +588,8 @@ fn execute_files_list<'a>(
 
     let org = ctx.get_org()?;
     let project = ctx.get_project_default().ok();
-    for artifact in ctx.api
+    for artifact in ctx
+        .api
         .list_release_files(org, project.as_ref().map(|x| x.as_str()), release)?
     {
         let row = table.add_row();
@@ -620,7 +623,8 @@ fn execute_files_delete<'a>(
     };
     let org = ctx.get_org()?;
     let project = ctx.get_project_default().ok();
-    for file in ctx.api
+    for file in ctx
+        .api
         .list_release_files(org, project.as_ref().map(|x| x.as_str()), release)?
     {
         if !(matches.is_present("all") || files.contains(&file.name)) {

--- a/src/config.rs
+++ b/src/config.rs
@@ -313,7 +313,8 @@ impl Config {
 
     /// Returns true if notifications should be displayed
     pub fn show_notifications(&self) -> Result<bool, Error> {
-        Ok(self.ini
+        Ok(self
+            .ini
             .get_from(Some("ui"), "show_notifications")
             .map(|x| x == "true")
             .unwrap_or(true))
@@ -321,7 +322,8 @@ impl Config {
 
     /// Returns the maximum DIF upload size
     pub fn get_max_dif_archive_size(&self) -> Result<u64, Error> {
-        Ok(self.ini
+        Ok(self
+            .ini
             .get_from(Some("dsym"), "max_upload_size")
             .and_then(|x| x.parse().ok())
             .unwrap_or(35 * 1024 * 1024))
@@ -386,7 +388,8 @@ impl Config {
 
     /// Does this installation want errors to sentry?
     pub fn internal_sentry_dsn(&self) -> Option<Dsn> {
-        if !self.ini
+        if !self
+            .ini
             .get_from(Some("crash_reporting"), "enabled")
             .map(|x| x == "1" || x == "true")
             .unwrap_or(false)

--- a/src/utils/appcenter.rs
+++ b/src/utils/appcenter.rs
@@ -51,7 +51,8 @@ impl<'de> de::Deserialize<'de> for AppCenterPackage {
             ) -> Result<AppCenterPackage, S::Error> {
                 // Since we only need the package label, we can deserialize the JSON string very
                 // efficiently by only looking at the first element.
-                let label = seq.next_element()?
+                let label = seq
+                    .next_element()?
                     .ok_or_else(|| de::Error::custom("missing package label"))?;
 
                 // Drain the sequence, ignoring all other values.

--- a/src/utils/args.rs
+++ b/src/utils/args.rs
@@ -17,8 +17,13 @@ fn validate_org(v: String) -> Result<(), String> {
 }
 
 pub fn validate_project(v: String) -> Result<(), String> {
-    if v.contains("/") || &v == "." || &v == ".." || v.contains(' ') || v.contains('\n')
-        || v.contains('\t') || v.contains('\r')
+    if v.contains("/")
+        || &v == "."
+        || &v == ".."
+        || v.contains(' ')
+        || v.contains('\n')
+        || v.contains('\t')
+        || v.contains('\r')
     {
         return Err("invalid value for project. Use the URL \
                     slug and not the name!"

--- a/src/utils/cordova.rs
+++ b/src/utils/cordova.rs
@@ -35,7 +35,8 @@ impl CordovaConfig {
     }
 
     pub fn android_version_code(&self) -> u64 {
-        if let Some(version) = self.root
+        if let Some(version) = self
+            .root
             .get_attr("android-versionCode")
             .and_then(|x| x.parse().ok())
         {

--- a/src/utils/crashreporting.rs
+++ b/src/utils/crashreporting.rs
@@ -24,16 +24,18 @@ pub fn bind_configured_client(cfg: Option<&Config>) {
     };
 
     Hub::with(|hub| {
-        hub.bind_client(Some(Arc::new(dsn.and_then(|dsn| {
-            Client::from_config((
-                dsn,
-                ClientOptions {
-                    release: sentry_crate_release!(),
-                    user_agent: Cow::Borrowed(USER_AGENT),
-                    ..Default::default()
-                },
-            ))
-        }).unwrap_or_else(Client::disabled))))
+        hub.bind_client(Some(Arc::new(
+            dsn.and_then(|dsn| {
+                Client::from_config((
+                    dsn,
+                    ClientOptions {
+                        release: sentry_crate_release!(),
+                        user_agent: Cow::Borrowed(USER_AGENT),
+                        ..Default::default()
+                    },
+                ))
+            }).unwrap_or_else(Client::disabled),
+        )))
     });
 }
 

--- a/src/utils/dif.rs
+++ b/src/utils/dif.rs
@@ -126,7 +126,8 @@ impl DifFile {
 
     pub fn variants(&self) -> BTreeMap<DebugId, Option<&'static str>> {
         match self {
-            &DifFile::Object(ref fat) => fat.objects()
+            &DifFile::Object(ref fat) => fat
+                .objects()
                 .filter_map(|result| result.ok())
                 .filter_map(|object| {
                     object
@@ -140,7 +141,8 @@ impl DifFile {
 
     pub fn ids(&self) -> Vec<DebugId> {
         match self {
-            &DifFile::Object(ref fat) => fat.objects()
+            &DifFile::Object(ref fat) => fat
+                .objects()
                 .filter_map(|result| result.ok())
                 .filter_map(|object| object.id())
                 .collect(),
@@ -150,7 +152,8 @@ impl DifFile {
 
     pub fn is_usable(&self) -> bool {
         match self {
-            &DifFile::Object(ref fat) => fat.objects()
+            &DifFile::Object(ref fat) => fat
+                .objects()
                 .filter_map(|result| result.ok())
                 .any(|object| object.debug_kind().is_some()),
             &DifFile::Proguard(ref pg) => pg.has_line_info(),

--- a/src/utils/dif_upload.rs
+++ b/src/utils/dif_upload.rs
@@ -809,7 +809,7 @@ fn process_symbol_maps<'a>(
 fn try_assemble_difs<'data>(
     difs: &'data [ChunkedDifMatch<'data>],
     options: &DifUpload,
-) -> Result<Option<MissingDifsInfo<'data>>, Error> {
+) -> Result<MissingDifsInfo<'data>, Error> {
     let api = Api::get_current();
     let request = difs.iter().map(ChunkedDifMatch::to_assemble).collect();
     let response = api.assemble_difs(&options.org, &options.project, &request)?;
@@ -832,8 +832,9 @@ fn try_assemble_difs<'data>(
         match file_response.state {
             ChunkedFileState::Error => {
                 // One of the files could not be uploaded properly and resulted
-                // in an error. We might still want to wait for all other files,
-                // however, so we ignore this file for now.
+                // in an error. We include this file in the return value so that
+                // it shows up in the final report.
+                difs.push(chunked_match);
             }
             ChunkedFileState::NotFound => {
                 // Assembling for one of the files has not started because some
@@ -865,11 +866,7 @@ fn try_assemble_difs<'data>(
         }
     }
 
-    if chunks.is_empty() {
-        Ok(None)
-    } else {
-        Ok(Some((difs, chunks)))
-    }
+    Ok((difs, chunks))
 }
 
 /// Concurrently uploads chunks specified in `missing_info` in batches. The
@@ -882,6 +879,13 @@ fn upload_missing_chunks(
     chunk_options: &ChunkUploadOptions,
 ) -> Result<(), Error> {
     let &(ref difs, ref chunks) = missing_info;
+
+    // Chunks might be empty if errors occurred in a previous upload. We do
+    // not need to render a progress bar or perform an upload in this case.
+    if chunks.is_empty() {
+        return Ok(());
+    }
+
     let progress_style = ProgressStyle::default_bar().template(&format!(
         "{} Uploading {} missing debug information file{}...\
          \n{{wide_bar}}  {{bytes}}/{{total_bytes}} ({{eta}})",
@@ -1101,16 +1105,14 @@ fn upload_difs_chunked(
         ChunkedDifMatch::from(m, chunk_options.chunk_size)
     })?;
 
-    // Upload until all chunks are present on the server
-    let mut initially_missing = None;
-    while let Some(missing_info) = try_assemble_difs(&chunked, options)? {
-        upload_missing_chunks(&missing_info, chunk_options)?;
-        initially_missing.get_or_insert(missing_info);
-    }
+    // Upload missing chunks to the server and remember incomplete difs
+    let missing_info = try_assemble_difs(&chunked, options)?;
+    upload_missing_chunks(&missing_info, chunk_options)?;
 
     // Only if DIFs were missing, poll until assembling is complete
-    if let Some((missing, _)) = initially_missing {
-        poll_dif_assemble(missing, options)
+    let (missing_difs, _) = missing_info;
+    if !missing_difs.is_empty() {
+        poll_dif_assemble(missing_difs, options)
     } else {
         println!(
             "{} Nothing to upload, all files are on the server",

--- a/src/utils/dif_upload.rs
+++ b/src/utils/dif_upload.rs
@@ -25,7 +25,8 @@ use rayon::prelude::*;
 use rayon::ThreadPoolBuilder;
 use sha1::Digest;
 use symbolic::common::{
-    byteview::ByteView, types::{ObjectClass, ObjectKind},
+    byteview::ByteView,
+    types::{ObjectClass, ObjectKind},
 };
 use symbolic::debuginfo::{DebugId, FatObject, Object};
 use walkdir::WalkDir;
@@ -480,7 +481,8 @@ where
         }
 
         let buffer = ByteView::from_path(path).map_err(SyncFailure::new)?;
-        let name = path.strip_prefix(&directory)
+        let name = path
+            .strip_prefix(&directory)
             .unwrap()
             .to_string_lossy()
             .into_owned();
@@ -891,7 +893,8 @@ fn upload_missing_chunks(
     // To make the progress bar more consistent for repeated and partial uploads
     // we also include already uploaded chunks in the progress bar. Thus, the
     // first chunk's progress starts at the amount of already uploaded bytes.
-    let total_bytes = difs.iter()
+    let total_bytes = difs
+        .iter()
         .flat_map(|m| m.chunks().map(|DifChunk((_, data))| data.len() as u64))
         .sum();
     let missing_bytes: u64 = chunks
@@ -1023,12 +1026,14 @@ fn poll_dif_assemble(
     // Print a summary of all successes first, so that errors show up at the
     // bottom for the user
     successes.sort_by(|a, b| {
-        let name_a = a.1
+        let name_a = a
+            .1
             .dif
             .as_ref()
             .map(|x| x.object_name.as_str())
             .unwrap_or("");
-        let name_b = b.1
+        let name_b = b
+            .1
             .dif
             .as_ref()
             .map(|x| x.object_name.as_str())

--- a/src/utils/releases.rs
+++ b/src/utils/releases.rs
@@ -52,7 +52,8 @@ pub fn get_xcode_release_name(plist: Option<InfoPlist>) -> Result<Option<String>
 pub fn infer_gradle_release_name(path: Option<PathBuf>) -> Result<Option<String>, Error> {
     lazy_static! {
         static ref APP_ID_RE: Regex = Regex::new(r#"applicationId\s+["']([^"']*)["']"#).unwrap();
-        static ref VERSION_NAME_RE: Regex = Regex::new(r#"versionName\s+["']([^"']*)["']"#).unwrap();
+        static ref VERSION_NAME_RE: Regex =
+            Regex::new(r#"versionName\s+["']([^"']*)["']"#).unwrap();
     }
 
     let mut contents = String::new();

--- a/src/utils/sourcemaps.rs
+++ b/src/utils/sourcemaps.rs
@@ -257,7 +257,8 @@ impl SourceMapProcessor {
             try!(f.read_to_end(&mut contents));
             let ty = if sourcemap::is_sourcemap_slice(&contents) {
                 SourceType::SourceMap
-            } else if path.file_name()
+            } else if path
+                .file_name()
                 .and_then(|x| x.to_str())
                 .map(|x| x.contains(".min."))
                 .unwrap_or(false) || is_likely_minified_js(&contents)
@@ -481,7 +482,8 @@ impl SourceMapProcessor {
 
         // get a list of release files first so we know the file IDs of
         // files that already exist.
-        let release_files: HashMap<_, _> = api.list_release_files(org, project, release)?
+        let release_files: HashMap<_, _> = api
+            .list_release_files(org, project, release)?
             .into_iter()
             .map(|artifact| ((artifact.dist, artifact.name), artifact.id))
             .collect();

--- a/src/utils/xcode.rs
+++ b/src/utils/xcode.rs
@@ -59,7 +59,8 @@ pub fn expand_xcodevars(s: String, vars: &HashMap<String, String>) -> String {
             return "".into();
         }
         let mut iter = key.splitn(2, ':');
-        let value = vars.get(iter.next().unwrap())
+        let value = vars
+            .get(iter.next().unwrap())
             .map(|x| x.as_str())
             .unwrap_or("");
         match iter.next() {


### PR DESCRIPTION
With this change, sentry-cli will always show errors for DIFs during the
assemble poll, even if all their chunks had already been uploaded. Previously,
such an upload would just show:

```
> Nothing to upload, all files are on the server
```

This made it hard to track and reproduce DIF upload and assembly errors.