### PR TITLE
fix: Follow symlinks when traversing during sourcemaps upload

### DIFF
--- a/src/utils/file_search.rs
+++ b/src/utils/file_search.rs
@@ -109,7 +109,11 @@ impl ReleaseFileSearch {
         let mut collected = Vec::new();
 
         let mut builder = WalkBuilder::new(&self.path);
-        builder.git_exclude(false).git_ignore(false).ignore(false);
+        builder
+            .follow_links(true)
+            .git_exclude(false)
+            .git_ignore(false)
+            .ignore(false);
 
         if !&self.extensions.is_empty() {
             let mut types_builder = TypesBuilder::new();


### PR DESCRIPTION
This behavior is already implemented in `upload-dif` and `difutil` commands. Verified it locally.

Fixes https://github.com/getsentry/sentry-cli/issues/711