### PR TITLE
fix(dif): Fix source bundle upload

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -607,7 +607,7 @@ dependencies = [
 [[package]]
 name = "gimli"
 version = "0.19.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
+source = "git+https://github.com/jan-auer/gimli?rev=bf8ea0f0079505681c360d3a55d0ac1e9b498df3#bf8ea0f0079505681c360d3a55d0ac1e9b498df3"
 dependencies = [
  "arrayvec 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1087,7 +1087,7 @@ dependencies = [
 [[package]]
 name = "pdb"
 version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
+source = "git+https://github.com/jan-auer/pdb?rev=79112ae2fd208fcb5c8e565dd148f4b55c3e58e3#79112ae2fd208fcb5c8e565dd148f4b55c3e58e3"
 dependencies = [
  "fallible-iterator 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "scroll 0.9.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1607,7 +1607,7 @@ dependencies = [
  "sha1 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "signal-hook 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "sourcemap 4.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "symbolic 6.1.3 (git+https://github.com/getsentry/symbolic?rev=32df00067d53e57309b7015a9bf1f62d9d011020)",
+ "symbolic 7.0.0 (git+https://github.com/getsentry/symbolic?rev=e9d35bbf58b6a080bf4debdddf09c06dc94d872c)",
  "uname 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "unix-daemonize 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 1.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1806,18 +1806,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "symbolic"
-version = "6.1.3"
-source = "git+https://github.com/getsentry/symbolic?rev=32df00067d53e57309b7015a9bf1f62d9d011020#32df00067d53e57309b7015a9bf1f62d9d011020"
+version = "7.0.0"
+source = "git+https://github.com/getsentry/symbolic?rev=e9d35bbf58b6a080bf4debdddf09c06dc94d872c#e9d35bbf58b6a080bf4debdddf09c06dc94d872c"
 dependencies = [
- "symbolic-common 6.1.3 (git+https://github.com/getsentry/symbolic?rev=32df00067d53e57309b7015a9bf1f62d9d011020)",
- "symbolic-debuginfo 6.1.3 (git+https://github.com/getsentry/symbolic?rev=32df00067d53e57309b7015a9bf1f62d9d011020)",
- "symbolic-proguard 6.1.3 (git+https://github.com/getsentry/symbolic?rev=32df00067d53e57309b7015a9bf1f62d9d011020)",
+ "symbolic-common 7.0.0 (git+https://github.com/getsentry/symbolic?rev=e9d35bbf58b6a080bf4debdddf09c06dc94d872c)",
+ "symbolic-debuginfo 7.0.0 (git+https://github.com/getsentry/symbolic?rev=e9d35bbf58b6a080bf4debdddf09c06dc94d872c)",
+ "symbolic-proguard 7.0.0 (git+https://github.com/getsentry/symbolic?rev=e9d35bbf58b6a080bf4debdddf09c06dc94d872c)",
 ]
 
 [[package]]
 name = "symbolic-common"
-version = "6.1.3"
-source = "git+https://github.com/getsentry/symbolic?rev=32df00067d53e57309b7015a9bf1f62d9d011020#32df00067d53e57309b7015a9bf1f62d9d011020"
+version = "7.0.0"
+source = "git+https://github.com/getsentry/symbolic?rev=e9d35bbf58b6a080bf4debdddf09c06dc94d872c#e9d35bbf58b6a080bf4debdddf09c06dc94d872c"
 dependencies = [
  "debugid 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1829,36 +1829,36 @@ dependencies = [
 
 [[package]]
 name = "symbolic-debuginfo"
-version = "6.1.3"
-source = "git+https://github.com/getsentry/symbolic?rev=32df00067d53e57309b7015a9bf1f62d9d011020#32df00067d53e57309b7015a9bf1f62d9d011020"
+version = "7.0.0"
+source = "git+https://github.com/getsentry/symbolic?rev=e9d35bbf58b6a080bf4debdddf09c06dc94d872c#e9d35bbf58b6a080bf4debdddf09c06dc94d872c"
 dependencies = [
  "dmsort 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "fallible-iterator 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "flate2 1.0.9 (registry+https://github.com/rust-lang/crates.io-index)",
- "gimli 0.19.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "gimli 0.19.0 (git+https://github.com/jan-auer/gimli?rev=bf8ea0f0079505681c360d3a55d0ac1e9b498df3)",
  "goblin 0.0.23 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazycell 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "pdb 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "pdb 0.5.0 (git+https://github.com/jan-auer/pdb?rev=79112ae2fd208fcb5c8e565dd148f4b55c3e58e3)",
  "pest 2.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "pest_derive 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.98 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.40 (registry+https://github.com/rust-lang/crates.io-index)",
  "smallvec 0.6.10 (registry+https://github.com/rust-lang/crates.io-index)",
- "symbolic-common 6.1.3 (git+https://github.com/getsentry/symbolic?rev=32df00067d53e57309b7015a9bf1f62d9d011020)",
+ "symbolic-common 7.0.0 (git+https://github.com/getsentry/symbolic?rev=e9d35bbf58b6a080bf4debdddf09c06dc94d872c)",
  "zip 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "symbolic-proguard"
-version = "6.1.3"
-source = "git+https://github.com/getsentry/symbolic?rev=32df00067d53e57309b7015a9bf1f62d9d011020#32df00067d53e57309b7015a9bf1f62d9d011020"
+version = "7.0.0"
+source = "git+https://github.com/getsentry/symbolic?rev=e9d35bbf58b6a080bf4debdddf09c06dc94d872c#e9d35bbf58b6a080bf4debdddf09c06dc94d872c"
 dependencies = [
  "proguard 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "symbolic-common 6.1.3 (git+https://github.com/getsentry/symbolic?rev=32df00067d53e57309b7015a9bf1f62d9d011020)",
+ "symbolic-common 7.0.0 (git+https://github.com/getsentry/symbolic?rev=e9d35bbf58b6a080bf4debdddf09c06dc94d872c)",
 ]
 
 [[package]]
@@ -2215,7 +2215,7 @@ dependencies = [
 "checksum fuchsia-cprng 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "a06f77d526c1a601b7c4cdd98f54b5eaabffc14d5f2f0296febdc7f357c6d3ba"
 "checksum gcc 0.3.55 (registry+https://github.com/rust-lang/crates.io-index)" = "8f5f3913fa0bfe7ee1fd8248b6b9f42a5af4b9d65ec2dd2c3c26132b950ecfc2"
 "checksum generic-array 0.12.3 (registry+https://github.com/rust-lang/crates.io-index)" = "c68f0274ae0e023facc3c97b2e00f076be70e254bc851d972503b328db79b2ec"
-"checksum gimli 0.19.0 (registry+https://github.com/rust-lang/crates.io-index)" = "162d18ae5f2e3b90a993d202f1ba17a5633c2484426f8bcae201f86194bacd00"
+"checksum gimli 0.19.0 (git+https://github.com/jan-auer/gimli?rev=bf8ea0f0079505681c360d3a55d0ac1e9b498df3)" = "<none>"
 "checksum git2 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c7339329bfa14a00223244311560d11f8f489b453fb90092af97f267a6090ab0"
 "checksum glob 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "9b919933a397b79c37e33b77bb2aa3dc8eb6e165ad809e58ff75bc7db2e34574"
 "checksum globset 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)" = "925aa2cac82d8834e2b2a4415b6f6879757fb5c0928fc445ae76461a12eed8f2"
@@ -2270,7 +2270,7 @@ dependencies = [
 "checksum parking_lot 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f842b1982eb6c2fe34036a4fbfb06dd185a3f5c8edfaacdf7d1ea10b07de6252"
 "checksum parking_lot_core 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "cb88cb1cb3790baa6776844f968fea3be44956cf184fa1be5a03341f5491278c"
 "checksum parking_lot_core 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)" = "b876b1b9e7ac6e1a74a6da34d25c42e17e8862aa409cbbbdcfc8d86c6f3bc62b"
-"checksum pdb 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e6b57b7067dc9dbd04b1305bb51a8ae7d0fc645956a73b6cb2807dd956ab6929"
+"checksum pdb 0.5.0 (git+https://github.com/jan-auer/pdb?rev=79112ae2fd208fcb5c8e565dd148f4b55c3e58e3)" = "<none>"
 "checksum percent-encoding 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "31010dd2e1ac33d5b46a5b413495239882813e0369f8ed8a5e266f173602f831"
 "checksum pest 2.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "933085deae3f32071f135d799d75667b63c8dc1f4537159756e3d4ceab41868c"
 "checksum pest_derive 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "833d1ae558dc601e9a60366421196a8d94bc0ac980476d0b67e1d0988d72b2d0"
@@ -2345,10 +2345,10 @@ dependencies = [
 "checksum string_cache_codegen 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "1eea1eee654ef80933142157fdad9dd8bc43cf7c74e999e369263496f04ff4da"
 "checksum string_cache_shared 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b1884d1bc09741d466d9b14e6d37ac89d6909cbcac41dd9ae982d4d063bbedfc"
 "checksum strsim 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
-"checksum symbolic 6.1.3 (git+https://github.com/getsentry/symbolic?rev=32df00067d53e57309b7015a9bf1f62d9d011020)" = "<none>"
-"checksum symbolic-common 6.1.3 (git+https://github.com/getsentry/symbolic?rev=32df00067d53e57309b7015a9bf1f62d9d011020)" = "<none>"
-"checksum symbolic-debuginfo 6.1.3 (git+https://github.com/getsentry/symbolic?rev=32df00067d53e57309b7015a9bf1f62d9d011020)" = "<none>"
-"checksum symbolic-proguard 6.1.3 (git+https://github.com/getsentry/symbolic?rev=32df00067d53e57309b7015a9bf1f62d9d011020)" = "<none>"
+"checksum symbolic 7.0.0 (git+https://github.com/getsentry/symbolic?rev=e9d35bbf58b6a080bf4debdddf09c06dc94d872c)" = "<none>"
+"checksum symbolic-common 7.0.0 (git+https://github.com/getsentry/symbolic?rev=e9d35bbf58b6a080bf4debdddf09c06dc94d872c)" = "<none>"
+"checksum symbolic-debuginfo 7.0.0 (git+https://github.com/getsentry/symbolic?rev=e9d35bbf58b6a080bf4debdddf09c06dc94d872c)" = "<none>"
+"checksum symbolic-proguard 7.0.0 (git+https://github.com/getsentry/symbolic?rev=e9d35bbf58b6a080bf4debdddf09c06dc94d872c)" = "<none>"
 "checksum syn 0.15.42 (registry+https://github.com/rust-lang/crates.io-index)" = "eadc09306ca51a40555dd6fc2b415538e9e18bc9f870e47b1a524a79fe2dcf5e"
 "checksum synstructure 0.10.2 (registry+https://github.com/rust-lang/crates.io-index)" = "02353edf96d6e4dc81aea2d8490a7e9db177bf8acb0e951c24940bf866cb313f"
 "checksum take_mut 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "f764005d11ee5f36500a149ace24e00e3da98b0158b3e2d53a7495660d3f4d60"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,7 +49,7 @@ serde_derive = "1.0.98"
 serde_json = "1.0.40"
 sha1 = { version = "0.6.0", features = ["serde"] }
 sourcemap = { version = "4.1.0", features = ["ram_bundle"] }
-symbolic = { git = "https://github.com/getsentry/symbolic", rev = "32df00067d53e57309b7015a9bf1f62d9d011020", features = ["debuginfo-serde", "proguard"] }
+symbolic = { git = "https://github.com/getsentry/symbolic", rev = "e9d35bbf58b6a080bf4debdddf09c06dc94d872c", features = ["debuginfo-serde", "proguard"] }
 url = "1.7.2"
 username = "0.2.0"
 uuid = { version = "0.7.4", features = ["v4", "serde"] }

--- a/src/commands/difutil_bundle_sources.rs
+++ b/src/commands/difutil_bundle_sources.rs
@@ -1,5 +1,5 @@
 use std::fs;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 use clap::{App, Arg, ArgMatches};
 use failure::Error;
@@ -29,49 +29,87 @@ pub fn make_app<'a, 'b: 'a>(app: App<'a, 'b>) -> App<'a, 'b> {
         )
 }
 
+fn is_dsym(path: &Path) -> bool {
+    path.extension().map_or(false, |e| e == "dSYM")
+}
+
+fn get_sane_parent(path: &Path) -> &Path {
+    let mut parent = path.parent().unwrap();
+
+    if parent.ends_with("Contents/Resources/DWARF") {
+        let mut dsym_parent = parent;
+        for _ in 0..3 {
+            dsym_parent = dsym_parent.parent().unwrap();
+        }
+        if is_dsym(dsym_parent) {
+            parent = dsym_parent.parent().unwrap();
+        }
+    }
+
+    parent
+}
+
+fn get_canonical_path<P: AsRef<Path>>(path: P) -> Result<PathBuf, Error> {
+    let mut canonical_path = Path::new(path.as_ref()).canonicalize()?;
+
+    if is_dsym(&canonical_path) {
+        if let Some(dsym_name) = canonical_path.file_stem() {
+            let mut dsym_path = canonical_path.join("Contents/Resources/DWARF");
+            dsym_path.push(dsym_name);
+            if dsym_path.is_file() {
+                canonical_path = dsym_path;
+            }
+        }
+    }
+
+    Ok(canonical_path)
+}
+
 pub fn execute<'a>(matches: &ArgMatches<'a>) -> Result<(), Error> {
     let output_path = matches.value_of("output").map(Path::new);
 
     for orig_path in matches.values_of("paths").unwrap() {
-        let path = Path::new(orig_path).canonicalize()?;
-        let archive = match DifFile::open_path(&path, None)? {
+        let canonical_path = get_canonical_path(orig_path)?;
+
+        let archive = match DifFile::open_path(&canonical_path, None)? {
             DifFile::Archive(archive) => archive,
             _ => {
-                warn!("Cannot build source bundles from {} files", orig_path);
+                warn!("Cannot build source bundles from {}", orig_path);
                 continue;
             }
         };
-        let archive = archive.get();
 
-        for (idx, object) in archive.objects().enumerate() {
+        // At this point we can be sure that we're dealing with a file
+        let parent_path = get_sane_parent(&canonical_path);
+        let filename = canonical_path.file_name().unwrap();
+
+        for (index, object) in archive.get().objects().enumerate() {
             let object = object?;
             if object.has_sources() {
-                println!("skipping {} because it contains source info", orig_path);
+                eprintln!("skipped {} (no source info)", orig_path);
                 continue;
             }
 
-            let mut out = output_path
-                .unwrap_or_else(|| path.parent().unwrap())
-                .join(path.file_name().unwrap());
-            if idx > 1 {
-                out.set_extension(&format!("{}.src.zip", idx));
-            } else {
-                out.set_extension("src.zip");
-            }
+            let mut out = output_path.unwrap_or(parent_path).join(filename);
+            match index {
+                0 => out.set_extension("src.zip"),
+                index => out.set_extension(&format!("{}.src.zip", index)),
+            };
+
             fs::create_dir_all(out.parent().unwrap())?;
             let writer = SourceBundleWriter::create(&out)?;
 
             // Resolve source files from the object and write their contents into the archive. Skip to
             // upload this bundle if no source could be written. This can happen if there is no file or
             // line information in the object file, or if none of the files could be resolved.
-            let written =
-                writer.write_object(&object, &path.file_name().unwrap().to_string_lossy())?;
+            let written = writer.write_object(&object, &filename.to_string_lossy())?;
+
             if !written {
-                warn!("Could not find any sources for {}", orig_path);
+                eprintln!("skipped {} (no files found)", orig_path);
                 fs::remove_file(&out)?;
                 continue;
             } else {
-                println!("Written sources for {} to {}", orig_path, out.display());
+                println!("{}", out.display());
             }
         }
     }


### PR DESCRIPTION
This PR fixes the upload of source bundles using `upload-dif`. 

Also, the `bundle-sources` command now detects dSYM folders and puts the ZIP files next to that. Finally, the output of `bundle-sources` has been adapted so that it can be consumed by scripts more easily: It prints all written files on stdout, and everything else on stderr.