### PR TITLE
deps: Update to sentry 0.23.0 and remove unused crashreporting code

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -138,7 +138,7 @@ checksum = "9fe17f59a06fe8b87a6fc8bf53bb70b3aba76d7685f432487a68cd5552853625"
 dependencies = [
  "getrandom 0.2.3",
  "instant",
- "rand 0.8.4",
+ "rand",
 ]
 
 [[package]]
@@ -176,15 +176,6 @@ name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
-
-[[package]]
-name = "bitmaps"
-version = "2.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "031043d04099746d8db04daf1fa424b2bc8bd69d92b25962dcde24da39ab64a2"
-dependencies = [
- "typenum",
-]
 
 [[package]]
 name = "blake2b_simd"
@@ -545,7 +536,7 @@ version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68df3f2b690c1b86e65ef7830956aededf3cb0a16f898f79b9a6f421a7b6211b"
 dependencies = [
- "rand 0.8.4",
+ "rand",
 ]
 
 [[package]]
@@ -847,17 +838,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "hostname"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c731c3e10504cc8ed35cfe2f1db4c9274c3d35fa486e3b31df46f068ef3e867"
-dependencies = [
- "libc",
- "match_cfg",
- "winapi 0.3.9",
-]
-
-[[package]]
 name = "httparse"
 version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -865,9 +845,9 @@ checksum = "acd94fdbe1d4ff688b67b04eee2e17bd50995534a61539e45adfefb45e5e5503"
 
 [[package]]
 name = "httpdate"
-version = "0.3.2"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "494b4d60369511e7dea41cf646832512a94e542f68bb9c49e54518e0f468eb47"
+checksum = "6456b8a6c8f33fee7d958fcd1b60d55b11940a79e63ae87013e6d22e26034440"
 
 [[package]]
 name = "id-arena"
@@ -925,20 +905,6 @@ dependencies = [
  "thread_local",
  "walkdir",
  "winapi-util",
-]
-
-[[package]]
-name = "im"
-version = "14.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "696059c87b83c5a258817ecd67c3af915e3ed141891fc35a1e79908801cf0ce7"
-dependencies = [
- "bitmaps",
- "rand_core 0.5.1",
- "rand_xoshiro",
- "sized-chunks",
- "typenum",
- "version_check",
 ]
 
 [[package]]
@@ -1133,12 +1099,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3e2e65a1a2e43cfcb47a895c4c8b10d1f4a61097f9f254f183aee60cad9c651d"
 
 [[package]]
-name = "match_cfg"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ffbee8634e0d45d258acb448e7eaab3fce7a0a467395d4d9f228e3c1f01fb2e4"
-
-[[package]]
 name = "matches"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1207,7 +1167,7 @@ dependencies = [
  "httparse",
  "lazy_static",
  "log",
- "rand 0.8.4",
+ "rand",
  "regex",
  "serde_json",
  "serde_urlencoded",
@@ -1482,6 +1442,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "pin-project-lite"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d31d11c69a6b52a174b42bdc0c30e5e11670f90788b2c471c31c1d17d449443"
+
+[[package]]
 name = "pkg-config"
 version = "0.3.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1622,37 +1588,14 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a6b1679d49b24bbfe0c803429aa1874472f50d9b363131f0e89fc356b544d03"
-dependencies = [
- "getrandom 0.1.16",
- "libc",
- "rand_chacha 0.2.2",
- "rand_core 0.5.1",
- "rand_hc 0.2.0",
-]
-
-[[package]]
-name = "rand"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2e7573632e6454cf6b99d7aac4ccca54be06da05aca2ef7423d22d27d4d4bcd8"
 dependencies = [
  "libc",
- "rand_chacha 0.3.1",
- "rand_core 0.6.3",
- "rand_hc 0.3.1",
-]
-
-[[package]]
-name = "rand_chacha"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4c8ed856279c9737206bf725bf36935d8666ead7aa69b52be55af369d193402"
-dependencies = [
- "ppv-lite86",
- "rand_core 0.5.1",
+ "rand_chacha",
+ "rand_core",
+ "rand_hc",
 ]
 
 [[package]]
@@ -1662,16 +1605,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
 dependencies = [
  "ppv-lite86",
- "rand_core 0.6.3",
-]
-
-[[package]]
-name = "rand_core"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90bde5296fc891b0cef12a6d03ddccc162ce7b2aff54160af9338f8d40df6d19"
-dependencies = [
- "getrandom 0.1.16",
+ "rand_core",
 ]
 
 [[package]]
@@ -1685,29 +1619,11 @@ dependencies = [
 
 [[package]]
 name = "rand_hc"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca3129af7b92a17112d59ad498c6f81eaf463253766b90396d39ea7a39d6613c"
-dependencies = [
- "rand_core 0.5.1",
-]
-
-[[package]]
-name = "rand_hc"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d51e9f596de227fda2ea6c84607f5558e196eeaf43c986b724ba4fb8fdf497e7"
 dependencies = [
- "rand_core 0.6.3",
-]
-
-[[package]]
-name = "rand_xoshiro"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9fcdd2e881d02f1d9390ae47ad8e5696a9e4be7b547a1da2afbc61973217004"
-dependencies = [
- "rand_core 0.5.1",
+ "rand_core",
 ]
 
 [[package]]
@@ -1960,26 +1876,15 @@ checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 
 [[package]]
 name = "sentry"
-version = "0.18.1"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b01b723fc1b0a0f9394ca1a8451daec6e20206d47f96c3dceea7fd11ec9eec0"
+checksum = "546b9b6f76c26c60ffbcf0b7136e15169fe13d43949b4aadb7c1edc1c3f3a26f"
 dependencies = [
- "backtrace",
  "curl",
- "failure",
- "hostname",
  "httpdate",
- "im",
- "lazy_static",
- "libc",
- "log",
- "rand 0.7.3",
- "regex",
- "rustc_version",
- "sentry-types",
+ "sentry-core",
  "serde_json",
- "uname",
- "url 2.2.2",
+ "tokio",
 ]
 
 [[package]]
@@ -2034,6 +1939,7 @@ dependencies = [
  "rust-ini",
  "semver 1.0.4",
  "sentry",
+ "sentry-types",
  "serde",
  "serde_json",
  "sha1",
@@ -2051,16 +1957,30 @@ dependencies = [
 ]
 
 [[package]]
-name = "sentry-types"
-version = "0.14.1"
+name = "sentry-core"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12ec406c11c060c8a7d5d67fc6f4beb2888338dcb12b9af409451995f124749d"
+checksum = "f9a957270c9a430218f8031c866493061a27e35a70250e9527f093563a33ce6b"
+dependencies = [
+ "chrono",
+ "lazy_static",
+ "rand",
+ "sentry-types",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "sentry-types"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4dd2266fee014a86e250e98e389191ecd23be546b5c42b6a2fb9af2972fadac"
 dependencies = [
  "chrono",
  "debugid",
- "failure",
  "serde",
  "serde_json",
+ "thiserror",
  "url 2.2.2",
  "uuid",
 ]
@@ -2181,16 +2101,6 @@ name = "siphasher"
 version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "533494a8f9b724d33625ab53c6c4800f7cc445895924a8ef649222dcb76e938b"
-
-[[package]]
-name = "sized-chunks"
-version = "0.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d59044ea371ad781ff976f7b06480b9f0180e834eda94114f2afb4afc12b7718"
-dependencies = [
- "bitmaps",
- "typenum",
-]
 
 [[package]]
 name = "smallvec"
@@ -2345,7 +2255,7 @@ checksum = "dac1c663cfc93810f88aed9b8941d48cabf856a1b111c29a40439018d870eb22"
 dependencies = [
  "cfg-if",
  "libc",
- "rand 0.8.4",
+ "rand",
  "redox_syscall 0.2.10",
  "remove_dir_all",
  "winapi 0.3.9",
@@ -2447,6 +2357,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 
 [[package]]
+name = "tokio"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2c2416fdedca8443ae44b4527de1ea633af61d8f7169ffa6e72c5b53d24efcc"
+dependencies = [
+ "autocfg",
+ "pin-project-lite",
+]
+
+[[package]]
 name = "treeline"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2463,15 +2383,6 @@ name = "ucd-trie"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56dee185309b50d1f11bfedef0fe6d036842e3fb77413abef29f8f8d1c5d4c1c"
-
-[[package]]
-name = "uname"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b72f89f0ca32e4db1c04e2a72f5345d59796d4866a1ee0609084569f73683dc8"
-dependencies = [
- "libc",
-]
 
 [[package]]
 name = "unicode-bidi"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,7 +45,8 @@ regex = "1.3.9"
 runas = "0.2.1"
 rust-ini = "0.17.0"
 semver = "1.0.3"
-sentry = { version = "0.18.0", default-features = false, features = ["with_client_implementation", "with_curl_transport", "with_panic", "with_failure", "with_log", "with_device_info", "with_rust_info", "with_debug_to_log"] }
+sentry = { version = "0.23.0", default-features = false, features = ["curl"] }
+sentry-types = "0.23.0"
 serde = { version = "1.0.114", features = ["derive"] }
 serde_json = "1.0.56"
 sha1 = { version = "0.6.0", features = ["serde"] }

--- a/src/api.rs
+++ b/src/api.rs
@@ -1823,7 +1823,7 @@ impl ApiResponse {
     pub fn pagination(&self) -> Pagination {
         self.get_header("link")
             .and_then(|x| x.parse().ok())
-            .unwrap_or_else(Default::default)
+            .unwrap_or_default()
     }
 
     /// Returns true if the response is JSON.

--- a/src/commands/bash_hook.rs
+++ b/src/commands/bash_hook.rs
@@ -10,7 +10,7 @@ use clap::{App, Arg, ArgMatches};
 use failure::Error;
 use lazy_static::lazy_static;
 use regex::Regex;
-use sentry::protocol::{Event, Exception, Frame, Stacktrace, User, Value};
+use sentry_types::protocol::latest::{Event, Exception, Frame, Stacktrace, User, Value};
 use username::get_user_name;
 use uuid::Uuid;
 

--- a/src/commands/send_event.rs
+++ b/src/commands/send_event.rs
@@ -5,7 +5,7 @@ use std::env;
 use clap::{App, Arg, ArgMatches};
 use failure::{err_msg, Error};
 use itertools::Itertools;
-use sentry::protocol::{Event, Level, LogEntry, User};
+use sentry_types::protocol::latest::{Event, Level, LogEntry, User};
 use serde_json::Value;
 use username::get_user_name;
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -11,7 +11,7 @@ use failure::{bail, err_msg, Error, ResultExt};
 use ini::Ini;
 use lazy_static::lazy_static;
 use parking_lot::Mutex;
-use sentry::internals::Dsn;
+use sentry_types::Dsn;
 
 use crate::constants::{CONFIG_RC_FILE_NAME, DEFAULT_RETRIES, DEFAULT_URL};
 use crate::utils::http::is_absolute_url;

--- a/src/utils/crashreporting.rs
+++ b/src/utils/crashreporting.rs
@@ -4,21 +4,19 @@ use std::time::Duration;
 
 use failure::Error;
 use log::Log;
-use sentry::integrations;
 use sentry::{release_name, Client, ClientOptions, Hub};
+use sentry_types::Dsn;
 
 use crate::config::Config;
 use crate::constants::USER_AGENT;
 
-pub fn setup(log: Box<dyn Log>) {
-    integrations::log::init(Some(log), Default::default());
-    integrations::panic::register_panic_handler();
+pub fn setup(_log: Box<dyn Log>) {
     bind_configured_client(None);
 }
 
 pub fn bind_configured_client(cfg: Option<&Config>) {
     Hub::with(|hub| {
-        let dsn = cfg.and_then(Config::internal_sentry_dsn);
+        let dsn: Option<Dsn> = cfg.and_then(Config::internal_sentry_dsn);
         let client = match dsn {
             Some(dsn) => Client::from_config((
                 dsn,
@@ -35,9 +33,10 @@ pub fn bind_configured_client(cfg: Option<&Config>) {
     });
 }
 
-pub fn try_report_to_sentry(err: &Error) {
-    integrations::failure::capture_error(err);
-    flush_events();
+pub fn try_report_to_sentry(_err: &Error) {
+    // TODO: Migrate from `failure` to `anyhow` crate and use `anyhow` feature for crash reporting once we decide to bring it back.
+    // capture_error(err);
+    // flush_events();
 }
 
 pub fn flush_events() {

--- a/src/utils/event.rs
+++ b/src/utils/event.rs
@@ -7,8 +7,9 @@ use chrono::Utc;
 use failure::{Error, ResultExt};
 use lazy_static::lazy_static;
 use regex::Regex;
-use sentry::protocol::{Breadcrumb, ClientSdkInfo, Event};
-use sentry::{internals::Dsn, Client, ClientOptions};
+use sentry::{Client, ClientOptions};
+use sentry_types::protocol::latest::{Breadcrumb, ClientSdkInfo, Event};
+use sentry_types::Dsn;
 
 use crate::constants::USER_AGENT;
 


### PR DESCRIPTION
~Crash reporting is disabled for over 3 years now, but we still have code instrumenting it. The problem is that it uses `sentry-failure` crate which is deprecated and removed from the latest version of `sentry` and it blocks us from updating.~

Ignore, I'll approach this differently.