### PR TITLE
fix(difutil): Render variants as list in difutil check

### DIFF
--- a/src/commands/difutil_check.rs
+++ b/src/commands/difutil_check.rs
@@ -63,22 +63,12 @@ pub fn execute<'a>(matches: &ArgMatches<'a>) -> Result<(), Error> {
 
     println!("  Contained debug identifiers:");
     for variant in dif.variants() {
-        match variant.arch {
-            Some(ref cpu_type) => println!(
-                "    > debug_id: {} ({})",
-                style(variant.debug_id).dim(),
-                style(cpu_type).cyan()
-            ),
-            None => println!("    > debug_id: {}", style(variant.debug_id).dim()),
+        println!("    > Debug ID: {}", style(variant.debug_id).dim());
+        if let Some(code_id) = variant.code_id {
+            println!("      Code ID:  {}", style(code_id).dim());
         }
-        match (variant.code_id, variant.arch) {
-            (Some(ref code_id), Some(ref cpu_type)) => println!(
-                "    > code_id: {} ({})",
-                style(code_id).dim(),
-                style(cpu_type).cyan()
-            ),
-            (Some(ref code_id), None) => println!("    > code_id: {}", style(code_id).dim()),
-            _ => {}
+        if let Some(arch) = variant.arch {
+            println!("      Arch:     {}", style(arch).dim());
         }
     }
 


### PR DESCRIPTION
Changes `difutil check` to output a list item per architecture contained in a fat file, instead of a flat list of individual duplicated information.

---

Before:
![image](https://user-images.githubusercontent.com/1433023/99237381-a9424f80-27f8-11eb-80d5-0723d34dd8c2.png)

After:
![image](https://user-images.githubusercontent.com/1433023/99237316-93cd2580-27f8-11eb-914e-22da9a78ac3c.png)
