### PR TITLE
fix: Correctly parse send-event --no-environ

### DIFF
--- a/src/commands/send_event.rs
+++ b/src/commands/send_event.rs
@@ -152,7 +152,7 @@ pub fn execute<'a>(matches: &ArgMatches<'a>) -> Result<(), Error> {
         event.tags.insert(key.into(), value.into());
     }
 
-    if !matches.is_present("no-environ") {
+    if !matches.is_present("no_environ") {
         event.extra.insert(
             "environ".into(),
             Value::Object(env::vars().map(|(k, v)| (k, Value::String(v))).collect()),


### PR DESCRIPTION
Fixes https://github.com/getsentry/sentry-cli/issues/383