### PR TITLE
feat(upload_dif): Support BCSymbolMap uploading

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2365,8 +2365,9 @@ checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
 
 [[package]]
 name = "symbolic"
-version = "8.0.5"
-source = "git+https://github.com/getsentry/symbolic?branch=master#d860eee4b6a8a795ec41d19214c4d47f42d076f2"
+version = "8.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4b052742c32348e5217c9bf28ba2a1a9d4169609ef1055eaea5333ccf7a7614"
 dependencies = [
  "symbolic-common",
  "symbolic-debuginfo",
@@ -2374,8 +2375,9 @@ dependencies = [
 
 [[package]]
 name = "symbolic-common"
-version = "8.0.5"
-source = "git+https://github.com/getsentry/symbolic?branch=master#d860eee4b6a8a795ec41d19214c4d47f42d076f2"
+version = "8.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be7dfa630954f18297ceae1ff2890cb7f5008a0b2d2106b0468dafc45b0b6b12"
 dependencies = [
  "debugid",
  "memmap",
@@ -2386,8 +2388,9 @@ dependencies = [
 
 [[package]]
 name = "symbolic-debuginfo"
-version = "8.0.5"
-source = "git+https://github.com/getsentry/symbolic?branch=master#d860eee4b6a8a795ec41d19214c4d47f42d076f2"
+version = "8.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6fec6e5e3c9575f509bafa63e82e98f178d50f886a23c385f27fdcbbc5f29bbf"
 dependencies = [
  "dmsort",
  "elementtree",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1424,9 +1424,9 @@ dependencies = [
 
 [[package]]
 name = "pdb"
-version = "0.6.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b66be5fcea88b52962d3d6fcc5194f1d77666f5aca256926688743a8de1152e4"
+checksum = "13f4d162ecaaa1467de5afbe62d597757b674b51da8bb4e587430c5fdb2af7aa"
 dependencies = [
  "fallible-iterator",
  "scroll 0.10.2",
@@ -2366,8 +2366,7 @@ checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
 [[package]]
 name = "symbolic"
 version = "8.0.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dfab5df108a9a21a1a34b44da7480d0caf0ec00fb8b0a1bf988aa4cf1fa9566b"
+source = "git+https://github.com/getsentry/symbolic?branch=master#d860eee4b6a8a795ec41d19214c4d47f42d076f2"
 dependencies = [
  "symbolic-common",
  "symbolic-debuginfo",
@@ -2376,8 +2375,7 @@ dependencies = [
 [[package]]
 name = "symbolic-common"
 version = "8.0.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7bf72c81c56cf2b1cba4c43f0ccf74da2354b503efa9fdf38119e955af38a17c"
+source = "git+https://github.com/getsentry/symbolic?branch=master#d860eee4b6a8a795ec41d19214c4d47f42d076f2"
 dependencies = [
  "debugid",
  "memmap",
@@ -2389,10 +2387,10 @@ dependencies = [
 [[package]]
 name = "symbolic-debuginfo"
 version = "8.0.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cbd9fc3ce8411bae7a1f9a7ebc8dcc1cda87c0dabe8760214704a1b0d36d7330"
+source = "git+https://github.com/getsentry/symbolic?branch=master#d860eee4b6a8a795ec41d19214c4d47f42d076f2"
 dependencies = [
  "dmsort",
+ "elementtree",
  "fallible-iterator",
  "flate2",
  "gimli",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,7 +50,8 @@ serde = { version = "1.0.114", features = ["derive"] }
 serde_json = "1.0.56"
 sha1 = { version = "0.6.0", features = ["serde"] }
 sourcemap = { version = "5.0.0", features = ["ram_bundle"] }
-symbolic = { version = "8.0.5", features = ["debuginfo-serde"] }
+# symbolic = { version = "8.0.5", features = ["debuginfo-serde"] }
+symbolic = { git = "https://github.com/getsentry/symbolic", branch="master", features = ["debuginfo-serde"]}
 url = "2.1.1"
 username = "0.2.0"
 uuid = { version = "0.8.1", features = ["v4", "serde"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,8 +50,7 @@ serde = { version = "1.0.114", features = ["derive"] }
 serde_json = "1.0.56"
 sha1 = { version = "0.6.0", features = ["serde"] }
 sourcemap = { version = "5.0.0", features = ["ram_bundle"] }
-# symbolic = { version = "8.0.5", features = ["debuginfo-serde"] }
-symbolic = { git = "https://github.com/getsentry/symbolic", branch="master", features = ["debuginfo-serde"]}
+symbolic = { version = "8.1.0", features = ["debuginfo-serde"] }
 url = "2.1.1"
 username = "0.2.0"
 uuid = { version = "0.8.1", features = ["v4", "serde"] }

--- a/src/api.rs
+++ b/src/api.rs
@@ -2297,7 +2297,7 @@ pub enum ChunkUploadCapability {
     Sources,
 
     /// Upload of BCSymbolMap and PList auxiliary DIFs
-    BCSymbolmap,
+    BcSymbolmap,
 
     /// Any other unsupported capability (ignored)
     Unknown,
@@ -2313,7 +2313,7 @@ impl<'de> Deserialize<'de> for ChunkUploadCapability {
             "release_files" => ChunkUploadCapability::ReleaseFiles,
             "pdbs" => ChunkUploadCapability::Pdbs,
             "sources" => ChunkUploadCapability::Sources,
-            "bcsymbolmaps" => ChunkUploadCapability::BCSymbolmap,
+            "bcsymbolmaps" => ChunkUploadCapability::BcSymbolmap,
             _ => ChunkUploadCapability::Unknown,
         })
     }

--- a/src/api.rs
+++ b/src/api.rs
@@ -2296,6 +2296,9 @@ pub enum ChunkUploadCapability {
     /// Uploads of source archives
     Sources,
 
+    /// Upload of BCSymbolMap and PList auxiliary DIFs
+    BCSymbolmap,
+
     /// Any other unsupported capability (ignored)
     Unknown,
 }
@@ -2310,6 +2313,7 @@ impl<'de> Deserialize<'de> for ChunkUploadCapability {
             "release_files" => ChunkUploadCapability::ReleaseFiles,
             "pdbs" => ChunkUploadCapability::Pdbs,
             "sources" => ChunkUploadCapability::Sources,
+            "bcsymbolmaps" => ChunkUploadCapability::BCSymbolmap,
             _ => ChunkUploadCapability::Unknown,
         })
     }

--- a/src/commands/upload_dif.rs
+++ b/src/commands/upload_dif.rs
@@ -14,7 +14,7 @@ use crate::api::Api;
 use crate::config::Config;
 use crate::utils::args::{validate_id, ArgExt};
 use crate::utils::dif::DifFeatures;
-use crate::utils::dif_upload::DifUpload;
+use crate::utils::dif_upload::{DifFormat, DifUpload};
 use crate::utils::progress::{ProgressBar, ProgressStyle};
 use crate::utils::system::QuietExit;
 use crate::utils::xcode::{InfoPlist, MayDetach};
@@ -39,7 +39,15 @@ pub fn make_app<'a, 'b: 'a>(app: App<'a, 'b>) -> App<'a, 'b> {
                 .value_name("TYPE")
                 .multiple(true)
                 .number_of_values(1)
-                .possible_values(&["dsym", "elf", "breakpad", "pdb", "pe", "sourcebundle"])
+                .possible_values(&[
+                    "dsym",
+                    "elf",
+                    "breakpad",
+                    "pdb",
+                    "pe",
+                    "sourcebundle",
+                    "bcsymbolmap",
+                ])
                 .help(
                     "Only consider debug information files of the given \
                      type.  By default, all types are considered.",
@@ -157,6 +165,16 @@ pub fn make_app<'a, 'b: 'a>(app: App<'a, 'b>) -> App<'a, 'b> {
              can only be displayed if --wait is specified, but this will \
              significantly slow down the upload process.",
         ))
+        .arg(
+            Arg::with_name("upload_symbol_maps")
+                .long("upload-symbol-maps")
+                .help(
+                    "Upload any BCSymbolMap files found to allow Sentry to resolve \
+                     hidden symbols, e.g. when it downloads dSYMs directly from App \
+                     Store Connect or when you upload dSYMs without first resolving \
+                     the hidden symbols using --symbol-maps.",
+                ),
+        )
 }
 
 fn execute_internal(matches: &ArgMatches<'_>, legacy: bool) -> Result<(), Error> {
@@ -185,7 +203,7 @@ fn execute_internal(matches: &ArgMatches<'_>, legacy: bool) -> Result<(), Error>
     if legacy {
         // Configure `upload-dsym` behavior (only dSYM files)
         upload
-            .filter_format(FileFormat::MachO)
+            .filter_format(DifFormat::Object(FileFormat::MachO))
             .filter_features(DifFeatures {
                 debug: true,
                 symtab: false,
@@ -201,15 +219,19 @@ fn execute_internal(matches: &ArgMatches<'_>, legacy: bool) -> Result<(), Error>
     } else {
         // Restrict symbol types, if specified by the user
         for ty in matches.values_of("types").unwrap_or_default() {
-            upload.filter_format(match ty {
-                "dsym" => FileFormat::MachO,
-                "elf" => FileFormat::Elf,
-                "breakpad" => FileFormat::Breakpad,
-                "pdb" => FileFormat::Pdb,
-                "pe" => FileFormat::Pe,
-                "sourcebundle" => FileFormat::SourceBundle,
+            match ty {
+                "dsym" => upload.filter_format(DifFormat::Object(FileFormat::MachO)),
+                "elf" => upload.filter_format(DifFormat::Object(FileFormat::Elf)),
+                "breakpad" => upload.filter_format(DifFormat::Object(FileFormat::Breakpad)),
+                "pdb" => upload.filter_format(DifFormat::Object(FileFormat::Pdb)),
+                "pe" => upload.filter_format(DifFormat::Object(FileFormat::Pe)),
+                "sourcebundle" => upload.filter_format(DifFormat::Object(FileFormat::SourceBundle)),
+                "bcsymbolmap" => {
+                    upload.filter_format(DifFormat::BcSymbolMap);
+                    upload.filter_format(DifFormat::PList)
+                }
                 other => bail!("Unsupported type: {}", other),
-            });
+            };
         }
 
         upload.filter_features(DifFeatures {

--- a/src/commands/upload_dif.rs
+++ b/src/commands/upload_dif.rs
@@ -13,7 +13,7 @@ use symbolic::debuginfo::FileFormat;
 use crate::api::Api;
 use crate::config::Config;
 use crate::utils::args::{validate_id, ArgExt};
-use crate::utils::dif::DifFeatures;
+use crate::utils::dif::ObjectDifFeatures;
 use crate::utils::dif_upload::{DifFormat, DifUpload};
 use crate::utils::progress::{ProgressBar, ProgressStyle};
 use crate::utils::system::QuietExit;
@@ -204,7 +204,7 @@ fn execute_internal(matches: &ArgMatches<'_>, legacy: bool) -> Result<(), Error>
         // Configure `upload-dsym` behavior (only dSYM files)
         upload
             .filter_format(DifFormat::Object(FileFormat::MachO))
-            .filter_features(DifFeatures {
+            .filter_features(ObjectDifFeatures {
                 debug: true,
                 symtab: false,
                 unwind: false,
@@ -234,7 +234,7 @@ fn execute_internal(matches: &ArgMatches<'_>, legacy: bool) -> Result<(), Error>
             };
         }
 
-        upload.filter_features(DifFeatures {
+        upload.filter_features(ObjectDifFeatures {
             // Allow stripped debug symbols. These are dSYMs, ELF binaries generated
             // with `objcopy --only-keep-debug` or Breakpad symbols. As a fallback,
             // we also upload all files with a public symbol table.

--- a/src/utils/dif.rs
+++ b/src/utils/dif.rs
@@ -62,10 +62,8 @@ impl str::FromStr for DifType {
 }
 
 /// Declares which features an object may have to be uploaded.
-// TODO(flub): Consider renaming this to ObjectDifFeatures, since non-object DIFs do not
-// have features.  The doc comment is correct here.
 #[derive(Clone, Copy, Debug)]
-pub struct DifFeatures {
+pub struct ObjectDifFeatures {
     /// Includes object files with debug information.
     pub debug: bool,
     /// Includes object files with a symbol table.
@@ -76,9 +74,9 @@ pub struct DifFeatures {
     pub sources: bool,
 }
 
-impl DifFeatures {
+impl ObjectDifFeatures {
     pub fn all() -> Self {
-        DifFeatures {
+        ObjectDifFeatures {
             debug: true,
             symtab: true,
             unwind: true,
@@ -87,7 +85,7 @@ impl DifFeatures {
     }
 
     pub fn none() -> Self {
-        DifFeatures {
+        ObjectDifFeatures {
             debug: false,
             symtab: false,
             unwind: false,
@@ -100,13 +98,13 @@ impl DifFeatures {
     }
 }
 
-impl Default for DifFeatures {
+impl Default for ObjectDifFeatures {
     fn default() -> Self {
         Self::all()
     }
 }
 
-impl fmt::Display for DifFeatures {
+impl fmt::Display for ObjectDifFeatures {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         let mut written = false;
 
@@ -299,10 +297,10 @@ impl<'a> DifFile<'a> {
         }
     }
 
-    pub fn features(&self) -> DifFeatures {
+    pub fn features(&self) -> ObjectDifFeatures {
         match self {
             DifFile::Archive(archive) => {
-                let mut features = DifFeatures::none();
+                let mut features = ObjectDifFeatures::none();
                 for object in archive.get().objects().filter_map(Result::ok) {
                     features.symtab = features.symtab || object.has_symbols();
                     features.debug = features.debug || object.has_debug_info();
@@ -311,7 +309,7 @@ impl<'a> DifFile<'a> {
                 }
                 features
             }
-            DifFile::Proguard(..) => DifFeatures::none(),
+            DifFile::Proguard(..) => ObjectDifFeatures::none(),
         }
     }
 

--- a/src/utils/dif.rs
+++ b/src/utils/dif.rs
@@ -62,6 +62,8 @@ impl str::FromStr for DifType {
 }
 
 /// Declares which features an object may have to be uploaded.
+// TODO(flub): Consider renaming this to ObjectDifFeatures, since non-object DIFs do not
+// have features.  The doc comment is correct here.
 #[derive(Clone, Copy, Debug)]
 pub struct DifFeatures {
     /// Includes object files with debug information.

--- a/src/utils/dif_upload.rs
+++ b/src/utils/dif_upload.rs
@@ -1828,7 +1828,7 @@ impl DifUpload {
 
             self.pdbs_allowed = chunk_options.supports(ChunkUploadCapability::Pdbs);
             self.sources_allowed = chunk_options.supports(ChunkUploadCapability::Sources);
-            self.bcsymbolmaps_allowed = chunk_options.supports(ChunkUploadCapability::BCSymbolmap);
+            self.bcsymbolmaps_allowed = chunk_options.supports(ChunkUploadCapability::BcSymbolmap);
 
             if chunk_options.supports(ChunkUploadCapability::DebugFiles) {
                 self.validate_capabilities();

--- a/src/utils/dif_upload.rs
+++ b/src/utils/dif_upload.rs
@@ -1944,7 +1944,7 @@ impl DifUpload {
             return false;
         }
 
-        // Skip if this DIF if it has no DebugId or we are only looking for certain IDs.
+        // Skip if this DIF has no DebugId or we are only looking for certain IDs.
         let id = dif.debug_id.unwrap_or_default();
         if id.is_nil() || !self.valid_id(id) {
             debug!("skipping {} because of debugid", dif.name);

--- a/src/utils/dif_upload.rs
+++ b/src/utils/dif_upload.rs
@@ -1345,7 +1345,7 @@ fn poll_dif_assemble(
                     k => format!(" {:#}", k),
                 },
                 ParsedDif::BcSymbolMap(_) => String::from("bcsymbolmap"),
-                ParsedDif::UuidMap(_) => String::from("plist"),
+                ParsedDif::UuidMap(_) => String::from("uuidmap"),
             };
 
             println!(

--- a/src/utils/dif_upload.rs
+++ b/src/utils/dif_upload.rs
@@ -1345,7 +1345,6 @@ fn poll_dif_assemble(
                     symbolic::debuginfo::ObjectKind::None => String::new(),
                     k => format!(" {:#}", k),
                 },
-                // TODO(flub): check this output looks fine, maybe just empty string instead
                 ParsedDif::BcSymbolMap(_) => String::from("bcsymbolmap"),
                 ParsedDif::PList(_) => String::from("plist"),
             };
@@ -1811,7 +1810,6 @@ impl DifUpload {
     ///
     /// The okay part of the return value is `(files, has_errors)`.  The
     /// latter can be used to indicate a fail state from the upload.
-    // flub: does the uploading
     pub fn upload(&mut self) -> Result<(Vec<DebugInfoFile>, bool), Error> {
         if self.paths.is_empty() {
             println!("{}: No paths were provided.", style("Warning").yellow());

--- a/src/utils/dif_upload.rs
+++ b/src/utils/dif_upload.rs
@@ -202,7 +202,6 @@ impl<'data> DifMatch<'data> {
 
     /// Returns the raw binary data of this DIF.
     pub fn data(&self) -> &[u8] {
-        // TODO(flub): Can this not always return self.dif.owner()?
         match self.dif.get() {
             ParsedDif::Object(ref obj) => obj.data(),
             ParsedDif::BcSymbolMap(_) => &self.dif.owner(),

--- a/src/utils/dif_upload.rs
+++ b/src/utils/dif_upload.rs
@@ -38,7 +38,7 @@ use crate::constants::{DEFAULT_MAX_DIF_SIZE, DEFAULT_MAX_WAIT};
 use crate::utils::chunks::{
     upload_chunks, BatchedSliceExt, Chunk, ItemSize, ASSEMBLE_POLL_INTERVAL,
 };
-use crate::utils::dif::DifFeatures;
+use crate::utils::dif::ObjectDifFeatures;
 use crate::utils::fs::{get_sha1_checksum, get_sha1_checksums, TempDir, TempFile};
 use crate::utils::progress::{ProgressBar, ProgressStyle};
 use crate::utils::ui::{copy_with_progress, make_byte_progress_bar};
@@ -1607,7 +1607,7 @@ pub struct DifUpload {
     paths: Vec<PathBuf>,
     ids: BTreeSet<DebugId>,
     formats: BTreeSet<DifFormat>,
-    features: DifFeatures,
+    features: ObjectDifFeatures,
     extensions: BTreeSet<OsString>,
     symbol_map: Option<PathBuf>,
     zips_allowed: bool,
@@ -1644,7 +1644,7 @@ impl DifUpload {
             paths: Vec::new(),
             ids: BTreeSet::new(),
             formats: BTreeSet::new(),
-            features: DifFeatures::all(),
+            features: ObjectDifFeatures::all(),
             extensions: BTreeSet::new(),
             symbol_map: None,
             zips_allowed: true,
@@ -1728,7 +1728,7 @@ impl DifUpload {
     /// Add an `ObjectFeature` to filter for.
     ///
     /// By default, all object features will be included.
-    pub fn filter_features(&mut self, features: DifFeatures) -> &mut Self {
+    pub fn filter_features(&mut self, features: ObjectDifFeatures) -> &mut Self {
         self.features = features;
         self
     }


### PR DESCRIPTION
Adds support for uploading BCSymbolMaps and their associated PList
files.

----

Related PRs:
https://github.com/getsentry/sentry/pull/25712
https://github.com/getsentry/symbolic/pull/373
https://github.com/getsentry/symbolicator/pull/414