### PR TITLE
fix: correct bin path

### DIFF
--- a/js/helper.js
+++ b/js/helper.js
@@ -12,7 +12,7 @@ const childProcess = require('child_process');
 let binaryPath =
   os.platform() === 'win32'
     ? path.resolve(__dirname, '..\\bin\\sentry-cli.exe')
-    : path.resolve(__dirname, '../sentry-cli');
+    : path.resolve(__dirname, '../bin/sentry-cli');
 
 /**
  * Overrides the default binary path with a mock value, useful for testing.


### PR DESCRIPTION
This seems, at least on my CI system, to fix the issue discussed here; https://github.com/getsentry/react-native-sentry/issues/401

This change might have some unknown consequences which I have not yet seen. Please review thoroughly before a possible merge.