### PR TITLE
fix: Make sure that requests are not authenticated twice and warn for relative urls

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -14,6 +14,7 @@ use parking_lot::Mutex;
 use sentry::internals::Dsn;
 
 use crate::constants::{CONFIG_RC_FILE_NAME, DEFAULT_RETRIES, DEFAULT_URL};
+use crate::utils::http::is_absolute_url;
 use crate::utils::logging::set_max_level;
 
 /// Represents the auth information
@@ -166,7 +167,7 @@ impl Config {
     /// Returns the base url (without trailing slashes)
     pub fn get_base_url(&self) -> Result<&str, Error> {
         let base = self.cached_base_url.trim_end_matches('/');
-        if !base.starts_with("http://") && !base.starts_with("https://") {
+        if !is_absolute_url(base) {
             bail!("bad sentry url: unknown scheme ({})", base);
         }
         if base.matches('/').count() != 2 {

--- a/src/utils/chunks.rs
+++ b/src/utils/chunks.rs
@@ -9,12 +9,14 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use failure::Error;
+use log::warn;
 use parking_lot::RwLock;
 use rayon::prelude::*;
 use rayon::ThreadPoolBuilder;
 use sha1::Digest;
 
 use crate::api::{Api, ChunkUploadOptions, ProgressBarMode};
+use crate::utils::http::is_absolute_url;
 use crate::utils::progress::{ProgressBar, ProgressStyle};
 
 /// Timeout for polling all assemble endpoints.
@@ -205,6 +207,11 @@ pub fn upload_chunks(
     let pool = ThreadPoolBuilder::new()
         .num_threads(chunk_options.concurrency as usize)
         .build()?;
+
+    if !is_absolute_url(&chunk_options.url) {
+        warn!("Uploading chunks to a relative url is not recommended. Please update your `system.url-prefix`\
+           configuration inside `config.yml` or use `Root URL` option at https://<sentry-url>/manage/settings/ directly.");
+    }
 
     pool.install(|| {
         batches

--- a/src/utils/http.rs
+++ b/src/utils/http.rs
@@ -63,6 +63,11 @@ pub fn parse_link_header<'a>(s: &'a str) -> Vec<HashMap<&'a str, &'a str>> {
     rv
 }
 
+/// Checkes whether an url starts with http:// or https:// prefix
+pub fn is_absolute_url(url: &str) -> bool {
+    url.starts_with("http://") || url.starts_with("https://")
+}
+
 #[test]
 fn test_parse_link_header() {
     let rv = parse_link_header("<https://sentry.io/api/0/organizations/sentry/releases/?&cursor=100:-1:1>; rel=\"previous\"; results=\"false\"; cursor=\"100:-1:1\", <https://sentry.io/api/0/organizations/sentry/releases/?&cursor=100:1:0>; rel=\"next\"; results=\"true\"; cursor=\"100:1:0\"");
@@ -86,4 +91,17 @@ fn test_parse_link_header() {
     assert_eq!(b.get("cursor").unwrap(), &"100:1:0");
     assert_eq!(b.get("rel").unwrap(), &"next");
     assert_eq!(b.get("results").unwrap(), &"true");
+}
+
+#[test]
+fn test_is_absolute_url() {
+    assert_eq!(is_absolute_url("https://sentry.io"), true);
+    assert_eq!(is_absolute_url("http://sentry.io"), true);
+    assert_eq!(is_absolute_url("https://sentry.io/path"), true);
+    assert_eq!(is_absolute_url("http://sentry.io/path"), true);
+    assert_eq!(is_absolute_url("http://sentry.io/path?query=foo"), true);
+    assert_eq!(is_absolute_url("https://sentry.io/path?query=foo"), true);
+
+    assert_eq!(is_absolute_url("/path"), false);
+    assert_eq!(is_absolute_url("/path?query=foo"), false);
 }


### PR DESCRIPTION
Closes: https://github.com/getsentry/sentry-cli/issues/649
Closes: https://github.com/getsentry/sentry-cli/issues/651
Closes: https://github.com/getsentry/sentry-cli/issues/663