### PR TITLE
meta: Add Linux support to the Homebrew formula

### DIFF
--- a/.craft.yml
+++ b/.craft.yml
@@ -42,7 +42,7 @@ targets:
         end
 
         def install
-          bin.install Dir["*"].first => "sentry-cli"
+          bin.install Dir["sentry-cli-*"].first => "sentry-cli"
         end
 
         test do

--- a/.craft.yml
+++ b/.craft.yml
@@ -26,15 +26,23 @@ targets:
     tap: getsentry/tools
     template: >
       class SentryCli < Formula
-        desc "This is a Sentry command-line client for some generic tasks."
+        desc "Sentry command-line client for some generic tasks"
         homepage "https://github.com/getsentry/sentry-cli"
-        url "https://downloads.sentry-cdn.com/sentry-cli/{{version}}/sentry-cli-Darwin-x86_64"
         version "{{version}}"
-        sha256 "{{checksums.sentry-cli-Darwin-x86_64}}"
+
+        if OS.mac?
+          url "https://downloads.sentry-cdn.com/sentry-cli/{{version}}/sentry-cli-Darwin-x86_64"
+          sha256 "{{checksums.sentry-cli-Darwin-x86_64}}"
+        elsif Hardware::CPU.is_64_bit?
+          url "https://downloads.sentry-cdn.com/sentry-cli/{{version}}/sentry-cli-Linux-x86_64"
+          sha256 "{{checksums.sentry-cli-Linux-x86_64}}"
+        else
+          url "https://downloads.sentry-cdn.com/sentry-cli/{{version}}/sentry-cli-Linux-i686"
+          sha256 "{{checksums.sentry-cli-Linux-i686}}"
+        end
 
         def install
-          mv "sentry-cli-Darwin-x86_64", "sentry-cli"
-          bin.install "sentry-cli"
+          bin.install Dir["*"].first => "sentry-cli"
         end
 
         test do


### PR DESCRIPTION
This is a follow-up to https://github.com/getsentry/homebrew-tools/pull/2.