### PR TITLE
ref: Remove warning about relative urls for chunk uploads

### DIFF
--- a/src/utils/chunks.rs
+++ b/src/utils/chunks.rs
@@ -9,14 +9,12 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use failure::Error;
-use log::warn;
 use parking_lot::RwLock;
 use rayon::prelude::*;
 use rayon::ThreadPoolBuilder;
 use sha1::Digest;
 
 use crate::api::{Api, ChunkUploadOptions, ProgressBarMode};
-use crate::utils::http::is_absolute_url;
 use crate::utils::progress::{ProgressBar, ProgressStyle};
 
 /// Timeout for polling all assemble endpoints.
@@ -207,11 +205,6 @@ pub fn upload_chunks(
     let pool = ThreadPoolBuilder::new()
         .num_threads(chunk_options.concurrency as usize)
         .build()?;
-
-    if !is_absolute_url(&chunk_options.url) {
-        warn!("Uploading chunks to a relative url is not recommended. Please update your `system.url-prefix`\
-           configuration inside `config.yml` or use `Root URL` option at https://<sentry-url>/manage/settings/ directly.");
-    }
 
     pool.install(|| {
         batches


### PR DESCRIPTION
It was introduced due to behavior explained here - https://github.com/getsentry/sentry-cli/issues/649#issuecomment-587077401
However since then, we changed how the endpoint is exposed from Sentry, so we do handle relative URLs correctly - https://github.com/getsentry/sentry/pull/29347

Fixes https://github.com/getsentry/sentry-cli/issues/1051
Fixes https://github.com/getsentry/sentry-webpack-plugin/issues/325