### PR TITLE
Use config generated chunk-upload URL and handle upload_chunks 301|302 statuses

### DIFF
--- a/src/api.rs
+++ b/src/api.rs
@@ -933,10 +933,10 @@ impl Api {
             }
         };
         // Override API returned ChunkUploadOptions.url with config generated endpoint URL
-        let mut option_struct : ChunkUploadOptions = options.unwrap().unwrap();
+        let mut option_struct: ChunkUploadOptions = options.unwrap().unwrap();
         let endpoint = self.config.get_api_endpoint(&url).unwrap();
         option_struct.url = endpoint;
-        return Ok(Some(option_struct))
+        return Ok(Some(option_struct));
     }
 
     /// Request DIF assembling and processing from chunks.

--- a/src/api.rs
+++ b/src/api.rs
@@ -1072,7 +1072,6 @@ impl Api {
                 Ok(())
             }
         }
-
     }
 
     /// Associate apple debug symbols with a build

--- a/src/api.rs
+++ b/src/api.rs
@@ -919,7 +919,7 @@ impl Api {
     /// Get the server configuration for chunked file uploads.
     pub fn get_chunk_upload_options(&self, org: &str) -> ApiResult<Option<ChunkUploadOptions>> {
         let url = format!("/organizations/{}/chunk-upload/", PathArg(org));
-        match self
+        let options = match self
             .get(&url)?
             .convert_rnf(ApiErrorKind::ChunkUploadNotSupported)
         {
@@ -931,7 +931,12 @@ impl Api {
                     Err(error)
                 }
             }
-        }
+        };
+        // Override API returned ChunkUploadOptions.url with config generated endpoint URL
+        let mut option_struct : ChunkUploadOptions = options.unwrap().unwrap();
+        let endpoint = self.config.get_api_endpoint(&url).unwrap();
+        option_struct.url = endpoint;
+        return Ok(Some(option_struct))
     }
 
     /// Request DIF assembling and processing from chunks.

--- a/src/api.rs
+++ b/src/api.rs
@@ -1063,8 +1063,16 @@ impl Api {
             None => request,
         };
 
-        request.send()?.into_result()?;
-        Ok(())
+        // Handle 301 or 302 requests as a missing project
+        let resp = request.send()?;
+        match resp.status() {
+            301 | 302 => Err(ApiErrorKind::ProjectNotFound.into()),
+            _ => {
+                resp.into_result()?;
+                Ok(())
+            }
+        }
+
     }
 
     /// Associate apple debug symbols with a build


### PR DESCRIPTION
Proposal to fix #649
I am not a Rust developer, so I apologize if this code is extremely naive.

This successfully attempts to:
1. Rewrite the ChunkUploadOptions.url with a locally generated API endpoint instead of the endpoint returned by `GET /organizations/{}/chunk-upload/`
2. Handles the case where `POST /organizations/{}/chunk-upload/` returns 301 or 302 redirects (the case with proxies/wrong address)