### PR TITLE
feat(sourcemaps): Implement basic parallel upload for source maps

### DIFF
--- a/src/api.rs
+++ b/src/api.rs
@@ -591,6 +591,7 @@ impl Api {
         name: &str,
         dist: Option<&str>,
         headers: Option<&[(String, String)]>,
+        progress_bar_mode: ProgressBarMode,
     ) -> ApiResult<Option<Artifact>> {
         let path = if let Some(project) = project {
             format!(
@@ -643,7 +644,7 @@ impl Api {
                     http::HTTP_STATUS_504_GATEWAY_TIMEOUT,
                 ],
             )?
-            .progress_bar_mode(ProgressBarMode::Request)?
+            .progress_bar_mode(progress_bar_mode)?
             .send()?;
         if resp.status() == 409 {
             Ok(None)

--- a/src/commands/releases.rs
+++ b/src/commands/releases.rs
@@ -15,7 +15,7 @@ use lazy_static::lazy_static;
 use log::{debug, info, warn};
 use regex::Regex;
 
-use crate::api::{Api, Deploy, FileContents, NewRelease, UpdatedRelease};
+use crate::api::{Api, Deploy, FileContents, NewRelease, ProgressBarMode, UpdatedRelease};
 use crate::config::Config;
 use crate::utils::args::{
     get_timestamp, validate_project, validate_seconds, validate_timestamp, ArgExt,
@@ -698,6 +698,7 @@ fn execute_files_upload<'a>(
         &name,
         dist,
         Some(&headers[..]),
+        ProgressBarMode::Request,
     )? {
         println!("A {}  ({} bytes)", artifact.sha1, artifact.size);
     } else {


### PR DESCRIPTION
This adds basic parallel uploads for source maps.  This is not the final say in
upload performance but adds some basic improvements in the short term.