### PR TITLE
fix(difutil): Mark files as unusable without id

### DIFF
--- a/src/constants.rs
+++ b/src/constants.rs
@@ -47,5 +47,7 @@ pub const DEFAULT_INITIAL_INTERVAL: u64 = 1000;
 pub const DEFAULT_MAX_INTERVAL: u64 = 5000;
 /// Default number of retry attempts
 pub const DEFAULT_RETRIES: u32 = 5;
+/// Default maximum file size of DIF uploads.
+pub const DEFAULT_MAX_DIF_SIZE: u64 = 2 * 1024 * 1024 * 1024; // 2GB
 
 include!(concat!(env!("OUT_DIR"), "/constants.gen.rs"));

--- a/src/utils/dif.rs
+++ b/src/utils/dif.rs
@@ -293,7 +293,7 @@ impl<'a> DifFile<'a> {
 
     pub fn is_usable(&self) -> bool {
         match self {
-            DifFile::Archive(_) => self.features().has_some(),
+            DifFile::Archive(_) => self.has_ids() && self.features().has_some(),
             DifFile::Proguard(pg) => pg.has_line_info(),
         }
     }
@@ -303,7 +303,13 @@ impl<'a> DifFile<'a> {
             None
         } else {
             Some(match self {
-                DifFile::Archive(..) => "missing debug or unwind information",
+                DifFile::Archive(..) => {
+                    if !self.has_ids() {
+                        "missing debug identifier, likely stripped"
+                    } else {
+                        "missing debug or unwind information"
+                    }
+                }
                 DifFile::Proguard(..) => "missing line information",
             })
         }
@@ -315,6 +321,10 @@ impl<'a> DifFile<'a> {
         } else {
             None
         }
+    }
+
+    fn has_ids(&self) -> bool {
+        self.ids().iter().any(|id| !id.is_nil())
     }
 }
 

--- a/src/utils/dif_upload.rs
+++ b/src/utils/dif_upload.rs
@@ -32,6 +32,7 @@ use crate::api::{
     Api, ChunkUploadCapability, ChunkUploadOptions, ChunkedDifRequest, ChunkedFileState,
 };
 use crate::config::Config;
+use crate::constants::DEFAULT_MAX_DIF_SIZE;
 use crate::utils::chunks::{
     upload_chunks, BatchedSliceExt, Chunk, ItemSize, ASSEMBLE_POLL_INTERVAL,
 };
@@ -1440,7 +1441,7 @@ impl DifUpload {
             extensions: BTreeSet::new(),
             symbol_map: None,
             zips_allowed: true,
-            max_file_size: 2 * 1024 * 1024 * 1024, // 2GB
+            max_file_size: DEFAULT_MAX_DIF_SIZE,
             pdbs_allowed: false,
             sources_allowed: false,
             include_sources: false,


### PR DESCRIPTION
The debug file upload skips all files without a debug id, since Sentry cannot handle them. This patch adds a message to difutil check so that it is easier to debug why the file is not being uploaded. 

We do not emit a warning, since it's quite common to point `sentry-cli` to directory that contain `.o` object files. Each of those would generate a warning during upload.