### PR TITLE
fix(craft): Bump version for the release action

### DIFF
--- a/scripts/bump-version.sh
+++ b/scripts/bump-version.sh
@@ -1,6 +1,12 @@
 #!/bin/bash
 set -eux
 
+if [ "$(uname -s)" != "Linux" ]; then
+    echo "sentry-cli can only be released on Linux!"
+    echo "Please use the GitHub Action instead."
+    exit 1
+fi
+
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 cd $SCRIPT_DIR/..
 
@@ -10,7 +16,7 @@ TARGET="${2}"
 echo "Current version: $VERSION"
 echo "Bumping version: $TARGET"
 
-sed -i '' -e "1,/^version/ s/^version.*/version = \"$TARGET\"/" Cargo.toml
+perl -pi -e "s/^version = .*\$/version = \"$TARGET\"/" Cargo.toml
 cargo update -p sentry-cli
 
 # Do not tag and commit changes made by "npm version"


### PR DESCRIPTION
Drops support for releasing sentry-cli locally and replaces sed for
compatibility with Linux.

