### PR TITLE
fix(sourcemap): Support absolute paths for sourcemaps

### DIFF
--- a/src/utils/sourcemaps.rs
+++ b/src/utils/sourcemaps.rs
@@ -96,10 +96,11 @@ fn unsplit_url(path: Option<&str>, basename: &str, ext: Option<&str>) -> String 
 }
 
 fn url_to_bundle_path(url: &str) -> Result<String, Error> {
+    let base = Url::parse("http://~").unwrap();
     let url = if url.starts_with("~/") {
-        Url::parse(&format!("http://{}", url))?
+        base.join(&url[2..])?
     } else {
-        Url::parse(url)?
+        base.join(url)?
     };
 
     let mut path = url.path();


### PR DESCRIPTION
This fixes a regression in #540 for sourcemap uploads with an absolute path in `--url-prefix`. Example:

```
$ sentry-cli releases files <release> upload-sourcemaps <path> --url-prefix /home/ubuntu/server
```

Fixes #543