### PR TITLE
ref: Always print the event ID in send-event

### DIFF
--- a/src/commands/bash_hook.rs
+++ b/src/commands/bash_hook.rs
@@ -150,9 +150,8 @@ fn send_event(traceback: &str, logfile: &str) -> Result<(), Error> {
         ..Default::default()
     });
 
-    if let Some(id) = with_sentry_client(config.get_dsn()?, |c| c.capture_event(event, None)) {
-        println!("{}", id);
-    }
+    let id = with_sentry_client(config.get_dsn()?, |c| c.capture_event(event, None));
+    println!("{}", id);
 
     Ok(())
 }

--- a/src/commands/send_event.rs
+++ b/src/commands/send_event.rs
@@ -14,7 +14,13 @@ use utils::releases::detect_release_name;
 
 pub fn make_app<'a, 'b: 'a>(app: App<'a, 'b>) -> App<'a, 'b> {
     app.about("Send a manual event to Sentry.")
-        .arg(
+        .long_about(
+            "Send a manual event to Sentry.{n}{n}\
+             NOTE: This command will validate input parameters and attempt to send an event to \
+             Sentry. Due to network errors, rate limits or sampling the event is not guaranteed to \
+             actually arrive. Check debug output for transmission errors by passing --log-level=\
+             debug or setting `SENTRY_LOG_LEVEL=debug`.",
+        ).arg(
             Arg::with_name("level")
                 .value_name("LEVEL")
                 .long("level")

--- a/src/commands/send_event.rs
+++ b/src/commands/send_event.rs
@@ -11,7 +11,6 @@ use username::get_user_name;
 use config::Config;
 use utils::event::{attach_logfile, get_sdk_info, with_sentry_client};
 use utils::releases::detect_release_name;
-use utils::system::QuietExit;
 
 pub fn make_app<'a, 'b: 'a>(app: App<'a, 'b>) -> App<'a, 'b> {
     app.about("Send a manual event to Sentry.")
@@ -205,12 +204,8 @@ pub fn execute<'a>(matches: &ArgMatches<'a>) -> Result<(), Error> {
         attach_logfile(&mut event, logfile, false)?;
     }
 
-    if let Some(id) = with_sentry_client(config.get_dsn()?, |c| c.capture_event(event, None)) {
-        println!("Event sent: {}", id);
-    } else {
-        eprintln!("error: could not send event");
-        return Err(QuietExit(1).into());
-    }
+    let id = with_sentry_client(config.get_dsn()?, |c| c.capture_event(event, None));
+    println!("{}", id);
 
     Ok(())
 }

--- a/src/utils/event.rs
+++ b/src/utils/event.rs
@@ -78,11 +78,9 @@ pub fn get_sdk_info() -> Cow<'static, ClientSdkInfo> {
 /// Executes the callback with an isolate sentry client on an empty isolate scope.
 ///
 /// Use the client's API to capture exceptions or manual events. The client will automatically drop
-/// after the callback has finished and drain its queue with a timeout of 2 seconds.
-///
-/// You can optionally return a value from the callback which will also be the return value of this
-/// function if draining the queue is successful. On error, the return value will be None.
-pub fn with_sentry_client<F, R>(dsn: Dsn, callback: F) -> Option<R>
+/// after the callback has finished and drain its queue with a timeout of 2 seconds. The return
+/// value of the callback is passed through to the caller.
+pub fn with_sentry_client<F, R>(dsn: Dsn, callback: F) -> R
 where
     F: FnOnce(&Client) -> R,
 {
@@ -95,9 +93,6 @@ where
     ));
 
     let rv = callback(&client);
-    if client.close(Some(Duration::from_secs(2))) {
-        Some(rv)
-    } else {
-        None
-    }
+    client.close(Some(Duration::from_secs(2)));
+    rv
 }


### PR DESCRIPTION
Fixes https://github.com/getsentry/sentry-cli/issues/350