### PR TITLE
fix(JS wrapper): Pass correct options when uploading source maps

### DIFF
--- a/js/releases/index.js
+++ b/js/releases/index.js
@@ -102,7 +102,7 @@ module.exports = {
 
       const args = ['releases', 'files', release, 'upload-sourcemaps', sourcemapPath];
       return helper.execute(
-        helper.prepareCommand(args, SOURCEMAPS_SCHEMA, options),
+        helper.prepareCommand(args, SOURCEMAPS_SCHEMA, newOptions),
         true
       );
     });


### PR DESCRIPTION
We add default ignoring (via the `newOptions` object), but then don't use it (we pass the original `options` object instead). This fixes that. 