### PR TITLE
Adding ignore-missing flag to setCommits types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## sentry-cli 1.65.1
+
+* fix: Adding `ignoreMissing` field to `SentryCliCommitsOptions` in `SentryCli` types
+
 ## sentry-cli 1.65.0
 
 * feat: Allow for ignoring missing commits in set-commit with `--ignore-missing` flag (#963)

--- a/js/index.d.ts
+++ b/js/index.d.ts
@@ -41,6 +41,7 @@ declare module '@sentry/cli' {
     repo?: string;
     commit?: string;
     previousCommit?: string;
+    ignoreMissing?: boolean;
   }
 
   export interface SentryCliReleases {

--- a/js/releases/index.js
+++ b/js/releases/index.js
@@ -68,6 +68,9 @@ class Releases {
    * release (in other words, the last commit of the previous release). If omitted,
    * this will default to the last commit of the previous release in Sentry. If there
    * was no previous release, the last 10 commits will be used.
+   * @param {boolean} options.ignoreMissing When the flag is set and the previous release
+   * commit was not found in the repository, will create a release with the default commits
+   * count (or the one specified with `--initial-depth`) instead of failing the command.
    * @returns {Promise} A promise that resolves when the commits have been associated
    * @memberof SentryReleases
    */
@@ -84,6 +87,10 @@ class Releases {
       commitFlags = ['--commit', `${options.repo}@${options.previousCommit}..${options.commit}`];
     } else {
       commitFlags = ['--commit', `${options.repo}@${options.commit}`];
+    }
+
+    if (options.ignoreMissing) {
+      commitFlags.push('--ignore-missing');
     }
 
     return this.execute(['releases', 'set-commits', release].concat(commitFlags));

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sentry/cli",
-  "version": "1.65.0",
+  "version": "1.65.1",
   "description": "A command line utility to work with Sentry. https://docs.sentry.io/hosted/learn/cli/",
   "homepage": "https://docs.sentry.io/hosted/learn/cli/",
   "license": "BSD-3-Clause",


### PR DESCRIPTION
Hey!

I just noticed that the last release added support for the `--ignore-missing` flag for set-commit.
Unfortunately that field is not in the `SentryCliCommitsOptions` types.
Hope this solves it.