### PR TITLE
feat: Use a connection pool for curl to avoid TLS and retry on more errors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -21,6 +21,11 @@ dependencies = [
 ]
 
 [[package]]
+name = "antidote"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "anylog"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1172,6 +1177,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "r2d2"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "antidote 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "scheduled-thread-pool 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "rand"
 version = "0.3.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1425,6 +1440,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "scheduled-thread-pool"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "antidote 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "scoped_threadpool"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1530,6 +1553,7 @@ dependencies = [
  "parking_lot 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "plist 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "prettytable-rs 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "r2d2 0.8.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "rayon 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "runas 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2078,6 +2102,7 @@ dependencies = [
 "checksum adler32 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "7e522997b529f05601e05166c07ed17789691f562762c7f3b987263d2dedee5c"
 "checksum advapi32-sys 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e06588080cb19d0acb6739808aafa5f26bfb2ca015b2b6370028b44cf7cb8a9a"
 "checksum aho-corasick 0.6.10 (registry+https://github.com/rust-lang/crates.io-index)" = "81ce3d38065e618af2d7b77e10c5ad9a069859b4be3c2250f674af3840d9c8a5"
+"checksum antidote 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "34fde25430d87a9388dadbe6e34d7f72a462c8b43ac8d309b42b0a8505d7e2a5"
 "checksum anylog 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "2fcf751df77bc8526b739628305302630756b4d9a1820b7cb87d1d7a2902d0a4"
 "checksum app_dirs 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "e73a24bad9bd6a94d6395382a6c69fe071708ae4409f763c5475e14ee896313d"
 "checksum arc-swap 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)" = "1025aeae2b664ca0ea726a89d574fe8f4e77dd712d443236ad1de00379450cf6"
@@ -2216,6 +2241,7 @@ dependencies = [
 "checksum proguard 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "2bff7e1d393e193d61310f6f2d2192afb008371238065bcf630d6fe9ec2ab52e"
 "checksum quick-error 1.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "9274b940887ce9addde99c4eee6b5c44cc494b182b97e73dc8ffdcb3397fd3f0"
 "checksum quote 0.6.11 (registry+https://github.com/rust-lang/crates.io-index)" = "cdd8e04bd9c52e0342b406469d494fcb033be4bdbe5c606016defbb1681411e1"
+"checksum r2d2 0.8.3 (registry+https://github.com/rust-lang/crates.io-index)" = "5d746fc8a0dab19ccea7ff73ad535854e90ddb3b4b8cdce953dd5cd0b2e7bd22"
 "checksum rand 0.3.23 (registry+https://github.com/rust-lang/crates.io-index)" = "64ac302d8f83c0c1974bf758f6b041c6c8ada916fbb44a609158ca8b064cc76c"
 "checksum rand 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)" = "552840b97013b1a26992c11eac34bdd778e464601a4c2054b5f0bff7c6761293"
 "checksum rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)" = "6d71dacdc3c88c1fde3885a3be3fbab9f35724e6ce99467f7d9c5026132184ca"
@@ -2245,6 +2271,7 @@ dependencies = [
 "checksum safemem 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "8dca453248a96cb0749e36ccdfe2b0b4e54a61bfef89fb97ec621eb8e0a93dd9"
 "checksum same-file 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "8f20c4be53a8a1ff4c1f1b2bd14570d2f634628709752f0702ecdd2b3f9a5267"
 "checksum schannel 0.1.14 (registry+https://github.com/rust-lang/crates.io-index)" = "0e1a231dc10abf6749cfa5d7767f25888d484201accbd919b66ab5413c502d56"
+"checksum scheduled-thread-pool 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1a2ff3fc5223829be817806c6441279c676e454cc7da608faf03b0ccc09d3889"
 "checksum scoped_threadpool 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)" = "1d51f5df5af43ab3f1360b429fa5e0152ac5ce8c0bd6485cae490332e96846a8"
 "checksum scopeguard 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "94258f53601af11e6a49f722422f6e3425c52b06245a5cf9bc09908b174f5e27"
 "checksum scroll 0.9.2 (registry+https://github.com/rust-lang/crates.io-index)" = "2f84d114ef17fd144153d608fba7c446b0145d038985e7a8cc5d08bb0ce20383"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,6 +57,7 @@ uuid = { version = "0.7.2", features = ["v4", "serde"] }
 walkdir = "2.2.7"
 which = "2.0.1"
 zip = "0.5.0"
+r2d2 = "0.8.3"
 
 [features]
 default = ["with_crash_reporting"]

--- a/src/commands/bash_hook.rs
+++ b/src/commands/bash_hook.rs
@@ -51,7 +51,7 @@ pub fn make_app<'a, 'b: 'a>(app: App<'a, 'b>) -> App<'a, 'b> {
 }
 
 fn send_event(traceback: &str, logfile: &str) -> Result<(), Error> {
-    let config = Config::get_current();
+    let config = Config::current();
     let mut event = Event::default();
 
     event.environment = config.get_environment().map(|e| e.into());

--- a/src/commands/info.rs
+++ b/src/commands/info.rs
@@ -50,7 +50,7 @@ fn describe_auth(auth: Option<&Auth>) -> &str {
 }
 
 fn get_config_status_json() -> Result<(), Error> {
-    let config = Config::get_current();
+    let config = Config::current();
     let mut rv = ConfigStatus::default();
 
     let (org, project) = config.get_org_and_project_defaults();
@@ -63,7 +63,7 @@ fn get_config_status_json() -> Result<(), Error> {
         Auth::Token(_) => "token".into(),
         Auth::Key(_) => "api_key".into(),
     });
-    rv.auth.successful = config.get_auth().is_some() && Api::get_current().get_auth_info().is_ok();
+    rv.auth.successful = config.get_auth().is_some() && Api::current().get_auth_info().is_ok();
     rv.have_dsn = config.get_dsn().is_ok();
 
     serde_json::to_writer_pretty(&mut io::stdout(), &rv)?;
@@ -76,9 +76,9 @@ pub fn execute<'a>(matches: &ArgMatches<'a>) -> Result<(), Error> {
         return get_config_status_json();
     }
 
-    let config = Config::get_current();
+    let config = Config::current();
     let (org, project) = config.get_org_and_project_defaults();
-    let info_rv = Api::get_current().get_auth_info();
+    let info_rv = Api::current().get_auth_info();
     let errors =
         project.is_none() || org.is_none() || config.get_auth().is_none() || info_rv.is_err();
 

--- a/src/commands/issues.rs
+++ b/src/commands/issues.rs
@@ -73,7 +73,7 @@ fn execute_change(
     filter: &IssueFilter,
     changes: &IssueChanges,
 ) -> Result<(), Error> {
-    if Api::get_current().bulk_update_issue(org, project, filter, changes)? {
+    if Api::current().bulk_update_issue(org, project, filter, changes)? {
         println!("Updated matching issues.");
         if let Some(status) = changes.new_status.as_ref() {
             println!("  new status: {}", status);
@@ -85,7 +85,7 @@ fn execute_change(
 }
 
 pub fn execute<'a>(matches: &ArgMatches<'a>) -> Result<(), Error> {
-    let config = Config::get_current();
+    let config = Config::current();
     let (org, project) = config.get_org_and_project(matches)?;
     let filter = get_filter_from_matches(matches)?;
     let mut changes: IssueChanges = Default::default();

--- a/src/commands/login.rs
+++ b/src/commands/login.rs
@@ -19,7 +19,7 @@ fn update_config(config: &Config, token: &str) -> Result<(), Error> {
 }
 
 pub fn execute<'a>(_matches: &ArgMatches<'a>) -> Result<(), Error> {
-    let config = Config::get_current();
+    let config = Config::current();
     let token_url = format!("{}/api/", config.get_base_url()?);
 
     println!("This helps you signing in your sentry-cli with an authentication token.");

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -8,7 +8,6 @@ use clap::{App, AppSettings, Arg, ArgMatches};
 use failure::{bail, Error};
 use log::{debug, info};
 
-use crate::api::Api;
 use crate::config::{prepare_environment, Auth, Config};
 use crate::constants::{ARCH, PLATFORM, VERSION};
 use crate::utils::system::{print_error, QuietExit};
@@ -297,10 +296,6 @@ fn setup() {
 pub fn main() {
     setup();
     let result = run();
-
-    if let Some(api) = Api::get_current_opt() {
-        api.reset();
-    }
 
     match result {
         Ok(()) => process::exit(0),

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -8,6 +8,7 @@ use clap::{App, AppSettings, Arg, ArgMatches};
 use failure::{bail, Error};
 use log::{debug, info};
 
+use crate::api::Api;
 use crate::config::{prepare_environment, Auth, Config};
 use crate::constants::{ARCH, PLATFORM, VERSION};
 use crate::utils::system::{print_error, QuietExit};
@@ -238,7 +239,7 @@ pub fn execute(args: &[String]) -> Result<(), Error> {
     config.bind_to_process();
     info!(
         "Loaded config from {}",
-        Config::get_current().get_filename().display()
+        Config::current().get_filename().display()
     );
 
     debug!(
@@ -297,19 +298,25 @@ pub fn main() {
     setup();
     let result = run();
 
-    match result {
-        Ok(()) => process::exit(0),
+    let status_code = match result {
+        Ok(()) => 0,
         Err(err) => {
             if let Some(&QuietExit(code)) = err.downcast_ref() {
-                process::exit(code);
+                code
             } else {
                 print_error(&err);
                 #[cfg(feature = "with_crash_reporting")]
                 {
                     crate::utils::crashreporting::try_report_to_sentry(&err);
                 }
-                process::exit(1);
+                1
             }
         }
-    }
+    };
+
+    // before we shut down we unbind the api to give the connection pool
+    // a chance to collect.  Not doing so has shown to cause hung threads
+    // on windows.
+    Api::dispose_pool();
+    process::exit(status_code);
 }

--- a/src/commands/monitors.rs
+++ b/src/commands/monitors.rs
@@ -49,10 +49,10 @@ pub fn make_app<'a, 'b: 'a>(app: App<'a, 'b>) -> App<'a, 'b> {
 }
 
 pub fn execute<'a>(matches: &ArgMatches<'a>) -> Result<(), Error> {
-    let config = Config::get_current();
+    let config = Config::current();
 
     let ctx = MonitorContext {
-        api: Api::get_current(),
+        api: Api::current(),
         org: config.get_org(matches)?,
     };
 

--- a/src/commands/monitors.rs
+++ b/src/commands/monitors.rs
@@ -1,6 +1,6 @@
 //! Implements a command for managing projects.
 use std::process;
-use std::rc::Rc;
+use std::sync::Arc;
 use std::time::Instant;
 
 use clap::{App, AppSettings, Arg, ArgMatches};
@@ -14,7 +14,7 @@ use crate::utils::formatting::Table;
 use crate::utils::system::QuietExit;
 
 struct MonitorContext {
-    pub api: Rc<Api>,
+    pub api: Arc<Api>,
     pub org: String,
 }
 

--- a/src/commands/projects.rs
+++ b/src/commands/projects.rs
@@ -15,8 +15,8 @@ pub fn make_app<'a, 'b: 'a>(app: App<'a, 'b>) -> App<'a, 'b> {
 }
 
 pub fn execute<'a>(matches: &ArgMatches<'a>) -> Result<(), Error> {
-    let config = Config::get_current();
-    let api = Api::get_current();
+    let config = Config::current();
+    let api = Api::current();
     let org = config.get_org(matches)?;
     let mut projects = api.list_organization_projects(&org)?;
     projects.sort_by_key(|p| (p.team.name.clone(), p.name.clone()));

--- a/src/commands/react_native_appcenter.rs
+++ b/src/commands/react_native_appcenter.rs
@@ -64,14 +64,14 @@ pub fn make_app<'a, 'b: 'a>(app: App<'a, 'b>) -> App<'a, 'b> {
 }
 
 pub fn execute<'a>(matches: &ArgMatches<'a>) -> Result<(), Error> {
-    let config = Config::get_current();
+    let config = Config::current();
     let here = env::current_dir()?;
     let here_str: &str = &here.to_string_lossy();
     let (org, project) = config.get_org_and_project(matches)?;
     let app = matches.value_of("app_name").unwrap();
     let platform = matches.value_of("platform").unwrap();
     let deployment = matches.value_of("deployment").unwrap_or("Staging");
-    let api = Api::get_current();
+    let api = Api::current();
     let print_release_name = matches.is_present("print_release_name");
 
     if !print_release_name {

--- a/src/commands/react_native_codepush.rs
+++ b/src/commands/react_native_codepush.rs
@@ -65,14 +65,14 @@ pub fn make_app<'a, 'b: 'a>(app: App<'a, 'b>) -> App<'a, 'b> {
 }
 
 pub fn execute<'a>(matches: &ArgMatches<'a>) -> Result<(), Error> {
-    let config = Config::get_current();
+    let config = Config::current();
     let here = env::current_dir()?;
     let here_str: &str = &here.to_string_lossy();
     let (org, project) = config.get_org_and_project(matches)?;
     let app = matches.value_of("app_name").unwrap();
     let platform = matches.value_of("platform").unwrap();
     let deployment = matches.value_of("deployment").unwrap_or("Staging");
-    let api = Api::get_current();
+    let api = Api::current();
     let print_release_name = matches.is_present("print_release_name");
 
     if !print_release_name {

--- a/src/commands/react_native_gradle.rs
+++ b/src/commands/react_native_gradle.rs
@@ -46,9 +46,9 @@ pub fn make_app<'a, 'b: 'a>(app: App<'a, 'b>) -> App<'a, 'b> {
 }
 
 pub fn execute<'a>(matches: &ArgMatches<'a>) -> Result<(), Error> {
-    let config = Config::get_current();
+    let config = Config::current();
     let (org, project) = config.get_org_and_project(matches)?;
-    let api = Api::get_current();
+    let api = Api::current();
     let base = env::current_dir()?;
 
     let sourcemap_path = PathBuf::from(matches.value_of("sourcemap").unwrap());

--- a/src/commands/react_native_xcode.rs
+++ b/src/commands/react_native_xcode.rs
@@ -96,9 +96,9 @@ fn find_node() -> String {
 }
 
 pub fn execute<'a>(matches: &ArgMatches<'a>) -> Result<(), Error> {
-    let config = Config::get_current();
+    let config = Config::current();
     let (org, project) = config.get_org_and_project(matches)?;
-    let api = Api::get_current();
+    let api = Api::current();
     let should_wrap = matches.is_present("force")
         || match env::var("CONFIGURATION") {
             Ok(config) => &config != "Debug",

--- a/src/commands/releases.rs
+++ b/src/commands/releases.rs
@@ -40,7 +40,7 @@ impl<'a> ReleaseContext<'a> {
         if let Some(ref proj) = self.project_default {
             Ok(proj.to_string())
         } else {
-            let config = Config::get_current();
+            let config = Config::current();
             Ok(config.get_project_default()?)
         }
     }
@@ -51,7 +51,7 @@ impl<'a> ReleaseContext<'a> {
         } else if let Some(project) = self.project_default {
             Ok(vec![project.to_string()])
         } else {
-            let config = Config::get_current();
+            let config = Config::current();
             Ok(vec![config.get_project_default()?])
         }
     }
@@ -410,7 +410,7 @@ fn execute_set_commits<'a>(
     let heads = if matches.is_present("auto") {
         let commits = find_heads(None, &repos)?;
         if commits.is_empty() {
-            let config = Config::get_current();
+            let config = Config::current();
 
             bail!(
                 "Could not determine any commits to be associated automatically.\n\
@@ -926,9 +926,9 @@ pub fn execute<'a>(matches: &ArgMatches<'a>) -> Result<(), Error> {
         return execute_propose_version();
     }
 
-    let config = Config::get_current();
+    let config = Config::current();
     let ctx = ReleaseContext {
-        api: Api::get_current(),
+        api: Api::current(),
         org: config.get_org(matches)?,
         project_default: matches.value_of("project"),
     };

--- a/src/commands/releases.rs
+++ b/src/commands/releases.rs
@@ -1,7 +1,7 @@
 //! Implements a command for managing releases.
 use std::collections::HashSet;
 use std::path::Path;
-use std::rc::Rc;
+use std::sync::Arc;
 
 use chrono::{DateTime, Duration, Utc};
 use clap::{App, AppSettings, Arg, ArgMatches};
@@ -26,7 +26,7 @@ use crate::utils::system::QuietExit;
 use crate::utils::vcs::{find_heads, CommitSpec};
 
 struct ReleaseContext<'a> {
-    pub api: Rc<Api>,
+    pub api: Arc<Api>,
     pub org: String,
     pub project_default: Option<&'a str>,
 }

--- a/src/commands/repos.rs
+++ b/src/commands/repos.rs
@@ -15,9 +15,9 @@ pub fn make_app<'a, 'b: 'a>(app: App<'a, 'b>) -> App<'a, 'b> {
 }
 
 pub fn execute<'a>(matches: &ArgMatches<'a>) -> Result<(), Error> {
-    let api = Api::get_current();
+    let api = Api::current();
 
-    let config = Config::get_current();
+    let config = Config::current();
     let org = config.get_org(matches)?;
     let repos = api.list_organization_repos(&org)?;
 

--- a/src/commands/send_event.rs
+++ b/src/commands/send_event.rs
@@ -132,7 +132,7 @@ pub fn make_app<'a, 'b: 'a>(app: App<'a, 'b>) -> App<'a, 'b> {
 }
 
 pub fn execute<'a>(matches: &ArgMatches<'a>) -> Result<(), Error> {
-    let config = Config::get_current();
+    let config = Config::current();
     let mut event = Event::default();
 
     event.sdk = Some(get_sdk_info());

--- a/src/commands/upload_dif.rs
+++ b/src/commands/upload_dif.rs
@@ -135,8 +135,8 @@ pub fn make_app<'a, 'b: 'a>(app: App<'a, 'b>) -> App<'a, 'b> {
 }
 
 fn execute_internal(matches: &ArgMatches<'_>, legacy: bool) -> Result<(), Error> {
-    let api = Api::get_current();
-    let config = Config::get_current();
+    let api = Api::current();
+    let config = Config::current();
     let (org, project) = config.get_org_and_project(matches)?;
 
     let ids = matches

--- a/src/commands/upload_proguard.rs
+++ b/src/commands/upload_proguard.rs
@@ -132,7 +132,7 @@ pub fn make_app<'a, 'b: 'a>(app: App<'a, 'b>) -> App<'a, 'b> {
 }
 
 pub fn execute<'a>(matches: &ArgMatches<'a>) -> Result<(), Error> {
-    let api = Api::get_current();
+    let api = Api::current();
 
     let paths: Vec<_> = match matches.values_of("paths") {
         Some(paths) => paths.collect(),
@@ -234,7 +234,7 @@ pub fn execute<'a>(matches: &ArgMatches<'a>) -> Result<(), Error> {
     }
 
     println!("{} uploading mappings", style(">").dim());
-    let config = Config::get_current();
+    let config = Config::current();
     let (org, project) = config.get_org_and_project(matches)?;
     let rv = api.upload_dif_archive(&org, &project, tf.path())?;
     println!(

--- a/src/config.rs
+++ b/src/config.rs
@@ -64,17 +64,17 @@ impl Config {
             let mut cfg = CONFIG.lock();
             *cfg = Some(Arc::new(self));
         }
-        Config::get_current()
+        Config::current()
     }
 
     /// Return the currently bound config as option.
-    pub fn get_current_opt() -> Option<Arc<Config>> {
+    pub fn current_opt() -> Option<Arc<Config>> {
         CONFIG.lock().as_ref().cloned()
     }
 
     /// Return the currently bound config.
-    pub fn get_current() -> Arc<Config> {
-        Config::get_current_opt().expect("Config not bound yet")
+    pub fn current() -> Arc<Config> {
+        Config::current_opt().expect("Config not bound yet")
     }
 
     /// Makes a copy of the config in a closure and boxes it.

--- a/src/utils/dif_upload.rs
+++ b/src/utils/dif_upload.rs
@@ -824,7 +824,7 @@ fn try_assemble_difs<'data>(
     difs: &'data [ChunkedDifMatch<'data>],
     options: &DifUpload,
 ) -> Result<MissingDifsInfo<'data>, Error> {
-    let api = Api::get_current();
+    let api = Api::current();
     let request = difs.iter().map(ChunkedDifMatch::to_assemble).collect();
     let response = api.assemble_difs(&options.org, &options.project, &request)?;
 
@@ -969,7 +969,7 @@ fn upload_missing_chunks(
             .enumerate()
             .map(|(index, (batch, size))| {
                 let mode = ProgressBarMode::Shared((progress.clone(), size, index, bytes.clone()));
-                Api::get_current().upload_chunks(&chunk_options.url, batch, mode, compression)
+                Api::current().upload_chunks(&chunk_options.url, batch, mode, compression)
             })
             .collect::<Result<(), _>>()
     })?;
@@ -1022,7 +1022,7 @@ fn poll_dif_assemble(
          \n{wide_bar}  {pos}/{len}",
     );
 
-    let api = Api::get_current();
+    let api = Api::current();
     let progress = ProgressBar::new(difs.len() as u64);
     progress.set_style(progress_style);
     progress.set_prefix(">");
@@ -1168,7 +1168,7 @@ fn get_missing_difs<'data>(
         &objects
     );
 
-    let api = Api::get_current();
+    let api = Api::current();
     let missing_checksums = {
         let checksums = objects.iter().map(|s| s.checksum());
         api.find_missing_dif_checksums(&options.org, &options.project, checksums)?
@@ -1207,8 +1207,8 @@ fn upload_in_batches(
     objects: &[HashedDifMatch<'_>],
     options: &DifUpload,
 ) -> Result<Vec<DebugInfoFile>, Error> {
-    let api = Api::get_current();
-    let max_size = Config::get_current().get_max_dif_archive_size()?;
+    let api = Api::current();
+    let max_size = Config::current().get_max_dif_archive_size()?;
     let mut dsyms = Vec::new();
 
     for (i, (batch, _)) in objects.batches(max_size, MAX_CHUNKS).enumerate() {
@@ -1498,7 +1498,7 @@ impl DifUpload {
             return Ok(Default::default());
         }
 
-        let api = Api::get_current();
+        let api = Api::current();
         if let Some(ref chunk_options) = api.get_chunk_upload_options(&self.org)? {
             if chunk_options.max_file_size > 0 {
                 self.max_file_size = chunk_options.max_file_size;

--- a/src/utils/dif_upload.rs
+++ b/src/utils/dif_upload.rs
@@ -961,7 +961,6 @@ fn upload_missing_chunks(
 
     let pool = ThreadPoolBuilder::new()
         .num_threads(chunk_options.concurrency as usize)
-        .exit_handler(|_| Api::get_current().reset())
         .build()?;
 
     pool.install(|| {

--- a/src/utils/system.rs
+++ b/src/utils/system.rs
@@ -125,7 +125,7 @@ pub fn print_error(err: &Error) {
         }
     }
 
-    if Config::get_current().get_log_level() < log::LevelFilter::Info {
+    if Config::current().get_log_level() < log::LevelFilter::Info {
         eprintln!();
         eprintln!("{}", style("Add --log-level=[info|debug] or export SENTRY_LOG_LEVEL=[info|debug] to see more output.").dim());
         eprintln!(
@@ -185,7 +185,7 @@ pub fn init_backtrace() {
 
 #[cfg(target_os = "macos")]
 pub fn get_model() -> Option<String> {
-    if let Some(model) = Config::get_current().get_model() {
+    if let Some(model) = Config::current().get_model() {
         return Some(model);
     }
 
@@ -214,7 +214,7 @@ pub fn get_model() -> Option<String> {
 
 #[cfg(target_os = "macos")]
 pub fn get_family() -> Option<String> {
-    if let Some(family) = Config::get_current().get_family() {
+    if let Some(family) = Config::current().get_family() {
         return Some(family);
     }
 
@@ -239,12 +239,12 @@ pub fn get_family() -> Option<String> {
 
 #[cfg(not(target_os = "macos"))]
 pub fn get_model() -> Option<String> {
-    Config::get_current().get_model()
+    Config::current().get_model()
 }
 
 #[cfg(not(target_os = "macos"))]
 pub fn get_family() -> Option<String> {
-    Config::get_current().get_family()
+    Config::current().get_family()
 }
 
 /// Indicates that sentry-cli should quit without printing anything.

--- a/src/utils/update.rs
+++ b/src/utils/update.rs
@@ -153,7 +153,7 @@ impl SentryCliUpdateInfo {
             exe.parent().unwrap().join(".sentry-cli.part")
         };
         let mut f = fs::File::create(&tmp_path)?;
-        let api = Api::get_current();
+        let api = Api::current();
         match api.download_with_progress(self.download_url()?, &mut f) {
             Ok(_) => {}
             Err(err) => {
@@ -169,7 +169,7 @@ impl SentryCliUpdateInfo {
 }
 
 pub fn get_latest_sentrycli_release() -> Result<SentryCliUpdateInfo, Error> {
-    let api = Api::get_current();
+    let api = Api::current();
     Ok(SentryCliUpdateInfo {
         latest_release: if let Ok(release) = api.get_latest_sentrycli_release() {
             release
@@ -250,7 +250,7 @@ fn update_nagger_impl() -> Result<(), Error> {
 }
 
 pub fn run_sentrycli_update_nagger() {
-    let config = match Config::get_current_opt() {
+    let config = match Config::current_opt() {
         Some(config) => config,
         None => return,
     };

--- a/src/utils/xcode.rs
+++ b/src/utils/xcode.rs
@@ -481,7 +481,7 @@ pub fn show_notification(title: &str, message: &str) -> Result<(), Error> {
         );
     }
 
-    let config = Config::get_current();
+    let config = Config::current();
     if !config.show_notifications()? {
         return Ok(());
     }


### PR DESCRIPTION
We're pretty confident that curl handles stashed into TLS causes all
kinds of mischief on thread shutdown which sometimes might even cause a
segfault.  This instead stashes the handles into an r2d2 connection
pool.

This PR also adds more retries for common network issues we encounter.