### PR TITLE
feat(difupload): Look into aar files as zip

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+"You know what they say. Fool me once, strike one, but fool me twice... strike three." — Michael Scott
+
 ## Unreleased
 
 * feat: `dif_upload` searches within .aar files as .zip (#1031)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-"You know what they say. Fool me once, strike one, but fool me twice... strike three." — Michael Scott 
+* feat: `dif_upload` searches within .aar files as .zip (#1031)
 
 ## sentry-cli 1.68.0
 

--- a/src/utils/dif_upload.rs
+++ b/src/utils/dif_upload.rs
@@ -454,9 +454,8 @@ where
     P: AsRef<Path>,
 {
     let ext = path.as_ref().extension();
-    if ext != Some("zip".as_ref())
-        // Also look into Android Archives for native symbols
-        && ext != Some("aar".as_ref()) {
+    // Also look into Android Archives for native symbols
+    if ext != Some("zip".as_ref()) && ext != Some("aar".as_ref()) {
         return Ok(None);
     }
 

--- a/src/utils/dif_upload.rs
+++ b/src/utils/dif_upload.rs
@@ -453,7 +453,10 @@ fn try_open_zip<P>(path: P) -> Result<Option<ZipFileArchive>, Error>
 where
     P: AsRef<Path>,
 {
-    if path.as_ref().extension() != Some("zip".as_ref()) {
+    let ext = path.as_ref().extension();
+    if ext != Some("zip".as_ref()
+        // Also look into Android Archives for native symbols
+        || ext != Some("aar".as_ref()) {
         return Ok(None);
     }
 

--- a/src/utils/dif_upload.rs
+++ b/src/utils/dif_upload.rs
@@ -454,9 +454,9 @@ where
     P: AsRef<Path>,
 {
     let ext = path.as_ref().extension();
-    if ext != Some("zip".as_ref()
+    if ext != Some("zip".as_ref())
         // Also look into Android Archives for native symbols
-        || ext != Some("aar".as_ref()) {
+        && ext != Some("aar".as_ref()) {
         return Ok(None);
     }
 


### PR DESCRIPTION
`.aar` are just zips: https://developer.android.com/studio/projects/android-library#aar-contents

This change will allow us running `dif-upload` pointing to a `.aar` without having to unzip it.

```
➜  sentry-cli git:(feat/android-aar-difupload) ✗ cargo build
   Compiling sentry-cli v1.68.0 (/Users/bruno/git/sentry-cli)
    Finished dev [unoptimized + debuginfo] target(s) in 7.97s
➜  sentry-cli git:(feat/android-aar-difupload) ✗ ./target/debug/sentry-cli  upload-dif -o sentry-sdks -p sentry-unity ~/git/sentry-unity/package-dev/Plugins/Android/Sentry/sentry-android-ndk-release.aar

  WARN    2021-09-24 15:20:03.937446 -04:00 Skipping BCSymbolMap with invalid filename: jni/
  WARN    2021-09-24 15:20:03.938707 -04:00 Skipping BCSymbolMap with invalid filename: jni/arm64-v8a/
  WARN    2021-09-24 15:20:04.184809 -04:00 Skipping BCSymbolMap with invalid filename: jni/armeabi-v7a/
  WARN    2021-09-24 15:20:04.358523 -04:00 Skipping BCSymbolMap with invalid filename: jni/x86/
  WARN    2021-09-24 15:20:04.602819 -04:00 Skipping BCSymbolMap with invalid filename: jni/x86_64/
  WARN    2021-09-24 15:20:04.847980 -04:00 Skipping BCSymbolMap with invalid filename: jni/include/
  WARN    2021-09-24 15:20:04.854626 -04:00 Skipping BCSymbolMap with invalid filename: x86_64/
  WARN    2021-09-24 15:20:04.855299 -04:00 Skipping BCSymbolMap with invalid filename: x86/
  WARN    2021-09-24 15:20:04.855946 -04:00 Skipping BCSymbolMap with invalid filename: arm64-v8a/
  WARN    2021-09-24 15:20:04.856592 -04:00 Skipping BCSymbolMap with invalid filename: armeabi-v7a/
> Found 6 debug information files
> Prepared debug information files for upload
> Uploading completed in 4.708s
> Uploaded 6 missing debug information files
> File upload complete:

  PENDING 9e41a498-9952-b10b-8e19-d7b9e2fc6e82 (jni/x86/libsentry.so; x86 library)
  PENDING 93530c65-e68b-cb5b-d0df-2fab5dff81ab (jni/arm64-v8a/libsentry.so; arm64 library)
  PENDING e78b04ab-2427-0f23-0fb7-3e90948f390d (jni/x86_64/libsentry-android.so; x86_64 library)
  PENDING 59b95341-5ff9-e21f-bae4-a666f0a6856b (jni/x86/libsentry-android.so; x86 library)
  PENDING 4844d009-8488-d205-a706-7f0edc958d1c (jni/x86_64/libsentry.so; x86_64 library)
  PENDING 4a8f1bca-4255-9223-d693-d08f14f32ca8 (jni/arm64-v8a/libsentry-android.so; arm64 library)
➜  sentry-cli git:(feat/android-aar-difupload) ✗
```