### PR TITLE
fix(docker): Add a warning about the new Docker entrypoint

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -4,3 +4,4 @@
 !Cargo.lock
 !Cargo.toml
 !build.rs
+!docker-entrypoint.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,5 +22,6 @@ RUN cp target/$BUILD_TARGET/release/sentry-cli /usr/local/bin/sentry-cli
 FROM alpine:3.7
 WORKDIR /work
 RUN apk add --no-cache ca-certificates
+COPY ./docker-entrypoint.sh /
 COPY --from=sentry-build /usr/local/bin/sentry-cli /bin
-ENTRYPOINT ["/bin/sentry-cli"]
+ENTRYPOINT ["/docker-entrypoint.sh"]

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ we recommend you to use the `latest` tag. To use it, run:
 
 ```sh
 docker pull getsentry/sentry-cli
-docker run --rm -it -v $(pwd):/work getsentry/sentry-cli --help
+docker run --rm -v $(pwd):/work getsentry/sentry-cli --help
 ```
 
 ## Compiling

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,14 @@
+#!/bin/sh
+
+# TODO Remove after 1.37 release
+if [ "${1}" == "sentry-cli" ]; then
+  echo >&2 "======================================================================"
+  echo >&2 "=== WARNING: Entrypoint of this Docker image has changed. ============"
+  echo >&2 "=== Future versions of the image might not work correctly for you. ==="
+  echo >&2 "=== More details: https://github.com/getsentry/sentry-cli#docker ====="
+  echo >&2 "======================================================================"
+  echo >&2
+  shift
+fi
+
+exec /bin/sentry-cli "$@"


### PR DESCRIPTION
To facilitate migration to the new entrypoint, let's allow both execution formats for now.
If "sentry-cli" is given as a first argument, show a scary warning.