### PR TITLE
Fix type for started and finished deploy options

### DIFF
--- a/js/index.d.ts
+++ b/js/index.d.ts
@@ -29,8 +29,8 @@ declare module '@sentry/cli' {
 
   export interface SentryCliNewDeployOptions {
     env: string;
-    started?: number;
-    finished?: number;
+    started?: string;
+    finished?: string;
     time?: number;
     name?: string;
     url?: string;


### PR DESCRIPTION
When passing a time number to `started` or `finished` option of `newDeploy` it errors with

```
Object({"dateFinished": Array([String("Datetime has wrong format. Use one of these formats instead: YYYY-MM-DDThh:mm[:ss[.uuuuuu]][+HH:MM|-HH:MM|Z].")]), "dateStarted": Array([String("Datetime has wrong format. Use one of these formats instead: YYYY-MM-DDThh:mm[:ss[.uuuuuu]][+HH:MM|-HH:MM|Z].")])})
```

This updates the type to be a string instead since this is what the cli expects.