### PR TITLE
feat(send-event): Add optional positional argument that allows to specify a path to JSON serialized event

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1939,7 +1939,6 @@ dependencies = [
  "rust-ini",
  "semver 1.0.4",
  "sentry",
- "sentry-types",
  "serde",
  "serde_json",
  "sha1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,7 +46,6 @@ runas = "0.2.1"
 rust-ini = "0.17.0"
 semver = "1.0.3"
 sentry = { version = "0.23.0", default-features = false, features = ["curl"] }
-sentry-types = "0.23.0"
 serde = { version = "1.0.114", features = ["derive"] }
 serde_json = "1.0.56"
 sha1 = { version = "0.6.0", features = ["serde"] }

--- a/src/commands/bash_hook.rs
+++ b/src/commands/bash_hook.rs
@@ -10,7 +10,7 @@ use clap::{App, Arg, ArgMatches};
 use failure::Error;
 use lazy_static::lazy_static;
 use regex::Regex;
-use sentry_types::protocol::latest::{Event, Exception, Frame, Stacktrace, User, Value};
+use sentry::protocol::{Event, Exception, Frame, Stacktrace, User, Value};
 use username::get_user_name;
 use uuid::Uuid;
 

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -302,7 +302,7 @@ pub fn main() {
                 print_error(&err);
                 #[cfg(feature = "with_crash_reporting")]
                 {
-                    crate::utils::crashreporting::try_report_to_sentry(&err);
+                    crate::utils::crashreporting::try_report_to_sentry(err);
                 }
                 1
             };

--- a/src/commands/send_event.rs
+++ b/src/commands/send_event.rs
@@ -1,11 +1,17 @@
 //! Implements a command for sending events to Sentry.
 use std::borrow::Cow;
 use std::env;
+use std::fs::File;
+use std::io::BufReader;
+use std::path::PathBuf;
 
 use clap::{App, Arg, ArgMatches};
 use failure::{err_msg, Error};
+use glob::{glob_with, MatchOptions};
 use itertools::Itertools;
-use sentry_types::protocol::latest::{Event, Level, LogEntry, User};
+use log::warn;
+use sentry::protocol::{Event, Level, LogEntry, User};
+use sentry::types::{Dsn, Uuid};
 use serde_json::Value;
 use username::get_user_name;
 
@@ -22,6 +28,13 @@ pub fn make_app<'a, 'b: 'a>(app: App<'a, 'b>) -> App<'a, 'b> {
              Sentry. Due to network errors, rate limits or sampling the event is not guaranteed to \
              actually arrive. Check debug output for transmission errors by passing --log-level=\
              debug or setting `SENTRY_LOG_LEVEL=debug`.",
+        )
+        .arg(
+            Arg::with_name("path")
+                .value_name("PATH")
+                .index(1)
+                .required(false)
+                .help("The path or glob to the file(s) in JSON format to send as event(s). When provided, all other arguments are ignored."),
         )
         .arg(
             Arg::with_name("level")
@@ -143,8 +156,36 @@ pub fn make_app<'a, 'b: 'a>(app: App<'a, 'b>) -> App<'a, 'b> {
         )
 }
 
+fn send_raw_event(event: Event<'static>, dsn: Dsn) -> Uuid {
+    with_sentry_client(dsn, |c| c.capture_event(event, None))
+}
+
 pub fn execute(matches: &ArgMatches<'_>) -> Result<(), Error> {
     let config = Config::current();
+    let dsn = config.get_dsn()?;
+
+    if let Some(path) = matches.value_of("path") {
+        let collected_paths: Vec<PathBuf> = glob_with(path, MatchOptions::new())
+            .unwrap()
+            .flatten()
+            .collect();
+
+        if collected_paths.is_empty() {
+            warn!("Did not match any .json files for pattern: {}", path);
+            return Ok(());
+        }
+
+        for path in collected_paths {
+            let p = path.as_path();
+            let file = File::open(p)?;
+            let reader = BufReader::new(file);
+            let event: Event = serde_json::from_reader(reader)?;
+            let id = send_raw_event(event, dsn.clone());
+            println!("Event from file {} dispatched: {}", p.display(), id);
+        }
+
+        return Ok(());
+    }
 
     let mut event = Event {
         sdk: Some(get_sdk_info()),
@@ -240,8 +281,8 @@ pub fn execute(matches: &ArgMatches<'_>) -> Result<(), Error> {
         attach_logfile(&mut event, logfile, matches.is_present("with_categories"))?;
     }
 
-    let id = with_sentry_client(config.get_dsn()?, |c| c.capture_event(event, None));
-    println!("{}", id);
+    let id = send_raw_event(event, dsn);
+    println!("Event dispatched: {}", id);
 
     Ok(())
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -11,7 +11,7 @@ use failure::{bail, err_msg, Error, ResultExt};
 use ini::Ini;
 use lazy_static::lazy_static;
 use parking_lot::Mutex;
-use sentry_types::Dsn;
+use sentry::types::Dsn;
 
 use crate::constants::{CONFIG_RC_FILE_NAME, DEFAULT_RETRIES, DEFAULT_URL};
 use crate::utils::http::is_absolute_url;

--- a/src/utils/event.rs
+++ b/src/utils/event.rs
@@ -7,9 +7,9 @@ use chrono::Utc;
 use failure::{Error, ResultExt};
 use lazy_static::lazy_static;
 use regex::Regex;
-use sentry::{Client, ClientOptions};
-use sentry_types::protocol::latest::{Breadcrumb, ClientSdkInfo, Event};
-use sentry_types::Dsn;
+use sentry::protocol::{Breadcrumb, ClientSdkInfo, Event};
+use sentry::types::Dsn;
+use sentry::{apply_defaults, Client, ClientOptions};
 
 use crate::constants::USER_AGENT;
 
@@ -84,10 +84,10 @@ where
 {
     let client = Client::from_config((
         dsn,
-        ClientOptions {
+        apply_defaults(ClientOptions {
             user_agent: USER_AGENT.into(),
             ..Default::default()
-        },
+        }),
     ));
 
     let rv = callback(&client);


### PR DESCRIPTION
```terminal
$ sentry-cli send-event ./events/foo.json
$ sentry-cli send-event './events/*.json'
```

Closes https://github.com/getsentry/sentry-cli/issues/702