### PR TITLE
ci: Update "gcs" target options, make zeus upload fail for releases

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -42,7 +42,7 @@ test_script:
   - cargo run --release -- releases list
 
 on_success:
-  - zeus upload -t "application/octet-stream" -n sentry-cli-Windows-%arch%.exe .\target\release\sentry-cli.exe
+  - zeus upload -t "application/octet-stream" -n sentry-cli-Windows-%arch%.exe .\target\release\sentry-cli.exe || [[ ! "$APPVEYOR_REPO_BRANCH" =~ ^release/ ]]
   - zeus job update --status=passed
 
 on_failure:

--- a/.craft.yml
+++ b/.craft.yml
@@ -1,5 +1,5 @@
 ---
-minVersion: '0.5.1'
+minVersion: '0.6.0'
 github:
   owner: getsentry
   repo: sentry-cli
@@ -30,12 +30,14 @@ targets:
     bucket: sentry-sdk-assets
     paths:
       - path: /sentry-cli/{{version}}/
-        maxCacheAge: 2592000
+        metadata:
+          cacheControl: 'public, max-age=2592000'
       - path: /sentry-cli/latest/
-        maxCacheAge: 600
+        metadata:
+          cacheControl: 'public, max-age=600'
   - name: registry
     type: app
     urlTemplate: "https://downloads.sentry-cdn.com/sentry-cli/{{version}}/{{file}}"
-    includeNames: /^.*sentry-cli.*$/
+    includeNames: /^sentry-cli-.*$/
     config:
       canonical: "app:sentry-cli"

--- a/.travis.yml
+++ b/.travis.yml
@@ -65,11 +65,11 @@ matrix:
       env:
         - TARGET=i686-unknown-linux-musl
         - DOCKER_TAG=i686-musl
-      script: bash scripts/build-in-docker.sh
-      after_success:
+      script:
+        - bash scripts/build-in-docker.sh
         - zeus upload -t "application/octet-stream"
                       -n "sentry-cli-Linux-i686"
-                      "./target/${TARGET}/release/sentry-cli"
+                      "./target/${TARGET}/release/sentry-cli" || [[ ! "$TRAVIS_BRANCH" =~ ^release/ ]]
 
     - name: "build: linux x86_64"
       os: linux
@@ -77,11 +77,11 @@ matrix:
       env:
         - TARGET=x86_64-unknown-linux-musl
         - DOCKER_TAG=x86_64-musl
-      script: bash scripts/build-in-docker.sh
-      after_success:
+      script:
+        - bash scripts/build-in-docker.sh
         - zeus upload -t "application/octet-stream"
                       -n "sentry-cli-Linux-x86_64"
-                      "./target/${TARGET}/release/sentry-cli"
+                      "./target/${TARGET}/release/sentry-cli" || [[ ! "$TRAVIS_BRANCH" =~ ^release/ ]]
 
     - name: "build: macOS x86_64"
       os: osx
@@ -93,10 +93,9 @@ matrix:
       script:
         - cargo build --release --locked
         - cargo run --release -- releases list
-      after_success:
         - zeus upload -t "application/octet-stream"
                       -n "sentry-cli-Darwin-x86_64"
-                      "./target/release/sentry-cli"
+                      "./target/release/sentry-cli" || [[ ! "$TRAVIS_BRANCH" =~ ^release/ ]]
 
     - name: "build: NPM package"
       os: linux
@@ -104,9 +103,9 @@ matrix:
       node_js: "8"
       install: true
       env: TARGET=npm
-      script: npm pack
-      after_success:
-        - zeus upload -t "application/tar+npm" *.tgz
+      script:
+        - npm pack
+        - zeus upload -t "application/tar+npm" *.tgz || [[ ! "$TRAVIS_BRANCH" =~ ^release/ ]]
 
 notifications:
   webhooks:


### PR DESCRIPTION
`|| [[ ! "$TRAVIS_BRANCH" =~ ^release/ ]]` will only fail the build if the command before it fails *and* it's a build on the release branch.