### PR TITLE
fix: Update proguard version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1628,9 +1628,9 @@ dependencies = [
 
 [[package]]
 name = "proguard"
-version = "4.0.1"
+version = "4.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a0d8a8e23b9f03fb2d05f7f00431cb671514ab40384a310e41059b0d29e650f"
+checksum = "6e2aaf95c3580a3560f1b5695920df195a7a9e2bed69762f9fa919d3443cd918"
 dependencies = [
  "lazy_static",
  "uuid",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,7 +38,7 @@ parking_lot = "0.10.0"
 percent-encoding = "2.1.0"
 plist = "0.5.3"
 prettytable-rs = "0.8.0"
-proguard = { version = "4.0.1", features = ["uuid"] }
+proguard = { version = "4.1.1", features = ["uuid"] }
 r2d2 = "0.8.8"
 rayon = "1.3.1"
 regex = "1.3.9"


### PR DESCRIPTION
Fixes has_line_info for certain mappings (warning: proguard mapping was ignored because it does not contain any line information.)

[More info](https://github.com/getsentry/rust-proguard/pull/21)