### PR TITLE
Upgrade symbolic to 7.5.0 to fix compilation errors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2264,9 +2264,9 @@ checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
 
 [[package]]
 name = "symbolic"
-version = "7.4.0"
+version = "7.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c8c91194bc844d4517afc8dfc97a735c205e98500d2a814a6250271ef56de0f"
+checksum = "80c1372a324a0765d0193d79eed3a76689023c5639ab5753f81ebcc05a246b98"
 dependencies = [
  "symbolic-common",
  "symbolic-debuginfo",
@@ -2274,9 +2274,9 @@ dependencies = [
 
 [[package]]
 name = "symbolic-common"
-version = "7.4.0"
+version = "7.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebdc6030725c03c26dd3a56a19962767c4f2d9a45f1bc67247db6650ef17c71e"
+checksum = "c97c98b6026c932123a976d0cd35f59256424507e3dec9d032f30828765f1bf2"
 dependencies = [
  "debugid",
  "failure",
@@ -2288,9 +2288,9 @@ dependencies = [
 
 [[package]]
 name = "symbolic-debuginfo"
-version = "7.4.0"
+version = "7.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10b44ab8250413b085c28f39fe894ba020aef8000cc56fe3878750dcb15228c5"
+checksum = "da05d4245f95dc3b263f76bb5ac6d2eb41caa4df90d9223f8a9e74398da758cb"
 dependencies = [
  "dmsort",
  "failure",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,7 +49,7 @@ serde = { version = "1.0.114", features = ["derive"] }
 serde_json = "1.0.56"
 sha1 = { version = "0.6.0", features = ["serde"] }
 sourcemap = { version = "5.0.0", features = ["ram_bundle"] }
-symbolic = { version = "7.4.0", features = ["debuginfo-serde"] }
+symbolic = { version = "7.5.0", features = ["debuginfo-serde"] }
 url = "2.1.1"
 username = "0.2.0"
 uuid = { version = "0.8.1", features = ["v4", "serde"] }


### PR DESCRIPTION
This fixes a compilation error on the old version of symbolic on stable and nightly compilers.

Before:

```
   Compiling symbolic-debuginfo v7.4.0
error[E0495]: cannot infer an appropriate lifetime for lifetime parameter `'d` due to conflicting requirements
   --> /home/svenstaro/.cargo/registry/src/github.com-1ecc6299db9ec823/symbolic-debuginfo-7.4.0/src/object.rs:348:23
    |
348 |         Box::new(self.symbols())
    |                       ^^^^^^^
    |
note: first, the lifetime cannot outlive the anonymous lifetime #1 defined on the method body at 347:5...
   --> /home/svenstaro/.cargo/registry/src/github.com-1ecc6299db9ec823/symbolic-debuginfo-7.4.0/src/object.rs:347:5
    |
347 |     fn symbols(&self) -> DynIterator<'_, Symbol<'_>> {
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
note: ...so that the types are compatible
   --> /home/svenstaro/.cargo/registry/src/github.com-1ecc6299db9ec823/symbolic-debuginfo-7.4.0/src/object.rs:348:9
    |
348 |         Box::new(self.symbols())
    |         ^^^^^^^^^^^^^^^^^^^^^^^^
    = note: expected `base::Symbol<'_>`
               found `base::Symbol<'_>`
note: but, the lifetime must be valid for the lifetime `'d` as defined on the impl at 311:6...
   --> /home/svenstaro/.cargo/registry/src/github.com-1ecc6299db9ec823/symbolic-debuginfo-7.4.0/src/object.rs:311:6
    |
311 | impl<'d> ObjectLike for Object<'d> {
    |      ^^
note: ...so that the types are compatible
   --> /home/svenstaro/.cargo/registry/src/github.com-1ecc6299db9ec823/symbolic-debuginfo-7.4.0/src/object.rs:348:23
    |
348 |         Box::new(self.symbols())
    |                       ^^^^^^^
    = note: expected `&object::Object<'_>`
               found `&object::Object<'d>`

error[E0495]: cannot infer an appropriate lifetime for lifetime parameter `'d` due to conflicting requirements
   --> /home/svenstaro/.cargo/registry/src/github.com-1ecc6299db9ec823/symbolic-debuginfo-7.4.0/src/pdb.rs:294:23
    |
294 |         Box::new(self.symbols())
    |                       ^^^^^^^
    |
note: first, the lifetime cannot outlive the anonymous lifetime #1 defined on the method body at 293:5...
   --> /home/svenstaro/.cargo/registry/src/github.com-1ecc6299db9ec823/symbolic-debuginfo-7.4.0/src/pdb.rs:293:5
    |
293 |     fn symbols(&self) -> DynIterator<'_, Symbol<'_>> {
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
note: ...so that the types are compatible
   --> /home/svenstaro/.cargo/registry/src/github.com-1ecc6299db9ec823/symbolic-debuginfo-7.4.0/src/pdb.rs:294:9
    |
294 |         Box::new(self.symbols())
    |         ^^^^^^^^^^^^^^^^^^^^^^^^
    = note: expected `base::Symbol<'_>`
               found `base::Symbol<'_>`
note: but, the lifetime must be valid for the lifetime `'d` as defined on the impl at 261:6...
   --> /home/svenstaro/.cargo/registry/src/github.com-1ecc6299db9ec823/symbolic-debuginfo-7.4.0/src/pdb.rs:261:6
    |
261 | impl<'d> ObjectLike for PdbObject<'d> {
    |      ^^
note: ...so that the types are compatible
   --> /home/svenstaro/.cargo/registry/src/github.com-1ecc6299db9ec823/symbolic-debuginfo-7.4.0/src/pdb.rs:294:23
    |
294 |         Box::new(self.symbols())
    |                       ^^^^^^^
    = note: expected `&pdb::PdbObject<'_>`
               found `&pdb::PdbObject<'d>`

error: aborting due to 2 previous errors

For more information about this error, try `rustc --explain E0495`.
error: could not compile `symbolic-debuginfo`.

To learn more, run the command again with --verbose.
```

After: compiles/tests fine.