### PR TITLE
fix(bug): Using annotated tags now returns the correct commit SHA

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,7 @@ cache:
 
 before_install:
   - npm install -g @zeus-ci/cli
+  - git fetch --tags
 
 matrix:
   include:

--- a/src/utils/vcs.rs
+++ b/src/utils/vcs.rs
@@ -393,22 +393,26 @@ fn test_find_matching_rev_with_lightweight_tag() {
         repo: String::from("getsentry/sentry-cli"),
         path: None,
         rev: String::from("1.9.2"),
-        prev_rev: Some(String::from("1.9.1"))
+        prev_rev: Some(String::from("1.9.1")),
     };
 
-    let repos = [
-        Repo {
-            id: String::from("1"),
-            name: String::from("getsentry/sentry-cli"),
-            url: Some(String::from("https://github.com/getsentry/sentry-cli")),
-            provider: RepoProvider { id: String::from("integrations:github"), name: String::from("GitHub") },
-            status: String::from("active"),
-            date_created: chrono::Utc::now()
-        }
-    ];
+    let repos = [Repo {
+        id: String::from("1"),
+        name: String::from("getsentry/sentry-cli"),
+        url: Some(String::from("https://github.com/getsentry/sentry-cli")),
+        provider: RepoProvider {
+            id: String::from("integrations:github"),
+            name: String::from("GitHub"),
+        },
+        status: String::from("active"),
+        date_created: chrono::Utc::now(),
+    }];
 
     let res_with_lightweight_tag = find_matching_rev(reference, &spec, &repos, false);
-    assert_eq!(res_with_lightweight_tag.unwrap(), Some(String::from("5bf28a6e4cbf54ff5bfb5a8dfb8dbc6387e53942")));
+    assert_eq!(
+        res_with_lightweight_tag.unwrap(),
+        Some(String::from("5bf28a6e4cbf54ff5bfb5a8dfb8dbc6387e53942"))
+    );
 }
 
 #[test]
@@ -418,22 +422,26 @@ fn test_find_matching_rev_with_annotated_tag() {
         repo: String::from("getsentry/sentry-cli"),
         path: None,
         rev: String::from("1.9.2-hw"),
-        prev_rev: Some(String::from("1.9.1"))
+        prev_rev: Some(String::from("1.9.1")),
     };
 
-    let repos = [
-        Repo {
-            id: String::from("1"),
-            name: String::from("getsentry/sentry-cli"),
-            url: Some(String::from("https://github.com/getsentry/sentry-cli")),
-            provider: RepoProvider { id: String::from("integrations:github"), name: String::from("GitHub") },
-            status: String::from("active"),
-            date_created: chrono::Utc::now()
-        }
-    ];
+    let repos = [Repo {
+        id: String::from("1"),
+        name: String::from("getsentry/sentry-cli"),
+        url: Some(String::from("https://github.com/getsentry/sentry-cli")),
+        provider: RepoProvider {
+            id: String::from("integrations:github"),
+            name: String::from("GitHub"),
+        },
+        status: String::from("active"),
+        date_created: chrono::Utc::now(),
+    }];
 
     let res_with_annotated_tag = find_matching_rev(reference, &spec, &repos, false);
-    assert_eq!(res_with_annotated_tag.unwrap(), Some(String::from("5bf28a6e4cbf54ff5bfb5a8dfb8dbc6387e53942")));
+    assert_eq!(
+        res_with_annotated_tag.unwrap(),
+        Some(String::from("5bf28a6e4cbf54ff5bfb5a8dfb8dbc6387e53942"))
+    );
 }
 
 #[test]

--- a/src/utils/vcs.rs
+++ b/src/utils/vcs.rs
@@ -44,6 +44,14 @@ struct VcsUrl {
     pub id: String,
 }
 
+macro_rules! log_match {
+    ($ex:expr) => {{
+        let val = $ex;
+        info!("  -> found matching revision {}", val);
+        val
+    }};
+}
+
 fn parse_rev_range(rng: &str) -> (Option<String>, String) {
     if rng == "" {
         return (None, "HEAD".into());
@@ -216,14 +224,6 @@ fn find_matching_rev(
     repos: &[Repo],
     disable_discovery: bool,
 ) -> Result<Option<String>, Error> {
-    macro_rules! log_match {
-        ($ex:expr) => {{
-            let val = $ex;
-            info!("  -> found matching revision {}", val);
-            val
-        }};
-    }
-
     info!("Resolving {} ({})", &reference, spec);
 
     let r = match reference {
@@ -252,13 +252,10 @@ fn find_matching_rev(
                 debug!("  found match: {} == {}, {:?}", url, &reference_url, r);
                 let head = repo.revparse_single(r)?;
                 if let Some(tag) = head.as_tag(){
-                    debug!("  tag.target(): {:?}", tag.target());
                     if let Ok(tag_commit) = tag.target() {
                         return Ok(Some(log_match!(tag_commit.id().to_string())));
                     }
                 }
-                debug!("  not a tag");
-
                 return Ok(Some(log_match!(head.id().to_string())));
             } else {
                 debug!("  not a match: {} != {}", url, &reference_url);
@@ -277,13 +274,6 @@ fn find_matching_submodule(
     reference_url: String,
     repo: git2::Repository,
 ) -> Result<Option<String>, Error> {
-    macro_rules! log_match {
-        ($ex:expr) => {{
-            let val = $ex;
-            info!("  -> found matching revision {}", val);
-            val
-        }};
-    }
     // in discovery mode we want to find that repo in associated submodules.
     for submodule in repo.submodules()? {
         if let Some(submodule_url) = submodule.url() {

--- a/src/utils/vcs.rs
+++ b/src/utils/vcs.rs
@@ -259,7 +259,7 @@ fn find_matching_rev(
                         return Ok(Some(log_match!(tag_commit.id().to_string())));
                     }
                 }
-                debug!("Not a tag");
+                debug!("  Not a tag");
                 return Ok(Some(log_match!(head.id().to_string())));
             } else {
                 debug!("  not a match: {} != {}", url, &reference_url);
@@ -387,8 +387,7 @@ pub fn find_heads(specs: Option<Vec<CommitSpec>>, repos: &[Repo]) -> Result<Vec<
 }
 
 #[test]
-fn test_find_matching_rev() {
-    //TODO: Make sure this works if you pass reference as GitReference::Commit, and pass in a SHA instead of a tag
+fn test_find_matching_rev_with_lightweight_tag() {
     let reference = GitReference::Symbolic("1.9.2");
     let spec = CommitSpec {
         repo: String::from("getsentry/sentry-cli"),
@@ -410,7 +409,10 @@ fn test_find_matching_rev() {
 
     let res_with_lightweight_tag = find_matching_rev(reference, &spec, &repos, false);
     assert_eq!(res_with_lightweight_tag.unwrap(), Some(String::from("5bf28a6e4cbf54ff5bfb5a8dfb8dbc6387e53942")));
+}
 
+#[test]
+fn test_find_matching_rev_with_annotated_tag() {
     let reference = GitReference::Symbolic("1.9.2-hw");
     let spec = CommitSpec {
         repo: String::from("getsentry/sentry-cli"),
@@ -432,7 +434,6 @@ fn test_find_matching_rev() {
 
     let res_with_annotated_tag = find_matching_rev(reference, &spec, &repos, false);
     assert_eq!(res_with_annotated_tag.unwrap(), Some(String::from("5bf28a6e4cbf54ff5bfb5a8dfb8dbc6387e53942")));
-
 }
 
 #[test]

--- a/src/utils/vcs.rs
+++ b/src/utils/vcs.rs
@@ -250,11 +250,9 @@ fn find_matching_rev(
         then {
             debug!("if_chain macro! {:?}, {:?}, {:?}", url, &reference_url, is_matching_url(url, &reference_url));
             if !discovery || is_matching_url(url, &reference_url) {
-                debug!("  found match: {} == {}", url, &reference_url);
-                debug!("  trying to revparse r (Commit or Tag?): {:?}", r);
+                debug!("  found match: {} == {}, {:?}", url, &reference_url, r);
                 let head = repo.revparse_single(r)?;
                 debug!("  head: {:?}", head);
-                debug!("  head.kind(): {:?}", head.kind());
                 if let Some(tag) = head.as_tag(){
                     debug!("  tag.target(): {:?}", tag.target());
                     if let Ok(tag_commit) = tag.target() {
@@ -391,7 +389,6 @@ pub fn find_heads(specs: Option<Vec<CommitSpec>>, repos: &[Repo]) -> Result<Vec<
 #[test]
 fn test_find_matching_rev() {
     //TODO: Make sure this works if you pass reference as GitReference::Commit, and pass in a SHA instead of a tag
-    //TODO: Add in more debug just in case this doesn't fix the issue - the customer can send over the debug output.
     let reference = GitReference::Symbolic("1.9.2");
     let spec = CommitSpec {
         repo: String::from("getsentry/sentry-cli"),


### PR DESCRIPTION
A customer was experiencing an issue when trying to specify commits using an annotated tag. The `find_matching_rev` function was returning the SHA of the tag instead of getting the SHA of it's associated commit.

This PR fixes that, and adds two tests (one against a lightweight tag, and one against an annotated tag) to ensure it's correctness and keep it correct.