### PR TITLE
fix(chunk_upload): Limit chunk upload waiting to 5 minutes

### DIFF
--- a/src/api.rs
+++ b/src/api.rs
@@ -2327,6 +2327,8 @@ pub struct ChunkUploadOptions {
     pub max_size: u64,
     #[serde(default)]
     pub max_file_size: u64,
+    #[serde(default)]
+    pub max_wait: u64,
     pub hash_algorithm: ChunkHashAlgorithm,
     pub chunk_size: u64,
     pub concurrency: u8,

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -1,5 +1,7 @@
 //! Provides some useful constants.
 
+use std::time::Duration;
+
 use app_dirs::AppInfo;
 
 pub const APP_INFO: &AppInfo = &AppInfo {
@@ -49,5 +51,7 @@ pub const DEFAULT_MAX_INTERVAL: u64 = 5000;
 pub const DEFAULT_RETRIES: u32 = 5;
 /// Default maximum file size of DIF uploads.
 pub const DEFAULT_MAX_DIF_SIZE: u64 = 2 * 1024 * 1024 * 1024; // 2GB
+/// Default maximum time to wait for file assembly.
+pub const DEFAULT_MAX_WAIT: Duration = Duration::from_secs(5 * 60);
 
 include!(concat!(env!("OUT_DIR"), "/constants.gen.rs"));

--- a/src/utils/file_upload.rs
+++ b/src/utils/file_upload.rs
@@ -260,7 +260,7 @@ fn upload_files_chunked(
             break response;
         }
 
-        if context.wait && assemble_start.elapsed() > max_wait {
+        if assemble_start.elapsed() > max_wait {
             break response;
         }
 

--- a/src/utils/file_upload.rs
+++ b/src/utils/file_upload.rs
@@ -278,7 +278,10 @@ fn upload_files_chunked(
         if context.wait {
             bail!("Failed to process files in {}s", max_wait.as_secs());
         } else {
-            println!("{} File upload complete (processing pending on server)", style(">").dim());
+            println!(
+                "{} File upload complete (processing pending on server)",
+                style(">").dim()
+            );
         }
     } else {
         println!("{} File processing complete", style(">").dim());

--- a/src/utils/file_upload.rs
+++ b/src/utils/file_upload.rs
@@ -278,7 +278,7 @@ fn upload_files_chunked(
         if context.wait {
             bail!("Failed to process files in {}s", max_wait.as_secs());
         } else {
-            println!("{} File upload complete", style(">").dim());
+            println!("{} File upload complete (processing pending on server)", style(">").dim());
         }
     } else {
         println!("{} File processing complete", style(">").dim());


### PR DESCRIPTION
Under some conditions, chunk upload may not respond within a given time frame or
even time out completely. This leads sentry-cli to wait forever on a response
from Sentry.

This PR introduces an upper bound of 5 minutes. In chunk upload options, the
Sentry server can override this limit. It is not configurable on the CLI.

Fixes https://github.com/getsentry/sentry-cli/issues/891 in combination with https://github.com/getsentry/sentry/pull/23455