### PR TITLE
feat: Add --ignore-empty flag that will not bail command when no patchset is created

### DIFF
--- a/src/commands/releases.rs
+++ b/src/commands/releases.rs
@@ -108,8 +108,8 @@ pub fn make_app<'a, 'b: 'a>(app: App<'a, 'b>) -> App<'a, 'b> {
                 .help("When the flag is set and the previous release commit was not found in the repository, \
                         will create a release with the default commits count (or the one specified with `--initial-depth`) \
                         instead of failing the command."))
-            .arg(Arg::with_name("allow-empty")
-                .long("allow-empty")
+            .arg(Arg::with_name("ignore-empty")
+                .long("ignore-empty")
                 .help("When the flag is set, command will not fail and just exit silently \
                         if no new commits for a given release have been found."))
             .arg(Arg::with_name("local")
@@ -592,13 +592,13 @@ fn execute_set_commits<'a>(
         let commits = generate_patch_set(&repo, commit_log, prev_commit, &parsed)?;
 
         if commits.is_empty() {
-            // NOTE: Make it a default behavior on next major release instead?
-            let allow_empty = matches.is_present("allow-empty");
+            // TODO(v2): Make it a default behavior on next major release instead?
+            let allow_empty = matches.is_present("ignore-empty");
             if allow_empty {
                 println!("No commits found. Leaving release alone.");
                 return Ok(());
             } else {
-                bail!("No commits found. Change commits range, initial depth or use --allow-empty to allow empty patch sets.");
+                bail!("No commits found. Change commits range, initial depth or use --ignore-empty to allow empty patch sets.");
             }
         }
 

--- a/src/commands/releases.rs
+++ b/src/commands/releases.rs
@@ -593,8 +593,8 @@ fn execute_set_commits<'a>(
 
         if commits.is_empty() {
             // TODO(v2): Make it a default behavior on next major release instead?
-            let allow_empty = matches.is_present("ignore-empty");
-            if allow_empty {
+            let ignore_empty = matches.is_present("ignore-empty");
+            if ignore_empty {
                 println!("No commits found. Leaving release alone.");
                 return Ok(());
             } else {


### PR DESCRIPTION
Otherwise, there is no easy way to ignore this error and allow the CI to progress when triggering the same `set-commit` command with no new commits. Simple `|| true` is not sufficient, as it will silent all possible valid errors.

Q: Not sure if we should call it `--allow-empty` or `--ignore-empty` to be consistent with newly added `ignore-missing` flag.