### PR TITLE
ref: is_outdated should not report when release contain older version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1952,7 +1952,7 @@ version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "138e3e0acb6c9fb258b19b67cb8abd63c00679d2851805ea151465464fe9030a"
 dependencies = [
- "semver",
+ "semver 0.9.0",
 ]
 
 [[package]]
@@ -2048,7 +2048,16 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d7eb9ef2c18661902cc47e535f9bc51b78acd254da71d375c2f6720d9a40403"
 dependencies = [
- "semver-parser",
+ "semver-parser 0.7.0",
+]
+
+[[package]]
+name = "semver"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f301af10236f6df4160f7c3f04eec6dbc70ace82d23326abad5edee88801c6b6"
+dependencies = [
+ "semver-parser 0.10.2",
 ]
 
 [[package]]
@@ -2056,6 +2065,15 @@ name = "semver-parser"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
+
+[[package]]
+name = "semver-parser"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00b0bef5b7f9e0df16536d3961cfb6e84331c065b4066afb39768d0e319411f7"
+dependencies = [
+ "pest",
+]
 
 [[package]]
 name = "sentry"
@@ -2131,6 +2149,7 @@ dependencies = [
  "regex",
  "runas",
  "rust-ini",
+ "semver 0.11.0",
  "sentry",
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,6 +44,7 @@ rayon = "1.3.1"
 regex = "1.3.9"
 runas = "0.2.1"
 rust-ini = "0.15.3"
+semver = "0.11.0"
 sentry = { version = "0.18.0", default-features = false, features = ["with_client_implementation", "with_curl_transport", "with_panic", "with_failure", "with_log", "with_device_info", "with_rust_info", "with_debug_to_log"] }
 serde = { version = "1.0.114", features = ["derive"] }
 serde_json = "1.0.56"

--- a/src/utils/update.rs
+++ b/src/utils/update.rs
@@ -9,6 +9,7 @@ use console::{style, user_attended};
 use failure::{bail, Error, ResultExt};
 use if_chain::if_chain;
 use log::{debug, info};
+use semver::Version;
 use serde::{Deserialize, Serialize};
 
 use crate::api::{Api, SentryCliRelease};
@@ -94,7 +95,7 @@ impl LastUpdateCheck {
             if let Some(ref release_v) = self.last_fetched_version;
             if let Some(ref check_v) = self.last_check_version;
             then {
-                release_v.as_str() != VERSION &&
+                Version::parse(release_v.as_str()) <= Version::parse(VERSION) &&
                 check_v.as_str() == VERSION
             } else {
                 false


### PR DESCRIPTION
This can happen only in the case of a broken registry, but we shouldn't report false-positives to the end-user.
https://sentry.io/get-cli/ is also using registry, so someone would let us know that it's not working correctly anyway.

Fixes https://github.com/getsentry/sentry-cli/issues/898