### PR TITLE
feat: Add support for INFOPLIST_OTHER_PREPROCESSOR_FLAGS

### DIFF
--- a/src/utils/xcode.rs
+++ b/src/utils/xcode.rs
@@ -239,6 +239,11 @@ impl InfoPlist {
         let mut rv = if vars.get("INFOPLIST_PREPROCESS").map(String::as_str) == Some("YES") {
             let mut c = process::Command::new("cc");
             c.arg("-xc").arg("-P").arg("-E");
+            if let Some(defs) = vars.get("INFOPLIST_OTHER_PREPROCESSOR_FLAGS") {
+                for token in defs.split_whitespace() {
+                    c.arg(token);
+                }
+            }
             if let Some(defs) = vars.get("INFOPLIST_PREPROCESSOR_DEFINITIONS") {
                 for token in defs.split_whitespace() {
                     c.arg(format!("-D{}", token));


### PR DESCRIPTION
Closes https://github.com/getsentry/sentry-cli/issues/278

ref: https://developer.apple.com/library/archive/documentation/DeveloperTools/Reference/XcodeBuildSettingRef/1-Build_Setting_Reference/build_setting_ref.html#//apple_ref/doc/uid/TP40003931-CH3-SW154
ref: https://gcc.gnu.org/onlinedocs/gcc/Preprocessor-Options.html#Preprocessor-Options