### PR TITLE
fix(releases) Accept more Azure Devops URLs

### DIFF
--- a/src/utils/system.rs
+++ b/src/utils/system.rs
@@ -219,7 +219,6 @@ pub fn get_family() -> Option<String> {
     }
 
     use if_chain::if_chain;
-    use regex::Regex;
 
     lazy_static! {
         static ref FAMILY_RE: Regex = Regex::new(r#"([a-zA-Z]+)\d"#).unwrap();

--- a/src/utils/vcs.rs
+++ b/src/utils/vcs.rs
@@ -120,6 +120,7 @@ impl VcsUrl {
         lazy_static! {
             static ref VS_DOMAIN_RE: Regex = Regex::new(r"^([^.]+)\.visualstudio.com$").unwrap();
             static ref VS_GIT_PATH_RE: Regex = Regex::new(r"^_git/(.+?)(?:\.git)?$").unwrap();
+            static ref VS_TRAILING_GIT_PATH_RE: Regex = Regex::new(r"(.+?)/_git$").unwrap();
         }
         if let Some(caps) = VS_DOMAIN_RE.captures(host) {
             let username = &caps[1];
@@ -127,6 +128,12 @@ impl VcsUrl {
                 return VcsUrl {
                     provider: host.into(),
                     id: format!("{}/{}", username, &caps[1]),
+                };
+            }
+            if let Some(caps) = VS_TRAILING_GIT_PATH_RE.captures(path) {
+                return VcsUrl {
+                    provider: host.into(),
+                    id: format!("{}", &caps[1]),
                 };
             }
         }
@@ -379,6 +386,13 @@ fn test_url_parsing() {
         VcsUrl {
             provider: "neilmanvar.visualstudio.com".into(),
             id: "neilmanvar/sentry-demo".into(),
+        }
+    );
+    assert_eq!(
+        VcsUrl::parse("https://project@mydomain.visualstudio.com/project/repo/_git"),
+        VcsUrl {
+            provider: "mydomain.visualstudio.com".into(),
+            id: "project/repo".into(),
         }
     );
     assert_eq!(

--- a/src/utils/vcs.rs
+++ b/src/utils/vcs.rs
@@ -133,7 +133,7 @@ impl VcsUrl {
             if let Some(caps) = VS_TRAILING_GIT_PATH_RE.captures(path) {
                 return VcsUrl {
                     provider: host.into(),
-                    id: format!("{}", &caps[1]),
+                    id: caps[1].to_string(),
                 };
             }
         }
@@ -223,7 +223,7 @@ fn find_matching_rev(
         if let Some(url) = remote.url();
         then {
             if !discovery || is_matching_url(url, &reference_url) {
-            debug!("  found match: {} == {}", url, &reference_url);
+                debug!("  found match: {} == {}", url, &reference_url);
                 let head = repo.revparse_single(r)?;
                 return Ok(Some(log_match!(head.id().to_string())));
             } else {


### PR DESCRIPTION
Parse SSH URLs from Azure DevOps that use the project name as the SSH username.

Fixes #11055