### PR TITLE
utils: Downgrade mkdirp as they drop support for node 8

### DIFF
--- a/js/__tests__/helper.test.js
+++ b/js/__tests__/helper.test.js
@@ -77,16 +77,9 @@ describe('SentryCli helper', () => {
       helper.prepareCommand(command, SOURCEMAPS_OPTIONS, { sourceMapReference: true })
     ).toEqual(['releases', 'files', 'release', 'upload-sourcemaps', '/dev/null']);
 
-    expect(
-      helper.prepareCommand(command, SOURCEMAPS_OPTIONS, { rewrite: true })
-    ).toEqual([
-      'releases',
-      'files',
-      'release',
-      'upload-sourcemaps',
-      '/dev/null',
-      '--rewrite',
-    ]);
+    expect(helper.prepareCommand(command, SOURCEMAPS_OPTIONS, { rewrite: true })).toEqual(
+      ['releases', 'files', 'release', 'upload-sourcemaps', '/dev/null', '--rewrite']
+    );
 
     expect(
       helper.prepareCommand(command, SOURCEMAPS_OPTIONS, { rewrite: false })

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
   "dependencies": {
     "fs-copy-file-sync": "^1.1.1",
     "https-proxy-agent": "^4.0.0",
-    "mkdirp": "^1.0.0",
+    "mkdirp": "^0.5.4",
     "node-fetch": "^2.1.2",
     "progress": "2.0.0",
     "proxy-from-env": "^1.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2546,6 +2546,11 @@ minimist@^1.1.1, minimist@^1.2.0:
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.0.tgz#a35008b20f41383eec1fb914f4cd5df79a264284"
   integrity sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=
 
+minimist@^1.2.5:
+  version "1.2.5"
+  resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.5.tgz#67d66014b66a6a8aaa0c083c5fd58df4e4e97602"
+  integrity sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==
+
 minimist@~0.0.1:
   version "0.0.10"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-0.0.10.tgz#de3f98543dbf96082be48ad1a0c7cda836301dcf"
@@ -2581,10 +2586,12 @@ mkdirp@^0.5.0, mkdirp@^0.5.1:
   dependencies:
     minimist "0.0.8"
 
-mkdirp@^1.0.0:
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-1.0.3.tgz#4cf2e30ad45959dddea53ad97d518b6c8205e1ea"
-  integrity sha512-6uCP4Qc0sWsgMLy1EOqqS/3rjDHOEnsStVr/4vtAIK2Y5i2kA7lFFejYrpIyiN9w0pYf4ckeCYT9f1r1P9KX5g==
+mkdirp@^0.5.4:
+  version "0.5.4"
+  resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-0.5.4.tgz#fd01504a6797ec5c9be81ff43d204961ed64a512"
+  integrity sha512-iG9AK/dJLtJ0XNgTuDbSyNS3zECqDlAhnQW4CsNxBG3LQJBbHmRX1egw39DmtOdCAqY+dKXV+sgPgilNWUKMVw==
+  dependencies:
+    minimist "^1.2.5"
 
 ms@2.0.0:
   version "2.0.0"


### PR DESCRIPTION
Fixes https://github.com/getsentry/sentry-cli/issues/695#issuecomment-604073843
Ref https://github.com/getsentry/sentry-cli/issues/698