### PR TITLE
fix: Prepare for making --rewrite the default

### DIFF
--- a/js/__tests__/helper.test.js
+++ b/js/__tests__/helper.test.js
@@ -81,6 +81,17 @@ describe('SentryCli helper', () => {
       ['releases', 'files', 'release', 'upload-sourcemaps', '/dev/null', '--rewrite']
     );
 
+    expect(
+      helper.prepareCommand(command, SOURCEMAPS_OPTIONS, { rewrite: false })
+    ).toEqual([
+      'releases',
+      'files',
+      'release',
+      'upload-sourcemaps',
+      '/dev/null',
+      '--no-rewrite',
+    ]);
+
     expect(() => {
       helper.prepareCommand(command, SOURCEMAPS_OPTIONS, { sourceMapReference: 'node' });
     }).toThrow();

--- a/js/helper.js
+++ b/js/helper.js
@@ -48,12 +48,13 @@ function mockBinaryPath(mockPath) {
  * @returns {string[]} An arguments array that can be passed via command line.
  */
 function serializeOptions(schema, options) {
-  return Object.keys(schema).reduce((newOptions2, option) => {
+  return Object.keys(schema).reduce((newOptions, option) => {
     const paramValue = options[option];
     if (paramValue === undefined) {
-      return newOptions2;
+      return newOptions;
     }
 
+    // eslint-disable-next-line no-shadow
     return schema[option].reduce((newOptions, action) => {
       const paramType = action.type;
       const paramName = action.param;
@@ -83,7 +84,7 @@ function serializeOptions(schema, options) {
       }
 
       return newOptions.concat(paramName, paramValue);
-    }, newOptions2);
+    }, newOptions);
   }, []);
 }
 

--- a/js/helper.js
+++ b/js/helper.js
@@ -67,28 +67,22 @@ function serializeOptions(schema, options) {
       );
     }
 
-    if (paramType === 'boolean' || paramType === 'inverted-boolean') {
+    if (paramType === 'boolean') {
       if (typeof paramValue !== 'boolean') {
         throw new Error(`${option} should be a bool`);
       }
 
-      if (paramType === 'boolean' && paramValue) {
+      const invertedParamName = schema[option].invertedParam;
+
+      if (paramValue && paramName !== undefined) {
         return newOptions.concat([paramName]);
       }
 
-      if (paramType === 'inverted-boolean' && paramValue === false) {
-        return newOptions.concat([paramName]);
+      if (!paramValue && invertedParamName !== undefined) {
+        return newOptions.concat([invertedParamName]);
       }
 
       return newOptions;
-    }
-
-    if (paramType === 'toggle') {
-      if (typeof paramValue !== 'boolean') {
-        throw new Error(`${option} should be a bool`);
-      }
-
-      return newOptions.concat([paramValue ? paramName : schema[option].invertedParam]);
     }
 
     return newOptions.concat(paramName, paramValue);

--- a/js/helper.js
+++ b/js/helper.js
@@ -54,37 +54,44 @@ function serializeOptions(schema, options) {
       return newOptions;
     }
 
-    // eslint-disable-next-line no-shadow
-    return schema[option].reduce((newOptions, action) => {
-      const paramType = action.type;
-      const paramName = action.param;
+    const paramType = schema[option].type;
+    const paramName = schema[option].param;
 
-      if (paramType === 'array') {
-        if (!Array.isArray(paramValue)) {
-          throw new Error(`${option} should be an array`);
-        }
-
-        return newOptions.concat(
-          paramValue.reduce((acc, value) => acc.concat([paramName, String(value)]), [])
-        );
+    if (paramType === 'array') {
+      if (!Array.isArray(paramValue)) {
+        throw new Error(`${option} should be an array`);
       }
 
-      if (paramType === 'boolean' || paramType === 'inverted-boolean') {
-        if (typeof paramValue !== 'boolean') {
-          throw new Error(`${option} should be a bool`);
-        }
-        if (paramType === 'boolean' && paramValue) {
-          return newOptions.concat([paramName]);
-        }
+      return newOptions.concat(
+        paramValue.reduce((acc, value) => acc.concat([paramName, String(value)]), [])
+      );
+    }
 
-        if (paramType === 'inverted-boolean' && paramValue === false) {
-          return newOptions.concat([paramName]);
-        }
-        return newOptions;
+    if (paramType === 'boolean' || paramType === 'inverted-boolean') {
+      if (typeof paramValue !== 'boolean') {
+        throw new Error(`${option} should be a bool`);
       }
 
-      return newOptions.concat(paramName, paramValue);
-    }, newOptions);
+      if (paramType === 'boolean' && paramValue) {
+        return newOptions.concat([paramName]);
+      }
+
+      if (paramType === 'inverted-boolean' && paramValue === false) {
+        return newOptions.concat([paramName]);
+      }
+
+      return newOptions;
+    }
+
+    if (paramType === 'toggle') {
+      if (typeof paramValue !== 'boolean') {
+        throw new Error(`${option} should be a bool`);
+      }
+
+      return newOptions.concat([paramValue ? paramName : schema[option].invertedParam]);
+    }
+
+    return newOptions.concat(paramName, paramValue);
   }, []);
 }
 

--- a/js/helper.js
+++ b/js/helper.js
@@ -48,42 +48,42 @@ function mockBinaryPath(mockPath) {
  * @returns {string[]} An arguments array that can be passed via command line.
  */
 function serializeOptions(schema, options) {
-  return Object.keys(schema).reduce((newOptions, option) => {
+  return Object.keys(schema).reduce((newOptions2, option) => {
     const paramValue = options[option];
     if (paramValue === undefined) {
-      return newOptions;
+      return newOptions2;
     }
 
-    const paramType = schema[option].type;
-    const paramName = schema[option].param;
+    return schema[option].reduce((newOptions, action) => {
+      const paramType = action.type;
+      const paramName = action.param;
 
-    if (paramType === 'array') {
-      if (!Array.isArray(paramValue)) {
-        throw new Error(`${option} should be an array`);
+      if (paramType === 'array') {
+        if (!Array.isArray(paramValue)) {
+          throw new Error(`${option} should be an array`);
+        }
+
+        return newOptions.concat(
+          paramValue.reduce((acc, value) => acc.concat([paramName, String(value)]), [])
+        );
       }
 
-      return newOptions.concat(
-        paramValue.reduce((acc, value) => acc.concat([paramName, String(value)]), [])
-      );
-    }
+      if (paramType === 'boolean' || paramType === 'inverted-boolean') {
+        if (typeof paramValue !== 'boolean') {
+          throw new Error(`${option} should be a bool`);
+        }
+        if (paramType === 'boolean' && paramValue) {
+          return newOptions.concat([paramName]);
+        }
 
-    if (paramType === 'boolean' || paramType === 'inverted-boolean') {
-      if (typeof paramValue !== 'boolean') {
-        throw new Error(`${option} should be a bool`);
+        if (paramType === 'inverted-boolean' && paramValue === false) {
+          return newOptions.concat([paramName]);
+        }
+        return newOptions;
       }
 
-      if (paramType === 'boolean' && paramValue) {
-        return newOptions.concat([paramName]);
-      }
-
-      if (paramType === 'inverted-boolean' && paramValue === false) {
-        return newOptions.concat([paramName]);
-      }
-
-      return newOptions;
-    }
-
-    return newOptions.concat(paramName, paramValue);
+      return newOptions.concat(paramName, paramValue);
+    }, newOptions2);
   }, []);
 }
 

--- a/js/releases/options/uploadSourcemaps.js
+++ b/js/releases/options/uploadSourcemaps.js
@@ -10,11 +10,11 @@ module.exports = {
   rewrite: {
     param: '--rewrite',
     invertedParam: '--no-rewrite',
-    type: 'toggle',
+    type: 'boolean',
   },
   sourceMapReference: {
-    param: '--no-sourcemap-reference',
-    type: 'inverted-boolean',
+    invertedParam: '--no-sourcemap-reference',
+    type: 'boolean',
   },
   stripPrefix: {
     param: '--strip-prefix',

--- a/js/releases/options/uploadSourcemaps.js
+++ b/js/releases/options/uploadSourcemaps.js
@@ -1,66 +1,43 @@
 module.exports = {
-  ignore: [
-    {
-      param: '--ignore',
-      type: 'array',
-    },
-  ],
-  ignoreFile: [
-    {
-      param: '--ignore-file',
-      type: 'string',
-    },
-  ],
-  rewrite: [
-    {
-      param: '--rewrite',
-      type: 'boolean',
-    },
-    {
-      param: '--no-rewrite',
-      type: 'inverted-boolean',
-    },
-  ],
-  sourceMapReference: [
-    {
-      param: '--no-sourcemap-reference',
-      type: 'inverted-boolean',
-    },
-  ],
-  stripPrefix: [
-    {
-      param: '--strip-prefix',
-      type: 'array',
-    },
-  ],
-  stripCommonPrefix: [
-    {
-      param: '--strip-common-prefix',
-      type: 'boolean',
-    },
-  ],
-  validate: [
-    {
-      param: '--validate',
-      type: 'boolean',
-    },
-  ],
-  urlPrefix: [
-    {
-      param: '--url-prefix',
-      type: 'string',
-    },
-  ],
-  urlSuffix: [
-    {
-      param: '--url-suffix',
-      type: 'string',
-    },
-  ],
-  ext: [
-    {
-      param: '--ext',
-      type: 'array',
-    },
-  ],
+  ignore: {
+    param: '--ignore',
+    type: 'array',
+  },
+  ignoreFile: {
+    param: '--ignore-file',
+    type: 'string',
+  },
+  rewrite: {
+    param: '--rewrite',
+    invertedParam: '--no-rewrite',
+    type: 'toggle',
+  },
+  sourceMapReference: {
+    param: '--no-sourcemap-reference',
+    type: 'inverted-boolean',
+  },
+  stripPrefix: {
+    param: '--strip-prefix',
+    type: 'array',
+  },
+  stripCommonPrefix: {
+    param: '--strip-common-prefix',
+    type: 'boolean',
+  },
+  validate: {
+    param: '--validate',
+    type: 'boolean',
+  },
+  urlPrefix: {
+    param: '--url-prefix',
+    type: 'string',
+  },
+  urlSuffix: {
+    param: '--url-suffix',
+    type: 'string',
+  },
+  ext: {
+    param: '--ext',
+    type: 'array',
+  },
 };

--- a/js/releases/options/uploadSourcemaps.js
+++ b/js/releases/options/uploadSourcemaps.js
@@ -1,42 +1,66 @@
 module.exports = {
-  ignore: {
-    param: '--ignore',
-    type: 'array',
-  },
-  ignoreFile: {
-    param: '--ignore-file',
-    type: 'string',
-  },
-  rewrite: {
-    param: '--rewrite',
-    type: 'boolean',
-  },
-  sourceMapReference: {
-    param: '--no-sourcemap-reference',
-    type: 'inverted-boolean',
-  },
-  stripPrefix: {
-    param: '--strip-prefix',
-    type: 'array',
-  },
-  stripCommonPrefix: {
-    param: '--strip-common-prefix',
-    type: 'boolean',
-  },
-  validate: {
-    param: '--validate',
-    type: 'boolean',
-  },
-  urlPrefix: {
-    param: '--url-prefix',
-    type: 'string',
-  },
-  urlSuffix: {
-    param: '--url-suffix',
-    type: 'string',
-  },
-  ext: {
-    param: '--ext',
-    type: 'array',
-  },
+  ignore: [
+    {
+      param: '--ignore',
+      type: 'array',
+    },
+  ],
+  ignoreFile: [
+    {
+      param: '--ignore-file',
+      type: 'string',
+    },
+  ],
+  rewrite: [
+    {
+      param: '--rewrite',
+      type: 'boolean',
+    },
+    {
+      param: '--no-rewrite',
+      type: 'inverted-boolean',
+    },
+  ],
+  sourceMapReference: [
+    {
+      param: '--no-sourcemap-reference',
+      type: 'inverted-boolean',
+    },
+  ],
+  stripPrefix: [
+    {
+      param: '--strip-prefix',
+      type: 'array',
+    },
+  ],
+  stripCommonPrefix: [
+    {
+      param: '--strip-common-prefix',
+      type: 'boolean',
+    },
+  ],
+  validate: [
+    {
+      param: '--validate',
+      type: 'boolean',
+    },
+  ],
+  urlPrefix: [
+    {
+      param: '--url-prefix',
+      type: 'string',
+    },
+  ],
+  urlSuffix: [
+    {
+      param: '--url-suffix',
+      type: 'string',
+    },
+  ],
+  ext: [
+    {
+      param: '--ext',
+      type: 'array',
+    },
+  ],
 };


### PR DESCRIPTION
- Write out warning if the option is not set in the js helper or not specified
as CLI flag.
- Make --rewrite and --no-rewrite actually mutually exclusive.
- If `rewrite` in the js helper is explicitly set to false, pass `--no-rewrite` to CLI