### PR TITLE
Add FreeBSD binary download URL

### DIFF
--- a/scripts/install.js
+++ b/scripts/install.js
@@ -42,8 +42,10 @@ function getDownloadUrl(platform, arch) {
     case 'win32':
       return `${releasesUrl}-Windows-${archString}.exe`;
     case 'linux':
-    case 'freebsd':
       return `${releasesUrl}-Linux-${archString}`;
+    case 'freebsd':
+      // Following url should be updated as soon as the binary is uploaded to default releases url
+      return `https://www.grinchenko.org/files/sentry-cli-FreeBSD-${archString}-1.52.1`;
     default:
       return null;
   }


### PR DESCRIPTION
The current url for the FreeBSD binary is using the Linux binary and it's not working. I've updated it to get directly from the URL pointed in https://github.com/getsentry/sentry-cli/issues/672 and it should be updated when the binary is uploaded to the default releases url.