### PR TITLE
Handle API change in repository provider IDs

### DIFF
--- a/src/utils/vcs.rs
+++ b/src/utils/vcs.rs
@@ -169,7 +169,7 @@ fn find_reference_url(repo: &str, repos: &[Repo]) -> Result<String, Error> {
         }
 
         match configured_repo.provider.id.as_str() {
-            "github" | "bitbucket" | "visualstudio" | "git" => {
+            "integrations:github" | "integrations:bitbucket" | "integrations:visualstudio" | "github" | "bitbucket" | "visualstudio" | "git" => {
                 if let Some(ref url) = configured_repo.url {
                     return Ok(url.clone());
                 }


### PR DESCRIPTION
The ID now might contain integrations: prefix.

I'm not really sure this is a correct fix, it's just wild guess and I currently can't compile the code locally to test it.

See https://github.com/getsentry/sentry-cli/issues/371