### PR TITLE
fix(sourcemaps): Allow dots in extensions for upload

### DIFF
--- a/src/commands/releases.rs
+++ b/src/commands/releases.rs
@@ -810,7 +810,8 @@ fn process_sources_from_paths<'a>(
         if check_ignore {
             let mut types_builder = TypesBuilder::new();
             for ext in &extensions {
-                types_builder.add(ext, &format!("*.{}", ext))?;
+                let ext_name = dbg!(ext.replace('.', ""));
+                types_builder.add(&ext_name, &format!("*.{}", ext))?;
             }
             builder.types(types_builder.select("all").build()?);
 

--- a/src/commands/releases.rs
+++ b/src/commands/releases.rs
@@ -810,7 +810,7 @@ fn process_sources_from_paths<'a>(
         if check_ignore {
             let mut types_builder = TypesBuilder::new();
             for ext in &extensions {
-                let ext_name = dbg!(ext.replace('.', ""));
+                let ext_name = ext.replace('.', "__");
                 types_builder.add(&ext_name, &format!("*.{}", ext))?;
             }
             builder.types(types_builder.select("all").build()?);


### PR DESCRIPTION
Fixes #587

`ignore::types::TypeBuilder` doesn't like dots in type names, and neither does it like underscores. We could either generate unique names, e.g. by enumerating the extensions, or simply replace all the dots out.