### PR TITLE
feat: Upload formatted commit metadata from local git tree to Sentry for a release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -496,6 +496,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "difference"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "524cbf6897b527295dff137cec09ecf3a05f4fddffd7dfcd1585403449e74198"
+
+[[package]]
 name = "digest"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -557,6 +563,12 @@ name = "dotenv"
 version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77c90badedccf4105eca100756a0b1289e191f6fcbdadd3cee1d2f614f97da8f"
+
+[[package]]
+name = "dtoa"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4358a9e11b9a09cf52383b451b49a169e8d797b68aa02301ff586d70d9661ea3"
 
 [[package]]
 name = "either"
@@ -906,6 +918,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "insta"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8386e795fb3927131ea4cede203c529a333652eb6dc4ff29616b832b27e9b096"
+dependencies = [
+ "console",
+ "difference",
+ "lazy_static",
+ "pest",
+ "pest_derive",
+ "serde",
+ "serde_json",
+ "serde_yaml",
+]
+
+[[package]]
 name = "instant"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1005,6 +1033,12 @@ checksum = "f30344350a2a51da54c1d53be93fade8a237e545dbcc4bdbe635413f2117cab9"
 dependencies = [
  "safemem",
 ]
+
+[[package]]
+name = "linked-hash-map"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8dd5a6d5999d9907cda8ed67bbd137d3af8085216c2ac62de5be860bd41f304a"
 
 [[package]]
 name = "lock_api"
@@ -1673,6 +1707,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7fe5bd57d1d7414c6b5ed48563a2c855d995ff777729dcd91c369ec7fea395ae"
 
 [[package]]
+name = "remove_dir_all"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a83fa3702a688b9359eccba92d153ac33fd2e8462f9e0e3fdf155239ea7792e"
+dependencies = [
+ "winapi 0.3.8",
+]
+
+[[package]]
 name = "runas"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1871,6 +1914,7 @@ dependencies = [
  "if_chain 1.0.0",
  "ignore",
  "indicatif",
+ "insta",
  "itertools",
  "java-properties",
  "lazy_static",
@@ -1897,6 +1941,7 @@ dependencies = [
  "signal-hook",
  "sourcemap",
  "symbolic",
+ "tempfile",
  "unix-daemonize",
  "url 2.1.1",
  "username",
@@ -1950,6 +1995,18 @@ dependencies = [
  "itoa",
  "ryu",
  "serde",
+]
+
+[[package]]
+name = "serde_yaml"
+version = "0.8.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae3e2dd40a7cdc18ca80db804b7f461a39bb721160a85c9a1fa30134bf3c02a5"
+dependencies = [
+ "dtoa",
+ "linked-hash-map",
+ "serde",
+ "yaml-rust",
 ]
 
 [[package]]
@@ -2172,6 +2229,20 @@ dependencies = [
  "quote 1.0.3",
  "syn 1.0.17",
  "unicode-xid 0.2.0",
+]
+
+[[package]]
+name = "tempfile"
+version = "3.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a6e24d9338a0a5be79593e2fa15a648add6138caa803e2d5bc782c371732ca9"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "rand 0.7.3",
+ "redox_syscall",
+ "remove_dir_all",
+ "winapi 0.3.8",
 ]
 
 [[package]]
@@ -2438,6 +2509,15 @@ name = "xml-rs"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "541b12c998c5b56aa2b4e6f18f03664eef9a4fd0a246a55594efae6cc2d964b5"
+
+[[package]]
+name = "yaml-rust"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39f0c922f1a334134dc2f7a8b67dc5d25f0735263feec974345ff706bcf20b0d"
+dependencies = [
+ "linked-hash-map",
+]
 
 [[package]]
 name = "zip"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -80,3 +80,7 @@ crossbeam-channel = "0.4.2"
 [profile.release]
 opt-level = 3
 panic = "abort"
+
+[dev-dependencies]
+insta = {version= "0.16.0", features= ["redactions"]}
+tempfile = "3.1.0"

--- a/package.json
+++ b/package.json
@@ -52,6 +52,9 @@
   },
   "jest": {
     "collectCoverage": true,
-    "testEnvironment": "node"
+    "testEnvironment": "node",
+    "testPathIgnorePatterns": [
+      "src/utils"
+    ]
   }
 }

--- a/src/api.rs
+++ b/src/api.rs
@@ -798,7 +798,7 @@ impl Api {
         );
         let resp = self.get(&path)?;
         if resp.status() == 404 {
-            Ok(OptionalReleaseInfo::None {})
+            Ok(OptionalReleaseInfo::None(NoneReleaseInfo {}))
         } else {
             resp.convert()
         }
@@ -1852,24 +1852,32 @@ pub struct ReleaseInfo {
     pub url: Option<String>,
     #[serde(rename = "dateCreated")]
     pub date_created: DateTime<Utc>,
-    #[serde(rename = "dateReleased")]
+    #[serde(default, rename = "dateReleased")]
     pub date_released: Option<DateTime<Utc>>,
-    #[serde(rename = "lastEvent")]
+    #[serde(default, rename = "lastEvent")]
     pub last_event: Option<DateTime<Utc>>,
-    #[serde(rename = "newGroups")]
+    #[serde(default, rename = "newGroups")]
     pub new_groups: u64,
     #[serde(default)]
     pub projects: Vec<ProjectSlugAndName>,
-    #[serde(rename = "lastCommit", skip_serializing_if = "Option::is_none")]
+    #[serde(
+        default,
+        rename = "lastCommit",
+        skip_serializing_if = "Option::is_none"
+    )]
     pub last_commit: Option<LastCommit>,
 }
 
 #[derive(Debug, Deserialize)]
 #[serde(untagged)]
 pub enum OptionalReleaseInfo {
-    None {},
+    None(NoneReleaseInfo),
     Some(ReleaseInfo),
 }
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct NoneReleaseInfo {}
 
 #[derive(Debug, Deserialize)]
 pub struct LastCommit {

--- a/src/api.rs
+++ b/src/api.rs
@@ -17,7 +17,7 @@ use std::sync::Arc;
 
 use backoff::backoff::Backoff;
 use brotli2::write::BrotliEncoder;
-use chrono::{DateTime, Duration, Utc};
+use chrono::{DateTime, Duration, FixedOffset, Utc};
 use failure::{Backtrace, Context, Error, Fail, ResultExt};
 use flate2::write::GzEncoder;
 use if_chain::if_chain;
@@ -781,6 +781,26 @@ impl Api {
             let path = format!("/organizations/{}/releases/", PathArg(org));
             self.get(&path)?
                 .convert_rnf::<Vec<ReleaseInfo>>(ApiErrorKind::OrganizationNotFound)
+        }
+    }
+
+    // Finds the most recent release with commits and returns it.
+    // If it does not exist `None` will be returned.
+    pub fn get_previous_release_with_commits(
+        &self,
+        org: &str,
+        version: &str,
+    ) -> ApiResult<OptionalReleaseInfo> {
+        let path = format!(
+            "/organizations/{}/releases/{}/previous-with-commits/",
+            PathArg(org),
+            PathArg(version)
+        );
+        let resp = self.get(&path)?;
+        if resp.status() == 404 {
+            Ok(OptionalReleaseInfo::None {})
+        } else {
+            resp.convert()
         }
     }
 
@@ -1821,6 +1841,8 @@ pub struct UpdatedRelease {
     pub date_released: Option<DateTime<Utc>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub refs: Option<Vec<Ref>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub commits: Option<Vec<GitCommit>>,
 }
 
 /// Provides all release information from already existing releases
@@ -1838,6 +1860,20 @@ pub struct ReleaseInfo {
     pub new_groups: u64,
     #[serde(default)]
     pub projects: Vec<ProjectSlugAndName>,
+    #[serde(rename = "lastCommit", skip_serializing_if = "Option::is_none")]
+    pub last_commit: Option<LastCommit>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(untagged)]
+pub enum OptionalReleaseInfo {
+    None {},
+    Some(ReleaseInfo),
+}
+
+#[derive(Debug, Deserialize)]
+pub struct LastCommit {
+    pub id: String,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -2238,4 +2274,23 @@ pub struct AssembleArtifactsResponse {
     pub state: ChunkedFileState,
     pub missing_chunks: Vec<Digest>,
     pub detail: Option<String>,
+}
+
+#[derive(Debug, Serialize, Clone)]
+pub struct PatchSet {
+    pub path: String,
+    #[serde(rename = "type")]
+    pub ty: String,
+}
+
+#[derive(Debug, Serialize, Clone)]
+pub struct GitCommit {
+    pub patch_set: Vec<PatchSet>,
+    pub repository: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub author_name: Option<String>,
+    pub author_email: Option<String>,
+    pub timestamp: DateTime<FixedOffset>,
+    pub message: Option<String>,
+    pub id: String,
 }

--- a/src/commands/releases.rs
+++ b/src/commands/releases.rs
@@ -7,6 +7,7 @@ use std::sync::Arc;
 use chrono::{DateTime, Duration, Utc};
 use clap::{App, AppSettings, Arg, ArgMatches};
 use failure::{bail, err_msg, Error};
+
 use ignore::overrides::OverrideBuilder;
 use ignore::types::TypesBuilder;
 use ignore::WalkBuilder;
@@ -15,16 +16,20 @@ use lazy_static::lazy_static;
 use log::{debug, info, warn};
 use regex::Regex;
 
-use crate::api::{Api, Deploy, FileContents, NewRelease, ProgressBarMode, UpdatedRelease};
+use crate::api::{
+    Api, Deploy, FileContents, NewRelease, OptionalReleaseInfo, ProgressBarMode, UpdatedRelease,
+};
 use crate::config::Config;
 use crate::utils::args::{
-    get_timestamp, validate_project, validate_seconds, validate_timestamp, ArgExt,
+    get_timestamp, validate_int, validate_project, validate_timestamp, ArgExt,
 };
 use crate::utils::formatting::{HumanDuration, Table};
 use crate::utils::releases::detect_release_name;
 use crate::utils::sourcemaps::{SourceMapProcessor, UploadContext};
 use crate::utils::system::QuietExit;
-use crate::utils::vcs::{find_heads, CommitSpec};
+use crate::utils::vcs::{
+    find_heads, generate_patch_set, get_commits_from_git, get_repo_from_remote, CommitSpec,
+};
 
 struct ReleaseContext<'a> {
     pub api: Arc<Api>,
@@ -118,6 +123,16 @@ pub fn make_app<'a, 'b: 'a>(app: App<'a, 'b>) -> App<'a, 'b> {
                         the current commit of the repository at the given PATH is \
                         assumed.  To override the revision `@REV` can be appended \
                         which will force the revision to a certain value.")))
+        .subcommand(App::new("set-manual-commits")
+            .about("Set commits of a release from local git.")
+            .version_arg(1)
+            .arg(Arg::with_name("commits-count")
+                .long("commits-count")
+                .short("c")
+                .value_name("COMMITS COUNT")
+                .validator(validate_int)
+                .help("Set the number of commits of the initial release. The default is 20.")))
+
         .subcommand(App::new("delete")
             .about("Delete a release.")
             .version_arg(1))
@@ -333,7 +348,7 @@ pub fn make_app<'a, 'b: 'a>(app: App<'a, 'b>) -> App<'a, 'b> {
                      .long("time")
                      .short("t")
                      .value_name("SECONDS")
-                     .validator(validate_seconds)
+                     .validator(validate_int)
                      .help("Optional deployment duration in seconds.{n}\
                             This can be specified alternatively to `--started` and `--finished`.")))
             .subcommand(App::new("list")
@@ -503,6 +518,65 @@ fn execute_set_commits<'a>(
     } else {
         println!("No commits found. Leaving release alone.");
     }
+
+    Ok(())
+}
+
+fn execute_set_manual_commits<'a>(
+    ctx: &ReleaseContext<'_>,
+    matches: &ArgMatches<'a>,
+) -> Result<(), Error> {
+    let version = matches.value_of("version").unwrap();
+    let org = ctx.get_org()?;
+    let default_count = matches
+        .value_of("commits-count")
+        .unwrap_or("20")
+        .parse::<usize>()?;
+
+    // make sure the release exists if projects are given
+    if let Ok(projects) = ctx.get_projects(matches) {
+        ctx.api.new_release(
+            &org,
+            &NewRelease {
+                version: version.into(),
+                projects,
+                ..Default::default()
+            },
+        )?;
+    }
+
+    // Get the commit of the most recent release.
+    let prev_commit = match ctx.api.get_previous_release_with_commits(org, version)? {
+        OptionalReleaseInfo::Some(prev) => prev.last_commit.map(|c| c.id).unwrap_or_default(),
+        OptionalReleaseInfo::None {} => String::new(),
+    };
+
+    // Find and connect to local git.
+    let repo = git2::Repository::open_from_env()?;
+
+    // Parse the git url.
+    let remote = Config::current().get_cached_vcs_remote();
+    let parsed = get_repo_from_remote(&remote);
+    // Fetch all the commits upto the `prev_commit` or return the default (20).
+    // Will return a tuple of Vec<GitCommits> and the `prev_commit` if it exists in the git tree.
+    let (commit_log, prev_commit) = get_commits_from_git(&repo, &prev_commit, default_count)?;
+
+    // Calculate the diff for each commit in the Vec<GitCommit>.
+    let commits = generate_patch_set(&repo, commit_log, prev_commit, &parsed)?;
+
+    let chunk_size = 50;
+    for chunk in commits.chunks(chunk_size) {
+        ctx.api.update_release(
+            ctx.get_org()?,
+            version,
+            &UpdatedRelease {
+                commits: Some(chunk.to_owned()),
+                ..Default::default()
+            },
+        )?;
+    }
+
+    println!("Success! Set commits for release {}.", version);
 
     Ok(())
 }
@@ -1041,6 +1115,9 @@ pub fn execute<'a>(matches: &ArgMatches<'a>) -> Result<(), Error> {
     }
     if let Some(sub_matches) = matches.subcommand_matches("set-commits") {
         return execute_set_commits(&ctx, sub_matches);
+    }
+    if let Some(sub_matches) = matches.subcommand_matches("set-manual-commits") {
+        return execute_set_manual_commits(&ctx, sub_matches);
     }
     if let Some(sub_matches) = matches.subcommand_matches("delete") {
         return execute_delete(&ctx, sub_matches);

--- a/src/commands/releases.rs
+++ b/src/commands/releases.rs
@@ -17,7 +17,8 @@ use log::{debug, info, warn};
 use regex::Regex;
 
 use crate::api::{
-    Api, Deploy, FileContents, NewRelease, OptionalReleaseInfo, ProgressBarMode, UpdatedRelease,
+    Api, Deploy, FileContents, NewRelease, NoneReleaseInfo, OptionalReleaseInfo, ProgressBarMode,
+    UpdatedRelease,
 };
 use crate::config::Config;
 use crate::utils::args::{
@@ -99,11 +100,24 @@ pub fn make_app<'a, 'b: 'a>(app: App<'a, 'b>) -> App<'a, 'b> {
                  .long("clear")
                  .help("Clear all current commits from the release."))
             .arg(Arg::with_name("auto")
-                 .long("auto")
-                 .help("Enable completely automated commit management.{n}\
+                .long("auto")
+                .help("Enable completely automated commit management.{n}\
                         This requires that the command is run from within a git repository.  \
                         sentry-cli will then automatically find remotely configured \
                         repositories and discover commits."))
+            .arg(Arg::with_name("local")
+                .conflicts_with_all(&["auto", "clear", "commits", ])
+                .long("local")
+                .help("Set commits of a release from local git.{n}\
+                        This requires that the command is run from within a git repository.  \
+                        sentry-cli will then automatically find remotely configured \
+                        repositories and discover commits."))
+            .arg(Arg::with_name("initial-depth")
+                .conflicts_with("auto")
+                .long("initial-depth")
+                .value_name("INITIAL DEPTH")
+                .validator(validate_int)
+                .help("Set the number of commits of the initial release. The default is 20."))
             .arg(Arg::with_name("commits")
                  .long("commit")
                  .short("c")
@@ -123,16 +137,6 @@ pub fn make_app<'a, 'b: 'a>(app: App<'a, 'b>) -> App<'a, 'b> {
                         the current commit of the repository at the given PATH is \
                         assumed.  To override the revision `@REV` can be appended \
                         which will force the revision to a certain value.")))
-        .subcommand(App::new("set-manual-commits")
-            .about("Set commits of a release from local git.")
-            .version_arg(1)
-            .arg(Arg::with_name("commits-count")
-                .long("commits-count")
-                .short("c")
-                .value_name("COMMITS COUNT")
-                .validator(validate_int)
-                .help("Set the number of commits of the initial release. The default is 20.")))
-
         .subcommand(App::new("delete")
             .about("Delete a release.")
             .version_arg(1))
@@ -428,6 +432,7 @@ fn execute_set_commits<'a>(
     matches: &ArgMatches<'a>,
 ) -> Result<(), Error> {
     let version = matches.value_of("version").unwrap();
+
     let org = ctx.get_org()?;
     let repos = ctx.api.list_organization_repos(org)?;
     let mut commit_specs = vec![];
@@ -443,21 +448,14 @@ fn execute_set_commits<'a>(
     let heads = if matches.is_present("auto") {
         let commits = find_heads(None, &repos, Some(config.get_cached_vcs_remote()))?;
         if commits.is_empty() {
-            let config = Config::current();
-
-            bail!(
-                "Could not determine any commits to be associated automatically.\n\
-                 Please provide commits explicitly using --commit | -c.\n\
-                 \n\
-                 HINT: Did you add the repo to your organization?\n\
-                 Configure it at {}/settings/{}/repos/",
-                config.get_base_url()?,
-                org
-            );
+            None
+        } else {
+            Some(commits)
         }
-        Some(commits)
     } else if matches.is_present("clear") {
         Some(vec![])
+    } else if matches.is_present("local") {
+        None
     } else {
         if let Some(commits) = matches.values_of("commits") {
             for spec in commits {
@@ -516,67 +514,51 @@ fn execute_set_commits<'a>(
         }
         ctx.api.set_release_refs(&org, version, heads)?;
     } else {
-        println!("No commits found. Leaving release alone.");
+        let default_count = matches
+            .value_of("initial-depth")
+            .unwrap_or("20")
+            .parse::<usize>()?;
+
+        if matches.is_present("auto") {
+            println!("Could not determine any commits to be associated with a repo-based integration. Proceeding to find commits from local git tree.");
+        }
+        // Get the commit of the most recent release.
+        let prev_commit = match ctx.api.get_previous_release_with_commits(org, version)? {
+            OptionalReleaseInfo::Some(prev) => prev.last_commit.map(|c| c.id).unwrap_or_default(),
+            OptionalReleaseInfo::None(NoneReleaseInfo {}) => String::new(),
+        };
+
+        // Find and connect to local git.
+        let repo = git2::Repository::open_from_env()?;
+
+        // Parse the git url.
+        let remote = config.get_cached_vcs_remote();
+        let parsed = get_repo_from_remote(&remote);
+        // Fetch all the commits upto the `prev_commit` or return the default (20).
+        // Will return a tuple of Vec<GitCommits> and the `prev_commit` if it exists in the git tree.
+        let (commit_log, prev_commit) = get_commits_from_git(&repo, &prev_commit, default_count)?;
+
+        // Calculate the diff for each commit in the Vec<GitCommit>.
+        let commits = generate_patch_set(&repo, commit_log, prev_commit, &parsed)?;
+
+        if commits.is_empty() {
+            bail!("No commits found. Leaving release alone.");
+        }
+
+        let chunk_size = 50;
+        for chunk in commits.chunks(chunk_size) {
+            ctx.api.update_release(
+                ctx.get_org()?,
+                version,
+                &UpdatedRelease {
+                    commits: Some(chunk.to_owned()),
+                    ..Default::default()
+                },
+            )?;
+        }
+
+        println!("Success! Set commits for release {}.", version);
     }
-
-    Ok(())
-}
-
-fn execute_set_manual_commits<'a>(
-    ctx: &ReleaseContext<'_>,
-    matches: &ArgMatches<'a>,
-) -> Result<(), Error> {
-    let version = matches.value_of("version").unwrap();
-    let org = ctx.get_org()?;
-    let default_count = matches
-        .value_of("commits-count")
-        .unwrap_or("20")
-        .parse::<usize>()?;
-
-    // make sure the release exists if projects are given
-    if let Ok(projects) = ctx.get_projects(matches) {
-        ctx.api.new_release(
-            &org,
-            &NewRelease {
-                version: version.into(),
-                projects,
-                ..Default::default()
-            },
-        )?;
-    }
-
-    // Get the commit of the most recent release.
-    let prev_commit = match ctx.api.get_previous_release_with_commits(org, version)? {
-        OptionalReleaseInfo::Some(prev) => prev.last_commit.map(|c| c.id).unwrap_or_default(),
-        OptionalReleaseInfo::None {} => String::new(),
-    };
-
-    // Find and connect to local git.
-    let repo = git2::Repository::open_from_env()?;
-
-    // Parse the git url.
-    let remote = Config::current().get_cached_vcs_remote();
-    let parsed = get_repo_from_remote(&remote);
-    // Fetch all the commits upto the `prev_commit` or return the default (20).
-    // Will return a tuple of Vec<GitCommits> and the `prev_commit` if it exists in the git tree.
-    let (commit_log, prev_commit) = get_commits_from_git(&repo, &prev_commit, default_count)?;
-
-    // Calculate the diff for each commit in the Vec<GitCommit>.
-    let commits = generate_patch_set(&repo, commit_log, prev_commit, &parsed)?;
-
-    let chunk_size = 50;
-    for chunk in commits.chunks(chunk_size) {
-        ctx.api.update_release(
-            ctx.get_org()?,
-            version,
-            &UpdatedRelease {
-                commits: Some(chunk.to_owned()),
-                ..Default::default()
-            },
-        )?;
-    }
-
-    println!("Success! Set commits for release {}.", version);
 
     Ok(())
 }
@@ -1115,9 +1097,6 @@ pub fn execute<'a>(matches: &ArgMatches<'a>) -> Result<(), Error> {
     }
     if let Some(sub_matches) = matches.subcommand_matches("set-commits") {
         return execute_set_commits(&ctx, sub_matches);
-    }
-    if let Some(sub_matches) = matches.subcommand_matches("set-manual-commits") {
-        return execute_set_manual_commits(&ctx, sub_matches);
     }
     if let Some(sub_matches) = matches.subcommand_matches("delete") {
         return execute_delete(&ctx, sub_matches);

--- a/src/utils/args.rs
+++ b/src/utils/args.rs
@@ -9,7 +9,7 @@ use uuid::Uuid;
 
 fn validate_org(v: String) -> Result<(), String> {
     if v.contains('/') || v == "." || v == ".." || v.contains(' ') {
-        Err("invalid value for organization. Use the URL slug and not the name!".to_string())
+        Err("Invalid value for organization. Use the URL slug and not the name!".to_string())
     } else {
         Ok(())
     }
@@ -24,7 +24,7 @@ pub fn validate_project(v: String) -> Result<(), String> {
         || v.contains('\t')
         || v.contains('\r')
     {
-        Err("invalid value for project. Use the URL slug and not the name!".to_string())
+        Err("Invalid value for project. Use the URL slug and not the name!".to_string())
     } else {
         Ok(())
     }
@@ -51,11 +51,11 @@ fn validate_version(v: String) -> Result<(), String> {
     }
 }
 
-pub fn validate_seconds(v: String) -> Result<(), String> {
+pub fn validate_int(v: String) -> Result<(), String> {
     if v.parse::<i64>().is_ok() {
         Ok(())
     } else {
-        Err("Invalid value (seconds as integer required)".to_string())
+        Err("Invalid number, integer required.".to_string())
     }
 }
 
@@ -69,7 +69,7 @@ pub fn validate_timestamp(v: String) -> Result<(), String> {
 
 pub fn validate_uuid(s: String) -> Result<(), String> {
     if Uuid::parse_str(&s).is_err() {
-        Err("Invalid UUID".to_string())
+        Err("Invalid UUID.".to_string())
     } else {
         Ok(())
     }
@@ -77,7 +77,7 @@ pub fn validate_uuid(s: String) -> Result<(), String> {
 
 pub fn validate_id(s: String) -> Result<(), String> {
     if DebugId::from_str(&s).is_err() {
-        Err("Invalid ID".to_string())
+        Err("Invalid ID.".to_string())
     } else {
         Ok(())
     }
@@ -91,7 +91,7 @@ pub fn get_timestamp(value: &str) -> Result<DateTime<Utc>, Error> {
     } else if let Ok(dt) = DateTime::parse_from_rfc2822(value) {
         Ok(dt.with_timezone(&Utc))
     } else {
-        bail!("not in valid format. Unix timestamp or ISO 8601 date expected.");
+        bail!("Not in valid format. Unix timestamp or ISO 8601 date expected.");
     }
 }
 

--- a/src/utils/snapshots/sentry_cli__utils__vcs__generate_patch_default_twenty.snap
+++ b/src/utils/snapshots/sentry_cli__utils__vcs__generate_patch_default_twenty.snap
@@ -1,0 +1,184 @@
+---
+source: src/utils/vcs.rs
+expression: patch_set
+---
+- patch_set:
+    - path: foo2.js
+      type: M
+  repository: example/test-repo
+  author_name: John Doe
+  author_email: john.doe@example.com
+  timestamp: "[timestamp]"
+  message: "\"final commit\"\n"
+  id: "[id]"
+- patch_set:
+    - path: foo19.js
+      type: A
+  repository: example/test-repo
+  author_name: John Doe
+  author_email: john.doe@example.com
+  timestamp: "[timestamp]"
+  message: "\"another commit\"\n"
+  id: "[id]"
+- patch_set:
+    - path: foo18.js
+      type: A
+  repository: example/test-repo
+  author_name: John Doe
+  author_email: john.doe@example.com
+  timestamp: "[timestamp]"
+  message: "\"another commit\"\n"
+  id: "[id]"
+- patch_set:
+    - path: foo17.js
+      type: A
+  repository: example/test-repo
+  author_name: John Doe
+  author_email: john.doe@example.com
+  timestamp: "[timestamp]"
+  message: "\"another commit\"\n"
+  id: "[id]"
+- patch_set:
+    - path: foo16.js
+      type: A
+  repository: example/test-repo
+  author_name: John Doe
+  author_email: john.doe@example.com
+  timestamp: "[timestamp]"
+  message: "\"another commit\"\n"
+  id: "[id]"
+- patch_set:
+    - path: foo15.js
+      type: A
+  repository: example/test-repo
+  author_name: John Doe
+  author_email: john.doe@example.com
+  timestamp: "[timestamp]"
+  message: "\"another commit\"\n"
+  id: "[id]"
+- patch_set:
+    - path: foo14.js
+      type: A
+  repository: example/test-repo
+  author_name: John Doe
+  author_email: john.doe@example.com
+  timestamp: "[timestamp]"
+  message: "\"another commit\"\n"
+  id: "[id]"
+- patch_set:
+    - path: foo13.js
+      type: A
+  repository: example/test-repo
+  author_name: John Doe
+  author_email: john.doe@example.com
+  timestamp: "[timestamp]"
+  message: "\"another commit\"\n"
+  id: "[id]"
+- patch_set:
+    - path: foo12.js
+      type: A
+  repository: example/test-repo
+  author_name: John Doe
+  author_email: john.doe@example.com
+  timestamp: "[timestamp]"
+  message: "\"another commit\"\n"
+  id: "[id]"
+- patch_set:
+    - path: foo11.js
+      type: A
+  repository: example/test-repo
+  author_name: John Doe
+  author_email: john.doe@example.com
+  timestamp: "[timestamp]"
+  message: "\"another commit\"\n"
+  id: "[id]"
+- patch_set:
+    - path: foo10.js
+      type: A
+  repository: example/test-repo
+  author_name: John Doe
+  author_email: john.doe@example.com
+  timestamp: "[timestamp]"
+  message: "\"another commit\"\n"
+  id: "[id]"
+- patch_set:
+    - path: foo9.js
+      type: A
+  repository: example/test-repo
+  author_name: John Doe
+  author_email: john.doe@example.com
+  timestamp: "[timestamp]"
+  message: "\"another commit\"\n"
+  id: "[id]"
+- patch_set:
+    - path: foo8.js
+      type: A
+  repository: example/test-repo
+  author_name: John Doe
+  author_email: john.doe@example.com
+  timestamp: "[timestamp]"
+  message: "\"another commit\"\n"
+  id: "[id]"
+- patch_set:
+    - path: foo7.js
+      type: A
+  repository: example/test-repo
+  author_name: John Doe
+  author_email: john.doe@example.com
+  timestamp: "[timestamp]"
+  message: "\"another commit\"\n"
+  id: "[id]"
+- patch_set:
+    - path: foo6.js
+      type: A
+  repository: example/test-repo
+  author_name: John Doe
+  author_email: john.doe@example.com
+  timestamp: "[timestamp]"
+  message: "\"another commit\"\n"
+  id: "[id]"
+- patch_set:
+    - path: foo5.js
+      type: A
+  repository: example/test-repo
+  author_name: John Doe
+  author_email: john.doe@example.com
+  timestamp: "[timestamp]"
+  message: "\"another commit\"\n"
+  id: "[id]"
+- patch_set:
+    - path: foo4.js
+      type: A
+  repository: example/test-repo
+  author_name: John Doe
+  author_email: john.doe@example.com
+  timestamp: "[timestamp]"
+  message: "\"another commit\"\n"
+  id: "[id]"
+- patch_set:
+    - path: foo3.js
+      type: A
+  repository: example/test-repo
+  author_name: John Doe
+  author_email: john.doe@example.com
+  timestamp: "[timestamp]"
+  message: "\"another commit\"\n"
+  id: "[id]"
+- patch_set:
+    - path: foo2.js
+      type: A
+  repository: example/test-repo
+  author_name: John Doe
+  author_email: john.doe@example.com
+  timestamp: "[timestamp]"
+  message: "\"another commit\"\n"
+  id: "[id]"
+- patch_set:
+    - path: foo1.js
+      type: A
+  repository: example/test-repo
+  author_name: John Doe
+  author_email: john.doe@example.com
+  timestamp: "[timestamp]"
+  message: "\"another commit\"\n"
+  id: "[id]"

--- a/src/utils/snapshots/sentry_cli__utils__vcs__generate_patch_set_base.snap
+++ b/src/utils/snapshots/sentry_cli__utils__vcs__generate_patch_set_base.snap
@@ -1,0 +1,31 @@
+---
+source: src/utils/vcs.rs
+expression: patch_set
+---
+- patch_set:
+    - path: foo2.js
+      type: M
+  repository: example/test-repo
+  author_name: John Doe
+  author_email: john.doe@example.com
+  timestamp: "[timestamp]"
+  message: "\"third commit\"\n"
+  id: "[id]"
+- patch_set:
+    - path: foo2.js
+      type: A
+  repository: example/test-repo
+  author_name: John Doe
+  author_email: john.doe@example.com
+  timestamp: "[timestamp]"
+  message: "\"second commit\"\n"
+  id: "[id]"
+- patch_set:
+    - path: foo.js
+      type: A
+  repository: example/test-repo
+  author_name: John Doe
+  author_email: john.doe@example.com
+  timestamp: "[timestamp]"
+  message: "\"initial commit\"\n"
+  id: "[id]"

--- a/src/utils/snapshots/sentry_cli__utils__vcs__generate_patch_set_previous_commit.snap
+++ b/src/utils/snapshots/sentry_cli__utils__vcs__generate_patch_set_previous_commit.snap
@@ -1,0 +1,22 @@
+---
+source: src/utils/vcs.rs
+expression: patch_set
+---
+- patch_set:
+    - path: foo2.js
+      type: M
+  repository: example/test-repo
+  author_name: John Doe
+  author_email: john.doe@example.com
+  timestamp: "[timestamp]"
+  message: "\"fifth commit\"\n"
+  id: "[id]"
+- patch_set:
+    - path: foo4.js
+      type: A
+  repository: example/test-repo
+  author_name: John Doe
+  author_email: john.doe@example.com
+  timestamp: "[timestamp]"
+  message: "\"fourth commit\"\n"
+  id: "[id]"

--- a/src/utils/snapshots/sentry_cli__utils__vcs__get_commits_from_git.snap
+++ b/src/utils/snapshots/sentry_cli__utils__vcs__get_commits_from_git.snap
@@ -1,0 +1,20 @@
+---
+source: src/utils/vcs.rs
+expression: "commits.0.iter().map(|c|\n                         {\n                             (c.author().name().unwrap().to_owned(),\n                              c.author().email().unwrap().to_owned(),\n                              c.summary())\n                         }).collect::<Vec<_>>()"
+---
+[
+    (
+        "John Doe",
+        "john.doe@example.com",
+        Some(
+            "\"second commit\"",
+        ),
+    ),
+    (
+        "John Doe",
+        "john.doe@example.com",
+        Some(
+            "\"initial commit\"",
+        ),
+    ),
+]

--- a/src/utils/vcs.rs
+++ b/src/utils/vcs.rs
@@ -1,13 +1,15 @@
 use std::fmt;
 use std::path::PathBuf;
 
+use chrono::{DateTime, FixedOffset, TimeZone};
 use failure::{bail, format_err, Error};
+use git2::{Commit, Repository, Time};
 use if_chain::if_chain;
 use lazy_static::lazy_static;
 use log::{debug, info};
 use regex::Regex;
 
-use crate::api::{Ref, Repo};
+use crate::api::{GitCommit, PatchSet, Ref, Repo};
 
 #[derive(Copy, Clone)]
 pub enum GitReference<'a> {
@@ -196,6 +198,11 @@ impl VcsUrl {
 
 fn is_matching_url(a: &str, b: &str) -> bool {
     VcsUrl::parse(a) == VcsUrl::parse(b)
+}
+
+pub fn get_repo_from_remote(repo: &str) -> String {
+    let obj = VcsUrl::parse(repo);
+    obj.id
 }
 
 fn find_reference_url(repo: &str, repos: &[Repo]) -> Result<String, Error> {
@@ -427,8 +434,128 @@ pub fn find_heads(
     Ok(rv)
 }
 
+// Get commits from git history upto previous commit.
+// Returns a tuple of Vec<GitCommits> and the `prev_commit` if it exists in the git tree.
+pub fn get_commits_from_git<'a>(
+    repo: &'a Repository,
+    prev_commit: &str,
+    default_count: usize,
+) -> Result<(Vec<Commit<'a>>, Option<Commit<'a>>), Error> {
+    let mut revwalk = repo.revwalk()?;
+    revwalk.push_head()?;
+
+    let commit_filter = move |id: Result<git2::Oid, git2::Error>| {
+        let id = id.ok()?;
+
+        let commit = repo.find_commit(id).ok()?;
+
+        Some(commit)
+    };
+
+    match git2::Oid::from_str(prev_commit) {
+        Ok(prev) => {
+            let mut found = false;
+            let mut result: Vec<Commit> = revwalk
+                .take_while(|id| match id {
+                    Ok(id) => {
+                        if found {
+                            return false;
+                        }
+                        if prev == *id {
+                            found = true;
+                        }
+                        true
+                    }
+                    _ => true,
+                })
+                .filter_map(commit_filter)
+                .collect();
+            // If there is a previous commit but cannot find it in git history, throw an error.
+            if !found {
+                return Err(format_err!(
+                    "Couldn’t not find the SHA of the previous release in the git history. Increase your git clone depth.",
+                ));
+            }
+            let prev = result.pop();
+            Ok((result, prev))
+        }
+        Err(_) => {
+            // If there is no previous commit, return the default number of commits
+            let mut result: Vec<Commit> = revwalk
+                .take(default_count + 1)
+                .filter_map(commit_filter)
+                .collect();
+
+            if result.len() == default_count + 1 {
+                let prev = result.pop();
+                Ok((result, prev))
+            } else {
+                Ok((result, None))
+            }
+        }
+    }
+}
+
+pub fn generate_patch_set(
+    repo: &Repository,
+    commits: Vec<Commit>,
+    previous: Option<Commit>,
+    repository: &str,
+) -> Result<Vec<GitCommit>, Error> {
+    let mut result = vec![];
+    for (index, commit) in commits.iter().enumerate() {
+        let mut git_commit = GitCommit {
+            id: commit.id().to_string(),
+            author_name: commit.author().name().map(|s| s.to_owned()),
+            author_email: commit.author().email().map(|s| s.to_owned()),
+            message: commit.message().map(|s| s.to_owned()),
+            repository: repository.to_string(),
+            timestamp: get_commit_time(commit.author().when()),
+            patch_set: vec![],
+        };
+
+        let old_tree = if commits.len() > index + 1 {
+            Some(commits[index + 1].tree()?)
+        } else {
+            previous.as_ref().map(|c| c.tree()).transpose()?
+        };
+
+        let new_tree = Some(commit.tree()?);
+        let diff = repo.diff_tree_to_tree(old_tree.as_ref(), new_tree.as_ref(), None)?;
+
+        diff.print(git2::DiffFormat::NameStatus, |_, _, l| {
+            let line = std::str::from_utf8(l.content()).unwrap();
+            let mut parsed = line.trim_end().splitn(2, '\t');
+            let patch_set = PatchSet {
+                ty: parsed.next().unwrap().to_owned(),
+                path: parsed.next().unwrap().to_owned(),
+            };
+            git_commit.patch_set.push(patch_set);
+
+            // Returning false from the callback will terminate the iteration and return an error from this function.
+            true
+        })?;
+
+        result.push(git_commit)
+    }
+
+    Ok(result)
+}
+
+pub fn get_commit_time(time: Time) -> DateTime<FixedOffset> {
+    FixedOffset::east(time.offset_minutes() * 60).timestamp(time.seconds(), 0)
+}
+
 #[cfg(test)]
-use crate::api::RepoProvider;
+use {
+    crate::api::RepoProvider,
+    insta::{assert_debug_snapshot, assert_yaml_snapshot},
+    std::fs::File,
+    std::io::Write,
+    std::path::Path,
+    std::process::Command,
+    tempfile::tempdir,
+};
 
 #[test]
 fn test_find_matching_rev_with_lightweight_tag() {
@@ -667,4 +794,204 @@ fn test_url_normalization() {
         "git+https://git@github.com/kamilogorek/picklerick.git",
         "https://github.com/kamilogorek/picklerick"
     ));
+}
+
+#[cfg(test)]
+fn test_initialize(dir: &Path) {
+    let mut initialize = Command::new("git")
+        .arg("init")
+        .current_dir(dir)
+        .spawn()
+        .expect("Failed to execute `git init`.");
+
+    initialize.wait().expect("Failed to wait on git init.");
+}
+
+#[cfg(test)]
+fn git_commit_test(dir: &Path, file_path: &str, content: &[u8], commit_message: &str) {
+    let path = dir.join(file_path);
+    let mut file = File::create(path).expect("Failed to execute.");
+    file.write_all(content).expect("Failed to execute.");
+
+    let mut add = Command::new("git")
+        .args(&["add", "."])
+        .current_dir(dir)
+        .spawn()
+        .expect("Failed to execute `git add .`");
+
+    add.wait().expect("Failed to wait on git add.");
+
+    let mut commit = Command::new("git")
+        .args(&[
+            "commit",
+            "-m",
+            commit_message,
+            "--author",
+            "John Doe <john.doe@example.com>",
+        ])
+        .current_dir(dir)
+        .spawn()
+        .expect("Failed to execute `git commit -m {message}`.");
+
+    commit.wait().expect("Failed to wait on git commit.");
+}
+
+#[test]
+fn test_get_commits_from_git() {
+    let dir = tempdir().expect("Failed to generate temp dir.");
+    test_initialize(dir.path());
+    git_commit_test(
+        dir.path(),
+        "foo.js",
+        b"console.log(\"Hello, world!\");",
+        "\"initial commit\"",
+    );
+
+    git_commit_test(
+        dir.path(),
+        "foo2.js",
+        b"console.log(\"Hello, world! Part 2\");",
+        "\"second commit\"",
+    );
+
+    let repo = git2::Repository::open(dir.path()).expect("Failed");
+    let commits = get_commits_from_git(&repo, "", 20).expect("Failed");
+
+    assert_debug_snapshot!(commits
+        .0
+        .iter()
+        .map(|c| {
+            (
+                c.author().name().unwrap().to_owned(),
+                c.author().email().unwrap().to_owned(),
+                c.summary(),
+            )
+        })
+        .collect::<Vec<_>>());
+}
+
+#[test]
+fn test_generate_patch_set_base() {
+    let dir = tempdir().expect("Failed to generate temp dir.");
+    test_initialize(dir.path());
+    git_commit_test(
+        dir.path(),
+        "foo.js",
+        b"console.log(\"Hello, world!\");",
+        "\"initial commit\"",
+    );
+
+    git_commit_test(
+        dir.path(),
+        "foo2.js",
+        b"console.log(\"Hello, world! Part 2\");",
+        "\"second commit\"",
+    );
+
+    git_commit_test(
+        dir.path(),
+        "foo2.js",
+        b"console.log(\"Hello, world! Part 3\");",
+        "\"third commit\"",
+    );
+
+    let repo = git2::Repository::open(dir.path()).expect("Failed");
+    let commits = get_commits_from_git(&repo, "", 20).expect("Failed");
+    println!("Commits: {}", commits.0.len());
+    let patch_set =
+        generate_patch_set(&repo, commits.0, commits.1, "example/test-repo").expect("Failed");
+
+    assert_yaml_snapshot!(patch_set, {
+        ".*.id" => "[id]",
+        ".*.timestamp" => "[timestamp]"
+    });
+}
+
+#[test]
+fn test_generate_patch_set_previous_commit() {
+    let dir = tempdir().expect("Failed to generate temp dir.");
+    test_initialize(dir.path());
+    let repo = git2::Repository::open(dir.path()).expect("Failed");
+    git_commit_test(
+        dir.path(),
+        "foo.js",
+        b"console.log(\"Hello, world!\");",
+        "\"initial commit\"",
+    );
+
+    git_commit_test(
+        dir.path(),
+        "foo2.js",
+        b"console.log(\"Hello, world! Part 2\");",
+        "\"second commit\"",
+    );
+
+    git_commit_test(
+        dir.path(),
+        "foo2.js",
+        b"console.log(\"Hello, world! Part 3\");",
+        "\"third commit\"",
+    );
+    let head = repo.revparse_single("HEAD").expect("Failed");
+    println!("HEAD: {:?}", head.id());
+
+    git_commit_test(
+        dir.path(),
+        "foo4.js",
+        b"console.log(\"Hello, world! Part 4\");",
+        "\"fourth commit\"",
+    );
+
+    git_commit_test(
+        dir.path(),
+        "foo2.js",
+        b"console.log(\"Hello, world! Part 5\");",
+        "\"fifth commit\"",
+    );
+
+    let commits = get_commits_from_git(&repo, &head.id().to_string(), 20).expect("Failed");
+    let patch_set =
+        generate_patch_set(&repo, commits.0, commits.1, "example/test-repo").expect("Failed");
+
+    assert_yaml_snapshot!(patch_set, {
+        ".*.id" => "[id]",
+        ".*.timestamp" => "[timestamp]"
+    });
+}
+
+#[test]
+fn test_generate_patch_default_twenty() {
+    let dir = tempdir().expect("Failed to generate temp dir.");
+    test_initialize(dir.path());
+    let repo = git2::Repository::open(dir.path()).expect("Failed");
+    git_commit_test(
+        dir.path(),
+        "foo.js",
+        b"console.log(\"Hello, world!\");",
+        "\"initial commit\"",
+    );
+    for n in 0..20 {
+        let file = format!("foo{}.js", n);
+        git_commit_test(
+            dir.path(),
+            &file,
+            b"console.log(\"Hello, world! Part 2\");",
+            "\"another commit\"",
+        );
+    }
+    git_commit_test(
+        dir.path(),
+        "foo2.js",
+        b"console.log(\"Hello, world!\");",
+        "\"final commit\"",
+    );
+
+    let commits = get_commits_from_git(&repo, "", 20).expect("Failed");
+    let patch_set =
+        generate_patch_set(&repo, commits.0, commits.1, "example/test-repo").expect("Failed");
+
+    assert_yaml_snapshot!(patch_set, {
+        ".*.id" => "[id]",
+        ".*.timestamp" => "[timestamp]"
+    });
 }

--- a/src/utils/vcs.rs
+++ b/src/utils/vcs.rs
@@ -205,8 +205,8 @@ pub fn get_repo_from_remote(repo: &str) -> String {
     obj.id
 }
 
-fn find_reference_url(repo: &str, repos: &[Repo]) -> Result<String, Error> {
-    let mut found_non_git = false;
+fn find_reference_url(repo: &str, repos: &[Repo]) -> Result<Option<String>, Error> {
+    let mut non_git = false;
     for configured_repo in repos {
         if configured_repo.name != repo {
             continue;
@@ -226,18 +226,18 @@ fn find_reference_url(repo: &str, repos: &[Repo]) -> Result<String, Error> {
             | "integrations:vsts" => {
                 if let Some(ref url) = configured_repo.url {
                     debug!("  Got reference URL for repo {}: {}", repo, url);
-                    return Ok(url.clone());
+                    return Ok(Some(url.clone()));
                 }
             }
             _ => {
                 debug!("  unknown repository {} skipped", configured_repo);
-                found_non_git = true;
+                non_git = true;
             }
         }
     }
 
-    if found_non_git {
-        bail!("For non git repositories explicit revisions are required");
+    if non_git {
+        Ok(None)
     } else {
         bail!("Could not find matching repository for {}", repo);
     }
@@ -265,34 +265,38 @@ fn find_matching_rev(
         (git2::Repository::open_from_env()?, !disable_discovery)
     };
 
-    let reference_url = find_reference_url(&spec.repo, repos)?;
-    debug!("  Looking for reference URL {}", &reference_url);
+    match find_reference_url(&spec.repo, repos)? {
+        None => Ok(None),
+        Some(reference_url) => {
+            debug!("  Looking for reference URL {}", &reference_url);
 
-    // direct reference in root repository found.  If we are in discovery
-    // mode we want to also check for matching URLs.
-    if_chain! {
-        if let Ok(remote) = repo.find_remote(&remote_name.unwrap_or_else(|| "origin".to_string()));
-        if let Some(url) = remote.url();
-        then {
-            if !discovery || is_matching_url(url, &reference_url) {
-                debug!("  found match: {} == {}, {:?}", url, &reference_url, r);
-                let head = repo.revparse_single(r)?;
-                if let Some(tag) = head.as_tag(){
-                    if let Ok(tag_commit) = tag.target() {
-                        return Ok(Some(log_match!(tag_commit.id().to_string())));
+            // direct reference in root repository found.  If we are in discovery
+            // mode we want to also check for matching URLs.
+            if_chain! {
+                if let Ok(remote) = repo.find_remote(&remote_name.unwrap_or_else(|| "origin".to_string()));
+                if let Some(url) = remote.url();
+                then {
+                    if !discovery || is_matching_url(url, &reference_url) {
+                        debug!("  found match: {} == {}, {:?}", url, &reference_url, r);
+                        let head = repo.revparse_single(r)?;
+                        if let Some(tag) = head.as_tag(){
+                            if let Ok(tag_commit) = tag.target() {
+                                return Ok(Some(log_match!(tag_commit.id().to_string())));
+                            }
+                        }
+                        return Ok(Some(log_match!(head.id().to_string())));
+                    } else {
+                        debug!("  not a match: {} != {}", url, &reference_url);
                     }
                 }
-                return Ok(Some(log_match!(head.id().to_string())));
-            } else {
-                debug!("  not a match: {} != {}", url, &reference_url);
             }
+            if let Ok(submodule_match) = find_matching_submodule(r, reference_url, repo) {
+                return Ok(submodule_match);
+            }
+            info!("  -> no matching revision found");
+            Ok(None)
         }
     }
-    if let Ok(submodule_match) = find_matching_submodule(r, reference_url, repo) {
-        return Ok(submodule_match);
-    }
-    info!("  -> no matching revision found");
-    Ok(None)
 }
 
 fn find_matching_submodule(
@@ -481,6 +485,10 @@ pub fn get_commits_from_git<'a>(
         }
         Err(_) => {
             // If there is no previous commit, return the default number of commits
+            println!(
+                "Could not find the previous commit. Creating a release with {} commits.",
+                default_count
+            );
             let mut result: Vec<Commit> = revwalk
                 .take(default_count + 1)
                 .filter_map(commit_filter)


### PR DESCRIPTION
## Objective
We want to enable users to send formatted commit metadata  through sentry-cli, even if they do not have a repo-based integration.

Currently, if you don’t have a repo based integration, you need to write your own script to send us commits for a release.

A lot of our customers write their own script for git. So, with this project, we’re hoping to reduce the amount of work a user needs to do to send us commits.