### PR TITLE
ensure is_matching_url and VcsUrl::parse is case insensitive

### DIFF
--- a/src/utils/vcs.rs
+++ b/src/utils/vcs.rs
@@ -125,14 +125,14 @@ impl VcsUrl {
             let username = &caps[1];
             if let Some(caps) = VS_GIT_PATH_RE.captures(path) {
                 return VcsUrl {
-                    provider: host.into(),
-                    id: format!("{}/{}", username, &caps[1]),
+                    provider: host.to_lowercase().into(),
+                    id: format!("{}/{}", username.to_lowercase(), &caps[1].to_lowercase()),
                 };
             }
         }
         VcsUrl {
-            provider: host.into(),
-            id: strip_git_suffix(path).into(),
+            provider: host.to_lowercase().into(),
+            id: strip_git_suffix(path).to_lowercase().into(),
         }
     }
 }
@@ -415,6 +415,13 @@ fn test_url_parsing() {
             provider: "gitlab.com".into(),
             id: "gitlab-org/gitlab-ce".into(),
         }
+    );
+    assert_eq!(
+        VcsUrl::parse("git@gitlab.com:gitlab-org/GitLab-CE.git"),
+        VcsUrl {
+            provider: "gitlab.com".into(),
+            id: "gitlab-org/gitlab-ce".into(),
+        }
     )
 }
 
@@ -438,6 +445,10 @@ fn test_url_normalization() {
     ));
     assert!(is_matching_url(
         "https://gitlab.example.com/gitlab-org/gitlab-ce",
+        "git@gitlab.example.com:gitlab-org/gitlab-ce.git"
+    ));
+    assert!(is_matching_url(
+        "https://gitlab.example.com/gitlab-org/GitLab-CE",
         "git@gitlab.example.com:gitlab-org/gitlab-ce.git"
     ))
 }

--- a/src/utils/vcs.rs
+++ b/src/utils/vcs.rs
@@ -125,14 +125,14 @@ impl VcsUrl {
             let username = &caps[1];
             if let Some(caps) = VS_GIT_PATH_RE.captures(path) {
                 return VcsUrl {
-                    provider: host.to_lowercase().into(),
+                    provider: host.to_lowercase(),
                     id: format!("{}/{}", username.to_lowercase(), &caps[1].to_lowercase()),
                 };
             }
         }
         VcsUrl {
-            provider: host.to_lowercase().into(),
-            id: strip_git_suffix(path).to_lowercase().into(),
+            provider: host.to_lowercase(),
+            id: strip_git_suffix(path).to_lowercase(),
         }
     }
 }


### PR DESCRIPTION
We ran into issues when associating commits from git repositories with mixed uppercasing in their url.