### PR TITLE
feat: update dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,20 +8,20 @@ ENV BUILD_TARGET=$BUILD_ARCH-unknown-linux-$BUILD_LIBC
 WORKDIR /work
 
 # Build only dependencies to speed up subsequent builds
-ADD Cargo.toml Cargo.lock build.rs ./
+COPY Cargo.toml Cargo.lock build.rs ./
 RUN mkdir -p src \
     && echo "fn main() {}" > src/main.rs \
     && cargo build --release --target=$BUILD_TARGET --locked
 
 # Add all sources and rebuild the actual sentry-cli
-ADD src src/
+COPY src src/
 
 RUN touch src/main.rs && cargo build --target=$BUILD_TARGET --release --features managed
 
 # Copy the compiled binary to a target-independent location so it can be picked up later
 RUN cp target/$BUILD_TARGET/release/sentry-cli /usr/local/bin/sentry-cli
 
-FROM alpine:3.12
+FROM alpine:3.14
 WORKDIR /work
 RUN apk add --no-cache ca-certificates
 COPY ./docker-entrypoint.sh /


### PR DESCRIPTION
This updates the base image of Alpine from `3.12` to `3.14.`

It also replaces the `ADD` statements with `COPY` per recommendation of [the Docker best practices](https://docs.docker.com/develop/develop-images/dockerfile_best-practices/#add-or-copy).

I have tested a `docker build .` locally and `sentry-cli` still works after my changes.