### PR TITLE
feat: Add pipeline env variable option and include it in UA string

### DIFF
--- a/src/api.rs
+++ b/src/api.rs
@@ -426,7 +426,7 @@ impl Api {
 
         let env = match self.config.get_pipeline_env() {
             Ok(env) => env,
-            Err(_) => String::new()
+            Err(_) => String::new(),
         };
 
         ApiRequest::create(handle, &method, &url, auth, env)
@@ -1413,7 +1413,7 @@ impl ApiRequest {
         method: &Method,
         url: &str,
         auth: Option<&Auth>,
-        pipeline_env: String
+        pipeline_env: String,
     ) -> ApiResult<Self> {
         debug!("request {} {}", method, url);
         debug!("pipeline: {}", pipeline_env);
@@ -1421,7 +1421,10 @@ impl ApiRequest {
         let mut headers = curl::easy::List::new();
         headers.append("Expect:").ok();
         headers
-            .append(&format!("User-Agent: sentry-cli/{} {}", VERSION, pipeline_env))
+            .append(&format!(
+                "User-Agent: sentry-cli/{} {}",
+                VERSION, pipeline_env
+            ))
             .ok();
 
         match method {

--- a/src/config.rs
+++ b/src/config.rs
@@ -306,15 +306,12 @@ impl Config {
     }
 
     /// Return the default pipeline env.
-    pub fn get_pipeline_env(&self) -> Result<String, Error> {
-        Ok(env::var("SENTRY_PIPELINE")
-            .ok()
-            .or_else(|| {
-                self.ini
-                    .get_from(Some("defaults"), "pipeline")
-                    .map(str::to_owned)
-            })
-            .unwrap_or_default())
+    pub fn get_pipeline_env(&self) -> Option<String> {
+        env::var("SENTRY_PIPELINE").ok().or_else(|| {
+            self.ini
+                .get_from(Some("defaults"), "pipeline")
+                .map(str::to_owned)
+        })
     }
 
     /// Returns the defaults for org and project.

--- a/src/config.rs
+++ b/src/config.rs
@@ -305,6 +305,18 @@ impl Config {
             .ok_or_else(|| err_msg("A project slug is required"))?)
     }
 
+    /// Return the default pipeline env.
+    pub fn get_pipeline_env(&self) -> Result<String, Error> {
+        Ok(env::var("SENTRY_PIPELINE")
+            .ok()
+            .or_else(|| {
+                self.ini
+                    .get_from(Some("defaults"), "pipeline")
+                    .map(str::to_owned)
+            }).unwrap_or_default()
+        )
+    }
+
     /// Returns the defaults for org and project.
     pub fn get_org_and_project_defaults(&self) -> (Option<String>, Option<String>) {
         (

--- a/src/config.rs
+++ b/src/config.rs
@@ -313,8 +313,8 @@ impl Config {
                 self.ini
                     .get_from(Some("defaults"), "pipeline")
                     .map(str::to_owned)
-            }).unwrap_or_default()
-        )
+            })
+            .unwrap_or_default())
     }
 
     /// Returns the defaults for org and project.


### PR DESCRIPTION
## Objective
We want to see how successful our pipelines are.

Our pipelines use `sentry-cli` to send release and commit information. We want to see how widely these pipelines are being used. So, we need to have some way of being able to distinguish when a release is created through a pipeline vs just via `sentry-cli`.

Currently, all `sentry-cli` requests are sent with a `sentry-cli` user agent. 

In this PR, we are allowing users to configure an environment variable for their pipeline that is then sent in through the user agent.

<img width="1055" alt="Screen Shot 2020-06-24 at 1 27 37 AM" src="https://user-images.githubusercontent.com/10491193/85522271-45558b00-b5ba-11ea-85bf-eb0f8f0d9a0d.png">
