### PR TITLE
ref: Box ParseDif::Object value to prevent large enum variant

### DIFF
--- a/src/utils/xcode.rs
+++ b/src/utils/xcode.rs
@@ -38,9 +38,7 @@ pub struct InfoPlist {
 #[derive(Deserialize, Debug)]
 pub struct XcodeProjectInfo {
     targets: Vec<String>,
-    schemes: Vec<String>,
     configurations: Vec<String>,
-    name: String,
     #[serde(default = "PathBuf::new")]
     path: PathBuf,
 }


### PR DESCRIPTION
In the latest version of clippy, `large_enum_variant` is turned on by default, which fails with the current implementation.

Two removed fields from `XcodeProjectInfo` were unused.