### PR TITLE
(issue #1007)  prevent progress bar from breaking install

### DIFF
--- a/scripts/install.js
+++ b/scripts/install.js
@@ -173,7 +173,6 @@ function downloadBinary() {
         decompressor = new stream.PassThrough();
       }
       const name = downloadUrl.match(/.*\/(.*?)$/)[1];
-      console.log(response.headers);
       const total = parseInt(response.headers.get('content-length'), 10);
       const progressBar = createProgressBar(name, total);
       const tempPath = getTempFile(cachedPath);

--- a/scripts/install.js
+++ b/scripts/install.js
@@ -173,6 +173,7 @@ function downloadBinary() {
         decompressor = new stream.PassThrough();
       }
       const name = downloadUrl.match(/.*\/(.*?)$/)[1];
+      console.log(response.headers);
       const total = parseInt(response.headers.get('content-length'), 10);
       const progressBar = createProgressBar(name, total);
       const tempPath = getTempFile(cachedPath);
@@ -181,7 +182,13 @@ function downloadBinary() {
       return new Promise((resolve, reject) => {
         response.body
           .on('error', e => reject(e))
-          .on('data', chunk => shouldRenderProgressBar() && progressBar.tick(chunk.length))
+          .on('data', chunk => {
+            try {
+              shouldRenderProgressBar() && progressBar.tick(chunk.length);
+            } catch {
+              // progress bar was unable to render
+            }
+          })
           .pipe(decompressor)
           .pipe(fs.createWriteStream(tempPath, { mode: '0755' }))
           .on('error', e => reject(e))


### PR DESCRIPTION
See Issue #1007 

Prevent the progress bar renderer from breaking when content-length http header does not exist ( or any other kind of weird breaking error )