### PR TITLE
(chunk-upload): add option to set URL when uploading chunks

### DIFF
--- a/src/api.rs
+++ b/src/api.rs
@@ -1102,13 +1102,11 @@ impl Api {
     {
         
         // If config.upload_url is set, override whatever was set by asking for the options.
-        let cached_upload_url = self.config.get_upload_url();
 
-        let url = if cached_upload_url.is_some() {
-            Cow::Owned(cached_upload_url.unwrap())
-        } else {
-            Cow::Borrowed(url)
-        };
+        let url = self.config.get_upload_url().unwrap_or_else(|| {
+            // Justs use the url..
+            url.to_string()
+        });
 
         // Curl stores a raw pointer to the stringified checksum internally. We first
         // transform all checksums to string and keep them in scope until the request

--- a/src/commands/info.rs
+++ b/src/commands/info.rs
@@ -59,6 +59,9 @@ fn get_config_status_json() -> Result<(), Error> {
     rv.config
         .insert("url".into(), Some(config.get_base_url()?.to_string()));
 
+    rv.config
+        .insert("upload_url".into(), Some(config.get_upload_url()).unwrap_or(None));
+
     rv.auth.auth_type = config.get_auth().map(|val| match val {
         Auth::Token(_) => "token".into(),
         Auth::Key(_) => "api_key".into(),
@@ -84,6 +87,11 @@ pub fn execute<'a>(matches: &ArgMatches<'a>) -> Result<(), Error> {
 
     if !matches.is_present("quiet") {
         println!("Sentry Server: {}", config.get_base_url().unwrap_or("-"));
+
+        if config.get_upload_url().is_some() {
+            println!("Sentry upload URL (chunks): {}", config.get_upload_url().unwrap_or("-".to_string()));
+        }
+
         println!(
             "Default Organization: {}",
             org.unwrap_or_else(|| "-".into())

--- a/src/commands/info.rs
+++ b/src/commands/info.rs
@@ -89,7 +89,7 @@ pub fn execute<'a>(matches: &ArgMatches<'a>) -> Result<(), Error> {
         println!("Sentry Server: {}", config.get_base_url().unwrap_or("-"));
 
         if config.get_upload_url().is_some() {
-            println!("Sentry upload URL (chunks): {}", config.get_upload_url().unwrap_or("-".to_string()));
+            println!("Sentry upload URL (chunks): {}", config.get_upload_url().unwrap_or_else(|| "-".to_string()));
         }
 
         println!(

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -114,6 +114,10 @@ fn configure_args(config: &mut Config, matches: &ArgMatches<'_>) -> Result<(), E
         config.set_base_url(url);
     }
 
+    if let Some(upload_url) = matches.value_of("upload_url") {
+        config.set_upload_url(upload_url);
+    }
+    
     if let Some(api_key) = matches.value_of("api_key") {
         config.set_auth(Auth::Key(api_key.to_owned()));
     }
@@ -231,6 +235,11 @@ pub fn execute(args: &[String]) -> Result<(), Error> {
                 .case_insensitive(true)
                 .global(true)
                 .help("Set the log output verbosity."),
+        )
+        .arg(Arg::with_name("upload_url")
+                 .value_name("UPLOAD_URL")
+                 .long("upload-url")
+                 .help("The URL to use for chunk uploads"),
         );
 
     app = add_commands(app);

--- a/src/config.rs
+++ b/src/config.rs
@@ -41,6 +41,7 @@ pub struct Config {
     cached_base_url: String,
     cached_log_level: log::LevelFilter,
     cached_vcs_remote: String,
+    cached_upload_url: Option<String>,
 }
 
 impl Config {
@@ -59,6 +60,7 @@ impl Config {
             cached_base_url: get_default_url(&ini),
             cached_log_level: get_default_log_level(&ini)?,
             cached_vcs_remote: get_default_vcs_remote(&ini),
+            cached_upload_url: get_default_upload_url(&ini),
             ini,
         })
     }
@@ -412,6 +414,19 @@ impl Config {
             None
         }
     }
+
+    /// Return upload url
+    pub fn get_upload_url(&self) -> Option<String> {
+        self.cached_upload_url.clone()
+    }
+
+    /// Sets the URL
+    pub fn set_upload_url(&mut self, url: &str) {
+        self.cached_upload_url = Some(url.to_owned());
+        self.ini
+            .set_to(Some("defaults"), "upload_url".into(), self.cached_upload_url.clone().unwrap());
+    }
+
 }
 
 fn find_global_config_file() -> Result<PathBuf, Error> {
@@ -524,6 +539,7 @@ impl Clone for Config {
             cached_base_url: self.cached_base_url.clone(),
             cached_log_level: self.cached_log_level,
             cached_vcs_remote: self.cached_vcs_remote.clone(),
+            cached_upload_url: self.cached_upload_url.clone(),
         }
     }
 }
@@ -549,6 +565,16 @@ fn get_default_url(ini: &Ini) -> String {
         val.to_owned()
     } else {
         DEFAULT_URL.to_owned()
+    }
+}
+
+fn get_default_upload_url(ini: &Ini) -> Option<String> {
+    if let Ok(val) = env::var("SENTRY_UPLOAD_URL") {
+        Some(val)
+    } else if let Some(val) = ini.get_from(Some("defaults"), "upload_url") {
+        Some(val.to_owned())
+    } else {
+        None
     }
 }
 

--- a/tests/commands/info.rs
+++ b/tests/commands/info.rs
@@ -39,3 +39,18 @@ fn info_fails_without_auth_token() {
         .assert()
         .failure();
 }
+
+#[test]
+fn info_sets_upload_url_with_args() {
+    Command::cargo_bin("sentry-cli")
+        .unwrap()
+        .envs(common::get_base_env())
+        .arg("--upload-url")
+        .arg("https://sentry.io/test")
+        .arg("info")
+        .assert()
+        .success()
+        .stdout(
+            contains("Sentry upload URL (chunks): https://sentry.io/test")
+        );
+}

--- a/tests/commands/info.rs
+++ b/tests/commands/info.rs
@@ -42,6 +42,12 @@ fn info_fails_without_auth_token() {
 
 #[test]
 fn info_sets_upload_url_with_args() {
+    let _server = mock("GET", "/api/0/")
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(r#"{"user":{"username":"kamil@sentry.io","id":"1337","name":"Kamil Ogórek","email":"kamil@sentry.io"},"auth":{"scopes":["project:read","project:releases"]}}"#)
+        .create();
+
     Command::cargo_bin("sentry-cli")
         .unwrap()
         .envs(common::get_base_env())


### PR DESCRIPTION
Fixes #839 - to bypass options received from GET request to /chunk-upload/

Add --upload-url parameter
Support for SENTRY_UPLOAD_URL environment variable
"hopefully" safe (this is my first time 'writing' rust...
Added test to check for output of upload url in sentry-cli info
command
I've tested on linux and macos (had someone cross compile for me) and it seems to be working fine for all tasks (uploading dsyms mostly), but I'm more trying to solve an issue here than actually understanding exactly what is going on with the tool.

That said, I am open to suggestions/code review for what I've added and changed.. As I said I am brand new to Rust (though not strictly new to programming..)