### PR TITLE
Add version name as parameter

### DIFF
--- a/src/commands/react_native_appcenter.rs
+++ b/src/commands/react_native_appcenter.rs
@@ -35,6 +35,14 @@ pub fn make_app<'a, 'b: 'a>(app: App<'a, 'b>) -> App<'a, 'b> {
                 ),
         )
         .arg(
+            Arg::with_name("version_name")
+                .value_name("VERSION_NAME")
+                .long("version-name")
+                .help(
+                    "Override version name in release name",
+                ),
+        )
+        .arg(
             Arg::with_name("print_release_name")
                 .long("print-release-name")
                 .help("Print the release name instead."),
@@ -83,7 +91,7 @@ pub fn execute<'a>(matches: &ArgMatches<'a>) -> Result<(), Error> {
 
     let package = get_appcenter_package(app, deployment)?;
     let release =
-        get_react_native_appcenter_release(&package, platform, matches.value_of("bundle_id"))?;
+        get_react_native_appcenter_release(&package, platform, matches.value_of("bundle_id"), matches.value_of("version_name"))?;
     if print_release_name {
         println!("{}", release);
         return Ok(());

--- a/src/commands/react_native_appcenter.rs
+++ b/src/commands/react_native_appcenter.rs
@@ -38,9 +38,7 @@ pub fn make_app<'a, 'b: 'a>(app: App<'a, 'b>) -> App<'a, 'b> {
             Arg::with_name("version_name")
                 .value_name("VERSION_NAME")
                 .long("version-name")
-                .help(
-                    "Override version name in release name",
-                ),
+                .help("Override version name in release name"),
         )
         .arg(
             Arg::with_name("print_release_name")
@@ -90,8 +88,12 @@ pub fn execute<'a>(matches: &ArgMatches<'a>) -> Result<(), Error> {
     }
 
     let package = get_appcenter_package(app, deployment)?;
-    let release =
-        get_react_native_appcenter_release(&package, platform, matches.value_of("bundle_id"), matches.value_of("version_name"))?;
+    let release = get_react_native_appcenter_release(
+        &package,
+        platform,
+        matches.value_of("bundle_id"),
+        matches.value_of("version_name"),
+    )?;
     if print_release_name {
         println!("{}", release);
         return Ok(());

--- a/src/utils/appcenter.rs
+++ b/src/utils/appcenter.rs
@@ -136,7 +136,10 @@ pub fn get_react_native_appcenter_release(
     let version_name_ovrr = version_name_override.unwrap_or("");
 
     if bundle_id_ovrr != "" && version_name_ovrr != "" {
-        return Ok(format!("{}-{}-codepush:{}", bundle_id_ovrr, version_name_ovrr, package.label));
+        return Ok(format!(
+            "{}-{}-codepush:{}",
+            bundle_id_ovrr, version_name_ovrr, package.label
+        ));
     }
 
     if platform == "ios" {
@@ -152,10 +155,21 @@ pub fn get_react_native_appcenter_release(
                 let pi = XcodeProjectInfo::from_path(&entry)?;
                 if let Some(ipl) = InfoPlist::from_project_info(&pi)? {
                     if let Some(release_name) = get_xcode_release_name(Some(ipl))? {
-                        let vec: Vec<&str> = release_name.split("-").collect();
-                        let bundle_id = if bundle_id_ovrr == "" { vec[0] } else { bundle_id_ovrr };
-                        let version_name = if version_name_ovrr == "" { vec[1] } else { version_name_ovrr };
-                        return Ok(format!("{}-{}-codepush:{}", bundle_id, version_name, package.label));
+                        let vec: Vec<&str> = release_name.split('-').collect();
+                        let bundle_id = if bundle_id_ovrr == "" {
+                            vec[0]
+                        } else {
+                            bundle_id_ovrr
+                        };
+                        let version_name = if version_name_ovrr == "" {
+                            vec[1]
+                        } else {
+                            version_name_ovrr
+                        };
+                        return Ok(format!(
+                            "{}-{}-codepush:{}",
+                            bundle_id, version_name, package.label
+                        ));
                     }
                 }
             }
@@ -169,7 +183,7 @@ pub fn get_react_native_appcenter_release(
             if android_folder.is_dir();
             then {
                 if let Some(release_name) = infer_gradle_release_name(Some(here.join("android")))? {
-                    let vec: Vec<&str> = release_name.split("-").collect();
+                    let vec: Vec<&str> = release_name.split('-').collect();
                     let bundle_id = if bundle_id_ovrr == "" { vec[0] } else { bundle_id_ovrr };
                     let version_name = if version_name_ovrr == "" { vec[1] } else { version_name_ovrr };
                     return Ok(format!("{}-{}-codepush:{}", bundle_id, version_name, package.label));

--- a/src/utils/appcenter.rs
+++ b/src/utils/appcenter.rs
@@ -130,9 +130,13 @@ pub fn get_react_native_appcenter_release(
     package: &AppCenterPackage,
     platform: &str,
     bundle_id_override: Option<&str>,
+    version_name_override: Option<&str>,
 ) -> Result<String, Error> {
-    if let Some(bundle_id) = bundle_id_override {
-        return Ok(format!("{}-codepush:{}", bundle_id, package.label));
+    let bundle_id_ovrr = bundle_id_override.unwrap_or("");
+    let version_name_ovrr = version_name_override.unwrap_or("");
+
+    if bundle_id_ovrr != "" && version_name_ovrr != "" {
+        return Ok(format!("{}-{}-codepush:{}", bundle_id_ovrr, version_name_ovrr, package.label));
     }
 
     if platform == "ios" {
@@ -148,7 +152,10 @@ pub fn get_react_native_appcenter_release(
                 let pi = XcodeProjectInfo::from_path(&entry)?;
                 if let Some(ipl) = InfoPlist::from_project_info(&pi)? {
                     if let Some(release_name) = get_xcode_release_name(Some(ipl))? {
-                        return Ok(format!("{}-codepush:{}", release_name, package.label));
+                        let vec: Vec<&str> = release_name.split("-").collect();
+                        let bundle_id = if bundle_id_ovrr == "" { vec[0] } else { bundle_id_ovrr };
+                        let version_name = if version_name_ovrr == "" { vec[1] } else { version_name_ovrr };
+                        return Ok(format!("{}-{}-codepush:{}", bundle_id, version_name, package.label));
                     }
                 }
             }
@@ -162,7 +169,10 @@ pub fn get_react_native_appcenter_release(
             if android_folder.is_dir();
             then {
                 if let Some(release_name) = infer_gradle_release_name(Some(here.join("android")))? {
-                    return Ok(format!("{}-codepush:{}", release_name, package.label));
+                    let vec: Vec<&str> = release_name.split("-").collect();
+                    let bundle_id = if bundle_id_ovrr == "" { vec[0] } else { bundle_id_ovrr };
+                    let version_name = if version_name_ovrr == "" { vec[1] } else { version_name_ovrr };
+                    return Ok(format!("{}-{}-codepush:{}", bundle_id, version_name, package.label));
                 } else {
                     bail!("Could not parse app id from build.gradle");
                 }


### PR DESCRIPTION
My app has `staging` and `production` environments. For each env, I have only 1 bundle name like `com.app.staging`, `com.app.production`. I integrate both CodePush and Sentry so I must upload bundle files to Sentry by manually. With your current cli, I have 2 options to set release version:

- Don't override `bundle-id` -> Sentry version: `com.app-1.0`
- Override `bundle-id` with `com.app.staging` -> Sentry version: `com.app.staging`

The problem is version number is not included in the 2nd option automatically. So I update code a little bit to resolve that problem. Also I add another parameter called `version-name` in case anyone want to override the value.

Please review and merge it if you think it's helpful.
Thanks!