### PR TITLE
fix: Set archString to "armv7" when arch="arm"

### DIFF
--- a/scripts/install.js
+++ b/scripts/install.js
@@ -66,6 +66,9 @@ function getDownloadUrl(platform, arch) {
     case 'arm64':
       archString = 'aarch64';
       break;
+    case 'arm':
+      archString = 'armv7';
+      break;
     default:
       archString = arch;
   }


### PR DESCRIPTION
When arch="arm", set archString="armv7", so that the install script will download the correct binary.

Closes #1023