### PR TITLE
Added possibility to support other arch than x86/x64

### DIFF
--- a/scripts/install.js
+++ b/scripts/install.js
@@ -37,7 +37,7 @@ function shouldRenderProgressBar() {
 
 function getDownloadUrl(platform, arch) {
   const releasesUrl = `${CDN_URL}/${pkgInfo.version}/sentry-cli`;
-  const archString = arch == "x64" ? 'x86_64' : arch == "x86" ? 'i686' : arch;
+  const archString = arch === "x64" ? 'x86_64' : arch === "x86" ? 'i686' : arch;
   switch (platform) {
     case 'darwin':
       return `${releasesUrl}-Darwin-x86_64`;

--- a/scripts/install.js
+++ b/scripts/install.js
@@ -37,7 +37,17 @@ function shouldRenderProgressBar() {
 
 function getDownloadUrl(platform, arch) {
   const releasesUrl = `${CDN_URL}/${pkgInfo.version}/sentry-cli`;
-  const archString = arch === "x64" ? 'x86_64' : arch === "x86" ? 'i686' : arch;
+  let archString = '';
+  switch (arch) {
+    case 'x64':
+      archString = 'x86_64';
+      break;
+    case 'x86':
+      archString = 'i686';
+      break;
+    default:
+      archString = arch;
+  }
   switch (platform) {
     case 'darwin':
       return `${releasesUrl}-Darwin-x86_64`;

--- a/scripts/install.js
+++ b/scripts/install.js
@@ -37,7 +37,7 @@ function shouldRenderProgressBar() {
 
 function getDownloadUrl(platform, arch) {
   const releasesUrl = `${CDN_URL}/${pkgInfo.version}/sentry-cli`;
-  const archString = arch.indexOf('64') > -1 ? 'x86_64' : 'i686';
+  const archString = arch == "x64" ? 'x86_64' : arch == "x86" ? 'i686' : arch;
   switch (platform) {
     case 'darwin':
       return `${releasesUrl}-Darwin-x86_64`;


### PR DESCRIPTION
This PR adds the possibility to download other architecture builds than x86_64 or i686.

os.arch returns the following possible values: 'arm', 'arm64', 'ia32', 'mips', 'mipsel', 'ppc', 'ppc64', 's390', 's390x', 'x32', and 'x64'. [https://nodejs.org/api/os.html#os_os_arch](Source)

With the current implementation, it is not possible to have it work with any other architecture, even when changing the CDN_URL value via env. variables as it always defaults to i686.