### PR TITLE
fix(bash-hook): Add missing underscores for template

### DIFF
--- a/src/commands/bash_hook.rs
+++ b/src/commands/bash_hook.rs
@@ -198,7 +198,7 @@ pub fn execute<'a>(matches: &ArgMatches<'a>) -> Result<(), Error> {
         script = script.replace("___SENTRY_CLI___", matches.value_of("cli").unwrap());
     } else {
         script = script.replace(
-            "__SENTRY_CLI__",
+            "___SENTRY_CLI___",
             &env::current_exe().unwrap().display().to_string(),
         );
     }


### PR DESCRIPTION
Fixes regression introduced in https://github.com/getsentry/sentry-cli/pull/852, where the path of `sentry-cli` would be interpolated as `_/usr/local/bin/sentry-cli_`.