### PR TITLE
Add options to JS SentryCli Constructor

### DIFF
--- a/js/helper.js
+++ b/js/helper.js
@@ -127,15 +127,16 @@ function getPath() {
  *
  * @param {string[]} args Command line arguments passed to `sentry-cli`.
  * @param {boolean} live We inherit stdio to display `sentry-cli` output directly.
+ * @param {boolean} silent Disable stdout for silents build (CI/Webpack Stats, ...)
  * @returns {Promise.<string>} A promise that resolves to the standard output.
  */
-function execute(args, live) {
+function execute(args, live, silent) {
   const env = Object.assign({}, process.env);
   return new Promise((resolve, reject) => {
     if (live === true) {
       const pid = childProcess.spawn(getPath(), args, {
         env,
-        stdio: 'inherit',
+        stdio: ['inherit', silent ? 'pipe' : 'inherit', 'inherit'],
       });
       pid.on('exit', () => {
         resolve();

--- a/js/index.js
+++ b/js/index.js
@@ -28,11 +28,11 @@ class SentryCli {
    * @param {string} [configFile] Relative or absolute path to the configuration file.
    * @param {Object} [options] More options to pass to the CLI
    */
-  constructor(configFile, options = { silent: false }) {
+  constructor(configFile, options) {
     if (typeof configFile === 'string') {
       process.env.SENTRY_PROPERTIES = configFile;
     }
-    this.options = options;
+    this.options = options || { silent: false };
   }
 
   /**

--- a/js/index.js
+++ b/js/index.js
@@ -26,11 +26,13 @@ class SentryCli {
    * overridden.
    *
    * @param {string} [configFile] Relative or absolute path to the configuration file.
+   * @param {Object} [options] More options to pass to the CLI
    */
-  constructor(configFile) {
+  constructor(configFile, options = { silent: false }) {
     if (typeof configFile === 'string') {
       process.env.SENTRY_PROPERTIES = configFile;
     }
+    this.options = options;
   }
 
   /**
@@ -56,7 +58,7 @@ class SentryCli {
    * @returns {Promise.<string>} A promise that resolves to the standard output.
    */
   execute(args, live) {
-    return helper.execute(args, live);
+    return helper.execute(args, live, this.options.silent);
   }
 }
 


### PR DESCRIPTION
- Add options to Sentry Constructor (JS part)
- Pass silent option to Sentry to disable stdout (need it for https://github.com/getsentry/sentry-webpack-plugin/issues/104)