### PR TITLE
fix: react-native xcode uses regex to detect Debug builds

### DIFF
--- a/src/commands/react_native_xcode.rs
+++ b/src/commands/react_native_xcode.rs
@@ -8,7 +8,9 @@ use chrono::Duration;
 use clap::{App, Arg, ArgMatches};
 use failure::{bail, Error};
 use if_chain::if_chain;
+use lazy_static::lazy_static;
 use log::info;
+use regex::Regex;
 use serde::{Deserialize, Serialize};
 
 use crate::api::{Api, NewRelease};
@@ -109,12 +111,16 @@ fn find_node() -> String {
 }
 
 pub fn execute<'a>(matches: &ArgMatches<'a>) -> Result<(), Error> {
+    lazy_static! {
+        static ref DEBUG_RE: Regex = Regex::new(r"Debug").unwrap();
+    }
+
     let config = Config::current();
     let (org, project) = config.get_org_and_project(matches)?;
     let api = Api::current();
     let should_wrap = matches.is_present("force")
         || match env::var("CONFIGURATION") {
-            Ok(config) => &config != "Debug",
+            Ok(config) => !DEBUG_RE.is_match(&config),
             Err(_) => bail!("Need to run this from Xcode"),
         };
     let base = env::current_dir()?;


### PR DESCRIPTION
The default react-native-xcode.sh script invoked builds determines
whether $CONFIGURATION is a debug build or not by loosely matching on
*Debug*. See: https://github.com/facebook/react-native/blob/f19fb2454d164d88aad619fd992edeae51981096/scripts/react-native-xcode.sh#L33

Using a similar regex prevents build failures from occurring anytime a
build configuration has a name that contains but is not exactly "Debug".
This is useful for projects that utilize build configs for different
product flavors (e.g. Debug-dev, Debug-beta, Debug-prod).