### PR TITLE
fix: fixes org not being parsed for subcommands

### DIFF
--- a/src/utils/args.rs
+++ b/src/utils/args.rs
@@ -112,6 +112,7 @@ impl<'a: 'b, 'b> ArgExt for clap::App<'a, 'b> {
                 .value_name("ORG")
                 .long("org")
                 .short("o")
+                .global(true)
                 .validator(validate_org)
                 .help("The organization slug"),
         )


### PR DESCRIPTION
Relates to Issue #723 

Following [the docs](https://docs.sentry.io/workflow/releases/?platform=javascript#create-release) for creating a new release was giving errors despite passing in the requested `org` command-line arg. I (think I) tracked it down to `new` not expecting the `organization` in its argument parsing despite searching for it on invocation.