### PR TITLE
Retrieve the events list for a project

### DIFF
--- a/src/api.rs
+++ b/src/api.rs
@@ -1330,6 +1330,42 @@ impl Api {
         resp.convert()
     }
 
+    /// List all events associated with an organization and a project
+    pub fn list_organization_project_events(
+        &self,
+        org: &str,
+        project: &str,
+    ) -> ApiResult<Vec<Event>> {
+        let mut rv = vec![];
+        let mut cursor = "".to_string();
+
+        loop {
+            let resp = self.get(&format!(
+                "/projects/{}/{}/events/?cursor={}",
+                PathArg(org),
+                PathArg(project),
+                QueryArg(&cursor)
+            ))?;
+
+            if resp.status() == 404 || (resp.status() == 400 && !cursor.is_empty()) {
+                if rv.is_empty() {
+                    return Err(ApiErrorKind::OrganizationNotFound.into());
+                } else {
+                    break;
+                }
+            }
+            let pagination = resp.pagination();
+            rv.extend(resp.convert::<Vec<Event>>()?.into_iter());
+            if let Some(next) = pagination.into_next_cursor() {
+                cursor = next;
+            } else {
+                break;
+            }
+        }
+
+        Ok(rv)
+    }
+
     /// List all projects associated with an organization
     pub fn list_organization_projects(&self, org: &str) -> ApiResult<Vec<Project>> {
         let mut rv = vec![];
@@ -2152,6 +2188,81 @@ pub struct Monitor {
     pub id: String,
     pub name: String,
     pub status: String,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct EventTag {
+    pub key: String,
+    pub value: String,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct EventTags(pub Vec<EventTag>);
+
+impl fmt::Display for EventTags {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        for event in &self.0 {
+            write!(f, "{} = {}, ", event.key, event.value)?;
+        }
+
+        Ok(())
+    }
+}
+
+#[derive(Debug, Deserialize)]
+pub struct EventUserOption {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub username: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub user: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub email: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub ip_address: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct EventUser(pub Option<EventUserOption>);
+
+impl fmt::Display for EventUser {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        if let Some(event) = &self.0 {
+            if let Some(ref id) = event.id {
+                write!(f, "ID: {}, ", id)?;
+            }
+
+            if let Some(ref username) = event.username {
+                write!(f, "Username: {}, ", username)?;
+            }
+
+            if let Some(ref user) = event.user {
+                write!(f, "User: {}, ", user)?;
+            }
+
+            if let Some(ref email) = event.email {
+                write!(f, "Email: {}, ", email)?;
+            }
+
+            if let Some(ref ip_address) = event.ip_address {
+                write!(f, "IP: {}, ", ip_address)?;
+            }
+        }
+
+        Ok(())
+    }
+}
+
+#[derive(Debug, Deserialize)]
+pub struct Event {
+    #[serde(rename = "eventID")]
+    pub event_id: String,
+    pub title: String,
+    #[serde(rename = "dateCreated")]
+    pub date_created: String,
+    pub tags: EventTags,
+    pub user: EventUser,
 }
 
 #[derive(Debug, Serialize, Deserialize)]

--- a/src/commands/events.rs
+++ b/src/commands/events.rs
@@ -1,0 +1,69 @@
+//! Implements a command for issue management.
+use clap::{App, AppSettings, Arg, ArgMatches};
+use failure::Error;
+use log::info;
+
+use crate::api::Api;
+use crate::config::Config;
+use crate::utils::args::ArgExt;
+use crate::utils::formatting::Table;
+
+pub fn make_app<'a, 'b: 'a>(app: App<'a, 'b>) -> App<'a, 'b> {
+    app.about("Manage events on Sentry.")
+        .setting(AppSettings::SubcommandRequiredElseHelp)
+        .org_project_args()
+        .arg(
+            Arg::with_name("user")
+                .long("user")
+                .short("u")
+                .help("Include user's info into the list."),
+        )
+        .arg(
+            Arg::with_name("tags")
+                .long("tags")
+                .short("t")
+                .help("Include tags into the list."),
+        )
+        .subcommand(App::new("list").about("List all events for a project."))
+}
+
+pub fn execute(matches: &ArgMatches<'_>) -> Result<(), Error> {
+    let config = Config::current();
+    let api = Api::current();
+    let (org, project) = config.get_org_and_project(matches)?;
+
+    info!("Get events for Organization: {} Project: {}", org, project);
+
+    let events = api.list_organization_project_events(&org, &project)?;
+
+    let mut table = Table::new();
+    let row = table.add_row();
+    row.add("Event ID").add("Date").add("Title");
+
+    if matches.is_present("user") {
+        row.add("User");
+    }
+
+    if matches.is_present("tags") {
+        row.add("Tags");
+    }
+
+    for event in &events {
+        let row = table.add_row();
+        row.add(&event.event_id)
+            .add(&event.date_created)
+            .add(&event.title);
+
+        if matches.is_present("user") {
+            row.add(&event.user);
+        }
+
+        if matches.is_present("tags") {
+            row.add(&event.tags);
+        }
+    }
+
+    table.print();
+
+    Ok(())
+}

--- a/src/commands/events.rs
+++ b/src/commands/events.rs
@@ -37,8 +37,7 @@ pub fn execute(matches: &ArgMatches<'_>) -> Result<(), Error> {
     let events = api.list_organization_project_events(&org, &project)?;
 
     let mut table = Table::new();
-    let row = table.add_row();
-    row.add("Event ID").add("Date").add("Title");
+    let row = table.title_row().add("Event ID").add("Date").add("Title");
 
     if matches.is_present("user") {
         row.add("User");

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -27,6 +27,7 @@ macro_rules! each_subcommand {
         $mac!(upload_dsym);
         $mac!(upload_proguard);
         $mac!(releases);
+        $mac!(events);
         $mac!(issues);
         $mac!(repos);
         $mac!(projects);
@@ -53,12 +54,13 @@ macro_rules! each_subcommand {
 
 // commands we want to run the update nagger on
 const UPDATE_NAGGER_CMDS: &[&str] = &[
-    "releases", "issues", "repos", "projects", "monitors", "info", "login", "difutil",
+    "releases", "events", "issues", "repos", "projects", "monitors", "info", "login", "difutil",
 ];
 
 // it would be great if this could be a macro expansion as well
 // but rust bug #37663 breaks location information then.
 pub mod bash_hook;
+pub mod events;
 pub mod info;
 pub mod issues;
 pub mod login;


### PR DESCRIPTION
This PR adds a new command:
```
Manage events on Sentry.

USAGE:
    sentry-cli events [OPTIONS] <SUBCOMMAND>

OPTIONS:
    -h, --help                     Prints help information
        --log-level <LOG_LEVEL>    Set the log output verbosity. [possible values:
                                   trace, debug, info, warn, error]
    -o, --org <ORG>                The organization slug
    -p, --project <PROJECT>        The project slug
    -t, --tags                     Include tags into the list.
    -u, --user                     Include user' info into the list.

SUBCOMMANDS:
    help    Prints this message or the help of the given subcommand(s)
    list    List all events for an project.
```

Using `events -o <org> -p <project> list` it shows all the events associated with that project of that organization. Using `-t` extend the table with the tags, and using `-u` extend the table with the user informations.