### PR TITLE
fix: binaryPath resolution on macos

### DIFF
--- a/js/helper.js
+++ b/js/helper.js
@@ -12,7 +12,7 @@ const childProcess = require('child_process');
 let binaryPath = path.resolve(
   __dirname,
 
-  os.platform() === 'win32' ? '..\\sentry-cli.exe' : '../sentry-cli'
+  os.platform() === 'win32' ? '..\\sentry-cli.exe' : '../bin/sentry-cli'
 );
 /**
  * Overrides the default binary path with a mock value, useful for testing.


### PR DESCRIPTION
The entry module for `@sentry/cli` is located at `./bin/sentry-cli`, 
yet the `binaryPath` variable resolves to `./sentry-cli` accidentally.