### PR TITLE
fix(js): Add example commands to errors re: updating/uninstalling `@sentry/cli`

### DIFF
--- a/src/commands/uninstall.rs
+++ b/src/commands/uninstall.rs
@@ -40,7 +40,13 @@ pub fn execute(matches: &ArgMatches<'_>) -> Result<(), Error> {
     }
     if is_npm_install() {
         println!("This installation of sentry-cli is managed through npm/yarn");
-        println!("Please use npm/yarn to uninstall sentry-cli");
+        println!(
+            "Please use npm/yarn to uninstall sentry-cli, using one of the following commands:"
+        );
+        println!("  yarn remove @sentry/cli");
+        println!("  yarn global remove @sentry/cli");
+        println!("  npm uninstall @sentry/cli");
+        println!("  npm uninstall --global @sentry/cli");
         return Err(QuietExit(1).into());
     }
     if cfg!(windows) {

--- a/src/utils/update.rs
+++ b/src/utils/update.rs
@@ -190,7 +190,11 @@ pub fn assert_updatable() -> Result<(), Error> {
         return Err(QuietExit(1).into());
     } else if is_npm_install() {
         println!("This installation of sentry-cli is managed through npm/yarn");
-        println!("Please use npm/yarn to update sentry-cli");
+        println!("Please use npm/yarn to update sentry-cli, using one of the following commands:");
+        println!("  yarn upgrade @sentry/cli");
+        println!("  yarn global upgrade @sentry/cli");
+        println!("  npm update @sentry/cli");
+        println!("  npm update -g @sentry/cli");
         return Err(QuietExit(1).into());
     }
     Ok(())


### PR DESCRIPTION
This adds example commands to the error messages we show when trying to update or uninstall a `sentry-cli` instance installed as part of `@sentry/cli`, both for convenience and as a hint that the npm package may be installed globally.