### PR TITLE
feat: Expose code IDs from difutil check

### DIFF
--- a/src/commands/difutil_check.rs
+++ b/src/commands/difutil_check.rs
@@ -62,10 +62,23 @@ pub fn execute<'a>(matches: &ArgMatches<'a>) -> Result<(), Error> {
     }
 
     println!("  Contained debug identifiers:");
-    for (id, cpu_type) in dif.variants() {
-        match cpu_type {
-            Some(cpu_type) => println!("    > {} ({})", style(id).dim(), style(cpu_type).cyan()),
-            None => println!("    > {}", style(id).dim()),
+    for variant in dif.variants() {
+        match variant.arch {
+            Some(ref cpu_type) => println!(
+                "    > debug_id: {} ({})",
+                style(variant.debug_id).dim(),
+                style(cpu_type).cyan()
+            ),
+            None => println!("    > debug_id: {}", style(variant.debug_id).dim()),
+        }
+        match (variant.code_id, variant.arch) {
+            (Some(ref code_id), Some(ref cpu_type)) => println!(
+                "    > code_id: {} ({})",
+                style(code_id).dim(),
+                style(cpu_type).cyan()
+            ),
+            (Some(ref code_id), None) => println!("    > code_id: {}", style(code_id).dim()),
+            _ => {}
         }
     }
 

--- a/src/commands/difutil_id.rs
+++ b/src/commands/difutil_id.rs
@@ -1,14 +1,17 @@
 use std::io;
 use std::path::Path;
 
-use clap::{App, Arg, ArgMatches};
+use clap::{App, Arg, ArgMatches, AppSettings};
 use failure::Error;
 
 use crate::utils::dif::DifFile;
 use crate::utils::system::QuietExit;
 
 pub fn make_app<'a, 'b: 'a>(app: App<'a, 'b>) -> App<'a, 'b> {
+    // this command is hidden.  It only returns debug ids which is not super useful.
+    // it's recommended to use difutil check instead.
     app.about("Print debug identifier(s) from a debug info file.")
+        .setting(AppSettings::Hidden)
         .alias("uuid")
         .arg(
             Arg::with_name("type")


### PR DESCRIPTION
This exposes code and debug IDs from difutil check and hides the
difutil id command.  It also changes the JSON format for the difutil check
command which is a backwards incompatible change.