### PR TITLE
:wrench: Fix option key typo

### DIFF
--- a/js/index.d.ts
+++ b/js/index.d.ts
@@ -37,7 +37,7 @@ declare module '@sentry/cli' {
      * Version control system remote name.
      * This value will update `SENTRY_VCS_REMOTE` env variable.
      */
-    vscRemote?: string;
+    vcsRemote?: string;
     /**
      * Unique identifier for the distribution, used to further segment your release.
      * Usually your build number.


### PR DESCRIPTION
I believe it should be vcsRemote instead of vscRemote 👍