### PR TITLE
ci: Fix PR builds from forks

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -40,9 +40,8 @@ build: false
 test_script:
   - set RUSTFLAGS=-Ctarget-feature=+crt-static
   - cargo build --release --locked
-  - echo %APPVEYOR_PULL_REQUEST_HEAD_REPO_NAME%
-  - cargo run --release -- releases list ||
-      if [%APPVEYOR_PULL_REQUEST_HEAD_REPO_NAME%] == [getsentry/sentry-cli] (fail) else (echo "Building branch or fork PR, ignoring")
+  - if [%APPVEYOR_PULL_REQUEST_HEAD_REPO_NAME%] == [getsentry/sentry-cli]
+      cargo run --release -- releases list
 
 on_success:
   - zeus upload -t "application/octet-stream" -n sentry-cli-Windows-%arch%.exe .\target\release\sentry-cli.exe ||

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -26,7 +26,7 @@ environment:
 install:
   # Push job information to Zeus
   - npm install -g @zeus-ci/cli
-  - zeus job update --status=pending -B "%APPVEYOR_PULL_REQUEST_TITLE%" -J "%APPVEYOR_JOB_NAME%"
+  - zeus job update --status=pending -B "%APPVEYOR_PULL_REQUEST_TITLE%" -J "%APPVEYOR_JOB_NAME%" || [[ ! "$APPVEYOR_REPO_BRANCH" =~ ^release/ ]]
   # Install the rest
   - appveyor DownloadFile https://win.rustup.rs/ -FileName rustup-init.exe
   - rustup-init -yv --default-toolchain %channel% --default-host %arch%-pc-windows-msvc
@@ -39,14 +39,14 @@ build: false
 test_script:
   - set RUSTFLAGS=-Ctarget-feature=+crt-static
   - cargo build --release --locked
-  - cargo run --release -- releases list
+  - cargo run --release -- releases list || [[ "${APPVEYOR_PULL_REQUEST_HEAD_REPO_NAME}" != "getsentry/sentry-cli" ]]
 
 on_success:
   - zeus upload -t "application/octet-stream" -n sentry-cli-Windows-%arch%.exe .\target\release\sentry-cli.exe || [[ ! "$APPVEYOR_REPO_BRANCH" =~ ^release/ ]]
-  - zeus job update --status=passed
+  - zeus job update --status=passed || [[ ! "$APPVEYOR_REPO_BRANCH" =~ ^release/ ]]
 
 on_failure:
-- zeus job update --status=failed
+  - zeus job update --status=failed || [[ ! "$APPVEYOR_REPO_BRANCH" =~ ^release/ ]]
 
 artifacts:
   - path: '.\target\release\sentry-cli.exe'

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -40,6 +40,7 @@ build: false
 test_script:
   - set RUSTFLAGS=-Ctarget-feature=+crt-static
   - cargo build --release --locked
+  - echo %APPVEYOR_PULL_REQUEST_HEAD_REPO_NAME%
   - cargo run --release -- releases list ||
       if [%APPVEYOR_PULL_REQUEST_HEAD_REPO_NAME%] == [getsentry/sentry-cli] (fail) else (echo "Building branch or fork PR, ignoring")
 

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -40,7 +40,11 @@ build: false
 test_script:
   - set RUSTFLAGS=-Ctarget-feature=+crt-static
   - cargo build --release --locked
-  - if [%APPVEYOR_PULL_REQUEST_HEAD_REPO_NAME%] == [getsentry/sentry-cli]
+  # Smoke test, but only when building from the same repo
+  - set SECRETS_AVAILABLE=false
+  - if [%APPVEYOR_PULL_REQUEST_HEAD_REPO_NAME%] == [getsentry/sentry-cli] (set SECRETS_AVAILABLE=true)
+  - if not defined APPVEYOR_PULL_REQUEST_HEAD_REPO_NAME (set SECRETS_AVAILABLE=true)
+  - if [%SECRETS_AVAILABLE%] == [true]
       cargo run --release -- releases list
 
 on_success:

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -26,7 +26,8 @@ environment:
 install:
   # Push job information to Zeus
   - npm install -g @zeus-ci/cli
-  - zeus job update --status=pending -B "%APPVEYOR_PULL_REQUEST_TITLE%" -J "%APPVEYOR_JOB_NAME%" || [[ ! "$APPVEYOR_REPO_BRANCH" =~ ^release/ ]]
+  - zeus job update --status=pending -B "%APPVEYOR_PULL_REQUEST_TITLE%" -J "%APPVEYOR_JOB_NAME%" ||
+      echo "%$APPVEYOR_REPO_BRANCH%" | findstr /V "release/">nul
   # Install the rest
   - appveyor DownloadFile https://win.rustup.rs/ -FileName rustup-init.exe
   - rustup-init -yv --default-toolchain %channel% --default-host %arch%-pc-windows-msvc
@@ -39,14 +40,18 @@ build: false
 test_script:
   - set RUSTFLAGS=-Ctarget-feature=+crt-static
   - cargo build --release --locked
-  - cargo run --release -- releases list || [[ "${APPVEYOR_PULL_REQUEST_HEAD_REPO_NAME}" != "getsentry/sentry-cli" ]]
+  - cargo run --release -- releases list ||
+      if [%APPVEYOR_PULL_REQUEST_HEAD_REPO_NAME%] == [getsentry/sentry-cli] (fail) else (echo "Building branch or fork PR, ignoring")
 
 on_success:
-  - zeus upload -t "application/octet-stream" -n sentry-cli-Windows-%arch%.exe .\target\release\sentry-cli.exe || [[ ! "$APPVEYOR_REPO_BRANCH" =~ ^release/ ]]
-  - zeus job update --status=passed || [[ ! "$APPVEYOR_REPO_BRANCH" =~ ^release/ ]]
+  - zeus upload -t "application/octet-stream" -n sentry-cli-Windows-%arch%.exe .\target\release\sentry-cli.exe ||
+      echo "%$APPVEYOR_REPO_BRANCH%" | findstr /V "release/">nul
+  - zeus job update --status=passed ||
+      echo "%$APPVEYOR_REPO_BRANCH%" | findstr /V "release/">nul
 
 on_failure:
-  - zeus job update --status=failed || [[ ! "$APPVEYOR_REPO_BRANCH" =~ ^release/ ]]
+  - zeus job update --status=failed ||
+      echo "%$APPVEYOR_REPO_BRANCH%" | findstr /V "release/">nul
 
 artifacts:
   - path: '.\target\release\sentry-cli.exe'

--- a/.travis.yml
+++ b/.travis.yml
@@ -92,7 +92,7 @@ matrix:
         - TARGET=x86_64-apple-darwin
       script:
         - cargo build --release --locked
-        - cargo run --release -- releases list
+        - cargo run --release -- releases list || [[ "${SENTRY_AUTH_TOKEN?x}" == "" ]]
         - zeus upload -t "application/octet-stream"
                       -n "sentry-cli-Darwin-x86_64"
                       "./target/release/sentry-cli" || [[ ! "$TRAVIS_BRANCH" =~ ^release/ ]]

--- a/.travis.yml
+++ b/.travis.yml
@@ -91,7 +91,7 @@ matrix:
       env:
         - TARGET=x86_64-apple-darwin
       script:
-        - echo $SENTRY_AUTH_TOKEN
+        - if [ -z ${SENTRY_AUTH_TOKEN+x} ]; then echo "var is unset"; else echo "var is set to '$SENTRY_AUTH_TOKEN'"; fi
         - cargo build --release --locked
         - cargo run --release -- releases list || [[ "${SENTRY_AUTH_TOKEN?x}" == "" ]]
         - zeus upload -t "application/octet-stream"

--- a/.travis.yml
+++ b/.travis.yml
@@ -91,6 +91,7 @@ matrix:
       env:
         - TARGET=x86_64-apple-darwin
       script:
+        - echo $SENTRY_AUTH_TOKEN
         - cargo build --release --locked
         - cargo run --release -- releases list || [[ "${SENTRY_AUTH_TOKEN?x}" == "" ]]
         - zeus upload -t "application/octet-stream"

--- a/.travis.yml
+++ b/.travis.yml
@@ -91,9 +91,8 @@ matrix:
       env:
         - TARGET=x86_64-apple-darwin
       script:
-        - if [ -z ${SENTRY_AUTH_TOKEN+x} ]; then echo "var is unset"; else echo "var is set to '$SENTRY_AUTH_TOKEN'"; fi
         - cargo build --release --locked
-        - cargo run --release -- releases list || [[ "${SENTRY_AUTH_TOKEN?x}" == "" ]]
+        - cargo run --release -- releases list || [[ ! "${TRAVIS_PULL_REQUEST_SLUG?x}" =~ ^(getsentry/sentry-cli)?$ ]]
         - zeus upload -t "application/octet-stream"
                       -n "sentry-cli-Darwin-x86_64"
                       "./target/release/sentry-cli" || [[ ! "$TRAVIS_BRANCH" =~ ^release/ ]]

--- a/scripts/build-in-docker.sh
+++ b/scripts/build-in-docker.sh
@@ -16,8 +16,10 @@ docker run \
   ${DOCKER_RUN_OPTS} \
   cargo build --release --target=${TARGET} --locked
 
-# Smoke test (but only when building from the same repo)
-if [[ "${SENTRY_AUTH_TOKEN?x}" != "" ]]; then
+# Smoke test (but only when building from the same repo).
+# $TRAVIS_PULL_REQUEST_SLUG is set either to head repo slug, or to "" when
+# building branches.
+if [[ "${TRAVIS_PULL_REQUEST_SLUG?x}" =~ ^(getsentry/sentry-cli)?$ ]]; then
   env | grep SENTRY_ > .env
   docker run \
     --env-file=.env \

--- a/scripts/build-in-docker.sh
+++ b/scripts/build-in-docker.sh
@@ -16,12 +16,14 @@ docker run \
   ${DOCKER_RUN_OPTS} \
   cargo build --release --target=${TARGET} --locked
 
-# Smoke test
-env | grep SENTRY_ > .env
-docker run \
-  --env-file=.env \
-  ${DOCKER_RUN_OPTS} \
-  cargo run --release --target=${TARGET} -- releases list
+# Smoke test (but only when building from the same repo)
+if [[ "${SENTRY_AUTH_TOKEN?x}" != "" ]]; then
+  env | grep SENTRY_ > .env
+  docker run \
+    --env-file=.env \
+    ${DOCKER_RUN_OPTS} \
+    cargo run --release --target=${TARGET} -- releases list
+fi
 
 # Fix permissions for shared directories
 USER_ID=$(id -u)


### PR DESCRIPTION
Ignore some CI failures (zeus operations, end-to-end test with sentry) when PR is created from a fork.

PR is intentionally created from a forked repo.