### PR TITLE
fix: Respect configFile for release commands

### DIFF
--- a/js/index.js
+++ b/js/index.js
@@ -35,7 +35,7 @@ class SentryCli {
     }
     this.options = options || { silent: false };
 
-    this.releases = new Releases(this.options);
+    this.releases = new Releases(this.options, configFile);
   }
 
   /**

--- a/js/index.js
+++ b/js/index.js
@@ -35,7 +35,9 @@ class SentryCli {
     }
     this.options = options || { silent: false };
 
-    this.releases = new Releases(this.options, configFile);
+    this.releases = new Releases(
+      Object.assign({}, this.options, { configFile: configFile })
+    );
   }
 
   /**

--- a/js/releases/index.js
+++ b/js/releases/index.js
@@ -23,13 +23,13 @@ class Releases {
    * Creates a new `Releases` instance.
    *
    * @param {Object} [options] More options to pass to the CLI
-   * @param {string} [configFile] Relative or absolute path to the CLI configuration file.
    */
-  constructor(options, configFile) {
+  constructor(options) {
     this.options = options || {};
-    if (typeof configFile === 'string') {
-      this.configFile = configFile;
+    if (typeof this.options.configFile === 'string') {
+      this.configFile = this.options.configFile;
     }
+    delete this.options.configFile;
   }
 
   /**


### PR DESCRIPTION
Follow-up for a bug introduced by #667

Before, initializing `SentryCli()` would override `process.env.SENTRY_PROPERTIES`. This was problematic if multiple SentryCli instances were being used in the same Node process, in addition to mutating a global process object. To improve this, #667 moved the `SENTRY_PROPERTIES` override to a local env override that only applies to each individual `execute()` call.

However, this fix didn't take into account that the `Releases` class calls `helper.execute()` directly, rather than `SentryCli().execute()`. This leads the release commands to not know about the overridden configFile that they are expecting.

https://github.com/getsentry/sentry-cli/blob/6d9ba9f3e3f061839735e986839d8935672e6121/js/releases/index.js#L42

To resolve this, I've added a second `configFile` parameter to the options object of the `Release` constructor. I've also refactored `helper.execute()` calls to a single `this.execute()` call, which consolidates usage of `this.options.silent` and `this.configFile` to avoid new commands from accidentally forgetting to provide either of these parameters to `execute()`.