### PR TITLE
support custom request header from env / config

### DIFF
--- a/src/api.rs
+++ b/src/api.rs
@@ -420,8 +420,9 @@ impl Api {
         handle.transfer_encoding(self.config.allow_transfer_encoding())?;
 
         let env = self.config.get_pipeline_env();
+        let custom_header = self.config.get_custom_header();
 
-        ApiRequest::create(handle, &method, &url, auth, env)
+        ApiRequest::create(handle, &method, &url, auth, env, custom_header)
     }
 
     /// Convenience method that performs a `GET` request.
@@ -1519,6 +1520,7 @@ impl ApiRequest {
         url: &str,
         auth: Option<&Auth>,
         pipeline_env: Option<String>,
+        custom_header: Option<String>,
     ) -> ApiResult<Self> {
         debug!("request {} {}", method, url);
 
@@ -1537,6 +1539,10 @@ impl ApiRequest {
                     .append(&format!("User-Agent: sentry-cli/{}", VERSION))
                     .ok();
             }
+        }
+
+        if let Some(custom_header) = custom_header {
+            headers.append(&custom_header).ok();
         }
 
         match method {

--- a/src/config.rs
+++ b/src/config.rs
@@ -315,6 +315,15 @@ impl Config {
         })
     }
 
+    /// Return the custom header added to all requests.
+    pub fn get_custom_header(&self) -> Option<String> {
+        env::var("CUSTOM_HEADER").ok().or_else(|| {
+            self.ini
+                .get_from(Some("defaults"), "custom_header")
+                .map(str::to_owned)
+        })
+    }
+
     /// Returns the defaults for org and project.
     pub fn get_org_and_project_defaults(&self) -> (Option<String>, Option<String>) {
         (


### PR DESCRIPTION
closes: https://github.com/getsentry/sentry-cli/issues/308

As discussed in the issue above, there are use cases where being able to attach a custom header to every request is useful.

This introduces support for a new env var `CUSTOM_HEADER`, as well as a config block under defaults called `custom_header`, that allows you to specify a string that is added directly as a request header to all outgoing requests. Note that this is not a key/value pair - this expects the format `key: value` as a string.

**Testing:**

Uploading a lib somewhere where we don't have permission:

```
$ /docker-entrypoint.sh --log-level DEBUG upload-dif -o 31 -p my_proj /usr/lib/libssl.so.1.1
...
  DEBUG   2021-06-02 18:17:31.558003600 +00:00 > GET /api/0/organizations/31/chunk-upload/ HTTP/1.1
  DEBUG   2021-06-02 18:17:31.558079800 +00:00 > Host: sentry.io
  DEBUG   2021-06-02 18:17:31.558097 +00:00 > Accept: */*
  DEBUG   2021-06-02 18:17:31.558111100 +00:00 > Connection: TE
  DEBUG   2021-06-02 18:17:31.558121500 +00:00 > TE: gzip
  DEBUG   2021-06-02 18:17:31.558214100 +00:00 > User-Agent: sentry-cli/1.65.0
...
```

Setting the env var:
```
$ CUSTOM_HEADER="x-request-id: 12345" /docker-entrypoint.sh --log-level DEBUG upload-dif -o 31 -p my_proj /usr/lib/libssl.so.1.1
...
  DEBUG   2021-06-02 18:17:53.609051800 +00:00 > GET /api/0/organizations/31/chunk-upload/ HTTP/1.1
  DEBUG   2021-06-02 18:17:53.609131500 +00:00 > Host: sentry.io
  DEBUG   2021-06-02 18:17:53.609157300 +00:00 > Accept: */*
  DEBUG   2021-06-02 18:17:53.609178300 +00:00 > Connection: TE
  DEBUG   2021-06-02 18:17:53.609194300 +00:00 > TE: gzip
  DEBUG   2021-06-02 18:17:53.609216900 +00:00 > User-Agent: sentry-cli/1.65.0
  DEBUG   2021-06-02 18:17:53.609239700 +00:00 > x-request-id: 12345
...
```

Setting the config:
```
$ printf "[defaults]\ncustom_header = x-request-id: 987\n" > ~/.sentryclirc
$ cat ~/.sentryclirc 
[defaults]
custom_header = x-request-id: 987
$ /docker-entrypoint.sh --log-level DEBUG upload-dif -o 31 -p my_proj /usr/lib/libssl.so.1.1
...
  DEBUG   2021-06-02 18:21:21.663774700 +00:00 > GET /api/0/organizations/31/chunk-upload/ HTTP/1.1
  DEBUG   2021-06-02 18:21:21.663855700 +00:00 > Host: sentry.io
  DEBUG   2021-06-02 18:21:21.663881900 +00:00 > Accept: */*
  DEBUG   2021-06-02 18:21:21.663900500 +00:00 > Connection: TE
  DEBUG   2021-06-02 18:21:21.663916600 +00:00 > TE: gzip
  DEBUG   2021-06-02 18:21:21.663939400 +00:00 > User-Agent: sentry-cli/1.65.0
  DEBUG   2021-06-02 18:21:21.664017700 +00:00 > x-request-id: 987
...
```

PTAL @jan-auer @mitsuhiko 