### PR TITLE
fix: Default to sending local commits if no repos linked

### DIFF
--- a/src/commands/releases.rs
+++ b/src/commands/releases.rs
@@ -470,14 +470,9 @@ fn execute_set_commits<'a>(
     let mut commit_specs = vec![];
     let config = Config::current();
 
-    if repos.is_empty() {
-        bail!(
-            "No repositories are configured in Sentry for \
-             your organization."
-        );
-    }
-
-    let heads = if matches.is_present("auto") {
+    let heads = if repos.is_empty() {
+        None
+    } else if matches.is_present("auto") {
         let commits = find_heads(None, &repos, Some(config.get_cached_vcs_remote()))?;
         if commits.is_empty() {
             None

--- a/src/config.rs
+++ b/src/config.rs
@@ -417,9 +417,9 @@ impl Config {
 fn find_global_config_file() -> Result<PathBuf, Error> {
     dirs::home_dir()
         .ok_or_else(|| err_msg("Could not find home dir"))
-        .and_then(|mut path| {
+        .map(|mut path| {
             path.push(CONFIG_RC_FILE_NAME);
-            Ok(path)
+            path
         })
 }
 

--- a/src/utils/system.rs
+++ b/src/utils/system.rs
@@ -12,7 +12,7 @@ use crate::config::Config;
 #[cfg(not(windows))]
 pub fn run_or_interrupt<F>(f: F)
 where
-    F: FnOnce() -> () + Send + 'static,
+    F: FnOnce() + Send + 'static,
 {
     let (tx, rx) = crossbeam_channel::bounded(100);
     let signals =


### PR DESCRIPTION
Refer to https://github.com/getsentry/sentry-cli/issues/789

## Objective
When an org has no integrations setup and runs `sentry-cli releases set-commits --auto`, it currently bails. The expected behaviour is to create a new repo (with Unknown Provider) in Sentry and upload the local git commit metadata.