### PR TITLE
build: macOS arm64 on stable Rust

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -52,8 +52,7 @@ jobs:
 
       - uses: actions-rs/toolchain@v1
         with:
-          # TODO: aarch64 requires beta, revert when 1.49.0 is released
-          toolchain: beta
+          toolchain: stable
           target: ${{ matrix.target }}
           profile: minimal
           override: true


### PR DESCRIPTION
With Rust 1.49.0, the `aarch64-apple-darwin` has hit the stable channel. This
allows us to revert binary builds to the stable channel.

