### PR TITLE
ci(release): Add support for release via getsentry/publish repo

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,41 @@
+name: release
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: Version to release
+        required: true
+      force:
+        description: Force a release even when there are release-blockers (optional)
+        required: false
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    name: 'Release a new version'
+    steps:
+      - name: Prepare release
+        uses: getsentry/action-prepare-release@main
+        with:
+          version: ${{ github.event.inputs.version }}
+          force: ${{ github.event.inputs.force }}
+      - uses: actions/checkout@v2
+        with:
+          token: ${{ secrets.GH_RELEASE_PAT }}
+          fetch-depth: 0
+      - uses: getsentry/craft@master
+        name: Craft Prepare
+        with:
+          action: prepare
+          version: ${{ env.RELEASE_VERSION }}
+      - name: Request publish
+        if: success()
+        uses: actions/github-script@v3
+        with:
+          github-token: ${{ secrets.GH_RELEASE_PAT }}
+          script: |
+            const repoInfo = context.repo;
+            await github.issues.create({
+              owner: repoInfo.owner,
+              repo: 'publish',
+              title: `publish: ${repoInfo.repo}@${process.env.RELEASE_VERSION}`,
+            });


### PR DESCRIPTION
Same as getsentry/symbolicator#319.

#skip-changelog
