### PR TITLE
Fix for commit requirement when release flag is set to auto

### DIFF
--- a/js/releases/index.js
+++ b/js/releases/index.js
@@ -59,9 +59,9 @@ class Releases {
    * @memberof SentryReleases
    */
   setCommits(release, options) {
-    if (!options || !options.repo || (!options.auto && !options.commit)) {
+    if (!options || (!options.auto && (!options.repo || !options.commit))) {
       throw new Error(
-        'options.repo, and either options.commit or options.auto must be specified'
+        'options.auto, or options.repo and options.commit must be specified'
       );
     }
 


### PR DESCRIPTION
When calling `setCommits` in the release module, it validates the input to always contain the `repo` key. However, when using `auto`, this repo key is never used.

This PR fixes that.

Also see getsentry/sentry-webpack-plugin#156