### PR TITLE
ref(sourcemaps): Add a command to skip waiting for assemble

### DIFF
--- a/src/commands/react_native_appcenter.rs
+++ b/src/commands/react_native_appcenter.rs
@@ -62,9 +62,9 @@ pub fn make_app<'a, 'b: 'a>(app: App<'a, 'b>) -> App<'a, 'b> {
                 .help("A list of folders with assets that should be processed."),
         )
         .arg(
-            Arg::with_name("no_wait")
-                .long("no-wait")
-                .help("Do not wait for the server to process uploaded files."),
+            Arg::with_name("wait")
+                .long("wait")
+                .help("Wait for the server to fully process uploaded files."),
         )
 }
 
@@ -134,7 +134,7 @@ pub fn execute<'a>(matches: &ArgMatches<'a>) -> Result<(), Error> {
         project: Some(&project),
         release: &release.version,
         dist: None,
-        wait: !matches.is_present("no_wait"),
+        wait: !matches.is_present("wait"),
     })?;
 
     Ok(())

--- a/src/commands/react_native_appcenter.rs
+++ b/src/commands/react_native_appcenter.rs
@@ -11,7 +11,7 @@ use crate::api::{Api, NewRelease};
 use crate::config::Config;
 use crate::utils::appcenter::{get_appcenter_package, get_react_native_appcenter_release};
 use crate::utils::args::ArgExt;
-use crate::utils::sourcemaps::SourceMapProcessor;
+use crate::utils::sourcemaps::{SourceMapProcessor, UploadContext};
 
 pub fn make_app<'a, 'b: 'a>(app: App<'a, 'b>) -> App<'a, 'b> {
     app.about("Upload react-native projects for AppCenter.")
@@ -60,6 +60,11 @@ pub fn make_app<'a, 'b: 'a>(app: App<'a, 'b>) -> App<'a, 'b> {
                 .required(true)
                 .multiple(true)
                 .help("A list of folders with assets that should be processed."),
+        )
+        .arg(
+            Arg::with_name("no_wait")
+                .long("no-wait")
+                .help("Do not wait for the server to process uploaded files."),
         )
 }
 
@@ -123,7 +128,14 @@ pub fn execute<'a>(matches: &ArgMatches<'a>) -> Result<(), Error> {
             ..Default::default()
         },
     )?;
-    processor.upload(&org, Some(&project), &release.version, None)?;
+
+    processor.upload(&UploadContext {
+        org: &org,
+        project: Some(&project),
+        release: &release.version,
+        dist: None,
+        wait: !matches.is_present("no_wait"),
+    })?;
 
     Ok(())
 }

--- a/src/commands/react_native_codepush.rs
+++ b/src/commands/react_native_codepush.rs
@@ -11,7 +11,7 @@ use crate::api::{Api, NewRelease};
 use crate::config::Config;
 use crate::utils::args::ArgExt;
 use crate::utils::codepush::{get_codepush_package, get_react_native_codepush_release};
-use crate::utils::sourcemaps::SourceMapProcessor;
+use crate::utils::sourcemaps::{SourceMapProcessor, UploadContext};
 
 pub fn make_app<'a, 'b: 'a>(app: App<'a, 'b>) -> App<'a, 'b> {
     app.about("DEPRECATED: Upload react-native projects for CodePush.")
@@ -61,6 +61,11 @@ pub fn make_app<'a, 'b: 'a>(app: App<'a, 'b>) -> App<'a, 'b> {
                 .required(true)
                 .multiple(true)
                 .help("A list of folders with assets that should be processed."),
+        )
+        .arg(
+            Arg::with_name("no_wait")
+                .long("no-wait")
+                .help("Do not wait for the server to process uploaded files."),
         )
 }
 
@@ -123,7 +128,14 @@ pub fn execute<'a>(matches: &ArgMatches<'a>) -> Result<(), Error> {
             ..Default::default()
         },
     )?;
-    processor.upload(&org, Some(&project), &release.version, None)?;
+
+    processor.upload(&UploadContext {
+        org: &org,
+        project: Some(&project),
+        release: &release.version,
+        dist: None,
+        wait: !matches.is_present("no_wait"),
+    })?;
 
     Ok(())
 }

--- a/src/commands/react_native_codepush.rs
+++ b/src/commands/react_native_codepush.rs
@@ -63,9 +63,9 @@ pub fn make_app<'a, 'b: 'a>(app: App<'a, 'b>) -> App<'a, 'b> {
                 .help("A list of folders with assets that should be processed."),
         )
         .arg(
-            Arg::with_name("no_wait")
-                .long("no-wait")
-                .help("Do not wait for the server to process uploaded files."),
+            Arg::with_name("wait")
+                .long("wait")
+                .help("Wait for the server to fully process uploaded files."),
         )
 }
 
@@ -134,7 +134,7 @@ pub fn execute<'a>(matches: &ArgMatches<'a>) -> Result<(), Error> {
         project: Some(&project),
         release: &release.version,
         dist: None,
-        wait: !matches.is_present("no_wait"),
+        wait: matches.is_present("wait"),
     })?;
 
     Ok(())

--- a/src/commands/react_native_gradle.rs
+++ b/src/commands/react_native_gradle.rs
@@ -9,7 +9,7 @@ use sourcemap::ram_bundle::RamBundle;
 use crate::api::{Api, NewRelease};
 use crate::config::Config;
 use crate::utils::args::ArgExt;
-use crate::utils::sourcemaps::SourceMapProcessor;
+use crate::utils::sourcemaps::{SourceMapProcessor, UploadContext};
 
 pub fn make_app<'a, 'b: 'a>(app: App<'a, 'b>) -> App<'a, 'b> {
     app.about("Upload react-native projects in a gradle build step.")
@@ -43,6 +43,11 @@ pub fn make_app<'a, 'b: 'a>(app: App<'a, 'b>) -> App<'a, 'b> {
                 .multiple(true)
                 .number_of_values(1)
                 .help("The names of the distributions to publish. Can be supplied multiple times."),
+        )
+        .arg(
+            Arg::with_name("no_wait")
+                .long("no-wait")
+                .help("Do not wait for the server to process uploaded files."),
         )
 }
 
@@ -92,7 +97,14 @@ pub fn execute<'a>(matches: &ArgMatches<'a>) -> Result<(), Error> {
             "Uploading sourcemaps for release {} distribution {}",
             &release.version, dist
         );
-        processor.upload(&org, Some(&project), &release.version, Some(dist))?;
+
+        processor.upload(&UploadContext {
+            org: &org,
+            project: Some(&project),
+            release: &release.version,
+            dist: Some(dist),
+            wait: !matches.is_present("no_wait"),
+        })?;
     }
 
     Ok(())

--- a/src/commands/react_native_gradle.rs
+++ b/src/commands/react_native_gradle.rs
@@ -45,9 +45,9 @@ pub fn make_app<'a, 'b: 'a>(app: App<'a, 'b>) -> App<'a, 'b> {
                 .help("The names of the distributions to publish. Can be supplied multiple times."),
         )
         .arg(
-            Arg::with_name("no_wait")
-                .long("no-wait")
-                .help("Do not wait for the server to process uploaded files."),
+            Arg::with_name("wait")
+                .long("wait")
+                .help("Wait for the server to fully process uploaded files."),
         )
 }
 
@@ -103,7 +103,7 @@ pub fn execute<'a>(matches: &ArgMatches<'a>) -> Result<(), Error> {
             project: Some(&project),
             release: &release.version,
             dist: Some(dist),
-            wait: !matches.is_present("no_wait"),
+            wait: matches.is_present("wait"),
         })?;
     }
 

--- a/src/commands/react_native_xcode.rs
+++ b/src/commands/react_native_xcode.rs
@@ -15,7 +15,7 @@ use crate::api::{Api, NewRelease};
 use crate::config::Config;
 use crate::utils::args::ArgExt;
 use crate::utils::fs::TempFile;
-use crate::utils::sourcemaps::SourceMapProcessor;
+use crate::utils::sourcemaps::{SourceMapProcessor, UploadContext};
 use crate::utils::system::propagate_exit_status;
 use crate::utils::xcode::{InfoPlist, MayDetach};
 
@@ -83,6 +83,11 @@ pub fn make_app<'a, 'b: 'a>(app: App<'a, 'b>) -> App<'a, 'b> {
                 .multiple(true)
                 .last(true)
                 .help("Optional arguments to pass to the build script."),
+        )
+        .arg(
+            Arg::with_name("no_wait")
+                .long("no-wait")
+                .help("Do not wait for the server to process uploaded files."),
         )
 }
 
@@ -253,7 +258,14 @@ pub fn execute<'a>(matches: &ArgMatches<'a>) -> Result<(), Error> {
                 ..Default::default()
             },
         )?;
-        processor.upload(&org, Some(&project), &release.version, Some(&plist.build()))?;
+
+        processor.upload(&UploadContext {
+            org: &org,
+            project: Some(&project),
+            release: &release.version,
+            dist: Some(&plist.build()),
+            wait: !matches.is_present("no_wait"),
+        })?;
 
         Ok(())
     })

--- a/src/commands/react_native_xcode.rs
+++ b/src/commands/react_native_xcode.rs
@@ -85,9 +85,9 @@ pub fn make_app<'a, 'b: 'a>(app: App<'a, 'b>) -> App<'a, 'b> {
                 .help("Optional arguments to pass to the build script."),
         )
         .arg(
-            Arg::with_name("no_wait")
-                .long("no-wait")
-                .help("Do not wait for the server to process uploaded files."),
+            Arg::with_name("wait")
+                .long("wait")
+                .help("Wait for the server to fully process uploaded files."),
         )
 }
 
@@ -264,7 +264,7 @@ pub fn execute<'a>(matches: &ArgMatches<'a>) -> Result<(), Error> {
             project: Some(&project),
             release: &release.version,
             dist: Some(&plist.build()),
-            wait: !matches.is_present("no_wait"),
+            wait: matches.is_present("wait"),
         })?;
 
         Ok(())

--- a/src/commands/releases.rs
+++ b/src/commands/releases.rs
@@ -212,9 +212,11 @@ pub fn make_app<'a, 'b: 'a>(app: App<'a, 'b>) -> App<'a, 'b> {
                 .arg(Arg::with_name("validate")
                     .long("validate")
                     .help("Enable basic sourcemap validation."))
-                .arg(Arg::with_name("no_wait")
-                    .long("no-wait")
-                    .help("Do not wait for the server to process uploaded files."))
+        .arg(
+            Arg::with_name("wait")
+                .long("wait")
+                .help("Wait for the server to fully process uploaded files."),
+        )
                 .arg(Arg::with_name("no_sourcemap_reference")
                     .long("no-sourcemap-reference")
                     .help("Disable emitting of automatic sourcemap references.{n}\
@@ -912,7 +914,7 @@ fn execute_files_upload_sourcemaps<'a>(
         project: project.as_ref().map(String::as_str),
         release: &release.version,
         dist: matches.value_of("dist"),
-        wait: !matches.is_present("no_wait"),
+        wait: matches.is_present("wait"),
     })?;
 
     Ok(())

--- a/src/commands/releases.rs
+++ b/src/commands/releases.rs
@@ -22,7 +22,7 @@ use crate::utils::args::{
 };
 use crate::utils::formatting::{HumanDuration, Table};
 use crate::utils::releases::detect_release_name;
-use crate::utils::sourcemaps::SourceMapProcessor;
+use crate::utils::sourcemaps::{SourceMapProcessor, UploadContext};
 use crate::utils::system::QuietExit;
 use crate::utils::vcs::{find_heads, CommitSpec};
 
@@ -212,6 +212,9 @@ pub fn make_app<'a, 'b: 'a>(app: App<'a, 'b>) -> App<'a, 'b> {
                 .arg(Arg::with_name("validate")
                     .long("validate")
                     .help("Enable basic sourcemap validation."))
+                .arg(Arg::with_name("no_wait")
+                    .long("no-wait")
+                    .help("Do not wait for the server to process uploaded files."))
                 .arg(Arg::with_name("no_sourcemap_reference")
                     .long("no-sourcemap-reference")
                     .help("Disable emitting of automatic sourcemap references.{n}\
@@ -892,6 +895,7 @@ fn execute_files_upload_sourcemaps<'a>(
     }
 
     let org = ctx.get_org()?;
+    let project = ctx.get_project_default().ok();
 
     // make sure the release exists
     let release = ctx.api.new_release(
@@ -903,14 +907,13 @@ fn execute_files_upload_sourcemaps<'a>(
         },
     )?;
 
-    let dist = matches.value_of("dist");
-    let project = ctx.get_project_default().ok();
-    processor.upload(
+    processor.upload(&UploadContext {
         org,
-        project.as_ref().map(String::as_ref),
-        &release.version,
-        dist,
-    )?;
+        project: project.as_ref().map(String::as_str),
+        release: &release.version,
+        dist: matches.value_of("dist"),
+        wait: !matches.is_present("no_wait"),
+    })?;
 
     Ok(())
 }


### PR DESCRIPTION
Adds `--wait` to all commands that upload sourcemaps. By default, users can upload even large bundles in a matter of seconds without waiting for the server to process them. With the optional flag, one can wait for release assembly, but that should not be necessary in most cases.

Example that uploads roughly 300 files to Sentry:

```
 $ time sentry-cli releases files 8beb5e7294d1e2f0608d24783eb9dc78e1ecc670 upload-sourcemaps ~/Downloads/sentry/ram
> Analyzing 2 sources
> Adding source map references
> Bundled 2 files for upload
> Uploaded release files to Sentry
> File processing complete

Source Map Upload Report
  Source Maps
    ~/main.jsbundle.map
  Indexed RAM Bundles (expanded)
    ~/main.jsbundle

0.47s user 0.09s system 16% cpu 3.345 total
```