### PR TITLE
fix: Use http_proxy config value directly in handler

### DIFF
--- a/src/api.rs
+++ b/src/api.rs
@@ -404,7 +404,9 @@ impl Api {
             )
         };
 
-        // the proxy url is discovered from the http_proxy envvar.
+        if let Some(proxy_url) = self.config.get_proxy_url() {
+            handle.proxy(&proxy_url)?;
+        }
         if let Some(proxy_username) = self.config.get_proxy_username() {
             handle.proxy_username(proxy_username)?;
         }

--- a/src/config.rs
+++ b/src/config.rs
@@ -111,11 +111,6 @@ impl Config {
         {
             crate::utils::crashreporting::bind_configured_client(Some(self));
         }
-        if env::var("http_proxy").is_err() {
-            if let Some(proxy) = self.get_proxy_url() {
-                env::set_var("http_proxy", proxy);
-            }
-        }
         #[cfg(not(windows))]
         {
             openssl_probe::init_ssl_cert_env_vars();
@@ -220,8 +215,8 @@ impl Config {
 
     /// Returns the proxy URL if defined.
     pub fn get_proxy_url(&self) -> Option<String> {
-        if env::var_os("proxy_url").is_some() {
-            env::var("proxy_url").ok()
+        if env::var_os("http_proxy").is_some() {
+            env::var("http_proxy").ok()
         } else if let Some(val) = self.ini.get_from(Some("http"), "proxy_url") {
             Some(val.to_owned())
         } else {

--- a/src/config.rs
+++ b/src/config.rs
@@ -219,8 +219,14 @@ impl Config {
     }
 
     /// Returns the proxy URL if defined.
-    fn get_proxy_url(&self) -> Option<&str> {
-        self.ini.get_from(Some("http"), "proxy_url")
+    pub fn get_proxy_url(&self) -> Option<String> {
+        if env::var_os("proxy_url").is_some() {
+            env::var("proxy_url").ok()
+        } else if let Some(val) = self.ini.get_from(Some("http"), "proxy_url") {
+            Some(val.to_owned())
+        } else {
+            None
+        }
     }
 
     /// Returns the proxy username if defined.


### PR DESCRIPTION
Fixes https://github.com/getsentry/sentry-cli/issues/472

ref https://docs.rs/curl/0.4.34/curl/easy/struct.Easy2.html#method.proxy