### PR TITLE
feat(js): allows the user to specify multiple projects for a release

### DIFF
--- a/js/helper.js
+++ b/js/helper.js
@@ -181,7 +181,7 @@ function execute(args, live, silent, configFile, config = {}) {
 }
 
 function getProjectFlagsFromOptions({ projects = [] } = {}) {
-  return projects.reduce((flags, project) => flags.concat('-p', project), [])
+  return projects.reduce((flags, project) => flags.concat('-p', project), []);
 }
 
 module.exports = {

--- a/js/helper.js
+++ b/js/helper.js
@@ -180,10 +180,22 @@ function execute(args, live, silent, configFile, config = {}) {
   });
 }
 
+function getProjectFlagsFromOptions(options) {
+  if (options && options.projects) {
+    return options.projects.reduce((projectFlags, project) => {
+      projectFlags.push('-p');
+      projectFlags.push(project);
+      return projectFlags;
+    }, []);
+  }
+  return [];
+}
+
 module.exports = {
   mockBinaryPath,
   serializeOptions,
   prepareCommand,
   getPath,
   execute,
+  getProjectFlagsFromOptions,
 };

--- a/js/helper.js
+++ b/js/helper.js
@@ -180,15 +180,8 @@ function execute(args, live, silent, configFile, config = {}) {
   });
 }
 
-function getProjectFlagsFromOptions(options) {
-  if (options && options.projects) {
-    return options.projects.reduce((projectFlags, project) => {
-      projectFlags.push('-p');
-      projectFlags.push(project);
-      return projectFlags;
-    }, []);
-  }
-  return [];
+function getProjectFlagsFromOptions({ projects = [] } = {}) {
+  return projects.reduce((flags, project) => flags.concat('-p', project), [])
 }
 
 module.exports = {

--- a/js/releases/__tests__/index.test.js
+++ b/js/releases/__tests__/index.test.js
@@ -3,9 +3,44 @@
 const SentryCli = require('../../');
 
 describe('SentryCli releases', () => {
+  afterEach(() => {
+    jest.resetModules();
+  });
   test('call sentry-cli releases propose-version', () => {
     expect.assertions(1);
     const cli = new SentryCli();
     return cli.releases.proposeVersion().then(version => expect(version).toBeTruthy());
+  });
+
+  describe('with mock', () => {
+    let cli, mockExecute;
+    beforeEach(() => {
+      mockExecute = jest.fn(async () => {});
+      jest.doMock('../../helper', () => ({
+        execute: mockExecute,
+      }));
+      const SentryCli = require('../../');
+      cli = new SentryCli();
+    });
+    test('new without projects', async () => {
+      await cli.releases.new('my-version');
+      expect(mockExecute).toHaveBeenCalledWith(
+        ['releases', 'new', 'my-version'],
+        null,
+        false,
+        undefined,
+        { silent: false }
+      );
+    });
+    test('new with projects', async () => {
+      await cli.releases.new('my-version', { projects: ['proj-a', 'proj-b'] });
+      expect(mockExecute).toHaveBeenCalledWith(
+        ['releases', 'new', 'my-version', '-p', 'proj-a', '-p', 'proj-b'],
+        null,
+        false,
+        undefined,
+        { silent: false }
+      );
+    });
   });
 });

--- a/js/releases/__tests__/index.test.js
+++ b/js/releases/__tests__/index.test.js
@@ -1,6 +1,6 @@
 /* eslint-env jest */
 
-const SentryCli = require('../../');
+const SentryCli = require('../..');
 
 describe('SentryCli releases', () => {
   afterEach(() => {
@@ -13,34 +13,84 @@ describe('SentryCli releases', () => {
   });
 
   describe('with mock', () => {
-    let cli, mockExecute;
+    let cli;
+    let mockExecute;
     beforeEach(() => {
       mockExecute = jest.fn(async () => {});
       jest.doMock('../../helper', () => ({
+        ...jest.requireActual('../../helper'),
         execute: mockExecute,
       }));
-      const SentryCli = require('../../');
-      cli = new SentryCli();
+      // eslint-disable-next-line global-require
+      const SentryCliLocal = require('../..');
+      cli = new SentryCliLocal();
     });
-    test('new without projects', async () => {
-      await cli.releases.new('my-version');
-      expect(mockExecute).toHaveBeenCalledWith(
-        ['releases', 'new', 'my-version'],
-        null,
-        false,
-        undefined,
-        { silent: false }
-      );
+    describe('new', () => {
+      test('without projects', async () => {
+        await cli.releases.new('my-version');
+        expect(mockExecute).toHaveBeenCalledWith(
+          ['releases', 'new', 'my-version'],
+          null,
+          false,
+          undefined,
+          { silent: false }
+        );
+      });
+      test('with projects', async () => {
+        await cli.releases.new('my-version', { projects: ['proj-a', 'proj-b'] });
+        expect(mockExecute).toHaveBeenCalledWith(
+          ['releases', 'new', 'my-version', '-p', 'proj-a', '-p', 'proj-b'],
+          null,
+          false,
+          undefined,
+          { silent: false }
+        );
+      });
     });
-    test('new with projects', async () => {
-      await cli.releases.new('my-version', { projects: ['proj-a', 'proj-b'] });
-      expect(mockExecute).toHaveBeenCalledWith(
-        ['releases', 'new', 'my-version', '-p', 'proj-a', '-p', 'proj-b'],
-        null,
-        false,
-        undefined,
-        { silent: false }
-      );
+    describe('uploadSourceMaps', () => {
+      test('without projects', async () => {
+        await cli.releases.uploadSourceMaps('my-version', { include: ['path'] });
+        expect(mockExecute).toHaveBeenCalledWith(
+          [
+            'releases',
+            'files',
+            'my-version',
+            'upload-sourcemaps',
+            'path',
+            '--ignore',
+            'node_modules',
+          ],
+          true,
+          false,
+          undefined,
+          { silent: false }
+        );
+      });
+      test('with projects', async () => {
+        await cli.releases.uploadSourceMaps('my-version', {
+          include: ['path'],
+          projects: ['proj-a', 'proj-b'],
+        });
+        expect(mockExecute).toHaveBeenCalledWith(
+          [
+            'releases',
+            '-p',
+            'proj-a',
+            '-p',
+            'proj-b',
+            'files',
+            'my-version',
+            'upload-sourcemaps',
+            'path',
+            '--ignore',
+            'node_modules',
+          ],
+          true,
+          false,
+          undefined,
+          { silent: false }
+        );
+      });
     });
   });
 });

--- a/js/releases/__tests__/index.test.js
+++ b/js/releases/__tests__/index.test.js
@@ -15,12 +15,15 @@ describe('SentryCli releases', () => {
   describe('with mock', () => {
     let cli;
     let mockExecute;
-    beforeEach(() => {
+    beforeAll(() => {
       mockExecute = jest.fn(async () => {});
       jest.doMock('../../helper', () => ({
         ...jest.requireActual('../../helper'),
         execute: mockExecute,
       }));
+    });
+    beforeEach(() => {
+      mockExecute.mockClear();
       // eslint-disable-next-line global-require
       const SentryCliLocal = require('../..');
       cli = new SentryCliLocal();

--- a/js/releases/index.js
+++ b/js/releases/index.js
@@ -51,14 +51,8 @@ class Releases {
    * @memberof SentryReleases
    */
   new(release, options) {
-    const commands = ['releases', 'new', release];
-    if (options && options.projects) {
-      options.projects.forEach(project => {
-        commands.push('-p');
-        commands.push(project);
-      });
-    }
-    return this.execute(commands, null);
+    const args = ['releases', 'new', release].concat(helper.getProjectFlagsFromOptions(options));
+    return this.execute(args, null);
   }
 
   /**
@@ -144,6 +138,7 @@ class Releases {
    *   urlPrefix: '',             // add a prefix source map urls after stripping them
    *   urlSuffix: '',             // add a suffix source map urls after stripping them
    *   ext: ['js', 'map', 'jsbundle', 'bundle'],  // override file extensions to scan for
+   *   projects: ['node']        // provide a list of projects
    * });
    *
    * @param {string} release Unique name of the release.
@@ -162,7 +157,9 @@ class Releases {
         newOptions.ignore = DEFAULT_IGNORE;
       }
 
-      const args = ['releases', 'files', release, 'upload-sourcemaps', sourcemapPath];
+      const args = ['releases']
+        .concat(helper.getProjectFlagsFromOptions(options))
+        .concat(['files', release, 'upload-sourcemaps', sourcemapPath]);
       return this.execute(helper.prepareCommand(args, SOURCEMAPS_SCHEMA, newOptions), true);
     });
 

--- a/js/releases/index.js
+++ b/js/releases/index.js
@@ -45,11 +45,20 @@ class Releases {
    * upload artifacts, such as source maps.
    *
    * @param {string} release Unique name of the new release.
+   * @param {object} options A set of options when creating a release.
+   * @param {array} options.projects The list of project slugs for a release.
    * @returns {Promise} A promise that resolves when the release has been created.
    * @memberof SentryReleases
    */
-  new(release) {
-    return this.execute(['releases', 'new', release], null);
+  new(release, options) {
+    const commands = ['releases', 'new', release];
+    if (options && options.projects) {
+      options.projects.forEach(project => {
+        commands.push('-p');
+        commands.push(project);
+      });
+    }
+    return this.execute(commands, null);
   }
 
   /**

--- a/src/api.rs
+++ b/src/api.rs
@@ -156,26 +156,17 @@ pub enum ProgressBarMode {
 impl ProgressBarMode {
     /// Returns if progress bars are generally enabled.
     pub fn active(&self) -> bool {
-        match *self {
-            ProgressBarMode::Disabled => false,
-            _ => true,
-        }
+        !matches!(*self, ProgressBarMode::Disabled)
     }
 
     /// Returns whether a progress bar should be displayed during upload.
     pub fn request(&self) -> bool {
-        match *self {
-            ProgressBarMode::Request | ProgressBarMode::Both => true,
-            _ => false,
-        }
+        matches!(*self, ProgressBarMode::Request | ProgressBarMode::Both)
     }
 
     /// Returns whether a progress bar should be displayed during download.
     pub fn response(&self) -> bool {
-        match *self {
-            ProgressBarMode::Response | ProgressBarMode::Both => true,
-            _ => false,
-        }
+        matches!(*self, ProgressBarMode::Response | ProgressBarMode::Both)
     }
 }
 

--- a/src/utils/dif_upload.rs
+++ b/src/utils/dif_upload.rs
@@ -1141,7 +1141,8 @@ fn poll_dif_assemble(
             .dif
             .as_ref()
             .map(|x| x.object_name.as_str())
-            .unwrap_or("");
+            .unwrap_or("")
+            .to_owned()
     });
 
     let difs_by_checksum: BTreeMap<_, _> = difs.iter().map(|m| (m.checksum, m)).collect();


### PR DESCRIPTION
This PR enables setting multiple projects when creating a release with the JS wrapper for the CLI. It adds a new optional parameter to the `new` function called `options` which has a `projects` field which is an array of strings. Example:

```
cli.releases.new('my-version', { projects: ['proj-a', 'proj-b'] });
```

Becomes:
```
sentry-cli releases new -p proj-a -p proj-b my-version
```
CLI docs: https://docs.sentry.io/product/releases/#using-the-cli

I've also added the multiple project options for the `uploadSourceMaps` command as well. However, the underlying CLI cannot handle multiple options and will throw this error:
```
error: The argument '--project <PROJECT>' was provided more than once, but cannot be used multiple times
```
However, you can still provide a single option which is useful so you can upload source maps in a loop. Furthermore, if we ever do update the CLI to handle multiple options we won't need to update the JS wrapper since it can pass the arguments correctly.

Discussion on this limitation here: https://github.com/getsentry/sentry-cli/issues/734#issuecomment-652318315

Note I did not update `setCommits` because that doesn't need a project at all. After creating the release with `new`, you just need to pass in the release name and it will work correctly.

Here's the script I was using to test these changes:

```
async function main() {
  const cli = new SentryCli().releases;
  const version = "10.9.2";
  const prefix = "static/js";

  const projects = ["test-sentry-cli-js", "test-steve"];
  await cli.new(version, { projects });
  await cli.setCommits(version, { auto: true });

  await Promise.all(
    projects.map((project) => {
      const sourceMapOptions = {
        projects: [project],
        urlPrefix: `~/${prefix}`,
        validate: true,
        include: [`build/${prefix}`],
      };
      return cli.uploadSourceMaps(version, sourceMapOptions);
    })
  );
}
```