### PR TITLE
fix: Override local env.SENTRY_PROPERTIES rather than global process.env

### DIFF
--- a/js/helper.js
+++ b/js/helper.js
@@ -128,10 +128,14 @@ function getPath() {
  * @param {string[]} args Command line arguments passed to `sentry-cli`.
  * @param {boolean} live We inherit stdio to display `sentry-cli` output directly.
  * @param {boolean} silent Disable stdout for silents build (CI/Webpack Stats, ...)
+ * @param {string} [configFile] Relative or absolute path to the configuration file.
  * @returns {Promise.<string>} A promise that resolves to the standard output.
  */
-function execute(args, live, silent) {
+function execute(args, live, silent, configFile) {
   const env = Object.assign({}, process.env);
+  if (configFile) {
+    env.SENTRY_PROPERTIES = configFile;
+  }
   return new Promise((resolve, reject) => {
     if (live === true) {
       const pid = childProcess.spawn(getPath(), args, {

--- a/js/index.js
+++ b/js/index.js
@@ -31,7 +31,7 @@ class SentryCli {
    */
   constructor(configFile, options) {
     if (typeof configFile === 'string') {
-      process.env.SENTRY_PROPERTIES = configFile;
+      this.configFile = configFile;
     }
     this.options = options || { silent: false };
 
@@ -61,7 +61,7 @@ class SentryCli {
    * @returns {Promise.<string>} A promise that resolves to the standard output.
    */
   execute(args, live) {
-    return helper.execute(args, live, this.options.silent);
+    return helper.execute(args, live, this.options.silent, this.configFile);
   }
 }
 


### PR DESCRIPTION
Potential fix for https://github.com/getsentry/sentry-webpack-plugin/issues/175

Right now, providing a `configFile` to `SentryCli()` overrides the `process.env.SENTRY_PROPERTIES` on the entire process. This is problematic when multiple instances of `SentryCli` are used in the same Node process, and each uses a different `configFile` parameter.

One potential fix for this is to override `SENTRY_PROPERTIES` at the local execution level, rather that mutating the global `process.env` environment. I'm open to feedback, though!