### PR TITLE
ci(gha): Build universal macOS binary on macos-latest

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -75,7 +75,7 @@ jobs:
   macos_universal:
     needs: macos
     name: macOS universal
-    runs-on: macos-11.0
+    runs-on: macos-latest
 
     steps:
       - uses: actions/download-artifact@v2


### PR DESCRIPTION
The `lipo` tool required for linking a universal binary is available on older macOS versions. Since `macos-latest` is expected to be the most available macOS release, this should speed up the build. While releasing 1.61.0, we noticed that builds using `macos-11.0` queue up for quite some time.