### PR TITLE
release list: Show a column with each release project's slug.

### DIFF
--- a/src/api.rs
+++ b/src/api.rs
@@ -1830,6 +1830,7 @@ pub struct ReleaseInfo {
     pub last_event: Option<DateTime<Utc>>,
     #[serde(rename = "newGroups")]
     pub new_groups: u64,
+    pub projects: Vec<ProjectSlugAndName>,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -1958,6 +1959,12 @@ pub struct AssociateDsymsResponse {
 #[derive(Deserialize, Debug)]
 pub struct Team {
     pub id: String,
+    pub slug: String,
+    pub name: String,
+}
+
+#[derive(Deserialize, Debug)]
+pub struct ProjectSlugAndName {
     pub slug: String,
     pub name: String,
 }

--- a/src/api.rs
+++ b/src/api.rs
@@ -1830,6 +1830,7 @@ pub struct ReleaseInfo {
     pub last_event: Option<DateTime<Utc>>,
     #[serde(rename = "newGroups")]
     pub new_groups: u64,
+    #[serde(default)]
     pub projects: Vec<ProjectSlugAndName>,
 }
 

--- a/src/commands/releases.rs
+++ b/src/commands/releases.rs
@@ -540,7 +540,11 @@ fn execute_list<'a>(ctx: &ReleaseContext<'_>, _matches: &ArgMatches<'a>) -> Resu
             row.add("(unreleased)");
         }
         row.add(&release_info.version);
-        let project_slugs = release_info.projects.iter().map(|p| p.slug.clone()).collect::<Vec<_>>();
+        let project_slugs = release_info
+            .projects
+            .iter()
+            .map(|p| p.slug.clone())
+            .collect::<Vec<_>>();
         if !project_slugs.is_empty() {
             row.add(project_slugs.join(","));
         } else {

--- a/src/commands/releases.rs
+++ b/src/commands/releases.rs
@@ -546,7 +546,7 @@ fn execute_list<'a>(ctx: &ReleaseContext<'_>, _matches: &ArgMatches<'a>) -> Resu
             .map(|p| p.slug)
             .collect::<Vec<_>>();
         if !project_slugs.is_empty() {
-            row.add(project_slugs.join(","));
+            row.add(project_slugs.join("\n"));
         } else {
             row.add("-");
         }

--- a/src/commands/releases.rs
+++ b/src/commands/releases.rs
@@ -542,8 +542,8 @@ fn execute_list<'a>(ctx: &ReleaseContext<'_>, _matches: &ArgMatches<'a>) -> Resu
         row.add(&release_info.version);
         let project_slugs = release_info
             .projects
-            .iter()
-            .map(|p| p.slug.clone())
+            .into_iter()
+            .map(|p| p.slug)
             .collect::<Vec<_>>();
         if !project_slugs.is_empty() {
             row.add(project_slugs.join(","));

--- a/src/commands/releases.rs
+++ b/src/commands/releases.rs
@@ -527,15 +527,11 @@ fn execute_list<'a>(ctx: &ReleaseContext<'_>, matches: &ArgMatches<'a>) -> Resul
         .list_releases(ctx.get_org()?, project.as_ref().map(String::as_ref))?;
     let mut table = Table::new();
     let title_row = table.title_row();
-    title_row
-        .add("Released")
-        .add("Version");
+    title_row.add("Released").add("Version");
     if matches.is_present("show_projects") {
         title_row.add("Projects");
     }
-    title_row
-        .add("New Events")
-        .add("Last Event");
+    title_row.add("New Events").add("Last Event");
     for release_info in releases {
         let row = table.add_row();
         if let Some(date) = release_info.date_released {

--- a/src/commands/releases.rs
+++ b/src/commands/releases.rs
@@ -526,6 +526,7 @@ fn execute_list<'a>(ctx: &ReleaseContext<'_>, _matches: &ArgMatches<'a>) -> Resu
         .title_row()
         .add("Released")
         .add("Version")
+        .add("Projects")
         .add("New Events")
         .add("Last Event");
     for release_info in releases {
@@ -539,6 +540,12 @@ fn execute_list<'a>(ctx: &ReleaseContext<'_>, _matches: &ArgMatches<'a>) -> Resu
             row.add("(unreleased)");
         }
         row.add(&release_info.version);
+        let project_slugs = release_info.projects.iter().map(|p| p.slug.clone()).collect::<Vec<_>>();
+        if !project_slugs.is_empty() {
+            row.add(project_slugs.join(","));
+        } else {
+            row.add("-");
+        }
         row.add(release_info.new_groups);
         if let Some(date) = release_info.last_event {
             row.add(format!(


### PR DESCRIPTION
Before this patch, the release list command would not show the
project(s) associated to each release.

After this patch the "Projects" column show the all the release's
project slugs.