### PR TITLE
Add an optional argument to override the entire release name for a CodePush release

### DIFF
--- a/src/commands/react_native_appcenter.rs
+++ b/src/commands/react_native_appcenter.rs
@@ -58,6 +58,7 @@ pub fn make_app<'a, 'b: 'a>(app: App<'a, 'b>) -> App<'a, 'b> {
             Arg::with_name("release_name")
                 .value_name("RELEASE_NAME")
                 .long("release-name")
+                .conflicts_with_all(&["bundle_id", "version_name"])
                 .help("Override the entire release-name"),
         )
         .arg(

--- a/src/commands/react_native_appcenter.rs
+++ b/src/commands/react_native_appcenter.rs
@@ -55,6 +55,12 @@ pub fn make_app<'a, 'b: 'a>(app: App<'a, 'b>) -> App<'a, 'b> {
                 .help("Print the release name instead."),
         )
         .arg(
+            Arg::with_name("release_name")
+                .value_name("RELEASE_NAME")
+                .long("release-name")
+                .help("Override the entire release-name")
+        )
+        .arg(
             Arg::with_name("app_name")
                 .value_name("APP_NAME")
                 .index(1)
@@ -106,12 +112,14 @@ pub fn execute<'a>(matches: &ArgMatches<'a>) -> Result<(), Error> {
         );
     }
 
+
     let package = get_appcenter_package(app, deployment)?;
     let release = get_react_native_appcenter_release(
         &package,
         platform,
         matches.value_of("bundle_id"),
         matches.value_of("version_name"),
+        matches.value_of("release_name")
     )?;
     if print_release_name {
         println!("{}", release);

--- a/src/commands/react_native_appcenter.rs
+++ b/src/commands/react_native_appcenter.rs
@@ -112,7 +112,6 @@ pub fn execute<'a>(matches: &ArgMatches<'a>) -> Result<(), Error> {
         );
     }
 
-
     let package = get_appcenter_package(app, deployment)?;
     let release = get_react_native_appcenter_release(
         &package,

--- a/src/commands/react_native_appcenter.rs
+++ b/src/commands/react_native_appcenter.rs
@@ -58,7 +58,7 @@ pub fn make_app<'a, 'b: 'a>(app: App<'a, 'b>) -> App<'a, 'b> {
             Arg::with_name("release_name")
                 .value_name("RELEASE_NAME")
                 .long("release-name")
-                .help("Override the entire release-name")
+                .help("Override the entire release-name"),
         )
         .arg(
             Arg::with_name("app_name")
@@ -119,7 +119,7 @@ pub fn execute<'a>(matches: &ArgMatches<'a>) -> Result<(), Error> {
         platform,
         matches.value_of("bundle_id"),
         matches.value_of("version_name"),
-        matches.value_of("release_name")
+        matches.value_of("release_name"),
     )?;
     if print_release_name {
         println!("{}", release);

--- a/src/utils/appcenter.rs
+++ b/src/utils/appcenter.rs
@@ -131,9 +131,15 @@ pub fn get_react_native_appcenter_release(
     platform: &str,
     bundle_id_override: Option<&str>,
     version_name_override: Option<&str>,
+    release_name_override: Option<&str>
 ) -> Result<String, Error> {
     let bundle_id_ovrr = bundle_id_override.unwrap_or("");
     let version_name_ovrr = version_name_override.unwrap_or("");
+    let release_name_ovrr = release_name_override.unwrap_or("");
+
+    if release_name_ovrr != "" {
+        return Ok(release_name_ovrr.to_string());
+    }
 
     if bundle_id_ovrr != "" && version_name_ovrr != "" {
         return Ok(format!(

--- a/src/utils/appcenter.rs
+++ b/src/utils/appcenter.rs
@@ -131,7 +131,7 @@ pub fn get_react_native_appcenter_release(
     platform: &str,
     bundle_id_override: Option<&str>,
     version_name_override: Option<&str>,
-    release_name_override: Option<&str>
+    release_name_override: Option<&str>,
 ) -> Result<String, Error> {
     let bundle_id_ovrr = bundle_id_override.unwrap_or("");
     let version_name_ovrr = version_name_override.unwrap_or("");


### PR DESCRIPTION
Add `--release-name` as an optional argument to `react-native appcenter` to override the entire release name. This can be used to get around issues with the CodePush package label (used by the CLI by default) not being consistent between CodePush environments (#372 ) among other uses.