### PR TITLE
feat: Relax the total limit of files in an artifact bundle

### DIFF
--- a/src/utils/sourcemaps.rs
+++ b/src/utils/sourcemaps.rs
@@ -885,15 +885,8 @@ impl SourceMapProcessor {
             }
         }
 
-        let concurrency = chunk_options.map_or(DEFAULT_CONCURRENCY, |o| usize::from(o.concurrency));
-        self.upload_files_parallel(context, concurrency)
-    }
-
-    /// Uploads all files
-    pub fn upload(&mut self, context: &UploadContext<'_>) -> Result<(), Error> {
-        self.flush_pending_sources()?;
-
-        // Do not permit uploads of more than 20k files. This is a termporary downside protection to
+        // Do not permit uploads of more than 20k files if the server does not
+        // support artifact bundles.  This is a termporary downside protection to
         // protect users from uploading more sources than we support.
         if self.sources.len() > 20_000 {
             bail!(
@@ -901,6 +894,14 @@ impl SourceMapProcessor {
                 self.sources.len()
             );
         }
+
+        let concurrency = chunk_options.map_or(DEFAULT_CONCURRENCY, |o| usize::from(o.concurrency));
+        self.upload_files_parallel(context, concurrency)
+    }
+
+    /// Uploads all files
+    pub fn upload(&mut self, context: &UploadContext<'_>) -> Result<(), Error> {
+        self.flush_pending_sources()?;
 
         self.do_upload(context)?;
         self.dump_log("Source Map Upload Report");


### PR DESCRIPTION
The reason for the 20.000 files limit on the client was a protection against a badly
perfoming file deletion loop caused by `upload_files_parallel` which first fetches
all old release files through pagination.

The artifact bundle code does not do that so it seems sensible to relax this
restriction for new artifact bundle based uploads.