### PR TITLE
feat: Allow for ignoring missing commits in set-commit

### DIFF
--- a/src/utils/snapshots/sentry_cli__utils__vcs__generate_patch_ignore_missing.snap
+++ b/src/utils/snapshots/sentry_cli__utils__vcs__generate_patch_ignore_missing.snap
@@ -1,0 +1,49 @@
+---
+source: src/utils/vcs.rs
+expression: patch_set
+---
+- patch_set:
+    - path: foo2.js
+      type: M
+  repository: example/test-repo
+  author_name: John Doe
+  author_email: john.doe@example.com
+  timestamp: "[timestamp]"
+  message: "\"final commit\"\n"
+  id: "[id]"
+- patch_set:
+    - path: foo4.js
+      type: A
+  repository: example/test-repo
+  author_name: John Doe
+  author_email: john.doe@example.com
+  timestamp: "[timestamp]"
+  message: "\"another commit\"\n"
+  id: "[id]"
+- patch_set:
+    - path: foo3.js
+      type: A
+  repository: example/test-repo
+  author_name: John Doe
+  author_email: john.doe@example.com
+  timestamp: "[timestamp]"
+  message: "\"another commit\"\n"
+  id: "[id]"
+- patch_set:
+    - path: foo2.js
+      type: A
+  repository: example/test-repo
+  author_name: John Doe
+  author_email: john.doe@example.com
+  timestamp: "[timestamp]"
+  message: "\"another commit\"\n"
+  id: "[id]"
+- patch_set:
+    - path: foo1.js
+      type: A
+  repository: example/test-repo
+  author_name: John Doe
+  author_email: john.doe@example.com
+  timestamp: "[timestamp]"
+  message: "\"another commit\"\n"
+  id: "[id]"

--- a/src/utils/vcs.rs
+++ b/src/utils/vcs.rs
@@ -405,6 +405,8 @@ pub fn find_heads(
 ) -> Result<Vec<Ref>, Error> {
     let mut rv = vec![];
 
+    println!("{:?}", repos);
+
     // if commit specs were explicitly provided find head commits with
     // limited amounts of magic.
     if let Some(specs) = specs {
@@ -448,21 +450,19 @@ pub fn get_commits_from_git<'a>(
     repo: &'a Repository,
     prev_commit: &str,
     default_count: usize,
+    ignore_missing: bool,
 ) -> Result<(Vec<Commit<'a>>, Option<Commit<'a>>), Error> {
-    let mut revwalk = repo.revwalk()?;
-    revwalk.push_head()?;
-
     let commit_filter = move |id: Result<git2::Oid, git2::Error>| {
         let id = id.ok()?;
-
         let commit = repo.find_commit(id).ok()?;
-
         Some(commit)
     };
 
     match git2::Oid::from_str(prev_commit) {
         Ok(prev) => {
             let mut found = false;
+            let mut revwalk = repo.revwalk()?;
+            revwalk.push_head()?;
             let mut result: Vec<Commit> = revwalk
                 .take_while(|id| match id {
                     Ok(id) => {
@@ -478,11 +478,38 @@ pub fn get_commits_from_git<'a>(
                 })
                 .filter_map(commit_filter)
                 .collect();
-            // If there is a previous commit but cannot find it in git history, throw an error.
+
+            // If there is a previous commit but cannot find it in git history
             if !found {
-                return Err(format_err!(
-                    "Could not find the SHA of the previous release in the git history. Increase your git clone depth.",
-                ));
+                // Create a new release with default count if `--ignore-missing` is present
+                if ignore_missing {
+                    println!(
+                        "Could not find the SHA of the previous release in the git history. Skipping previous release and creating a new one with {} commits.",
+                        default_count
+                    );
+
+                    let mut revwalk = repo.revwalk()?;
+                    revwalk.push_head()?;
+
+                    let mut result: Vec<Commit> = revwalk
+                        .take(default_count + 1)
+                        .filter_map(commit_filter)
+                        .collect();
+
+                    if result.len() == default_count + 1 {
+                        let prev = result.pop();
+                        return Ok((result, prev));
+                    } else {
+                        return Ok((result, None));
+                    }
+                // Or throw an error and point to the right solution otherwise.
+                } else {
+                    return Err(format_err!(
+                        "Could not find the SHA of the previous release in the git history. If you limit the clone depth, try to increase it. \
+                        Otherwise, it means that the commit we are looking for was amended or squashed and cannot be retrieved. \
+                        Use --ignore-missing flag to skip it and create a new release with the default commits count.",
+                    ));
+                }
             }
             let prev = result.pop();
             Ok((result, prev))
@@ -493,6 +520,9 @@ pub fn get_commits_from_git<'a>(
                 "Could not find the previous commit. Creating a release with {} commits.",
                 default_count
             );
+
+            let mut revwalk = repo.revwalk()?;
+            revwalk.push_head()?;
             let mut result: Vec<Commit> = revwalk
                 .take(default_count + 1)
                 .filter_map(commit_filter)
@@ -894,7 +924,7 @@ fn test_get_commits_from_git() {
     );
 
     let repo = git2::Repository::open(dir.path()).expect("Failed");
-    let commits = get_commits_from_git(&repo, "", 20).expect("Failed");
+    let commits = get_commits_from_git(&repo, "", 20, false).expect("Failed");
 
     assert_debug_snapshot!(commits
         .0
@@ -936,7 +966,7 @@ fn test_generate_patch_set_base() {
     );
 
     let repo = git2::Repository::open(dir.path()).expect("Failed");
-    let commits = get_commits_from_git(&repo, "", 20).expect("Failed");
+    let commits = get_commits_from_git(&repo, "", 20, false).expect("Failed");
     let patch_set =
         generate_patch_set(&repo, commits.0, commits.1, "example/test-repo").expect("Failed");
 
@@ -989,7 +1019,7 @@ fn test_generate_patch_set_previous_commit() {
         "\"fifth commit\"",
     );
 
-    let commits = get_commits_from_git(&repo, &head.id().to_string(), 20).expect("Failed");
+    let commits = get_commits_from_git(&repo, &head.id().to_string(), 20, false).expect("Failed");
     let patch_set =
         generate_patch_set(&repo, commits.0, commits.1, "example/test-repo").expect("Failed");
 
@@ -1029,7 +1059,47 @@ fn test_generate_patch_default_twenty() {
     );
 
     let repo = git2::Repository::open(dir.path()).expect("Failed");
-    let commits = get_commits_from_git(&repo, "", 20).expect("Failed");
+    let commits = get_commits_from_git(&repo, "", 20, false).expect("Failed");
+    let patch_set =
+        generate_patch_set(&repo, commits.0, commits.1, "example/test-repo").expect("Failed");
+
+    assert_yaml_snapshot!(patch_set, {
+        ".*.id" => "[id]",
+        ".*.timestamp" => "[timestamp]"
+    });
+}
+
+#[test]
+fn test_generate_patch_ignore_missing() {
+    let dir = tempdir().expect("Failed to generate temp dir.");
+    test_initialize(dir.path());
+
+    git_commit_test(
+        dir.path(),
+        "foo.js",
+        b"console.log(\"Hello, world!\");",
+        "\"initial commit\"",
+    );
+
+    for n in 0..5 {
+        let file = format!("foo{}.js", n);
+        git_commit_test(
+            dir.path(),
+            &file,
+            b"console.log(\"Hello, world! Part 2\");",
+            "\"another commit\"",
+        );
+    }
+
+    git_commit_test(
+        dir.path(),
+        "foo2.js",
+        b"console.log(\"Hello, world!\");",
+        "\"final commit\"",
+    );
+
+    let repo = git2::Repository::open(dir.path()).expect("Failed");
+    let commits = get_commits_from_git(&repo, "nonexistinghash", 5, true).expect("Failed");
     let patch_set =
         generate_patch_set(&repo, commits.0, commits.1, "example/test-repo").expect("Failed");
 


### PR DESCRIPTION
We _could_ go with the more complex route of fetching all N releases and use their previous commits one by one, until we find a working one, however:
- it wouldn't cut it for fresh projects (a single release which has squashed commit)
- it would require us to fetch all that data from the API, as `get_previous_release_with_commits` that we use currently, is a very specific `/previous-with-commits` endpoint that returns only a single release

This change will allow us to be more "generous" for malformed repositories and it will still work fine with `initial-depth` option. Tested it on production already and works as expected.

Fixes: https://github.com/getsentry/sentry-cli/issues/792
Fixes https://github.com/getsentry/sentry-cli/issues/945
Fixes: https://github.com/getsentry/sentry-cli/issues/956
Fixes: https://github.com/Exelord/ember-cli-deploy-sentry-cli/issues/10