### PR TITLE
rename arm64 as aarch64

### DIFF
--- a/scripts/install.js
+++ b/scripts/install.js
@@ -46,6 +46,9 @@ function getDownloadUrl(platform, arch) {
     case 'ia32':
       archString = 'i686';
       break;
+    case 'arm64':
+      archString = 'aarch64';
+      break;
     default:
       archString = arch;
   }


### PR DESCRIPTION
- When install v1.64.0 inside arm64 Linux Docker, we got 403 error.
```
Error: Unable to download sentry-cli binary from https://downloads.sentry-cdn.com/sentry-cli/1.63.0/sentry-cli-Linux-arm64.
Server returned 403: Forbidden.
```
- In #890 , arm64 renamed as aarch64, so we should update install/scripts as same.

## Ref
- https://github.com/getsentry/sentry-cli/issues/913