### PR TITLE
feat: Batch upload; Release file upload refactor;

### DIFF
--- a/src/api.rs
+++ b/src/api.rs
@@ -10,7 +10,7 @@ use std::ffi::OsStr;
 use std::fmt;
 use std::fs::File;
 use std::io::{self, Read, Write};
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::rc::Rc;
 use std::str::FromStr;
 use std::sync::Arc;
@@ -18,6 +18,7 @@ use std::sync::Arc;
 use backoff::backoff::Backoff;
 use brotli2::write::BrotliEncoder;
 use chrono::{DateTime, Duration, FixedOffset, Utc};
+use console::style;
 use failure::{Backtrace, Context, Error, Fail, ResultExt};
 use flate2::write::GzEncoder;
 use if_chain::if_chain;
@@ -37,7 +38,7 @@ use crate::config::{Auth, Config};
 use crate::constants::{ARCH, EXT, PLATFORM, RELEASE_REGISTRY_LATEST_URL, VERSION};
 use crate::utils::android::AndroidManifest;
 use crate::utils::http::{self, is_absolute_url, parse_link_header};
-use crate::utils::progress::ProgressBar;
+use crate::utils::progress::{make_progress_bar, ProgressBar};
 use crate::utils::retry::{get_default_backoff, DurationAsMilliseconds};
 use crate::utils::sourcemaps::get_sourcemap_reference_from_headers;
 use crate::utils::ui::{capitalize_string, make_byte_progress_bar};
@@ -45,6 +46,13 @@ use crate::utils::xcode::InfoPlist;
 
 const QUERY_ENCODE_SET: AsciiSet = CONTROLS.add(b' ').add(b'"').add(b'#').add(b'<').add(b'>');
 const DEFAULT_ENCODE_SET: AsciiSet = QUERY_ENCODE_SET.add(b'`').add(b'?').add(b'{').add(b'}');
+
+/// Represents file contents temporarily
+#[derive(Clone, Debug)]
+pub enum FileContents<'a> {
+    FromPath(&'a Path),
+    FromBytes(&'a [u8]),
+}
 
 /// Wrapper that escapes arguments for URL path segments.
 pub struct PathArg<A: fmt::Display>(A);
@@ -175,12 +183,6 @@ impl ProgressBarMode {
 pub struct Api {
     config: Arc<Config>,
     pool: r2d2::Pool<CurlConnectionManager>,
-}
-
-/// Represents file contents temporarily
-pub enum FileContents<'a> {
-    FromPath(&'a Path),
-    FromBytes(&'a [u8]),
 }
 
 #[derive(Debug, Fail)]
@@ -581,7 +583,7 @@ impl Api {
         org: &str,
         project: Option<&str>,
         version: &str,
-        contents: &FileContents<'_>,
+        contents: &FileContents,
         name: &str,
         dist: Option<&str>,
         headers: Option<&[(String, String)]>,
@@ -645,6 +647,86 @@ impl Api {
         } else {
             resp.convert_rnf(ApiErrorKind::ReleaseNotFound)
         }
+    }
+
+    pub fn upload_release_files(
+        &self,
+        org: &str,
+        project: Option<&str>,
+        version: &str,
+        sources: HashSet<(String, PathBuf)>,
+        dist: Option<&str>,
+        headers: Option<&[(String, String)]>,
+    ) -> Result<(), Error> {
+        if sources.is_empty() {
+            return Ok(());
+        }
+
+        let mut successful_req = vec![];
+        let mut failed_req = vec![];
+
+        println!(
+            "{} Uploading {} files for release {}",
+            style(">").dim(),
+            style(sources.len()).cyan(),
+            style(version).cyan()
+        );
+
+        let pb = make_progress_bar(sources.len() as u64);
+
+        for (url, path) in sources {
+            pb.set_message(&path.to_str().unwrap());
+
+            let upload_result = self.upload_release_file(
+                org,
+                project,
+                version,
+                &FileContents::FromPath(&path),
+                &url.to_owned(),
+                dist,
+                headers,
+                ProgressBarMode::Disabled,
+            );
+
+            match upload_result {
+                Ok(Some(artifact)) => {
+                    successful_req.push((path, artifact));
+                }
+                Ok(None) => {
+                    failed_req.push((path, url, String::from("File already present")));
+                }
+                Err(err) => {
+                    failed_req.push((path, url, err.to_string()));
+                }
+            };
+
+            pb.inc(1);
+        }
+
+        pb.finish_and_clear();
+
+        for (path, url, reason) in failed_req.iter() {
+            println!(
+                "    Failed to upload: {} as {} ({})",
+                &path.display(),
+                &url,
+                reason
+            );
+        }
+
+        for (path, artifact) in successful_req.iter() {
+            println!(
+                "    Successfully uploaded: {} as {} ({}) ({} bytes)",
+                &path.display(),
+                artifact.name,
+                artifact.sha1,
+                artifact.size
+            );
+        }
+
+        println!("{} Done uploading.", style(">").dim());
+
+        Ok(())
     }
 
     /// Creates a new release.

--- a/src/commands/react_native_appcenter.rs
+++ b/src/commands/react_native_appcenter.rs
@@ -12,7 +12,9 @@ use crate::api::{Api, NewRelease};
 use crate::config::Config;
 use crate::utils::appcenter::{get_appcenter_package, get_react_native_appcenter_release};
 use crate::utils::args::ArgExt;
-use crate::utils::sourcemaps::{SourceMapProcessor, UploadContext};
+use crate::utils::file_search::ReleaseFileSearch;
+use crate::utils::file_upload::UploadContext;
+use crate::utils::sourcemaps::SourceMapProcessor;
 
 pub fn make_app<'a, 'b: 'a>(app: App<'a, 'b>) -> App<'a, 'b> {
     app.about("Upload react-native projects for AppCenter.")
@@ -143,7 +145,7 @@ pub fn execute<'a>(matches: &ArgMatches<'a>) -> Result<(), Error> {
                    ext == OsStr::new("bundle");
                 then {
                     let url = format!("~/{}", filename);
-                    processor.add(&url, &entry.path())?;
+                    processor.add(&url, ReleaseFileSearch::collect_file(entry.path())?)?;
                 }
             }
         }

--- a/src/commands/react_native_codepush.rs
+++ b/src/commands/react_native_codepush.rs
@@ -12,7 +12,9 @@ use crate::api::{Api, NewRelease};
 use crate::config::Config;
 use crate::utils::args::ArgExt;
 use crate::utils::codepush::{get_codepush_package, get_react_native_codepush_release};
-use crate::utils::sourcemaps::{SourceMapProcessor, UploadContext};
+use crate::utils::file_search::ReleaseFileSearch;
+use crate::utils::file_upload::UploadContext;
+use crate::utils::sourcemaps::SourceMapProcessor;
 
 pub fn make_app<'a, 'b: 'a>(app: App<'a, 'b>) -> App<'a, 'b> {
     app.about("DEPRECATED: Upload react-native projects for CodePush.")
@@ -117,7 +119,7 @@ pub fn execute<'a>(matches: &ArgMatches<'a>) -> Result<(), Error> {
                    ext == OsStr::new("bundle");
                 then {
                     let url = format!("~/{}", filename);
-                    processor.add(&url, &entry.path())?;
+                    processor.add(&url, ReleaseFileSearch::collect_file(entry.path())?)?;
                 }
             }
         }

--- a/src/commands/react_native_gradle.rs
+++ b/src/commands/react_native_gradle.rs
@@ -9,7 +9,9 @@ use sourcemap::ram_bundle::RamBundle;
 use crate::api::{Api, NewRelease};
 use crate::config::Config;
 use crate::utils::args::ArgExt;
-use crate::utils::sourcemaps::{SourceMapProcessor, UploadContext};
+use crate::utils::file_search::ReleaseFileSearch;
+use crate::utils::file_upload::UploadContext;
+use crate::utils::sourcemaps::SourceMapProcessor;
 
 pub fn make_app<'a, 'b: 'a>(app: App<'a, 'b>) -> App<'a, 'b> {
     app.about("Upload react-native projects in a gradle build step.")
@@ -75,8 +77,14 @@ pub fn execute<'a>(matches: &ArgMatches<'a>) -> Result<(), Error> {
     info!("  sourcemap path: {}", sourcemap_path.display());
 
     let mut processor = SourceMapProcessor::new();
-    processor.add(&bundle_url, &bundle_path)?;
-    processor.add(&sourcemap_url, &sourcemap_path)?;
+    processor.add(
+        &bundle_url,
+        ReleaseFileSearch::collect_file(bundle_path.clone())?,
+    )?;
+    processor.add(
+        &sourcemap_url,
+        ReleaseFileSearch::collect_file(sourcemap_path)?,
+    )?;
 
     if let Ok(ram_bundle) = RamBundle::parse_unbundle_from_path(&bundle_path) {
         debug!("File RAM bundle found, extracting its contents...");

--- a/src/commands/react_native_xcode.rs
+++ b/src/commands/react_native_xcode.rs
@@ -14,8 +14,10 @@ use serde::{Deserialize, Serialize};
 use crate::api::{Api, NewRelease};
 use crate::config::Config;
 use crate::utils::args::ArgExt;
+use crate::utils::file_search::ReleaseFileSearch;
+use crate::utils::file_upload::UploadContext;
 use crate::utils::fs::TempFile;
-use crate::utils::sourcemaps::{SourceMapProcessor, UploadContext};
+use crate::utils::sourcemaps::SourceMapProcessor;
 use crate::utils::system::propagate_exit_status;
 use crate::utils::xcode::{InfoPlist, MayDetach};
 
@@ -258,8 +260,11 @@ pub fn execute<'a>(matches: &ArgMatches<'a>) -> Result<(), Error> {
         info!("  sourcemap path: {}", sourcemap_path.display());
 
         let mut processor = SourceMapProcessor::new();
-        processor.add(&bundle_url, &bundle_path)?;
-        processor.add(&sourcemap_url, &sourcemap_path)?;
+        processor.add(&bundle_url, ReleaseFileSearch::collect_file(bundle_path)?)?;
+        processor.add(
+            &sourcemap_url,
+            ReleaseFileSearch::collect_file(sourcemap_path)?,
+        )?;
         processor.rewrite(&[base.parent().unwrap().to_str().unwrap()])?;
         processor.add_sourcemap_references()?;
 

--- a/src/commands/releases.rs
+++ b/src/commands/releases.rs
@@ -783,11 +783,11 @@ fn execute_files_upload<'a>(
         let ignores = matches
             .values_of("ignore")
             .map(|ignores| ignores.map(|i| format!("!{}", i)).collect())
-            .unwrap_or_else(|| vec![]);
+            .unwrap_or_else(Vec::new);
         let extensions = matches
             .values_of("extensions")
             .map(|extensions| extensions.map(|ext| ext.trim_start_matches('.')).collect())
-            .unwrap_or_else(|| vec![]);
+            .unwrap_or_else(Vec::new);
 
         let sources = ReleaseFileSearch::new(path.to_path_buf())
             .ignore_file(ignore_file)
@@ -951,7 +951,7 @@ fn process_sources_from_paths<'a>(
     let ignores = matches
         .values_of("ignore")
         .map(|ignores| ignores.map(|i| format!("!{}", i)).collect())
-        .unwrap_or_else(|| vec![]);
+        .unwrap_or_else(Vec::new);
 
     for path in paths {
         // if we start walking over something that is an actual file then

--- a/src/commands/releases.rs
+++ b/src/commands/releases.rs
@@ -7,14 +7,11 @@ use std::sync::Arc;
 use chrono::{DateTime, Duration, Utc};
 use clap::{App, AppSettings, Arg, ArgMatches};
 use failure::{bail, err_msg, Error};
-
-use ignore::overrides::OverrideBuilder;
-use ignore::types::TypesBuilder;
-use ignore::WalkBuilder;
 use indicatif::HumanBytes;
 use lazy_static::lazy_static;
-use log::{debug, info, warn};
+use log::{debug, warn};
 use regex::Regex;
+use symbolic::debuginfo::sourcebundle::SourceFileType;
 
 use crate::api::{
     Api, Deploy, FileContents, NewRelease, NoneReleaseInfo, OptionalReleaseInfo, ProgressBarMode,
@@ -24,9 +21,11 @@ use crate::config::Config;
 use crate::utils::args::{
     get_timestamp, validate_int, validate_project, validate_timestamp, ArgExt,
 };
+use crate::utils::file_search::ReleaseFileSearch;
+use crate::utils::file_upload::{ReleaseFile, ReleaseFileUpload, UploadContext};
 use crate::utils::formatting::{HumanDuration, Table};
 use crate::utils::releases::detect_release_name;
-use crate::utils::sourcemaps::{SourceMapProcessor, UploadContext};
+use crate::utils::sourcemaps::SourceMapProcessor;
 use crate::utils::system::QuietExit;
 use crate::utils::vcs::{
     find_heads, generate_patch_set, get_commits_from_git, get_repo_from_remote, CommitSpec,
@@ -188,12 +187,15 @@ pub fn make_app<'a, 'b: 'a>(app: App<'a, 'b>) -> App<'a, 'b> {
                     .multiple(true)
                     .help("Filenames to delete.")))
             .subcommand(App::new("upload")
-                .about("Upload a file for a release.")
+                .about("Upload files for a release.")
                 .arg(Arg::with_name("dist")
                     .long("dist")
                     .short("d")
                     .value_name("DISTRIBUTION")
                     .help("Optional distribution identifier for this file."))
+                .arg(Arg::with_name("wait")
+                    .long("wait")
+                    .help("Wait for the server to fully process uploaded files."))
                 .arg(Arg::with_name("headers")
                     .long("header")
                     .short("H")
@@ -205,11 +207,41 @@ pub fn make_app<'a, 'b: 'a>(app: App<'a, 'b>) -> App<'a, 'b> {
                     .value_name("PATH")
                     .index(1)
                     .required(true)
-                    .help("The path to the file to upload."))
+                    .help("The path to the file or directory to upload."))
                 .arg(Arg::with_name("name")
                     .index(2)
                     .value_name("NAME")
-                    .help("The name of the file on the server.")))
+                    .help("The name of the file on the server."))
+                .arg(Arg::with_name("url_prefix")
+                    .short("u")
+                    .long("url-prefix")
+                    .value_name("PREFIX")
+                    .help("The URL prefix to prepend to all filenames."))
+                .arg(Arg::with_name("url_suffix")
+                    .long("url-suffix")
+                    .value_name("SUFFIX")
+                    .help("The URL suffix to append to all filenames."))
+                .arg(Arg::with_name("ignore")
+                    .long("ignore")
+                    .short("i")
+                    .value_name("IGNORE")
+                    .multiple(true)
+                    .help("Ignores all files and folders matching the given glob"))
+                .arg(Arg::with_name("ignore_file")
+                    .long("ignore-file")
+                    .short("I")
+                    .value_name("IGNORE_FILE")
+                    .help("Ignore all files and folders specified in the given \
+                           ignore file, e.g. .gitignore."))
+                .arg(Arg::with_name("extensions")
+                    .long("ext")
+                    .short("x")
+                    .value_name("EXT")
+                    .multiple(true)
+                    .number_of_values(1)
+                    .help("Set the file extensions that are considered for upload. \
+                           This overrides the default extensions. To add an extension, all default \
+                           extensions must be repeated. Specify once per extension.")))
             .subcommand(App::new("upload-sourcemaps")
                 .about("Upload sourcemaps for a release.")
                 .arg(Arg::with_name("paths")
@@ -728,14 +760,6 @@ fn execute_files_upload<'a>(
     matches: &ArgMatches<'a>,
     version: &str,
 ) -> Result<(), Error> {
-    let path = Path::new(matches.value_of("path").unwrap());
-    let name = match matches.value_of("name") {
-        Some(name) => name,
-        None => Path::new(path)
-            .file_name()
-            .and_then(OsStr::to_str)
-            .ok_or_else(|| err_msg("No filename provided."))?,
-    };
     let dist = matches.value_of("dist");
     let mut headers = vec![];
     if let Some(header_list) = matches.values_of("header") {
@@ -751,21 +775,84 @@ fn execute_files_upload<'a>(
     };
     let org = ctx.get_org()?;
     let project = ctx.get_project_default().ok();
-    if let Some(artifact) = ctx.api.upload_release_file(
-        org,
-        project.as_deref(),
-        &version,
-        &FileContents::FromPath(&path),
-        &name,
-        dist,
-        Some(&headers[..]),
-        ProgressBarMode::Request,
-    )? {
-        println!("A {}  ({} bytes)", artifact.sha1, artifact.size);
-    } else {
-        bail!("File already present!");
+    let path = Path::new(matches.value_of("path").unwrap());
+
+    // Batch files upload
+    if path.is_dir() {
+        let ignore_file = matches.value_of("ignore_file").unwrap_or("");
+        let ignores = matches
+            .values_of("ignore")
+            .map(|ignores| ignores.map(|i| format!("!{}", i)).collect())
+            .unwrap_or_else(|| vec![]);
+        let extensions = matches
+            .values_of("extensions")
+            .map(|extensions| extensions.map(|ext| ext.trim_start_matches('.')).collect())
+            .unwrap_or_else(|| vec![]);
+
+        let sources = ReleaseFileSearch::new(path.to_path_buf())
+            .ignore_file(ignore_file)
+            .ignores(ignores)
+            .extensions(extensions)
+            .collect_files()?;
+
+        let url_prefix = get_url_prefix_from_args(matches);
+        let url_suffix = get_url_suffix_from_args(matches);
+        let files = sources
+            .iter()
+            .map(|source| {
+                let local_path = source.path.strip_prefix(&source.base_path).unwrap();
+                let url = format!("{}/{}{}", url_prefix, path_as_url(local_path), url_suffix);
+
+                (
+                    url.to_string(),
+                    ReleaseFile {
+                        url,
+                        path: source.path.clone(),
+                        contents: source.contents.clone(),
+                        ty: SourceFileType::Source,
+                        headers: headers.clone(),
+                        messages: vec![],
+                    },
+                )
+            })
+            .collect();
+
+        let ctx = &UploadContext {
+            org,
+            project: project.as_deref(),
+            release: &version,
+            dist,
+            wait: matches.is_present("wait"),
+        };
+
+        ReleaseFileUpload::new(ctx).files(&files).upload()
     }
-    Ok(())
+    // Single file upload
+    else {
+        let name = match matches.value_of("name") {
+            Some(name) => name,
+            None => Path::new(path)
+                .file_name()
+                .and_then(OsStr::to_str)
+                .ok_or_else(|| err_msg("No filename provided."))?,
+        };
+
+        if let Some(artifact) = ctx.api.upload_release_file(
+            org,
+            project.as_deref(),
+            &version,
+            &FileContents::FromPath(path),
+            &name,
+            dist,
+            Some(&headers[..]),
+            ProgressBarMode::Request,
+        )? {
+            println!("A {}  ({} bytes)", artifact.sha1, artifact.size);
+        } else {
+            bail!("File already present!");
+        }
+        Ok(())
+    }
 }
 
 fn get_url_prefix_from_args<'a, 'b>(matches: &'b ArgMatches<'a>) -> &'b str {
@@ -818,8 +905,14 @@ fn process_sources_from_bundle<'a>(
     debug!("Bundle path: {}", bundle_path.display());
     debug!("Sourcemap path: {}", sourcemap_path.display());
 
-    processor.add(&bundle_url, &bundle_path)?;
-    processor.add(&sourcemap_url, &sourcemap_path)?;
+    processor.add(
+        &bundle_url,
+        ReleaseFileSearch::collect_file(bundle_path.clone())?,
+    )?;
+    processor.add(
+        &sourcemap_url,
+        ReleaseFileSearch::collect_file(sourcemap_path)?,
+    )?;
 
     if let Ok(ram_bundle) = sourcemap::ram_bundle::RamBundle::parse_unbundle_from_path(&bundle_path)
     {
@@ -850,17 +943,15 @@ fn process_sources_from_paths<'a>(
     processor: &mut SourceMapProcessor,
 ) -> Result<(), Error> {
     let paths = matches.values_of("paths").unwrap();
+    let ignore_file = matches.value_of("ignore_file").unwrap_or("");
     let extensions = matches
         .values_of("extensions")
         .map(|extensions| extensions.map(|ext| ext.trim_start_matches('.')).collect())
         .unwrap_or_else(|| vec!["js", "map", "jsbundle", "bundle"]);
     let ignores = matches
         .values_of("ignore")
-        .map(|ignores| ignores.map(|i| format!("!{}", i)).collect::<Vec<_>>());
-    let ignore_file = matches.value_of("ignore_file");
-
-    let url_prefix = get_url_prefix_from_args(matches);
-    let url_suffix = get_url_suffix_from_args(matches);
+        .map(|ignores| ignores.map(|i| format!("!{}", i)).collect())
+        .unwrap_or_else(|| vec![]);
 
     for path in paths {
         // if we start walking over something that is an actual file then
@@ -874,46 +965,24 @@ fn process_sources_from_paths<'a>(
             (path, true)
         };
 
-        let mut builder = WalkBuilder::new(path);
-        builder.git_exclude(false).git_ignore(false).ignore(false);
+        let mut search = ReleaseFileSearch::new(path.to_path_buf());
 
         if check_ignore {
-            let mut types_builder = TypesBuilder::new();
-            for ext in &extensions {
-                let ext_name = ext.replace('.', "__");
-                types_builder.add(&ext_name, &format!("*.{}", ext))?;
-            }
-            builder.types(types_builder.select("all").build()?);
-
-            if let Some(ignore_file) = ignore_file {
-                // This could yield an optional partial error
-                // We ignore this error to match behavior of git
-                builder.add_ignore(ignore_file);
-            }
-
-            if let Some(ref ignores) = ignores {
-                let mut override_builder = OverrideBuilder::new(path);
-                for ignore in ignores {
-                    override_builder.add(&ignore)?;
-                }
-                builder.overrides(override_builder.build()?);
-            }
+            search
+                .ignore_file(ignore_file)
+                .ignores(ignores.clone())
+                .extensions(extensions.clone());
         }
 
-        for result in builder.build() {
-            let file = result?;
-            if file.file_type().map_or(false, |t| t.is_dir()) {
-                continue;
-            }
+        let sources = search.collect_files()?;
 
-            info!(
-                "found: {} ({} bytes)",
-                file.path().display(),
-                file.metadata().unwrap().len()
-            );
-            let local_path = file.path().strip_prefix(&base_path).unwrap();
+        let url_prefix = get_url_prefix_from_args(matches);
+        let url_suffix = get_url_suffix_from_args(matches);
+
+        for source in sources {
+            let local_path = source.path.strip_prefix(base_path).unwrap();
             let url = format!("{}/{}{}", url_prefix, path_as_url(local_path), url_suffix);
-            processor.add(&url, file.path())?;
+            processor.add(&url, source)?;
         }
     }
 

--- a/src/utils/file_search.rs
+++ b/src/utils/file_search.rs
@@ -1,0 +1,177 @@
+use std::collections::BTreeSet;
+use std::fs;
+use std::io::Read;
+use std::path::PathBuf;
+
+use console::style;
+use failure::Error;
+use ignore::overrides::OverrideBuilder;
+use ignore::types::TypesBuilder;
+use ignore::WalkBuilder;
+use log::info;
+
+use crate::utils::progress::{ProgressBar, ProgressStyle};
+
+pub struct ReleaseFileSearch {
+    path: PathBuf,
+    extensions: BTreeSet<String>,
+    ignores: BTreeSet<String>,
+    ignore_file: Option<String>,
+}
+
+#[derive(Eq, PartialEq, Hash)]
+pub struct ReleaseFileMatch {
+    pub base_path: PathBuf,
+    pub path: PathBuf,
+    pub contents: Vec<u8>,
+}
+
+impl ReleaseFileSearch {
+    pub fn new(path: PathBuf) -> Self {
+        ReleaseFileSearch {
+            path,
+            extensions: BTreeSet::new(),
+            ignore_file: None,
+            ignores: BTreeSet::new(),
+        }
+    }
+
+    pub fn extension<E>(&mut self, extension: E) -> &mut Self
+    where
+        E: Into<String>,
+    {
+        self.extensions.insert(extension.into());
+        self
+    }
+
+    pub fn extensions<E>(&mut self, extensions: E) -> &mut Self
+    where
+        E: IntoIterator,
+        E::Item: Into<String>,
+    {
+        for extension in extensions {
+            self.extensions.insert(extension.into());
+        }
+        self
+    }
+
+    pub fn ignore<I>(&mut self, ignore: I) -> &mut Self
+    where
+        I: Into<String>,
+    {
+        self.ignores.insert(ignore.into());
+        self
+    }
+
+    pub fn ignores<I>(&mut self, ignores: I) -> &mut Self
+    where
+        I: IntoIterator,
+        I::Item: Into<String>,
+    {
+        for ignore in ignores {
+            self.ignores.insert(ignore.into());
+        }
+        self
+    }
+
+    pub fn ignore_file<P>(&mut self, path: P) -> &mut Self
+    where
+        P: Into<String>,
+    {
+        let path = path.into();
+        if !path.is_empty() {
+            self.ignore_file = Some(path);
+        }
+        self
+    }
+
+    pub fn collect_file(path: PathBuf) -> Result<ReleaseFileMatch, Error> {
+        let mut f = fs::File::open(path.clone())?;
+        let mut contents = Vec::new();
+        f.read_to_end(&mut contents)?;
+        Ok(ReleaseFileMatch {
+            base_path: path.clone(),
+            path,
+            contents,
+        })
+    }
+
+    pub fn collect_files(&self) -> Result<Vec<ReleaseFileMatch>, Error> {
+        let progress_style = ProgressStyle::default_spinner().template(
+            "{spinner} Searching for release files...\
+        \n  found {prefix:.yellow} {msg:.dim}",
+        );
+
+        let progress = ProgressBar::new_spinner();
+        progress.enable_steady_tick(100);
+        progress.set_style(progress_style);
+
+        let mut collected = Vec::new();
+
+        let mut builder = WalkBuilder::new(&self.path);
+        builder.git_exclude(false).git_ignore(false).ignore(false);
+
+        if !&self.extensions.is_empty() {
+            let mut types_builder = TypesBuilder::new();
+            for ext in &self.extensions {
+                let ext_name = ext.replace('.', "__");
+                types_builder.add(&ext_name, &format!("*.{}", ext))?;
+            }
+            builder.types(types_builder.select("all").build()?);
+        }
+
+        if let Some(ignore_file) = &self.ignore_file {
+            // This could yield an optional partial error
+            // We ignore this error to match behavior of git
+            builder.add_ignore(ignore_file);
+        }
+
+        if !&self.ignores.is_empty() {
+            let mut override_builder = OverrideBuilder::new(&self.path);
+            for ignore in &self.ignores {
+                override_builder.add(&ignore)?;
+            }
+            builder.overrides(override_builder.build()?);
+        }
+
+        for result in builder.build() {
+            let file = result?;
+            if file.file_type().map_or(false, |t| t.is_dir()) {
+                continue;
+            }
+            progress.set_message(&format!("{}", file.path().display()));
+
+            info!(
+                "found: {} ({} bytes)",
+                file.path().display(),
+                file.metadata().unwrap().len()
+            );
+
+            let mut f = fs::File::open(file.path())?;
+            let mut contents = Vec::new();
+            f.read_to_end(&mut contents)?;
+
+            let file_match = ReleaseFileMatch {
+                base_path: self.path.clone(),
+                path: file.path().to_path_buf(),
+                contents,
+            };
+            collected.push(file_match);
+
+            progress.set_prefix(&collected.len().to_string());
+        }
+
+        progress.finish_and_clear();
+        println!(
+            "{} Found {} release {}",
+            style(">").dim(),
+            style(collected.len()).yellow(),
+            match collected.len() {
+                1 => "file",
+                _ => "files",
+            }
+        );
+
+        Ok(collected)
+    }
+}

--- a/src/utils/file_upload.rs
+++ b/src/utils/file_upload.rs
@@ -1,0 +1,349 @@
+//! Searches, processes and uploads release files.
+use std::collections::HashMap;
+use std::fmt;
+use std::io::BufWriter;
+use std::path::PathBuf;
+use std::str;
+use std::sync::Arc;
+
+use console::style;
+use failure::{bail, Error};
+use parking_lot::RwLock;
+use rayon::prelude::*;
+use rayon::ThreadPoolBuilder;
+use symbolic::common::ByteView;
+use symbolic::debuginfo::sourcebundle::{SourceBundleWriter, SourceFileInfo, SourceFileType};
+use url::Url;
+
+use crate::api::{Api, ChunkUploadCapability, ChunkUploadOptions, FileContents, ProgressBarMode};
+use crate::utils::chunks::{upload_chunks, Chunk, ASSEMBLE_POLL_INTERVAL};
+use crate::utils::fs::{get_sha1_checksums, TempFile};
+use crate::utils::progress::{ProgressBar, ProgressStyle};
+
+/// Fallback concurrency for release file uploads.
+static DEFAULT_CONCURRENCY: usize = 4;
+
+pub struct UploadContext<'a> {
+    pub org: &'a str,
+    pub project: Option<&'a str>,
+    pub release: &'a str,
+    pub dist: Option<&'a str>,
+    pub wait: bool,
+}
+
+#[derive(PartialEq, Debug, Copy, Clone)]
+pub enum LogLevel {
+    Warning,
+    Error,
+}
+
+impl fmt::Display for LogLevel {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match *self {
+            LogLevel::Warning => write!(f, "warning"),
+            LogLevel::Error => write!(f, "error"),
+        }
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct ReleaseFile {
+    pub url: String,
+    pub path: PathBuf,
+    pub contents: Vec<u8>,
+    pub ty: SourceFileType,
+    pub headers: Vec<(String, String)>,
+    pub messages: Vec<(LogLevel, String)>,
+}
+
+impl ReleaseFile {
+    pub fn log(&mut self, level: LogLevel, msg: String) {
+        self.messages.push((level, msg));
+    }
+
+    pub fn warn(&mut self, msg: String) {
+        self.log(LogLevel::Warning, msg);
+    }
+
+    pub fn error(&mut self, msg: String) {
+        self.log(LogLevel::Error, msg);
+    }
+}
+
+pub type ReleaseFiles = HashMap<String, ReleaseFile>;
+
+pub struct ReleaseFileUpload<'a> {
+    context: &'a UploadContext<'a>,
+    files: ReleaseFiles,
+}
+
+impl<'a> ReleaseFileUpload<'a> {
+    pub fn new(context: &'a UploadContext) -> Self {
+        ReleaseFileUpload {
+            context,
+            files: HashMap::new(),
+        }
+    }
+
+    pub fn files(&mut self, files: &ReleaseFiles) -> &mut Self {
+        for (k, v) in files {
+            self.files.insert(k.to_owned(), v.to_owned());
+        }
+        self
+    }
+
+    pub fn upload(&self) -> Result<(), Error> {
+        let api = Api::current();
+
+        let chunk_options = api.get_chunk_upload_options(self.context.org)?;
+        if let Some(ref chunk_options) = chunk_options {
+            if chunk_options.supports(ChunkUploadCapability::ReleaseFiles) {
+                return upload_files_chunked(self.context, &self.files, chunk_options);
+            }
+        }
+
+        // Do not permit uploads of more than 20k files if the server does not
+        // support artifact bundles.  This is a termporary downside protection to
+        // protect users from uploading more sources than we support.
+        if self.files.len() > 20_000 {
+            bail!(
+                "Too many sources: {} exceeds maximum allowed files per release",
+                &self.files.len()
+            );
+        }
+
+        let concurrency = chunk_options.map_or(DEFAULT_CONCURRENCY, |o| usize::from(o.concurrency));
+        upload_files_parallel(self.context, &self.files, concurrency)
+    }
+}
+
+fn upload_files_parallel(
+    context: &UploadContext,
+    files: &ReleaseFiles,
+    num_threads: usize,
+) -> Result<(), Error> {
+    let api = Api::current();
+
+    // get a list of release files first so we know the file IDs of
+    // files that already exist.
+    let release_files: HashMap<_, _> = api
+        .list_release_files(context.org, context.project, context.release)?
+        .into_iter()
+        .map(|artifact| ((artifact.dist, artifact.name), artifact.id))
+        .collect();
+
+    println!(
+        "{} Uploading source maps for release {}",
+        style(">").dim(),
+        style(context.release).cyan()
+    );
+
+    let progress_style = ProgressStyle::default_bar().template(&format!(
+        "{} Uploading {} source map{}...\
+     \n{{wide_bar}}  {{bytes}}/{{total_bytes}} ({{eta}})",
+        style(">").dim(),
+        style(files.len().to_string()).yellow(),
+        if files.len() == 1 { "" } else { "s" }
+    ));
+
+    let total_bytes = files.values().map(|file| file.contents.len() as u64).sum();
+    let files = files.iter().collect::<Vec<_>>();
+
+    let pb = Arc::new(ProgressBar::new(total_bytes));
+    pb.set_style(progress_style);
+
+    let pool = ThreadPoolBuilder::new().num_threads(num_threads).build()?;
+    let bytes = Arc::new(RwLock::new(vec![0u64; files.len()]));
+
+    pool.install(|| {
+        files
+            .into_par_iter()
+            .enumerate()
+            .map(|(index, (_, file))| -> Result<(), Error> {
+                let api = Api::current();
+                let mode = ProgressBarMode::Shared((
+                    pb.clone(),
+                    file.contents.len() as u64,
+                    index,
+                    bytes.clone(),
+                ));
+
+                if let Some(old_id) =
+                    release_files.get(&(context.dist.map(|x| x.into()), file.url.clone()))
+                {
+                    api.delete_release_file(
+                        context.org,
+                        context.project,
+                        &context.release,
+                        &old_id,
+                    )
+                    .ok();
+                }
+
+                api.upload_release_file(
+                    context.org,
+                    context.project,
+                    context.release,
+                    &FileContents::FromBytes(&file.contents),
+                    &file.url,
+                    context.dist,
+                    Some(file.headers.as_slice()),
+                    mode,
+                )?;
+
+                Ok(())
+            })
+            .collect::<Result<(), _>>()
+    })?;
+
+    pb.finish_and_clear();
+
+    Ok(())
+}
+
+fn upload_files_chunked(
+    context: &UploadContext,
+    files: &ReleaseFiles,
+    options: &ChunkUploadOptions,
+) -> Result<(), Error> {
+    let archive = build_artifact_bundle(context, files)?;
+
+    let progress_style =
+        ProgressStyle::default_spinner().template("{spinner} Optimizing bundle for upload...");
+
+    let progress = ProgressBar::new_spinner();
+    progress.enable_steady_tick(100);
+    progress.set_style(progress_style);
+
+    let view = ByteView::open(archive.path())?;
+    let (checksum, checksums) = get_sha1_checksums(&view, options.chunk_size)?;
+    let chunks = view
+        .chunks(options.chunk_size as usize)
+        .zip(checksums.iter())
+        .map(|(data, checksum)| Chunk((*checksum, data)))
+        .collect::<Vec<_>>();
+
+    progress.finish_and_clear();
+
+    let progress_style = ProgressStyle::default_bar().template(&format!(
+        "{} Uploading release files...\
+       \n{{wide_bar}}  {{bytes}}/{{total_bytes}} ({{eta}})",
+        style(">").dim(),
+    ));
+
+    upload_chunks(&chunks, options, progress_style)?;
+    println!("{} Uploaded release files to Sentry", style(">").dim(),);
+
+    let progress_style = ProgressStyle::default_spinner().template("{spinner} Processing files...");
+
+    let progress = ProgressBar::new_spinner();
+    progress.enable_steady_tick(100);
+    progress.set_style(progress_style);
+
+    let api = Api::current();
+    let response = loop {
+        let response =
+            api.assemble_artifacts(context.org, context.release, checksum, &checksums)?;
+
+        // Poll until there is a response, unless the user has specified to skip polling. In
+        // that case, we return the potentially partial response from the server. This might
+        // still contain a cached error.
+        if !context.wait || response.state.is_finished() {
+            break response;
+        }
+
+        std::thread::sleep(ASSEMBLE_POLL_INTERVAL);
+    };
+
+    if response.state.is_err() {
+        let message = match response.detail {
+            Some(ref detail) => detail,
+            None => "unknown error",
+        };
+
+        bail!("Failed to process uploaded files: {}", message);
+    }
+
+    progress.finish_and_clear();
+
+    if response.state.is_pending() {
+        println!("{} File upload complete", style(">").dim());
+    } else {
+        println!("{} File processing complete", style(">").dim());
+    }
+
+    Ok(())
+}
+
+fn build_artifact_bundle(context: &UploadContext, files: &ReleaseFiles) -> Result<TempFile, Error> {
+    let progress_style = ProgressStyle::default_bar().template(
+        "{prefix:.dim} Bundling files for upload... {msg:.dim}\
+       \n{wide_bar}  {pos}/{len}",
+    );
+
+    let progress = ProgressBar::new(files.len() as u64);
+    progress.set_style(progress_style);
+    progress.set_prefix(">");
+
+    let archive = TempFile::create()?;
+    let mut bundle = SourceBundleWriter::start(BufWriter::new(archive.open()?))?;
+
+    bundle.set_attribute("org".to_owned(), context.org.to_owned());
+    if let Some(project) = context.project {
+        bundle.set_attribute("project".to_owned(), project.to_owned());
+    }
+    bundle.set_attribute("release".to_owned(), context.release.to_owned());
+    if let Some(dist) = context.dist {
+        bundle.set_attribute("dist".to_owned(), dist.to_owned());
+    }
+
+    for file in files.values() {
+        progress.inc(1);
+        progress.set_message(&file.url);
+
+        let mut info = SourceFileInfo::new();
+        info.set_ty(file.ty);
+        info.set_url(file.url.clone());
+        for (k, v) in &file.headers {
+            info.add_header(k.clone(), v.clone());
+        }
+
+        let bundle_path = url_to_bundle_path(&file.url)?;
+        bundle.add_file(bundle_path, file.contents.as_slice(), info)?;
+    }
+
+    bundle.finish()?;
+
+    progress.finish_and_clear();
+    println!(
+        "{} Bundled {} {} for upload",
+        style(">").dim(),
+        style(files.len()).yellow(),
+        match files.len() {
+            1 => "file",
+            _ => "files",
+        }
+    );
+
+    Ok(archive)
+}
+
+fn url_to_bundle_path(url: &str) -> Result<String, Error> {
+    let base = Url::parse("http://~").unwrap();
+    let url = if url.starts_with("~/") {
+        base.join(&url[2..])?
+    } else {
+        base.join(url)?
+    };
+
+    let mut path = url.path();
+    if path.starts_with('/') {
+        path = &path[1..];
+    }
+
+    Ok(match url.host_str() {
+        Some("~") => format!("_/_/{}", path),
+        Some(host) => format!("{}/{}/{}", url.scheme(), host, path),
+        None => format!("{}/_/{}", url.scheme(), path),
+    })
+}

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -9,6 +9,8 @@ pub mod dif;
 pub mod dif_upload;
 pub mod enc;
 pub mod event;
+pub mod file_search;
+pub mod file_upload;
 pub mod formatting;
 pub mod fs;
 pub mod http;

--- a/src/utils/progress.rs
+++ b/src/utils/progress.rs
@@ -1,3 +1,4 @@
+use console::{style, Term};
 use std::env;
 use std::ops::Deref;
 use std::sync::Arc;
@@ -71,4 +72,14 @@ impl Deref for ProgressBar {
     fn deref(&self) -> &Self::Target {
         &self.inner
     }
+}
+
+pub fn make_progress_bar(len: u64) -> ProgressBar {
+    let pb = ProgressBar::new(len);
+    pb.set_draw_target(ProgressDrawTarget::to_term(Term::stdout(), None));
+    pb.set_style(ProgressStyle::default_bar().template(&format!(
+        "{} {{msg}}\n{{wide_bar}} {{pos}}/{{len}}",
+        style(">").cyan()
+    )));
+    pb
 }


### PR DESCRIPTION
Summary of the changes:
- introduce batch upload for release files, which recursively walks directories in order to find all matching files (mimics behavior of sourcemap upload, with all the `ignore`, `ignore_file`, `extensions` flags)
- decouple source map processing from the upload step
- decouple release files searching and release files uploading into two separate things
- reuse file searching, processing and and uploading across both commands (sourcemaps and regular release files)

Closes: https://github.com/getsentry/sentry-cli/issues/704