### PR TITLE
ref: Provide a helpful error messages for xcode/codepush/appcenter binary calls

### DIFF
--- a/src/commands/react_native_xcode.rs
+++ b/src/commands/react_native_xcode.rs
@@ -238,7 +238,13 @@ pub fn execute(matches: &ArgMatches<'_>) -> Result<(), Error> {
                 md.may_detach()?;
             }
             let mut f = fs::File::open(report_file.path())?;
-            let report: SourceMapReport = serde_json::from_reader(&mut f)?;
+            let report: SourceMapReport = serde_json::from_reader(&mut f).unwrap_or_else(|_| {
+                let err_msg = format!(
+                    "File {} doesn't contain a valid JSON data.",
+                    report_file.path().display()
+                );
+                panic!("{}", err_msg);
+            });
             if report.bundle_path.is_none() || report.sourcemap_path.is_none() {
                 println!("Warning: build produced no sourcemaps.");
                 return Ok(());

--- a/src/utils/appcenter.rs
+++ b/src/utils/appcenter.rs
@@ -106,7 +106,10 @@ pub fn get_appcenter_deployment_history(
         })?;
 
     if output.status.success() {
-        Ok(serde_json::from_slice(&output.stdout)?)
+        Ok(serde_json::from_slice(&output.stdout).unwrap_or_else(|_| {
+            let err_msg = format!("Command `{} codepush deployment history {} --app {} --output json` failed to produce a valid JSON output.", appcenter_bin, deployment, app);
+            panic!("{}", err_msg);
+        }))
     } else {
         Err(get_appcenter_error(&output)
             .context("Failed to load AppCenter deployment history")

--- a/src/utils/codepush.rs
+++ b/src/utils/codepush.rs
@@ -75,7 +75,10 @@ pub fn get_codepush_deployments(app: &str) -> Result<Vec<CodePushDeployment>, Er
         })?;
 
     if output.status.success() {
-        Ok(serde_json::from_slice(&output.stdout)?)
+        Ok(serde_json::from_slice(&output.stdout).unwrap_or_else(|_| {
+            let err_msg = format!("Command `{} deployment ls {} --format json` failed to produce a valid JSON output.", codepush_bin, app);
+            panic!("{}", err_msg);
+        }))
     } else {
         Err(get_codepush_error(&output)
             .context("Failed to get codepush deployments")

--- a/src/utils/xcode.rs
+++ b/src/utils/xcode.rs
@@ -119,7 +119,10 @@ impl XcodeProjectInfo {
             .arg("-project")
             .arg(path.as_ref().as_os_str())
             .output()?;
-        let mut rv: Output = serde_json::from_slice(&p.stdout)?;
+        let mut rv: Output = serde_json::from_slice(&p.stdout).unwrap_or_else(|_| {
+            let err_msg = format!("Command `xcodebuild -list -json -project {}` failed to produce a valid JSON output.", path.as_ref().display());
+            panic!("{}", err_msg);
+        });
         rv.project.path = path.as_ref().canonicalize()?;
         Ok(rv.project)
     }


### PR DESCRIPTION
This should make the debugging way easier than cryptic `EOF while parsing a value at line 1 column 0` error message.

Fixes https://github.com/getsentry/sentry-cli/issues/901

Ref https://github.com/getsentry/sentry-cli/issues/797
Ref https://github.com/getsentry/sentry-cli/issues/567
Ref https://github.com/getsentry/sentry-cli/issues/564
Ref https://github.com/getsentry/sentry-cli/issues/374
Ref https://github.com/getsentry/sentry-cli/issues/137
Ref https://github.com/getsentry/sentry-cli/issues/94