### PR TITLE
fix(dif): Skip files larger than 1MB

### DIFF
--- a/src/utils/dif_upload.rs
+++ b/src/utils/dif_upload.rs
@@ -853,14 +853,14 @@ fn process_symbol_maps<'a>(
 
 /// Default filter function to skip over bad sources we do not want to include.
 pub fn filter_bad_sources(entry: &FileEntry) -> bool {
-    // always ignore pch files
     if entry.name_str().ends_with(".pch") {
+        // always ignore pch files
         false
-    // ignore files larger than 1MB
     } else if let Ok(meta) = fs::metadata(&entry.abs_path_str()) {
-        meta.len() > 1_000_000
-    // if a file metadata could not be read it will be skipped later.
+        // ignore files larger than 1MB
+        meta.len() < 1_000_000
     } else {
+        // if a file metadata could not be read it will be skipped later.
         true
     }
 }


### PR DESCRIPTION
Fixes a regression in #624 which skipped all source files smaller than 1MB, instead of the ones larger than 1MB.