### PR TITLE
Verify CLI installation before launching

### DIFF
--- a/bin/sentry-cli
+++ b/bin/sentry-cli
@@ -12,7 +12,6 @@ const cliPath = cli.getPath();
 if (!fs.existsSync(cliPath)) {
   console.error('error: sentry-cli was not installed by @sentry/cli install script');
   process.exit(-20);
-  return;
 }
 
 const child = childProcess.spawn(cliPath, process.argv.slice(2), {

--- a/bin/sentry-cli
+++ b/bin/sentry-cli
@@ -4,9 +4,18 @@
 'use strict';
 
 const childProcess = require('child_process');
+const fs = require('fs');
 const cli = require('../js');
 
-const child = childProcess.spawn(cli.getPath(), process.argv.slice(2), {
+const cliPath = cli.getPath();
+
+if (!fs.existsSync(cliPath)) {
+  console.error('error: sentry-cli was not installed by @sentry/cli install script');
+  process.exit(-20);
+  return;
+}
+
+const child = childProcess.spawn(cliPath, process.argv.slice(2), {
   stdio: 'inherit',
 });
 


### PR DESCRIPTION
It looks like `spawn` does not fail if the command does not exist, causing the script to return a 0 code although it didn't actually run.

We have had problems with the CLI not downloading on `npm install`, that caused the built React Native app to not contain the JS bundle.

Code uses synchronous/blocking flavor of `fs.exists()`: because we run in a separate process we can allow to block. I chose the exit code at random (as long as it is non-zero).