### PR TITLE
fix(upload): Flush archives before uploading them

### DIFF
--- a/src/commands/react_native_xcode.rs
+++ b/src/commands/react_native_xcode.rs
@@ -153,8 +153,8 @@ pub fn execute<'a>(matches: &ArgMatches<'a>) -> Result<(), Error> {
         let sourcemap_path;
         let bundle_url;
         let sourcemap_url;
-        let bundle_file;
-        let sourcemap_file;
+        let mut bundle_file;
+        let mut sourcemap_file;
 
         // If we have a fetch URL we need to fetch them from there now.  In that
         // case we do indeed fetch it right from the running packager and then
@@ -178,11 +178,11 @@ pub fn execute<'a>(matches: &ArgMatches<'a>) -> Result<(), Error> {
 
             api.download(
                 &format!("{}/index.ios.bundle?platform=ios&dev=true", url),
-                &mut bundle_file.open(),
+                bundle_file.open()?,
             )?;
             api.download(
                 &format!("{}/index.ios.map?platform=ios&dev=true", url),
-                &mut sourcemap_file.open(),
+                sourcemap_file.open()?,
             )?;
 
         // This is the case where we need to hook into the release process to

--- a/src/commands/react_native_xcode.rs
+++ b/src/commands/react_native_xcode.rs
@@ -153,8 +153,8 @@ pub fn execute<'a>(matches: &ArgMatches<'a>) -> Result<(), Error> {
         let sourcemap_path;
         let bundle_url;
         let sourcemap_url;
-        let mut bundle_file;
-        let mut sourcemap_file;
+        let bundle_file;
+        let sourcemap_file;
 
         // If we have a fetch URL we need to fetch them from there now.  In that
         // case we do indeed fetch it right from the running packager and then

--- a/src/commands/react_native_xcode.rs
+++ b/src/commands/react_native_xcode.rs
@@ -178,11 +178,11 @@ pub fn execute<'a>(matches: &ArgMatches<'a>) -> Result<(), Error> {
 
             api.download(
                 &format!("{}/index.ios.bundle?platform=ios&dev=true", url),
-                bundle_file.open()?,
+                &mut bundle_file.open()?,
             )?;
             api.download(
                 &format!("{}/index.ios.map?platform=ios&dev=true", url),
-                sourcemap_file.open()?,
+                &mut sourcemap_file.open()?,
             )?;
 
         // This is the case where we need to hook into the release process to

--- a/src/commands/upload_proguard.rs
+++ b/src/commands/upload_proguard.rs
@@ -210,20 +210,17 @@ pub fn execute<'a>(matches: &ArgMatches<'a>) -> Result<(), Error> {
     let mut tf = TempFile::create()?;
     {
         let mut handle = tf.open()?;
-        {
-            let mut zip = zip::ZipWriter::new(&mut handle);
+        let mut zip = zip::ZipWriter::new(&mut handle);
 
-            for mapping in &mappings {
-                let pb = make_byte_progress_bar(mapping.size);
-                zip.start_file(
-                    format!("proguard/{}.txt", mapping.uuid),
-                    zip::write::FileOptions::default(),
-                )?;
-                copy_with_progress(&pb, &mut fs::File::open(&mapping.path)?, &mut zip)?;
-                pb.finish_and_clear();
-            }
+        for mapping in &mappings {
+            let pb = make_byte_progress_bar(mapping.size);
+            zip.start_file(
+                format!("proguard/{}.txt", mapping.uuid),
+                zip::write::FileOptions::default(),
+            )?;
+            copy_with_progress(&pb, &mut fs::File::open(&mapping.path)?, &mut zip)?;
+            pb.finish_and_clear();
         }
-        handle.sync_all()?;
     }
 
     // write UUIDs into the mapping file.

--- a/src/commands/upload_proguard.rs
+++ b/src/commands/upload_proguard.rs
@@ -207,23 +207,19 @@ pub fn execute<'a>(matches: &ArgMatches<'a>) -> Result<(), Error> {
     }
 
     println!("{} compressing mappings", style(">").dim());
-    let mut tf = TempFile::create()?;
+    let tf = TempFile::create()?;
     {
-        let mut handle = tf.open()?;
-        {
-            let mut zip = zip::ZipWriter::new(&mut handle);
+        let mut zip = zip::ZipWriter::new(tf.open()?);
 
-            for mapping in &mappings {
-                let pb = make_byte_progress_bar(mapping.size);
-                zip.start_file(
-                    format!("proguard/{}.txt", mapping.uuid),
-                    zip::write::FileOptions::default(),
-                )?;
-                copy_with_progress(&pb, &mut fs::File::open(&mapping.path)?, &mut zip)?;
-                pb.finish_and_clear();
-            }
+        for mapping in &mappings {
+            let pb = make_byte_progress_bar(mapping.size);
+            zip.start_file(
+                format!("proguard/{}.txt", mapping.uuid),
+                zip::write::FileOptions::default(),
+            )?;
+            copy_with_progress(&pb, &mut fs::File::open(&mapping.path)?, &mut zip)?;
+            pb.finish_and_clear();
         }
-        handle.sync_all()?;
     }
 
     // write UUIDs into the mapping file.

--- a/src/commands/upload_proguard.rs
+++ b/src/commands/upload_proguard.rs
@@ -210,17 +210,20 @@ pub fn execute<'a>(matches: &ArgMatches<'a>) -> Result<(), Error> {
     let mut tf = TempFile::create()?;
     {
         let mut handle = tf.open()?;
-        let mut zip = zip::ZipWriter::new(&mut handle);
+        {
+            let mut zip = zip::ZipWriter::new(&mut handle);
 
-        for mapping in &mappings {
-            let pb = make_byte_progress_bar(mapping.size);
-            zip.start_file(
-                format!("proguard/{}.txt", mapping.uuid),
-                zip::write::FileOptions::default(),
-            )?;
-            copy_with_progress(&pb, &mut fs::File::open(&mapping.path)?, &mut zip)?;
-            pb.finish_and_clear();
+            for mapping in &mappings {
+                let pb = make_byte_progress_bar(mapping.size);
+                zip.start_file(
+                    format!("proguard/{}.txt", mapping.uuid),
+                    zip::write::FileOptions::default(),
+                )?;
+                copy_with_progress(&pb, &mut fs::File::open(&mapping.path)?, &mut zip)?;
+                pb.finish_and_clear();
+            }
         }
+        handle.sync_all()?;
     }
 
     // write UUIDs into the mapping file.

--- a/src/utils/dif_upload.rs
+++ b/src/utils/dif_upload.rs
@@ -1188,19 +1188,15 @@ fn get_missing_difs<'data>(
 fn create_batch_archive(difs: &[HashedDifMatch<'_>]) -> Result<TempFile, Error> {
     let total_bytes = difs.iter().map(|sym| sym.size()).sum();
     let pb = make_byte_progress_bar(total_bytes);
-    let mut tf = TempFile::create()?;
+    let tf = TempFile::create()?;
 
     {
-        let mut handle = tf.open()?;
-        {
-            let mut zip = ZipWriter::new(&mut handle);
+        let mut zip = ZipWriter::new(tf.open()?);
 
-            for symbol in difs {
-                zip.start_file(symbol.file_name(), FileOptions::default())?;
-                copy_with_progress(&pb, &mut symbol.data(), &mut zip)?;
-            }
+        for symbol in difs {
+            zip.start_file(symbol.file_name(), FileOptions::default())?;
+            copy_with_progress(&pb, &mut symbol.data(), &mut zip)?;
         }
-        handle.sync_all()?;
     }
 
     pb.finish_and_clear();

--- a/src/utils/dif_upload.rs
+++ b/src/utils/dif_upload.rs
@@ -1191,12 +1191,16 @@ fn create_batch_archive(difs: &[HashedDifMatch<'_>]) -> Result<TempFile, Error> 
     let mut tf = TempFile::create()?;
 
     {
-        let mut zip = ZipWriter::new(tf.open()?);
+        let mut handle = tf.open()?;
+        {
+            let mut zip = ZipWriter::new(&mut handle);
 
-        for symbol in difs {
-            zip.start_file(symbol.file_name(), FileOptions::default())?;
-            copy_with_progress(&pb, &mut symbol.data(), &mut zip)?;
+            for symbol in difs {
+                zip.start_file(symbol.file_name(), FileOptions::default())?;
+                copy_with_progress(&pb, &mut symbol.data(), &mut zip)?;
+            }
         }
+        handle.sync_all()?;
     }
 
     pb.finish_and_clear();

--- a/src/utils/dif_upload.rs
+++ b/src/utils/dif_upload.rs
@@ -1191,16 +1191,12 @@ fn create_batch_archive(difs: &[HashedDifMatch<'_>]) -> Result<TempFile, Error> 
     let mut tf = TempFile::create()?;
 
     {
-        let mut handle = tf.open()?;
-        {
-            let mut zip = ZipWriter::new(&mut handle);
+        let mut zip = ZipWriter::new(tf.open()?);
 
-            for symbol in difs {
-                zip.start_file(symbol.file_name(), FileOptions::default())?;
-                copy_with_progress(&pb, &mut symbol.data(), &mut zip)?;
-            }
+        for symbol in difs {
+            zip.start_file(symbol.file_name(), FileOptions::default())?;
+            copy_with_progress(&pb, &mut symbol.data(), &mut zip)?;
         }
-        handle.sync_all()?;
     }
 
     pb.finish_and_clear();

--- a/src/utils/fs.rs
+++ b/src/utils/fs.rs
@@ -2,7 +2,6 @@ use std::env;
 use std::fs;
 use std::io;
 use std::io::{Read, Seek, SeekFrom};
-use std::mem;
 use std::path::{Path, PathBuf};
 
 use failure::{bail, Error};
@@ -42,7 +41,6 @@ impl Drop for TempDir {
 /// Helper for temporary file access
 #[derive(Debug)]
 pub struct TempFile {
-    f: Option<fs::File>,
     path: PathBuf,
 }
 
@@ -52,16 +50,9 @@ impl TempFile {
         let mut path = env::temp_dir();
         path.push(Uuid::new_v4().to_hyphenated_ref().to_string());
 
-        let f = fs::OpenOptions::new()
-            .read(true)
-            .write(true)
-            .create(true)
-            .open(&path)?;
-
-        Ok(TempFile {
-            f: Some(f),
-            path: path.to_path_buf(),
-        })
+        let tf = TempFile { path };
+        tf.open()?;
+        Ok(tf)
     }
 
     /// Assumes ownership over an existing file and moves it to a temp location.
@@ -70,20 +61,17 @@ impl TempFile {
         destination.push(Uuid::new_v4().to_hyphenated_ref().to_string());
 
         fs::rename(&path, &destination)?;
-        let f = fs::OpenOptions::new()
-            .read(true)
-            .write(true)
-            .open(&destination)?;
-
-        Ok(TempFile {
-            f: Some(f),
-            path: destination,
-        })
+        Ok(TempFile { path: destination })
     }
 
     /// Opens the tempfile at the beginning.
-    pub fn open(&mut self) -> io::Result<&mut fs::File> {
-        let f = self.f.as_mut().unwrap();
+    pub fn open(&self) -> io::Result<fs::File> {
+        let mut f = fs::OpenOptions::new()
+            .read(true)
+            .write(true)
+            .create(true)
+            .open(&self.path)?;
+
         f.seek(SeekFrom::Start(0)).ok();
         Ok(f)
     }
@@ -94,15 +82,15 @@ impl TempFile {
     }
 
     /// Returns the size of the temp file.
-    pub fn size(&mut self) -> io::Result<u64> {
+    pub fn size(&self) -> io::Result<u64> {
         self.open()?.seek(SeekFrom::End(0))
     }
 }
 
 impl Drop for TempFile {
     fn drop(&mut self) {
-        mem::drop(self.f.take());
-        let _ = fs::remove_file(&self.path);
+        // mem::drop(self.f.take());
+        fs::remove_file(&self.path).ok();
     }
 }
 

--- a/src/utils/fs.rs
+++ b/src/utils/fs.rs
@@ -81,22 +81,21 @@ impl TempFile {
         })
     }
 
-    /// Opens the tempfile
-    pub fn open(&self) -> fs::File {
-        let mut f = self.f.as_ref().unwrap().try_clone().unwrap();
-        let _ = f.seek(SeekFrom::Start(0));
-        f
+    /// Opens the tempfile at the beginning.
+    pub fn open(&mut self) -> io::Result<&mut fs::File> {
+        let f = self.f.as_mut().unwrap();
+        f.seek(SeekFrom::Start(0)).ok();
+        Ok(f)
     }
 
-    /// Returns the path to the tempfile
+    /// Returns the path to the tempfile.
     pub fn path(&self) -> &Path {
         &self.path
     }
 
     /// Returns the size of the temp file.
-    pub fn size(&self) -> io::Result<u64> {
-        let mut f = self.open();
-        Ok(f.seek(SeekFrom::End(0))?)
+    pub fn size(&mut self) -> io::Result<u64> {
+        self.open()?.seek(SeekFrom::End(0))
     }
 }
 

--- a/src/utils/fs.rs
+++ b/src/utils/fs.rs
@@ -89,7 +89,6 @@ impl TempFile {
 
 impl Drop for TempFile {
     fn drop(&mut self) {
-        // mem::drop(self.f.take());
         fs::remove_file(&self.path).ok();
     }
 }


### PR DESCRIPTION
Fixes incomplete DIF and Proguard uploads on Windows. 

Instead of Cloning the file handle, we now return a mutable reference to the actual file, instead. Additionally, this flushes all data to **disk** before passing the path on to libcurl. Without that, libcurl on Windows seems to pick up an incomplete state of the file.

I yet have to find out why Sentry did not recognize the form field at all before.