### PR TITLE
ref: Hide upload-symbol-maps flag for upload-dif command

### DIFF
--- a/src/commands/upload_dif.rs
+++ b/src/commands/upload_dif.rs
@@ -173,7 +173,10 @@ pub fn make_app<'a, 'b: 'a>(app: App<'a, 'b>) -> App<'a, 'b> {
                      hidden symbols, e.g. when it downloads dSYMs directly from App \
                      Store Connect or when you upload dSYMs without first resolving \
                      the hidden symbols using --symbol-maps.",
-                ),
+                )
+                // NOTE(kamil): Hidden until we make it usable. We cannot remove it as it's already included in sentry-fastlane-plugin.
+                // See: https://github.com/getsentry/sentry-cli/issues/1009#issuecomment-911516666
+                .hidden(true),
         )
 }
 


### PR DESCRIPTION
Hidden until we make it usable, see: https://github.com/getsentry/sentry-cli/issues/1009#issuecomment-911516666

Closes https://github.com/getsentry/sentry-cli/issues/1009