### PR TITLE
feat: Retry on upload-related operations (chunk-upload, assemble)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -69,6 +69,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "backoff"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "rand 0.3.22 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "backtrace"
 version = "0.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1790,6 +1798,7 @@ version = "1.37.1"
 dependencies = [
  "anylog 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "app_dirs 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "backoff 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "backtrace 0.3.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "brotli2 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "chan 0.1.23 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2647,6 +2656,7 @@ dependencies = [
 "checksum argon2rs 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)" = "3f67b0b6a86dae6e67ff4ca2b6201396074996379fba2b92ff649126f37cb392"
 "checksum arrayvec 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)" = "f405cc4c21cd8b784f6c8fc2adf9bc00f59558f0049b5ec21517f875963040cc"
 "checksum atty 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)" = "9a7d5b8723950951411ee34d271d99dddcc2035a16ab25310ea2c8cfd4369652"
+"checksum backoff 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "b7bd67d02cc9dfe9bb1891cb6b4f0169f53cdf0a78b07276ab2141452aaf5789"
 "checksum backtrace 0.3.12 (registry+https://github.com/rust-lang/crates.io-index)" = "a2eff3830839471718ef8522b9025b399bfb713e25bc220da721364efb660d7d"
 "checksum backtrace-sys 0.1.24 (registry+https://github.com/rust-lang/crates.io-index)" = "c66d56ac8dabd07f6aacdaf633f4b8262f5b3601a810a0dcddffd5c22c69daa0"
 "checksum base64 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "979d348dc50dfcd050a87df408ec61f01a0a27ee9b4ebdc6085baba8275b2c7f"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ edition = "2018"
 [dependencies]
 anylog = "0.3.0"
 app_dirs = "1.2.1"
+backoff = "0.1.2"
 backtrace = "0.3.9"
 brotli2 = "0.3.2"
 chardet = "0.2.4"

--- a/src/api.rs
+++ b/src/api.rs
@@ -905,8 +905,7 @@ impl Api {
     pub fn get_chunk_upload_options(&self, org: &str) -> ApiResult<Option<ChunkUploadOptions>> {
         let url = format!("/organizations/{}/chunk-upload/", org);
         match self
-            .request(Method::Get, &url)?
-            .send()?
+            .get(&url)?
             .convert_rnf(ApiErrorKind::ChunkUploadNotSupported)
         {
             Ok(options) => Ok(Some(options)),

--- a/src/api.rs
+++ b/src/api.rs
@@ -1399,8 +1399,7 @@ impl<'a> ApiRequest<'a> {
         Ok(self)
     }
 
-    /// Sends the request and writes response data into the given file
-    /// instead of the response object's in memory buffer.
+    /// Sends the request and writes response data into the given buffer
     pub fn send_into<W: Write>(mut self, out: &mut W) -> ApiResult<ApiResponse> {
         self.handle.http_headers(self.headers)?;
 

--- a/src/api.rs
+++ b/src/api.rs
@@ -43,7 +43,7 @@ use crate::utils::http::{
     HTTP_STATUS_504_GATEWAY_TIMEOUT,
 };
 use crate::utils::progress::ProgressBar;
-use crate::utils::retry::{get_default_backoff, AsMilliseconds};
+use crate::utils::retry::{get_default_backoff, DurationAsMilliseconds};
 use crate::utils::sourcemaps::get_sourcemap_reference_from_headers;
 use crate::utils::ui::{capitalize_string, make_byte_progress_bar};
 use crate::utils::xcode::InfoPlist;

--- a/src/config.rs
+++ b/src/config.rs
@@ -326,9 +326,9 @@ impl Config {
     }
 
     pub fn get_max_retry_count(&self) -> Result<u32, Error> {
-        if env::var_os("SENTRY_REQUEST_MAX_RETRY").is_some() {
-            Ok(env::var("SENTRY_REQUEST_MAX_RETRY")?.parse()?)
-        } else if let Some(val) = self.ini.get_from(Some("http"), "max_retry_count") {
+        if env::var_os("SENTRY_HTTP_MAX_RETRIES").is_some() {
+            Ok(env::var("SENTRY_HTTP_MAX_RETRIES")?.parse()?)
+        } else if let Some(val) = self.ini.get_from(Some("http"), "max_retries") {
             Ok(val.parse()?)
         } else {
             Ok(DEFAULT_RETRIES)

--- a/src/config.rs
+++ b/src/config.rs
@@ -13,7 +13,7 @@ use lazy_static::lazy_static;
 use parking_lot::Mutex;
 use sentry::Dsn;
 
-use crate::constants::{CONFIG_RC_FILE_NAME, DEFAULT_URL};
+use crate::constants::{CONFIG_RC_FILE_NAME, DEFAULT_RETRIES, DEFAULT_URL};
 use crate::utils::logging::set_max_level;
 
 /// Represents the auth information
@@ -323,6 +323,16 @@ impl Config {
             .get_from(Some("dsym"), "max_upload_size")
             .and_then(|x| x.parse().ok())
             .unwrap_or(35 * 1024 * 1024))
+    }
+
+    pub fn get_max_retry_count(&self) -> Result<u32, Error> {
+        if env::var_os("SENTRY_REQUEST_MAX_RETRY").is_some() {
+            Ok(env::var("SENTRY_REQUEST_MAX_RETRY")?.parse()?)
+        } else if let Some(val) = self.ini.get_from(Some("http"), "max_retry_count") {
+            Ok(val.parse()?)
+        } else {
+            Ok(DEFAULT_RETRIES)
+        }
     }
 
     /// Return the DSN

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -40,4 +40,13 @@ lazy_static! {
 }
 */
 
+/// Backoff multiplier (1.5 which is 50% increase per backoff).
+pub const DEFAULT_MULTIPLIER: f64 = 1.5;
+/// Backoff randomization factor (0 means no randomization).
+pub const DEFAULT_RANDOMIZATION: f64 = 0.0;
+/// Initial backoff interval in milliseconds.
+pub const DEFAULT_INITIAL_INTERVAL: u64 = 500;
+/// Maximum backoff interval in milliseconds.
+pub const DEFAULT_MAX_INTERVAL: u64 = 4000;
+
 include!(concat!(env!("OUT_DIR"), "/constants.gen.rs"));

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -48,5 +48,7 @@ pub const DEFAULT_RANDOMIZATION: f64 = 0.1;
 pub const DEFAULT_INITIAL_INTERVAL: u64 = 500;
 /// Maximum backoff interval in milliseconds.
 pub const DEFAULT_MAX_INTERVAL: u64 = 4000;
+/// Default number of retry attempts
+pub const DEFAULT_RETRIES: u32 = 5;
 
 include!(concat!(env!("OUT_DIR"), "/constants.gen.rs"));

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -43,7 +43,7 @@ lazy_static! {
 /// Backoff multiplier (1.5 which is 50% increase per backoff).
 pub const DEFAULT_MULTIPLIER: f64 = 1.5;
 /// Backoff randomization factor (0 means no randomization).
-pub const DEFAULT_RANDOMIZATION: f64 = 0.0;
+pub const DEFAULT_RANDOMIZATION: f64 = 0.1;
 /// Initial backoff interval in milliseconds.
 pub const DEFAULT_INITIAL_INTERVAL: u64 = 500;
 /// Maximum backoff interval in milliseconds.

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -45,9 +45,9 @@ pub const DEFAULT_MULTIPLIER: f64 = 1.5;
 /// Backoff randomization factor (0 means no randomization).
 pub const DEFAULT_RANDOMIZATION: f64 = 0.1;
 /// Initial backoff interval in milliseconds.
-pub const DEFAULT_INITIAL_INTERVAL: u64 = 500;
+pub const DEFAULT_INITIAL_INTERVAL: u64 = 1000;
 /// Maximum backoff interval in milliseconds.
-pub const DEFAULT_MAX_INTERVAL: u64 = 4000;
+pub const DEFAULT_MAX_INTERVAL: u64 = 5000;
 /// Default number of retry attempts
 pub const DEFAULT_RETRIES: u32 = 5;
 

--- a/src/utils/http.rs
+++ b/src/utils/http.rs
@@ -3,6 +3,11 @@ use std::collections::HashMap;
 use lazy_static::lazy_static;
 use regex::Regex;
 
+// Http statuses
+pub const HTTP_STATUS_502_BAD_GATEWAY: u32 = 502;
+pub const HTTP_STATUS_503_SERVICE_UNAVAILABLE: u32 = 503;
+pub const HTTP_STATUS_504_GATEWAY_TIMEOUT: u32 = 504;
+
 lazy_static! {
     static ref LINK_TOKEN_RE: Regex = Regex::new(
         r#"(?x)

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -16,6 +16,7 @@ pub mod iter;
 pub mod logging;
 pub mod progress;
 pub mod releases;
+pub mod retry;
 pub mod sourcemaps;
 pub mod system;
 pub mod ui;

--- a/src/utils/retry.rs
+++ b/src/utils/retry.rs
@@ -24,11 +24,11 @@ pub fn get_default_backoff() -> ExponentialBackoff {
 }
 
 /// Trait for displaying duration-like in milliseconds
-pub trait AsMilliseconds {
+pub trait DurationAsMilliseconds {
     fn as_milliseconds(&self) -> u64;
 }
 
-impl AsMilliseconds for Duration {
+impl DurationAsMilliseconds for Duration {
     fn as_milliseconds(&self) -> u64 {
         self.as_secs() * 1000 + self.subsec_millis() as u64
     }

--- a/src/utils/retry.rs
+++ b/src/utils/retry.rs
@@ -30,6 +30,6 @@ pub trait DurationAsMilliseconds {
 
 impl DurationAsMilliseconds for Duration {
     fn as_milliseconds(&self) -> u64 {
-        self.as_secs() * 1000 + self.subsec_millis() as u64
+        self.as_secs() * 1000 + u64::from(self.subsec_millis())
     }
 }

--- a/src/utils/retry.rs
+++ b/src/utils/retry.rs
@@ -1,0 +1,35 @@
+use std::time::{Duration, Instant};
+
+use backoff::backoff::Backoff;
+use backoff::ExponentialBackoff;
+
+use crate::constants::{
+    DEFAULT_INITIAL_INTERVAL, DEFAULT_MAX_INTERVAL, DEFAULT_MULTIPLIER, DEFAULT_RANDOMIZATION,
+};
+
+/// Returns an ExponentialBackoff object instantianted with default values
+pub fn get_default_backoff() -> ExponentialBackoff {
+    let mut eb = ExponentialBackoff {
+        current_interval: Duration::from_millis(DEFAULT_INITIAL_INTERVAL),
+        initial_interval: Duration::from_millis(DEFAULT_INITIAL_INTERVAL),
+        randomization_factor: DEFAULT_RANDOMIZATION,
+        multiplier: DEFAULT_MULTIPLIER,
+        max_interval: Duration::from_millis(DEFAULT_MAX_INTERVAL),
+        max_elapsed_time: None,
+        clock: Default::default(),
+        start_time: Instant::now(),
+    };
+    eb.reset();
+    eb
+}
+
+/// Trait for displaying duration-like in milliseconds
+pub trait AsMilliseconds {
+    fn as_milliseconds(&self) -> u64;
+}
+
+impl AsMilliseconds for Duration {
+    fn as_milliseconds(&self) -> u64 {
+        self.as_secs() * 1000 + self.subsec_millis() as u64
+    }
+}


### PR DESCRIPTION
Adds `with_retry` method on `ApiRequest` that retries the request with exponential (but constrained) backoff.