### PR TITLE
feat(upload): Implement PDB and PE upload

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -664,7 +664,7 @@ dependencies = [
 [[package]]
 name = "goblin"
 version = "0.0.22"
-source = "registry+https://github.com/rust-lang/crates.io-index"
+source = "git+https://github.com/jan-auer/goblin?rev=dd199e4b9027c9ca4389d5b066f5e264ef507e43#dd199e4b9027c9ca4389d5b066f5e264ef507e43"
 dependencies = [
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "plain 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1110,7 +1110,7 @@ dependencies = [
 [[package]]
 name = "pdb"
 version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
+source = "git+https://github.com/jan-auer/pdb?rev=da040f145d98c1d86da7cda3894fbc4dae1ba796#da040f145d98c1d86da7cda3894fbc4dae1ba796"
 dependencies = [
  "fallible-iterator 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "scroll 0.9.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1629,7 +1629,7 @@ dependencies = [
  "sha1 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "signal-hook 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "sourcemap 4.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "symbolic 6.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "symbolic 6.1.3 (git+https://github.com/getsentry/symbolic?rev=755c2f3c21c8f44726e51f0bbf93e6eb3c8ae980)",
  "uname 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "unix-daemonize 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 1.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1829,17 +1829,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "symbolic"
 version = "6.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
+source = "git+https://github.com/getsentry/symbolic?rev=755c2f3c21c8f44726e51f0bbf93e6eb3c8ae980#755c2f3c21c8f44726e51f0bbf93e6eb3c8ae980"
 dependencies = [
- "symbolic-common 6.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "symbolic-debuginfo 6.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "symbolic-proguard 6.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "symbolic-common 6.1.3 (git+https://github.com/getsentry/symbolic?rev=755c2f3c21c8f44726e51f0bbf93e6eb3c8ae980)",
+ "symbolic-debuginfo 6.1.3 (git+https://github.com/getsentry/symbolic?rev=755c2f3c21c8f44726e51f0bbf93e6eb3c8ae980)",
+ "symbolic-proguard 6.1.3 (git+https://github.com/getsentry/symbolic?rev=755c2f3c21c8f44726e51f0bbf93e6eb3c8ae980)",
 ]
 
 [[package]]
 name = "symbolic-common"
 version = "6.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
+source = "git+https://github.com/getsentry/symbolic?rev=755c2f3c21c8f44726e51f0bbf93e6eb3c8ae980#755c2f3c21c8f44726e51f0bbf93e6eb3c8ae980"
 dependencies = [
  "debugid 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1852,31 +1852,31 @@ dependencies = [
 [[package]]
 name = "symbolic-debuginfo"
 version = "6.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
+source = "git+https://github.com/getsentry/symbolic?rev=755c2f3c21c8f44726e51f0bbf93e6eb3c8ae980#755c2f3c21c8f44726e51f0bbf93e6eb3c8ae980"
 dependencies = [
  "dmsort 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "fallible-iterator 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "flate2 1.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "gimli 0.18.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "goblin 0.0.22 (registry+https://github.com/rust-lang/crates.io-index)",
+ "goblin 0.0.22 (git+https://github.com/jan-auer/goblin?rev=dd199e4b9027c9ca4389d5b066f5e264ef507e43)",
  "lazycell 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "pdb 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "pdb 0.4.0 (git+https://github.com/jan-auer/pdb?rev=da040f145d98c1d86da7cda3894fbc4dae1ba796)",
  "pest 2.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "pest_derive 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.91 (registry+https://github.com/rust-lang/crates.io-index)",
  "smallvec 0.6.9 (registry+https://github.com/rust-lang/crates.io-index)",
- "symbolic-common 6.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "symbolic-common 6.1.3 (git+https://github.com/getsentry/symbolic?rev=755c2f3c21c8f44726e51f0bbf93e6eb3c8ae980)",
 ]
 
 [[package]]
 name = "symbolic-proguard"
 version = "6.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
+source = "git+https://github.com/getsentry/symbolic?rev=755c2f3c21c8f44726e51f0bbf93e6eb3c8ae980#755c2f3c21c8f44726e51f0bbf93e6eb3c8ae980"
 dependencies = [
  "proguard 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "symbolic-common 6.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "symbolic-common 6.1.3 (git+https://github.com/getsentry/symbolic?rev=755c2f3c21c8f44726e51f0bbf93e6eb3c8ae980)",
 ]
 
 [[package]]
@@ -2246,7 +2246,7 @@ dependencies = [
 "checksum git2 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c7339329bfa14a00223244311560d11f8f489b453fb90092af97f267a6090ab0"
 "checksum glob 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "9b919933a397b79c37e33b77bb2aa3dc8eb6e165ad809e58ff75bc7db2e34574"
 "checksum globset 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)" = "ef4feaabe24a0a658fd9cf4a9acf6ed284f045c77df0f49020ba3245cfb7b454"
-"checksum goblin 0.0.22 (registry+https://github.com/rust-lang/crates.io-index)" = "7f55d53401eb2fd30afd025c570b1946b6966344acf21b42e31286f3bf89e6a8"
+"checksum goblin 0.0.22 (git+https://github.com/jan-auer/goblin?rev=dd199e4b9027c9ca4389d5b066f5e264ef507e43)" = "<none>"
 "checksum hostname 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "21ceb46a83a85e824ef93669c8b390009623863b5c195d1ba747292c0c72f94e"
 "checksum httpdate 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "494b4d60369511e7dea41cf646832512a94e542f68bb9c49e54518e0f468eb47"
 "checksum humantime 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3ca7e5f2e110db35f93b837c81797f3714500b81d517bf20c431b16d3ca4f114"
@@ -2299,7 +2299,7 @@ dependencies = [
 "checksum parking_lot 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "fa7767817701cce701d5585b9c4db3cdd02086398322c1d7e8bf5094a96a2ce7"
 "checksum parking_lot_core 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "94c8c7923936b28d546dfd14d4472eaf34c99b14e1c973a32b3e6d4eb04298c9"
 "checksum parking_lot_core 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "cb88cb1cb3790baa6776844f968fea3be44956cf184fa1be5a03341f5491278c"
-"checksum pdb 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d20e4149903e61369c42aa2791d3bb014ade5e4be59c3ed54f3c414f073ce7f2"
+"checksum pdb 0.4.0 (git+https://github.com/jan-auer/pdb?rev=da040f145d98c1d86da7cda3894fbc4dae1ba796)" = "<none>"
 "checksum percent-encoding 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "31010dd2e1ac33d5b46a5b413495239882813e0369f8ed8a5e266f173602f831"
 "checksum pest 2.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "933085deae3f32071f135d799d75667b63c8dc1f4537159756e3d4ceab41868c"
 "checksum pest_derive 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "833d1ae558dc601e9a60366421196a8d94bc0ac980476d0b67e1d0988d72b2d0"
@@ -2374,10 +2374,10 @@ dependencies = [
 "checksum string_cache_codegen 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "1eea1eee654ef80933142157fdad9dd8bc43cf7c74e999e369263496f04ff4da"
 "checksum string_cache_shared 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b1884d1bc09741d466d9b14e6d37ac89d6909cbcac41dd9ae982d4d063bbedfc"
 "checksum strsim 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
-"checksum symbolic 6.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "ef2faba45f83bbf9e3604000f17c69b1f186e23df158d550077912fd8a2408ea"
-"checksum symbolic-common 6.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "a0cf7b9d82976d47679706a4205dfbba3d11e29c5108b66adce53e689e1fed35"
-"checksum symbolic-debuginfo 6.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "eb00316187c1a3aa75610c71d96232be8ff74c95b4b9f52858f4b6529e38e457"
-"checksum symbolic-proguard 6.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "df3637250345ceea9e3b549cba224d4c674d004be074a0475a9503f738ab4ce0"
+"checksum symbolic 6.1.3 (git+https://github.com/getsentry/symbolic?rev=755c2f3c21c8f44726e51f0bbf93e6eb3c8ae980)" = "<none>"
+"checksum symbolic-common 6.1.3 (git+https://github.com/getsentry/symbolic?rev=755c2f3c21c8f44726e51f0bbf93e6eb3c8ae980)" = "<none>"
+"checksum symbolic-debuginfo 6.1.3 (git+https://github.com/getsentry/symbolic?rev=755c2f3c21c8f44726e51f0bbf93e6eb3c8ae980)" = "<none>"
+"checksum symbolic-proguard 6.1.3 (git+https://github.com/getsentry/symbolic?rev=755c2f3c21c8f44726e51f0bbf93e6eb3c8ae980)" = "<none>"
 "checksum syn 0.15.34 (registry+https://github.com/rust-lang/crates.io-index)" = "a1393e4a97a19c01e900df2aec855a29f71cf02c402e2f443b8d2747c25c5dbe"
 "checksum synstructure 0.10.2 (registry+https://github.com/rust-lang/crates.io-index)" = "02353edf96d6e4dc81aea2d8490a7e9db177bf8acb0e951c24940bf866cb313f"
 "checksum term 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "edd106a334b7657c10b7c540a0106114feadeb4dc314513e97df481d5d966f42"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,7 +49,7 @@ serde_derive = "1.0.91"
 serde_json = "1.0.39"
 sha1 = { version = "0.6.0", features = ["serde"] }
 sourcemap = { version = "4.1.0", features = ["ram_bundle"] }
-symbolic = { version = "6.1.3", features = ["debuginfo-serde", "proguard"] }
+symbolic = { git = "https://github.com/getsentry/symbolic", rev = "755c2f3c21c8f44726e51f0bbf93e6eb3c8ae980", features = ["debuginfo-serde", "proguard"] }
 url = "1.7.2"
 username = "0.2.0"
 uuid = { version = "0.7.4", features = ["v4", "serde"] }

--- a/src/api.rs
+++ b/src/api.rs
@@ -2185,6 +2185,8 @@ impl ChunkedFileState {
 #[derive(Debug, Serialize)]
 pub struct ChunkedDifRequest<'a> {
     pub name: &'a str,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub debug_id: Option<DebugId>,
     pub chunks: &'a [Digest],
 }
 

--- a/src/api.rs
+++ b/src/api.rs
@@ -2106,6 +2106,7 @@ impl<'de> Deserialize<'de> for ChunkCompression {
 pub enum ChunkUploadCapability {
     DebugFiles,
     ReleaseFiles,
+    Pdbs,
     Unknown,
 }
 
@@ -2117,6 +2118,7 @@ impl<'de> Deserialize<'de> for ChunkUploadCapability {
         Ok(match String::deserialize(deserializer)?.as_str() {
             "debug_files" => ChunkUploadCapability::DebugFiles,
             "release_files" => ChunkUploadCapability::ReleaseFiles,
+            "pdbs" => ChunkUploadCapability::Pdbs,
             _ => ChunkUploadCapability::Unknown,
         })
     }

--- a/src/commands/upload_dif.rs
+++ b/src/commands/upload_dif.rs
@@ -39,7 +39,7 @@ pub fn make_app<'a, 'b: 'a>(app: App<'a, 'b>) -> App<'a, 'b> {
                 .value_name("TYPE")
                 .multiple(true)
                 .number_of_values(1)
-                .possible_values(&["dsym", "elf", "breakpad"])
+                .possible_values(&["dsym", "elf", "breakpad", "pdb", "pe"])
                 .help(
                     "Only consider debug information files of the given \
                      type.  By default, all types are considered.",
@@ -174,6 +174,8 @@ fn execute_internal(matches: &ArgMatches<'_>, legacy: bool) -> Result<(), Error>
                 "dsym" => FileFormat::MachO,
                 "elf" => FileFormat::Elf,
                 "breakpad" => FileFormat::Breakpad,
+                "pdb" => FileFormat::Pdb,
+                "pe" => FileFormat::Pe,
                 other => bail!("Unsupported type: {}", other),
             });
         }

--- a/src/utils/dif_upload.rs
+++ b/src/utils/dif_upload.rs
@@ -1223,6 +1223,7 @@ pub struct DifUpload {
     symbol_map: Option<PathBuf>,
     zips_allowed: bool,
     max_file_size: u64,
+    pdbs_allowed: bool,
 }
 
 impl DifUpload {
@@ -1254,6 +1255,7 @@ impl DifUpload {
             symbol_map: None,
             zips_allowed: true,
             max_file_size: 2 * 1024 * 1024 * 1024, // 2GB
+            pdbs_allowed: false,
         }
     }
 
@@ -1403,6 +1405,10 @@ impl DifUpload {
                 self.max_file_size = chunk_options.max_file_size;
             }
 
+            if chunk_options.supports(ChunkUploadCapability::Pdbs) {
+                self.pdbs_allowed = true;
+            }
+
             if chunk_options.supports(ChunkUploadCapability::DebugFiles) {
                 return upload_difs_chunked(self, chunk_options);
             }
@@ -1424,7 +1430,8 @@ impl DifUpload {
     /// Determines if this `FileFormat` matches the search criteria.
     fn valid_format(&self, format: FileFormat) -> bool {
         match format {
-            FileFormat::Unknown | FileFormat::Pdb | FileFormat::Pe => false,
+            FileFormat::Unknown => false,
+            FileFormat::Pdb | FileFormat::Pe if !self.pdbs_allowed => false,
             format => self.formats.is_empty() || self.formats.contains(&format),
         }
     }


### PR DESCRIPTION
This implements the upload of PE and PDB files.

`sentry-cli` only attempts the upload if the `pdbs` capability is returned by the chunk upload endpoint. Otherwise, it silently skips PDBs like before.

If PDBs are selected for upload, `sentry-cli` **additionally** scans for PEs and remembers their age. Once all files have been compiled, the PDBs' age is fixed using the one from the PE. The PE files are only uploaded if they are selected and contain usable information (either a symbol table, or unwind info on x64 builds)

See https://github.com/getsentry/sentry/pull/13725