### PR TITLE
ref: Use SOURCE_VERSION first prior to HEROKU_SLUG_COMMIT in Heroku

### DIFF
--- a/src/utils/releases.rs
+++ b/src/utils/releases.rs
@@ -90,15 +90,15 @@ pub fn detect_release_name() -> Result<String, Error> {
         return Ok(release);
     }
 
-    // try Heroku #1: https://docs.sentry.io/workflow/integrations/legacy-integrations/heroku/#configure-releases
-    if let Ok(release) = env::var("HEROKU_SLUG_COMMIT") {
+    // try Heroku #1 https://devcenter.heroku.com/changelog-items/630
+    if let Ok(release) = env::var("SOURCE_VERSION") {
         if !release.is_empty() {
             return Ok(release);
         }
     }
 
-    // try Heroku #2 https://devcenter.heroku.com/changelog-items/630
-    if let Ok(release) = env::var("SOURCE_VERSION") {
+    // try Heroku #2: https://docs.sentry.io/product/integrations/deployment/heroku/#configure-releases
+    if let Ok(release) = env::var("HEROKU_SLUG_COMMIT") {
         if !release.is_empty() {
             return Ok(release);
         }


### PR DESCRIPTION
@faergeek has a good explanation for it in https://github.com/getsentry/sentry-cli/issues/892

Also per https://stackoverflow.com/a/43661131/1690906

> Unfortunately, at this point, our dyno metadata lab flags and the config vars made available during the build don't entirely match up. During the build, you can use the SOURCE_VERSION environment variable, which will be the commit hash. Then, at runtime, you can use HEROKU_SLUG_COMMIT to get the same value.
>
> The reason behind this difference is mostly a difference of context. Naming that variable HEROKU_SLUG_COMMIT during build wouldn't make sense, as it's not a slug yet.
>
> Since we will never set both config vars, you should be able to use any of them, and fallback to the other if it's not set.

Closes https://github.com/getsentry/sentry-cli/issues/892

ref: https://devcenter.heroku.com/changelog-items/630
ref: https://devcenter.heroku.com/articles/buildpack-api