### PR TITLE
feat: mv set-manual-commits into set-commits --auto

### DIFF
--- a/src/api.rs
+++ b/src/api.rs
@@ -798,7 +798,7 @@ impl Api {
         );
         let resp = self.get(&path)?;
         if resp.status() == 404 {
-            Ok(OptionalReleaseInfo::None {})
+            Ok(OptionalReleaseInfo::None(NoneReleaseInfo {}))
         } else {
             resp.convert()
         }
@@ -1852,24 +1852,32 @@ pub struct ReleaseInfo {
     pub url: Option<String>,
     #[serde(rename = "dateCreated")]
     pub date_created: DateTime<Utc>,
-    #[serde(rename = "dateReleased")]
+    #[serde(default, rename = "dateReleased")]
     pub date_released: Option<DateTime<Utc>>,
-    #[serde(rename = "lastEvent")]
+    #[serde(default, rename = "lastEvent")]
     pub last_event: Option<DateTime<Utc>>,
-    #[serde(rename = "newGroups")]
+    #[serde(default, rename = "newGroups")]
     pub new_groups: u64,
     #[serde(default)]
     pub projects: Vec<ProjectSlugAndName>,
-    #[serde(rename = "lastCommit", skip_serializing_if = "Option::is_none")]
+    #[serde(
+        default,
+        rename = "lastCommit",
+        skip_serializing_if = "Option::is_none"
+    )]
     pub last_commit: Option<LastCommit>,
 }
 
 #[derive(Debug, Deserialize)]
 #[serde(untagged)]
 pub enum OptionalReleaseInfo {
-    None {},
+    None(NoneReleaseInfo),
     Some(ReleaseInfo),
 }
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct NoneReleaseInfo {}
 
 #[derive(Debug, Deserialize)]
 pub struct LastCommit {

--- a/src/commands/releases.rs
+++ b/src/commands/releases.rs
@@ -519,7 +519,7 @@ fn execute_set_commits<'a>(
             .unwrap_or("20")
             .parse::<usize>()?;
 
-        if matches.is_present("local") {
+        if matches.is_present("auto") {
             println!("Could not determine any commits to be associated with a repo-based integration. Proceeding to find commits from local git tree.");
         }
         // Get the commit of the most recent release.

--- a/src/utils/vcs.rs
+++ b/src/utils/vcs.rs
@@ -206,7 +206,7 @@ pub fn get_repo_from_remote(repo: &str) -> String {
 }
 
 fn find_reference_url(repo: &str, repos: &[Repo]) -> Result<Option<String>, Error> {
-    let mut found_non_git = false;
+    let mut non_git = false;
     for configured_repo in repos {
         if configured_repo.name != repo {
             continue;
@@ -231,12 +231,12 @@ fn find_reference_url(repo: &str, repos: &[Repo]) -> Result<Option<String>, Erro
             }
             _ => {
                 debug!("  unknown repository {} skipped", configured_repo);
-                found_non_git = true;
+                non_git = true;
             }
         }
     }
 
-    if found_non_git {
+    if non_git {
         Ok(None)
     } else {
         bail!("Could not find matching repository for {}", repo);
@@ -486,7 +486,7 @@ pub fn get_commits_from_git<'a>(
         Err(_) => {
             // If there is no previous commit, return the default number of commits
             println!(
-                "Could not find previous commit. We will create a release with {} commits",
+                "Could not find the previous commit. Creating a release with {} commits.",
                 default_count
             );
             let mut result: Vec<Commit> = revwalk


### PR DESCRIPTION
## Objective
In this PR, we are moving the code in `set-manual-commits` into `set-commits`. When you run `set-commits --auto` if the user does not have a repo based integration, run the `set-manual-commits` code.
We have agreed to use `--local` optional flag to represent always using the local git tree to get the commits and to use `--initial-depth` as the optional flag for the number of commits for the initial release.