### PR TITLE
feat: Allow for configuring max item size for dif bundles

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -13,6 +13,8 @@ use lazy_static::lazy_static;
 use parking_lot::Mutex;
 use sentry::types::Dsn;
 
+use crate::constants::DEFAULT_MAX_DIF_ITEM_SIZE;
+use crate::constants::DEFAULT_MAX_DIF_UPLOAD_SIZE;
 use crate::constants::{CONFIG_RC_FILE_NAME, DEFAULT_RETRIES, DEFAULT_URL};
 use crate::utils::http::is_absolute_url;
 use crate::utils::logging::set_max_level;
@@ -350,12 +352,19 @@ impl Config {
     }
 
     /// Returns the maximum DIF upload size
-    pub fn get_max_dif_archive_size(&self) -> Result<u64, Error> {
-        Ok(self
-            .ini
+    pub fn get_max_dif_archive_size(&self) -> u64 {
+        self.ini
             .get_from(Some("dsym"), "max_upload_size")
             .and_then(|x| x.parse().ok())
-            .unwrap_or(35 * 1024 * 1024))
+            .unwrap_or(DEFAULT_MAX_DIF_UPLOAD_SIZE)
+    }
+
+    /// Returns the maximum file size of a single file inside DIF bundle
+    pub fn get_max_dif_item_size(&self) -> u64 {
+        self.ini
+            .get_from(Some("dsym"), "max_item_size")
+            .and_then(|x| x.parse().ok())
+            .unwrap_or(DEFAULT_MAX_DIF_ITEM_SIZE)
     }
 
     pub fn get_max_retry_count(&self) -> Result<u32, Error> {

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -51,6 +51,10 @@ pub const DEFAULT_MAX_INTERVAL: u64 = 5000;
 pub const DEFAULT_RETRIES: u32 = 5;
 /// Default maximum file size of DIF uploads.
 pub const DEFAULT_MAX_DIF_SIZE: u64 = 2 * 1024 * 1024 * 1024; // 2GB
+/// Default maximum file size of a single file inside DIF bundle.
+pub const DEFAULT_MAX_DIF_ITEM_SIZE: u64 = 1024 * 1024; // 1MB
+/// Default maximum DIF upload size.
+pub const DEFAULT_MAX_DIF_UPLOAD_SIZE: u64 = 35 * 1024 * 1024; // 35MB
 /// Default maximum time to wait for file assembly.
 pub const DEFAULT_MAX_WAIT: Duration = Duration::from_secs(5 * 60);
 

--- a/src/utils/dif_upload.rs
+++ b/src/utils/dif_upload.rs
@@ -1029,12 +1029,14 @@ fn process_symbol_maps<'a>(
 
 /// Default filter function to skip over bad sources we do not want to include.
 pub fn filter_bad_sources(entry: &FileEntry) -> bool {
+    let max_size = Config::current().get_max_dif_item_size();
+
     if entry.name_str().ends_with(".pch") {
         // always ignore pch files
         false
     } else if let Ok(meta) = fs::metadata(&entry.abs_path_str()) {
-        // ignore files larger than 1MB
-        meta.len() < 1_000_000
+        // ignore files larger than limit (defaults to 1MB)
+        meta.len() < max_size
     } else {
         // if a file metadata could not be read it will be skipped later.
         true
@@ -1495,7 +1497,7 @@ fn upload_in_batches(
     options: &DifUpload,
 ) -> Result<Vec<DebugInfoFile>, Error> {
     let api = Api::current();
-    let max_size = Config::current().get_max_dif_archive_size()?;
+    let max_size = Config::current().get_max_dif_archive_size();
     let mut dsyms = Vec::new();
 
     for (i, (batch, _)) in objects.batches(max_size, MAX_CHUNKS).enumerate() {


### PR DESCRIPTION
Currently, we have a hard limit of 1MB, and any source files larger than this are filtered out and not bundled, effectively making them unavailable for processing on the Sentry side. We do this by default, as most files larger than that default limit, are useless for our needs, and shouldn't be uploaded. There are however cases, where it might be desirable.

By adding `max_item_size` option under `dsym` group to `ini` config file, and using it inside the bundling function, we allow end-user to override this limit and bundle larger files.

I specifically didn't do that through additional argument, as it'd then have to be passed down the calls, which is kinda obscure and inefficient. Additionally, this is rather not a common use case, thus not exposing it widely is preferable. 

Resolves https://github.com/getsentry/sentry-cli/issues/1072