### PR TITLE
fix(releases): Clarify help text for `--ext` option

### DIFF
--- a/src/commands/releases.rs
+++ b/src/commands/releases.rs
@@ -212,11 +212,9 @@ pub fn make_app<'a, 'b: 'a>(app: App<'a, 'b>) -> App<'a, 'b> {
                 .arg(Arg::with_name("validate")
                     .long("validate")
                     .help("Enable basic sourcemap validation."))
-        .arg(
-            Arg::with_name("wait")
-                .long("wait")
-                .help("Wait for the server to fully process uploaded files."),
-        )
+                .arg(Arg::with_name("wait")
+                    .long("wait")
+                    .help("Wait for the server to fully process uploaded files."))
                 .arg(Arg::with_name("no_sourcemap_reference")
                     .long("no-sourcemap-reference")
                     .help("Disable emitting of automatic sourcemap references.{n}\
@@ -246,7 +244,7 @@ pub fn make_app<'a, 'b: 'a>(app: App<'a, 'b>) -> App<'a, 'b> {
                     .help("When used with a `--rewrite` option, strips the given prefix from \
                            all sources references inside the upload sourcemaps (paths used within \
                            the sourcemap content, to map minified code to it's original source). \
-                           Only sources that start with the given prefix will be stripped.{n} \
+                           Only sources that start with the given prefix will be stripped.{n}\
                            This will not modify the uploaded sources paths. To do that, point the upload \
                            or upload-sourcemaps command to a more precise directory instead.")
                     .conflicts_with("no_rewrite"))
@@ -290,9 +288,10 @@ pub fn make_app<'a, 'b: 'a>(app: App<'a, 'b>) -> App<'a, 'b> {
                     .value_name("EXT")
                     .multiple(true)
                     .number_of_values(1)
-                    .help("Add a file extension to the list of files to upload. Must be \
-                           repeated once for each extension.{n}Note that this overrides the \
-                           defaults, so if you use this, you must include ALL desired extensions."))))
+                    .help("Set the file extensions that are considered for upload. \
+                           This overrides the default extensions. To add an extension, all default \
+                           extensions must be repeated. Specify once per extension.{n}\
+                           Defaults to: `--ext=js --ext=map --ext=jsbundle --ext=bundle`"))))
         .subcommand(App::new("deploys")
             .about("Manage release deployments.")
             .setting(AppSettings::SubcommandRequiredElseHelp)

--- a/src/commands/releases.rs
+++ b/src/commands/releases.rs
@@ -284,7 +284,9 @@ pub fn make_app<'a, 'b: 'a>(app: App<'a, 'b>) -> App<'a, 'b> {
                     .value_name("EXT")
                     .multiple(true)
                     .number_of_values(1)
-                    .help("Add a file extension to the list of files to upload."))))
+                    .help("Add a file extension to the list of files to upload. Must be \
+                           repeated once for each extension.{n}Note that this overrides the \
+                           defaults, so if you use this, you must include ALL desired extensions."))))
         .subcommand(App::new("deploys")
             .about("Manage release deployments.")
             .setting(AppSettings::SubcommandRequiredElseHelp)


### PR DESCRIPTION
(based on customer confusion)

Make it clear that any use of this option overwrites the defaults, so things like `.js` and `.map` need to be included explicitly.