### PR TITLE
Enable associating commits via js API

### DIFF
--- a/js/releases/index.js
+++ b/js/releases/index.js
@@ -34,6 +34,20 @@ module.exports = {
   },
 
   /**
+   * Associates commits with this release.
+   *
+   * @param {string} release Unique name of the new release.
+   * @param {string} commitsToSet Option designating which commits to associate.
+   * Either 'auto' or 'my-repo@from..to'
+   * @returns {Promise} A promise that resolves when the commits have been associated.
+   * @memberof SentryReleases
+   */
+  setCommits(release, commitsToSet) {
+    const commitFlags = commitsToSet === 'auto' ? ['--auto'] : ['--commit', commitsToSet];
+    return helper.execute(['releases', 'set-commits', release].concat(commitFlags));
+  },
+
+  /**
    * Marks this release as complete. This should be called once all artifacts has been
    * uploaded.
    *
@@ -91,7 +105,7 @@ module.exports = {
    */
   uploadSourceMaps(release, options) {
     if (!options || !options.include) {
-      throw new Error('options.include must be a vaild path(s)');
+      throw new Error('options.include must be a valid path(s)');
     }
 
     const uploads = options.include.map(sourcemapPath => {


### PR DESCRIPTION
This PR adds an endpoint to the js API that can be used to associate commits. If approved, I would follow up with a PR for sentry-webpack-plugin.

relevant sentry-webpack-plugin issue: https://github.com/getsentry/sentry-webpack-plugin/issues/71
my sentry-webpack-plugin branch: https://github.com/uturnr/sentry-webpack-plugin/tree/feature/associate-commit 