### PR TITLE
feat(bash-hook): Add cli arg to override sentry-cli command

### DIFF
--- a/src/bashsupport.sh
+++ b/src/bashsupport.sh
@@ -30,7 +30,7 @@ _sentry_err_trap() {
   echo "@exit_code:${_exit_code}" >> "$_SENTRY_TRACEBACK_FILE"
 
   : >> "$_SENTRY_LOG_FILE"
-  export SENTRY_LAST_EVENT=$("___SENTRY_CLI___" bash-hook --send-event --traceback "$_SENTRY_TRACEBACK_FILE" --log "$_SENTRY_LOG_FILE" ___SENTRY_NO_ENVIRON___)
+  export SENTRY_LAST_EVENT=$(___SENTRY_CLI___ bash-hook --send-event --traceback "$_SENTRY_TRACEBACK_FILE" --log "$_SENTRY_LOG_FILE" ___SENTRY_NO_ENVIRON___)
   rm -f "$_SENTRY_TRACEBACK_FILE" "$_SENTRY_LOG_FILE"
 }
 

--- a/src/commands/bash_hook.rs
+++ b/src/commands/bash_hook.rs
@@ -36,6 +36,12 @@ pub fn make_app<'a, 'b: 'a>(app: App<'a, 'b>) -> App<'a, 'b> {
                 .help("Do not send environment variables along"),
         )
         .arg(
+            Arg::with_name("cli")
+                .long("cli")
+                .value_name("CMD")
+                .help("Explicitly set/override the sentry-cli command"),
+        )
+        .arg(
             Arg::with_name("send_event")
                 .long("send-event")
                 .requires_all(&["traceback", "log"])
@@ -186,11 +192,17 @@ pub fn execute<'a>(matches: &ArgMatches<'a>) -> Result<(), Error> {
             "___SENTRY_TRACEBACK_FILE___",
             &traceback.display().to_string(),
         )
-        .replace("___SENTRY_LOG_FILE___", &log.display().to_string())
-        .replace(
+        .replace("___SENTRY_LOG_FILE___", &log.display().to_string());
+
+        if matches.is_present("cli") {
+            script = script.replace(
             "___SENTRY_CLI___",
-            &env::current_exe().unwrap().display().to_string(),
-        );
+            matches.value_of("cli").unwrap()
+            );
+        } else {
+            script = script.replace("__SENTRY_CLI__", &env::current_exe().unwrap().display().to_string());
+        }
+
 
     if matches.is_present("no_environ") {
         script = script.replace("___SENTRY_NO_ENVIRON___", "--no-environ");

--- a/src/commands/bash_hook.rs
+++ b/src/commands/bash_hook.rs
@@ -194,15 +194,14 @@ pub fn execute<'a>(matches: &ArgMatches<'a>) -> Result<(), Error> {
         )
         .replace("___SENTRY_LOG_FILE___", &log.display().to_string());
 
-        if matches.is_present("cli") {
-            script = script.replace(
-            "___SENTRY_CLI___",
-            matches.value_of("cli").unwrap()
-            );
-        } else {
-            script = script.replace("__SENTRY_CLI__", &env::current_exe().unwrap().display().to_string());
-        }
-
+    if matches.is_present("cli") {
+        script = script.replace("___SENTRY_CLI___", matches.value_of("cli").unwrap());
+    } else {
+        script = script.replace(
+            "__SENTRY_CLI__",
+            &env::current_exe().unwrap().display().to_string(),
+        );
+    }
 
     if matches.is_present("no_environ") {
         script = script.replace("___SENTRY_NO_ENVIRON___", "--no-environ");


### PR DESCRIPTION
When using `sentry-cli` through Docker, the bash hook does not work as:
1. The inferred path of `sentry-cli` becomes the path inside the container, and does not apply to the host
2. The files used for reporting live outside the container and they need to be mapped to the container when running it.

This patch chooses the more flexible `--cli` argument to solve both problems where one can do something like

```shell
docker run --rm getsentry/sentry-cli bash-hook --cli='docker run --rm -v "$_SENTRY_TRACEBACK_FILE:$SENTRY_TRACEBACK_FILE" -v "$_SENTRY_LOG_FILE:$_SENTRY_LOG_FILE" getsentry/sentry-cli
```

Now that's ugly as hell, yes and we may opt to have auto detection for running inside docker to handle this. The downside is then we'd not support any other container engine.
