### PR TITLE
lint: Fix all clippy warnings

### DIFF
--- a/src/commands/react_native_xcode.rs
+++ b/src/commands/react_native_xcode.rs
@@ -274,7 +274,7 @@ pub fn execute(matches: &ArgMatches<'_>) -> Result<(), Error> {
         processor.rewrite(&[base.parent().unwrap().to_str().unwrap()])?;
         processor.add_sourcemap_references()?;
 
-        let dist = env::var("SENTRY_DIST").unwrap_or(plist.build().to_string());
+        let dist = env::var("SENTRY_DIST").unwrap_or_else(|_| plist.build().to_string());
         let release_name = env::var("SENTRY_RELEASE").unwrap_or(format!(
             "{}@{}+{}",
             plist.bundle_id(),

--- a/src/utils/http.rs
+++ b/src/utils/http.rs
@@ -95,13 +95,13 @@ fn test_parse_link_header() {
 
 #[test]
 fn test_is_absolute_url() {
-    assert_eq!(is_absolute_url("https://sentry.io"), true);
-    assert_eq!(is_absolute_url("http://sentry.io"), true);
-    assert_eq!(is_absolute_url("https://sentry.io/path"), true);
-    assert_eq!(is_absolute_url("http://sentry.io/path"), true);
-    assert_eq!(is_absolute_url("http://sentry.io/path?query=foo"), true);
-    assert_eq!(is_absolute_url("https://sentry.io/path?query=foo"), true);
+    assert!(is_absolute_url("https://sentry.io"));
+    assert!(is_absolute_url("http://sentry.io"));
+    assert!(is_absolute_url("https://sentry.io/path"));
+    assert!(is_absolute_url("http://sentry.io/path"));
+    assert!(is_absolute_url("http://sentry.io/path?query=foo"));
+    assert!(is_absolute_url("https://sentry.io/path?query=foo"));
 
-    assert_eq!(is_absolute_url("/path"), false);
-    assert_eq!(is_absolute_url("/path?query=foo"), false);
+    assert!(!is_absolute_url("/path"));
+    assert!(!is_absolute_url("/path?query=foo"));
 }


### PR DESCRIPTION
Just a linter, so self-assigned after CI passes.