### PR TITLE
feat: install git in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,7 @@ RUN cp target/$BUILD_TARGET/release/sentry-cli /usr/local/bin/sentry-cli
 
 FROM alpine:3.12
 WORKDIR /work
-RUN apk add --no-cache ca-certificates
+RUN apk add --no-cache ca-certificates git
 COPY ./docker-entrypoint.sh /
 COPY --from=sentry-build /usr/local/bin/sentry-cli /bin
 ENTRYPOINT ["/docker-entrypoint.sh"]


### PR DESCRIPTION
The following command depends on `git` being available:

```sh
sentry-cli releases set-commits --auto 1.2.3
```

This increases the Docker image size from 23.6MB to 39.6MB. IMO this is a relatively big, but acceptable increase.