### PR TITLE
fix: Dont limit commits count for release updates

### DIFF
--- a/src/commands/releases.rs
+++ b/src/commands/releases.rs
@@ -572,17 +572,14 @@ fn execute_set_commits<'a>(
             bail!("No commits found. Leaving release alone.");
         }
 
-        let chunk_size = 50;
-        for chunk in commits.chunks(chunk_size) {
-            ctx.api.update_release(
-                ctx.get_org()?,
-                version,
-                &UpdatedRelease {
-                    commits: Some(chunk.to_owned()),
-                    ..Default::default()
-                },
-            )?;
-        }
+        ctx.api.update_release(
+            ctx.get_org()?,
+            version,
+            &UpdatedRelease {
+                commits: Some(commits),
+                ..Default::default()
+            },
+        )?;
 
         println!("Success! Set commits for release {}.", version);
     }


### PR DESCRIPTION
Fixes https://github.com/getsentry/sentry-cli/issues/806

If anything, it should be done in the Sentry, not the CLI.