### PR TITLE
feat(releases): Protect against uploads of too many files

### DIFF
--- a/src/utils/sourcemaps.rs
+++ b/src/utils/sourcemaps.rs
@@ -487,6 +487,15 @@ impl SourceMapProcessor {
     ) -> Result<(), Error> {
         self.flush_pending_sources()?;
 
+        // Do not permit uploads of more than 20k files. This is a termporary downside protection to
+        // protect users from uploading more sources than we support.
+        if self.sources.len() > 20_000 {
+            bail!(
+                "Too many sources: {} exceeds maximum allowed files per release",
+                self.sources.len()
+            );
+        }
+
         // get a list of release files first so we know the file IDs of
         // files that already exist.
         let release_files: HashMap<_, _> = api


### PR DESCRIPTION
This adds a simple check for the number of files uploaded to a release. This does not prevent the upload of more than 20k files over multiple requests, but ensures that large releases are not even attempted.
