### PR TITLE
feat: Cache binaries on npm/yarn install

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,8 +30,9 @@
     "sentry-cli": "bin/sentry-cli"
   },
   "dependencies": {
-    "fs-extra": "^7.0.1",
+    "fs-copy-file-sync": "^1.1.1",
     "https-proxy-agent": "^2.2.1",
+    "mkdirp": "^0.5.1",
     "node-fetch": "^2.1.2",
     "progress": "2.0.0",
     "proxy-from-env": "^1.0.0"

--- a/scripts/install.js
+++ b/scripts/install.js
@@ -2,7 +2,7 @@
 
 'use strict';
 
-const fs = require('fs-extra');
+const fs = require('fs');
 const http = require('http');
 const os = require('os');
 const path = require('path');
@@ -12,6 +12,8 @@ const HttpsProxyAgent = require('https-proxy-agent');
 const fetch = require('node-fetch');
 const ProgressBar = require('progress');
 const Proxy = require('proxy-from-env');
+const copyFileSync = require('fs-copy-file-sync');
+const mkdirp = require('mkdirp');
 
 const helper = require('../js/helper');
 const pkgInfo = require('../package.json');
@@ -114,7 +116,7 @@ function downloadBinary() {
 
   const cachedPath = getCachedPath(downloadUrl);
   if (fs.existsSync(cachedPath)) {
-    fs.copyFileSync(cachedPath, outputPath);
+    copyFileSync(cachedPath, outputPath);
     return Promise.resolve();
   }
 
@@ -136,7 +138,7 @@ function downloadBinary() {
     const progressBar = createProgressBar(name, total);
 
     const tempPath = getTempFile(cachedPath);
-    fs.ensureDirSync(path.dirname(tempPath));
+    mkdirp.sync(path.dirname(tempPath));
 
     return new Promise((resolve, reject) => {
       response.body
@@ -146,8 +148,8 @@ function downloadBinary() {
         .on('error', e => reject(e))
         .on('close', () => resolve());
     }).then(() => {
-      fs.copyFileSync(tempPath, cachedPath);
-      fs.copyFileSync(tempPath, outputPath);
+      copyFileSync(tempPath, cachedPath);
+      copyFileSync(tempPath, outputPath);
       fs.unlinkSync(tempPath);
     });
   });

--- a/yarn.lock
+++ b/yarn.lock
@@ -1447,14 +1447,10 @@ from@~0:
   resolved "https://registry.yarnpkg.com/from/-/from-0.1.7.tgz#83c60afc58b9c56997007ed1a768b3ab303a44fe"
   integrity sha1-g8YK/Fi5xWmXAH7Rp2izqzA6RP4=
 
-fs-extra@^7.0.1:
-  version "7.0.1"
-  resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-7.0.1.tgz#4f189c44aa123b895f722804f55ea23eadc348e9"
-  integrity sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==
-  dependencies:
-    graceful-fs "^4.1.2"
-    jsonfile "^4.0.0"
-    universalify "^0.1.0"
+fs-copy-file-sync@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/fs-copy-file-sync/-/fs-copy-file-sync-1.1.1.tgz#11bf32c096c10d126e5f6b36d06eece776062918"
+  integrity sha512-2QY5eeqVv4m2PfyMiEuy9adxNP+ajf+8AR05cEi+OAzPcOj90hvFImeZhTmKLBgSd9EvG33jsD7ZRxsx9dThkQ==
 
 fs.realpath@^1.0.0:
   version "1.0.0"
@@ -1592,11 +1588,6 @@ graceful-fs@^4.1.11, graceful-fs@^4.1.2:
   version "4.1.11"
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.1.11.tgz#0e8bdfe4d1ddb8854d64e04ea7c00e2a026e5658"
   integrity sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=
-
-graceful-fs@^4.1.6:
-  version "4.1.15"
-  resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.1.15.tgz#ffb703e1066e8a0eeaa4c8b80ba9253eeefbfb00"
-  integrity sha512-6uHUhOPEBgQ24HM+r6b/QwWfZq+yiFcipKFrOFiBEnWdy5sdzYoi+pJeQaPI5qOLRFqWmAXUPQNsielzdLoecA==
 
 growly@^1.3.0:
   version "1.3.0"
@@ -2507,13 +2498,6 @@ json5@^0.5.1:
   version "0.5.1"
   resolved "https://registry.yarnpkg.com/json5/-/json5-0.5.1.tgz#1eade7acc012034ad84e2396767ead9fa5495821"
   integrity sha1-Hq3nrMASA0rYTiOWdn6tn6VJWCE=
-
-jsonfile@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/jsonfile/-/jsonfile-4.0.0.tgz#8771aae0799b64076b76640fca058f9c10e33ecb"
-  integrity sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=
-  optionalDependencies:
-    graceful-fs "^4.1.6"
 
 jsonify@~0.0.0:
   version "0.0.0"
@@ -4093,11 +4077,6 @@ union-value@^1.0.0:
     get-value "^2.0.6"
     is-extendable "^0.1.1"
     set-value "^0.4.3"
-
-universalify@^0.1.0:
-  version "0.1.2"
-  resolved "https://registry.yarnpkg.com/universalify/-/universalify-0.1.2.tgz#b646f69be3942dabcecc9d6639c80dc105efaa66"
-  integrity sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==
 
 unset-value@^1.0.0:
   version "1.0.0"


### PR DESCRIPTION
Cache binaries locally which helps when using a poor or intermittent connection but also allows the cli to support offline yarn install.

Fixes: #279 and #273

Also fixes an issue where a failed partial download could only be remedied by removing the partial binary or nuking `node_modules`.

- Cache location and temp file logic comes from [`prebuilt-install`](https://github.com/prebuild/prebuild-install/blob/0da7f4e7d838dfcf4f197350a3de960ee66b20fa/util.js#L79) which is robust and well tested
  - Addition of `npm_config_yarn_offline_mirror` as cache location
- Fixed `package.json` scripts so they work on Windows