### PR TITLE
build: ARM for Linux

### DIFF
--- a/.craft.yml
+++ b/.craft.yml
@@ -34,6 +34,12 @@ targets:
         if OS.mac?
           url "https://downloads.sentry-cdn.com/sentry-cli/{{version}}/sentry-cli-Darwin-universal"
           sha256 "{{checksums.sentry-cli-Darwin-universal}}"
+        elsif Hardware::CPU.arm? && Hardware::CPU.is_64_bit?
+          url "https://downloads.sentry-cdn.com/sentry-cli/{{version}}/sentry-cli-Linux-aarch64"
+          sha256 "{{checksums.sentry-cli-Linux-aarch64}}"
+        elsif Hardware::CPU.arm?
+          url "https://downloads.sentry-cdn.com/sentry-cli/{{version}}/sentry-cli-Linux-armv7"
+          sha256 "{{checksums.sentry-cli-Linux-armv7}}"
         elsif Hardware::CPU.is_64_bit?
           url "https://downloads.sentry-cdn.com/sentry-cli/{{version}}/sentry-cli-Linux-x86_64"
           sha256 "{{checksums.sentry-cli-Linux-x86_64}}"
@@ -68,5 +74,7 @@ requireNames:
   - /^sentry-cli-Darwin-universal$/
   - /^sentry-cli-Linux-i686$/
   - /^sentry-cli-Linux-x86_64$/
+  - /^sentry-cli-Linux-armv7$/
+  - /^sentry-cli-Linux-aarch64$/
   - /^sentry-cli-Windows-i686.exe$/
   - /^sentry-cli-Windows-x86_64.exe$/

--- a/.craft.yml
+++ b/.craft.yml
@@ -34,18 +34,28 @@ targets:
         if OS.mac?
           url "https://downloads.sentry-cdn.com/sentry-cli/{{version}}/sentry-cli-Darwin-universal"
           sha256 "{{checksums.sentry-cli-Darwin-universal}}"
-        elsif Hardware::CPU.arm? && Hardware::CPU.is_64_bit?
-          url "https://downloads.sentry-cdn.com/sentry-cli/{{version}}/sentry-cli-Linux-aarch64"
-          sha256 "{{checksums.sentry-cli-Linux-aarch64}}"
-        elsif Hardware::CPU.arm?
-          url "https://downloads.sentry-cdn.com/sentry-cli/{{version}}/sentry-cli-Linux-armv7"
-          sha256 "{{checksums.sentry-cli-Linux-armv7}}"
-        elsif Hardware::CPU.is_64_bit?
-          url "https://downloads.sentry-cdn.com/sentry-cli/{{version}}/sentry-cli-Linux-x86_64"
-          sha256 "{{checksums.sentry-cli-Linux-x86_64}}"
+        elsif OS.linux?
+          if Hardware::CPU.arm?
+            if Hardware::CPU.is_64_bit?
+              url "https://downloads.sentry-cdn.com/sentry-cli/{{version}}/sentry-cli-Linux-aarch64"
+              sha256 "{{checksums.sentry-cli-Linux-aarch64}}"
+            else
+              url "https://downloads.sentry-cdn.com/sentry-cli/{{version}}/sentry-cli-Linux-armv7"
+              sha256 "{{checksums.sentry-cli-Linux-armv7}}"
+            end
+          elseif Hardware::CPU.intel?
+            if Hardware::CPU.is_64_bit?
+              url "https://downloads.sentry-cdn.com/sentry-cli/{{version}}/sentry-cli-Linux-x86_64"
+              sha256 "{{checksums.sentry-cli-Linux-x86_64}}"
+            else
+              url "https://downloads.sentry-cdn.com/sentry-cli/{{version}}/sentry-cli-Linux-i686"
+              sha256 "{{checksums.sentry-cli-Linux-i686}}"
+            end
+          else
+            raise "Unsupported architecture"
+          end
         else
-          url "https://downloads.sentry-cdn.com/sentry-cli/{{version}}/sentry-cli-Linux-i686"
-          sha256 "{{checksums.sentry-cli-Linux-i686}}"
+            raise "Unsupported operating system"
         end
 
         def install

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,7 +10,15 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        arch: [i686, x86_64]
+        include:
+          - arch: i686
+            target: i686-unknown-linux-musl
+          - arch: x86_64
+            target: x86_64-unknown-linux-musl
+          - arch: armv7
+            target: armv7-unknown-linux-musleabi
+          - arch: aarch64
+            target: aarch64-unknown-linux-musl
 
     name: Linux ${{ matrix.arch }}
     runs-on: ubuntu-latest
@@ -21,7 +29,7 @@ jobs:
       - name: Build in Docker
         run: scripts/build-in-docker.sh
         env:
-          TARGET: ${{ matrix.arch }}-unknown-linux-musl
+          TARGET: ${{ matrix.target }}
           DOCKER_TAG: ${{ matrix.arch }}-musl
 
       - name: Rename Binary

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,6 +5,8 @@ on:
     branches:
       - release/**
 
+  pull_request: # TODO: Remove this before merge
+
 jobs:
   linux:
     strategy:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,12 +15,16 @@ jobs:
         include:
           - arch: i686
             target: i686-unknown-linux-musl
+            container: i686-musl
           - arch: x86_64
             target: x86_64-unknown-linux-musl
+            container: x86_64-musl
           - arch: armv7
             target: armv7-unknown-linux-musleabi
+            container: armv7-musleabi
           - arch: aarch64
             target: aarch64-unknown-linux-musl
+            container: aarch64-musl
 
     name: Linux ${{ matrix.arch }}
     runs-on: ubuntu-latest
@@ -32,7 +36,7 @@ jobs:
         run: scripts/build-in-docker.sh
         env:
           TARGET: ${{ matrix.target }}
-          DOCKER_TAG: ${{ matrix.arch }}-musl
+          DOCKER_TAG: ${{ matrix.container }}
 
       - name: Rename Binary
         run: mv target/*/release/sentry-cli sentry-cli-Linux-${{ matrix.arch }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,8 +5,6 @@ on:
     branches:
       - release/**
 
-  pull_request: # TODO: Remove this before merge
-
 jobs:
   linux:
     strategy:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,10 @@
 ARG BUILD_ARCH=x86_64
-FROM getsentry/rust-musl-cross:$BUILD_ARCH-musl AS sentry-build
+ARG BUILD_LIBC=musl
+FROM messense/rust-musl-cross:$BUILD_ARCH-$BUILD_LIBC AS sentry-build
 
 ARG BUILD_ARCH
-ENV BUILD_TARGET=$BUILD_ARCH-unknown-linux-musl
+ARG BUILD_LIBC
+ENV BUILD_TARGET=$BUILD_ARCH-unknown-linux-$BUILD_LIBC
 WORKDIR /work
 
 # Build only dependencies to speed up subsequent builds

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 ARG BUILD_ARCH=x86_64
 ARG BUILD_LIBC=musl
-FROM messense/rust-musl-cross:$BUILD_ARCH-$BUILD_LIBC AS sentry-build
+FROM getsentry/rust-musl-cross:$BUILD_ARCH-$BUILD_LIBC AS sentry-build
 
 ARG BUILD_ARCH
 ARG BUILD_LIBC

--- a/build.rs
+++ b/build.rs
@@ -11,13 +11,14 @@ fn main() {
     let target = env::var("TARGET").unwrap();
     let mut target_bits = target.split('-');
 
-    let arch = match target_bits.next().unwrap() {
-        "aarch64" => "arm64", // Linux and Darwin convention. Matches `uname -m`
-        arch => arch,
-    };
-
-    target_bits.next();
+    // https://rust-lang.github.io/rfcs/0131-target-specification.html#detailed-design
+    let mut arch = target_bits.next().unwrap();
+    let _vendor = target_bits.next();
     let platform = target_bits.next().unwrap();
+
+    if platform == "darwin" && arch == "aarch64" {
+        arch = "arm64"; // enforce Darwin naming conventions
+    }
 
     writeln!(f, "/// The platform identifier").ok();
     writeln!(f, "pub const PLATFORM: &str = \"{}\";", platform).ok();

--- a/scripts/build-in-docker.sh
+++ b/scripts/build-in-docker.sh
@@ -4,11 +4,14 @@ set -eux
 DOCKER_IMAGE="messense/rust-musl-cross:${DOCKER_TAG}"
 BUILD_DIR="/work"
 
+# TODO: Remove OPENSSL_NO_VENDOR once openssl-src >111.11.0 is released.
+
 DOCKER_RUN_OPTS="
   -w ${BUILD_DIR}
   -v $(pwd):${BUILD_DIR}:ro
   -v $(pwd)/target:${BUILD_DIR}/target
   -v $HOME/.cargo/registry:/root/.cargo/registry
+  -e ARMV7_UNKNOWN_LINUX_MUSLEABI_OPENSSL_NO_VENDOR=1
   ${DOCKER_IMAGE}
 "
 

--- a/scripts/build-in-docker.sh
+++ b/scripts/build-in-docker.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -eux
 
-DOCKER_IMAGE="messense/rust-musl-cross:${DOCKER_TAG}"
+DOCKER_IMAGE="getsentry/rust-musl-cross:${DOCKER_TAG}"
 BUILD_DIR="/work"
 
 # TODO: Remove OPENSSL_NO_VENDOR once openssl-src >111.11.0 is released.

--- a/scripts/build-in-docker.sh
+++ b/scripts/build-in-docker.sh
@@ -4,8 +4,6 @@ set -eux
 DOCKER_IMAGE="getsentry/rust-musl-cross:${DOCKER_TAG}"
 BUILD_DIR="/work"
 
-# TODO: Remove OPENSSL_NO_VENDOR once openssl-src >111.11.0 is released.
-
 DOCKER_RUN_OPTS="
   -w ${BUILD_DIR}
   -v $(pwd):${BUILD_DIR}:ro

--- a/scripts/build-in-docker.sh
+++ b/scripts/build-in-docker.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -eux
 
-DOCKER_IMAGE="getsentry/rust-musl-cross:${DOCKER_TAG}"
+DOCKER_IMAGE="messense/rust-musl-cross:${DOCKER_TAG}"
 BUILD_DIR="/work"
 
 DOCKER_RUN_OPTS="

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -103,6 +103,7 @@ fn preexecute_hooks() -> Result<bool, Error> {
         Ok(false)
     }
 
+    #[allow(clippy::unnecessary_wraps)]
     #[cfg(not(target_os = "macos"))]
     fn sentry_react_native_xcode_wrap() -> Result<bool, Error> {
         Ok(false)


### PR DESCRIPTION
TODO:

- [x] Set up ARM builds for https://github.com/getsentry/rust-musl-cross
- [x] Build aarch64
- [x] Build armv7
- [x] Update homebrew
- [x] Check updater target
- [x] Update install script in getsentry

We need to decide whether this should be called `aarch64`, which seems to be the output of `uname -m` by 64-bit applications, or `arm64`, which would also match macOS.

get-cli: https://github.com/getsentry/sentry-cli/pull/890