### PR TITLE
fix: Silence the git output in tests

### DIFF
--- a/src/utils/vcs.rs
+++ b/src/utils/vcs.rs
@@ -825,7 +825,7 @@ fn test_url_normalization() {
 #[cfg(test)]
 fn test_initialize(dir: &Path) {
     let mut initialize = Command::new("git")
-        .arg("init")
+        .args(&["init", "--quiet"])
         .current_dir(dir)
         .spawn()
         .expect("Failed to execute `git init`.");
@@ -854,6 +854,7 @@ fn git_commit_test(dir: &Path, file_path: &str, content: &[u8], commit_message: 
             commit_message,
             "--author",
             "John Doe <john.doe@example.com>",
+            "--quiet",
         ])
         .current_dir(dir)
         .spawn()


### PR DESCRIPTION
## Objective
We want to silence the output of the setup for the snapshot tests for `set-commits --local`.

_Before_
![image (2)](https://user-images.githubusercontent.com/10491193/86158045-14df8680-babd-11ea-9eb0-bac519f7f817.png)

_After
<img width="895" alt="Screen Shot 2020-06-30 at 10 33 20 AM" src="https://user-images.githubusercontent.com/10491193/86158084-232da280-babd-11ea-9b2d-43d49a7eb911.png">
_