### PR TITLE
feat: Report non zero status for server side processing errors on dif upload

### DIFF
--- a/src/commands/upload_dif.rs
+++ b/src/commands/upload_dif.rs
@@ -220,7 +220,7 @@ fn execute_internal(matches: &ArgMatches<'_>, legacy: bool) -> Result<(), Error>
         }
 
         // Execute the upload
-        let uploaded = upload.upload()?;
+        let (uploaded, has_processing_errors) = upload.upload()?;
 
         // Associate the dSYMs with the Info.plist data, if available
         if let Some(ref info_plist) = info_plist {
@@ -270,7 +270,7 @@ fn execute_internal(matches: &ArgMatches<'_>, legacy: bool) -> Result<(), Error>
             let missing_ids: Vec<_> = required_ids.difference(&found_ids).collect();
 
             if !missing_ids.is_empty() {
-                println!();
+                eprintln!();
                 eprintln!("{}", style("Error: Some symbols could not be found!").red());
                 eprintln!("The following symbols are still missing:");
                 for id in missing_ids {
@@ -279,6 +279,16 @@ fn execute_internal(matches: &ArgMatches<'_>, legacy: bool) -> Result<(), Error>
 
                 return Err(QuietExit(1).into());
             }
+        }
+
+        // report a non 0 status code if the server encountered issues.
+        if has_processing_errors {
+            eprintln!();
+            eprintln!(
+                "{}",
+                style("Error: some symbols did not process correctly/")
+            );
+            return Err(QuietExit(1).into());
         }
 
         Ok(())

--- a/src/utils/dif_upload.rs
+++ b/src/utils/dif_upload.rs
@@ -1017,7 +1017,7 @@ fn render_detail(detail: &Option<String>, fallback: Option<&str>) {
 fn poll_dif_assemble(
     difs: &[&ChunkedDifMatch<'_>],
     options: &DifUpload,
-) -> Result<Vec<DebugInfoFile>, Error> {
+) -> Result<(Vec<DebugInfoFile>, bool), Error> {
     let progress_style = ProgressStyle::default_bar().template(
         "{prefix:.dim} Processing files...\
          \n{wide_bar}  {pos}/{len}",
@@ -1104,20 +1104,24 @@ fn poll_dif_assemble(
     }
     errored.sort_by_key(|x| x.0.file_name());
 
+    let has_errors = !errored.is_empty();
     for (dif, error) in errored {
         println!("  {} {}", style("ERROR").red(), dif.file_name());
         render_detail(&error.detail, Some("An unknown error occurred"));
     }
 
     // Return only successful uploads
-    Ok(successes.into_iter().filter_map(|(_, r)| r.dif).collect())
+    Ok((
+        successes.into_iter().filter_map(|(_, r)| r.dif).collect(),
+        has_errors,
+    ))
 }
 
 /// Uploads debug info files using the chunk-upload endpoint.
 fn upload_difs_chunked(
     options: &DifUpload,
     chunk_options: &ChunkUploadOptions,
-) -> Result<Vec<DebugInfoFile>, Error> {
+) -> Result<(Vec<DebugInfoFile>, bool), Error> {
     // Search for debug files in the file system and ZIPs
     let found = search_difs(options)?;
     if found.is_empty() {
@@ -1151,7 +1155,7 @@ fn upload_difs_chunked(
             style(">").dim()
         );
 
-        Ok(Default::default())
+        Ok((Default::default(), true))
     }
 }
 
@@ -1483,7 +1487,10 @@ impl DifUpload {
     ///     .search_path(".")
     ///     .upload()?;
     /// ```
-    pub fn upload(&mut self) -> Result<Vec<DebugInfoFile>, Error> {
+    ///
+    /// The okay part of the return value is `(files, has_errors)`.  The
+    /// latter can be used to indicate a fail state from the upload.
+    pub fn upload(&mut self) -> Result<(Vec<DebugInfoFile>, bool), Error> {
         if self.paths.is_empty() {
             println!("{}: No paths were provided.", style("Warning").yellow());
             return Ok(Default::default());
@@ -1497,7 +1504,7 @@ impl DifUpload {
 
             upload_difs_chunked(self, chunk_options)
         } else {
-            upload_difs_batched(self)
+            Ok((upload_difs_batched(self)?, false))
         }
     }
 


### PR DESCRIPTION
Previously even if the server encountered errors the dif upload command would
report 0 as success code.  This changes it to return 1 instead so that build
processes can respond to it.