### PR TITLE
chores: update to new clippy lint names

### DIFF
--- a/src/commands/difutil_find.rs
+++ b/src/commands/difutil_find.rs
@@ -94,7 +94,7 @@ fn id_hint(id: &DebugId) -> &'static str {
 }
 
 // TODO: Reduce complexity of this function
-#[allow(clippy::cyclomatic_complexity)]
+#[allow(clippy::cognitive_complexity)]
 fn find_ids(
     paths: &HashSet<PathBuf>,
     types: &HashSet<DifType>,

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -151,7 +151,7 @@ fn add_commands<'a, 'b>(mut app: App<'a, 'b>) -> App<'a, 'b> {
     app
 }
 
-#[allow(clippy::cyclomatic_complexity)]
+#[allow(clippy::cognitive_complexity)]
 fn run_command(matches: &ArgMatches<'_>) -> Result<(), Error> {
     macro_rules! execute_subcommand {
         ($name:ident) => {{


### PR DESCRIPTION
Makes 1.35 clippy happy.