### PR TITLE
Revert "feat(difupload): Look into aar files as zip"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,8 @@
 # Changelog
 
-"You know what they say. Fool me once, strike one, but fool me twice... strike three." — Michael Scott
-
 ## Unreleased
 
-* feat: `dif_upload` searches within .aar files as .zip (#1031)
+"You know what they say. Fool me once, strike one, but fool me twice... strike three." — Michael Scott 
 
 ## sentry-cli 1.68.0
 

--- a/src/utils/dif_upload.rs
+++ b/src/utils/dif_upload.rs
@@ -453,9 +453,7 @@ fn try_open_zip<P>(path: P) -> Result<Option<ZipFileArchive>, Error>
 where
     P: AsRef<Path>,
 {
-    let ext = path.as_ref().extension();
-    // Also look into Android Archives for native symbols
-    if ext != Some("zip".as_ref()) && ext != Some("aar".as_ref()) {
+    if path.as_ref().extension() != Some("zip".as_ref()) {
         return Ok(None);
     }
 


### PR DESCRIPTION
Reverts getsentry/sentry-cli#1031

Due to: https://github.com/getsentry/sentry-cli/pull/1031#discussion_r716638761
We decided not to peek into .aar for symbols.