### PR TITLE
fix: log missing if errtrace is used

### DIFF
--- a/src/bashsupport.sh
+++ b/src/bashsupport.sh
@@ -28,6 +28,8 @@ _sentry_err_trap() {
   _sentry_traceback 1
   echo "@command:${_command}" >> "$_SENTRY_TRACEBACK_FILE"
   echo "@exit_code:${_exit_code}" >> "$_SENTRY_TRACEBACK_FILE"
+
+  : >> "$_SENTRY_LOG_FILE"
   export SENTRY_LAST_EVENT=$("___SENTRY_CLI___" bash-hook --send-event --traceback "$_SENTRY_TRACEBACK_FILE" --log "$_SENTRY_LOG_FILE")
   rm -f "$_SENTRY_TRACEBACK_FILE" "$_SENTRY_LOG_FILE"
 }


### PR DESCRIPTION
How to reproduce:

```
#!/bin/bash
set -E

eval "$(sentry-cli bash-hook)"

>&2 echo error
$(false)
echo no error
```

this gives:
```
error: Could not open logfile
  caused by: No such file or directory (os error 2)
```

Actually i'm using this workaround:
```
eval "$(sentry-cli bash-hook | sed 's/: > "\$_SENTRY_LOG_FILE"//g' | sed 's/export SENTRY_LAST_EVENT/: > "\$_SENTRY_LOG_FILE"\n  export SENTRY_LAST_EVENT/g')"
```

