### PR TITLE
Fixed OS arch detection for IA32

### DIFF
--- a/scripts/install.js
+++ b/scripts/install.js
@@ -43,6 +43,7 @@ function getDownloadUrl(platform, arch) {
       archString = 'x86_64';
       break;
     case 'x86':
+    case 'ia32':
       archString = 'i686';
       break;
     default:


### PR DESCRIPTION
Fixes OS detection for 32 bits `ia32` (https://github.com/getsentry/sentry-cli/pull/811#discussion_r487866892)