### PR TITLE
fix: Do not error when offsetting too far on enumeration

### DIFF
--- a/src/api.rs
+++ b/src/api.rs
@@ -1168,7 +1168,7 @@ impl Api {
                 PathArg(org),
                 QueryArg(&cursor)
             ))?;
-            if resp.status() == 404 {
+            if resp.status() == 404 || (resp.status() == 400 && !cursor.is_empty()) {
                 if rv.is_empty() {
                     return Err(ApiErrorKind::ResourceNotFound.into());
                 } else {
@@ -1229,7 +1229,7 @@ impl Api {
                 PathArg(org),
                 QueryArg(&cursor)
             ))?;
-            if resp.status() == 404 {
+            if resp.status() == 404 || (resp.status() == 400 && !cursor.is_empty()) {
                 if rv.is_empty() {
                     return Err(ApiErrorKind::OrganizationNotFound.into());
                 } else {


### PR DESCRIPTION
Presumably this happens if someone has exactly a multiple of per-page files uploaded.