### PR TITLE
CUSTOM_HEADER support for JS wrapper

### DIFF
--- a/js/helper.js
+++ b/js/helper.js
@@ -159,6 +159,9 @@ function execute(args, live, silent, configFile, config = {}) {
   if (config.vcsRemote) {
     env.SENTRY_VCS_REMOTE = config.vcsRemote;
   }
+  if (config.customHeader) {
+    env.CUSTOM_HEADER = config.customHeader;
+  }
   return new Promise((resolve, reject) => {
     if (live === true) {
       const output = silent ? 'ignore' : 'inherit'

--- a/js/index.d.ts
+++ b/js/index.d.ts
@@ -47,6 +47,11 @@ declare module '@sentry/cli' {
      * If true, all logs are suppressed.
      */
     silent?: boolean;
+    /**
+     * A header added to every outgoing network request.
+     * This value will update `CUSTOM_HEADER` env variable.
+     */
+    customHeader?: string;
   }
 
   /**


### PR DESCRIPTION
Follow up to https://github.com/getsentry/sentry-cli/pull/970. This option has proved quite useful so far, and it would be great to have support in the JS wrapper of the CLI as well.

PTAL @kamilogorek @jan-auer @mitsuhiko 