### PR TITLE
fix: Allow for release names with leading hyphen

### DIFF
--- a/src/utils/args.rs
+++ b/src/utils/args.rs
@@ -3,6 +3,7 @@
 use std::str::FromStr;
 
 use chrono::{DateTime, TimeZone, Utc};
+use clap::AppSettings;
 use failure::{bail, Error};
 use symbolic::common::DebugId;
 use uuid::Uuid;
@@ -143,7 +144,7 @@ impl<'a: 'b, 'b> ArgExt for clap::App<'a, 'b> {
     }
 
     fn version_arg(self, index: u64) -> clap::App<'a, 'b> {
-        self.arg(
+        self.setting(AppSettings::AllowLeadingHyphen).arg(
             clap::Arg::with_name("version")
                 .value_name("VERSION")
                 .required(true)


### PR DESCRIPTION
We should use https://docs.rs/clap/2.33.1/clap/struct.Arg.html#method.allow_hyphen_values but it's currently broken for positional arguments https://github.com/clap-rs/clap/issues/1437 https://github.com/clap-rs/clap/issues/1287
so we have to use https://docs.rs/clap/2.33.1/clap/enum.AppSettings.html#variant.AllowLeadingHyphen instead.

closes: https://github.com/getsentry/sentry-cli/issues/769
ref: https://github.com/getsentry/sentry-webpack-plugin/issues/197