### PR TITLE
fix: Prevent daemonize mode from crashing upload process

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -66,7 +66,7 @@ predicates = "2.0.0"
 tempfile = "3.1.0"
 
 [features]
-default = ["with_crash_reporting"]
+default = []
 managed = []
 with_crash_reporting = []
 

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -283,8 +283,7 @@ fn setup() {
     }
     #[cfg(not(feature = "with_crash_reporting"))]
     {
-        static LOGGER: Logger = Logger;
-        log::set_logger(&Logger);
+        log::set_logger(&Logger).unwrap();
     }
 }
 

--- a/src/commands/react_native_xcode.rs
+++ b/src/commands/react_native_xcode.rs
@@ -113,7 +113,6 @@ fn find_node() -> String {
 pub fn execute(matches: &ArgMatches<'_>) -> Result<(), Error> {
     let config = Config::current();
     let (org, project) = config.get_org_and_project(matches)?;
-    let api = Api::current();
     let should_wrap = matches.is_present("force")
         || match env::var("CONFIGURATION") {
             Ok(config) => !&config.contains("Debug"),
@@ -183,6 +182,7 @@ pub fn execute(matches: &ArgMatches<'_>) -> Result<(), Error> {
             if !matches.is_present("force_foreground") {
                 md.may_detach()?;
             }
+            let api = Api::current();
             let url = url.trim_end_matches('/');
             bundle_file = TempFile::create()?;
             bundle_path = bundle_file.path().to_path_buf();
@@ -282,6 +282,7 @@ pub fn execute(matches: &ArgMatches<'_>) -> Result<(), Error> {
             dist
         ));
 
+        let api = Api::current();
         let release = api.new_release(
             &org,
             &NewRelease {

--- a/src/commands/upload_dif.rs
+++ b/src/commands/upload_dif.rs
@@ -190,7 +190,6 @@ pub fn make_app<'a, 'b: 'a>(app: App<'a, 'b>) -> App<'a, 'b> {
 }
 
 fn execute_internal(matches: &ArgMatches<'_>, legacy: bool) -> Result<(), Error> {
-    let api = Api::current();
     let config = Config::current();
     let (org, project) = config.get_org_and_project(matches)?;
 
@@ -298,6 +297,7 @@ fn execute_internal(matches: &ArgMatches<'_>, legacy: bool) -> Result<(), Error>
 
         // Execute the upload
         let (uploaded, has_processing_errors) = upload.upload()?;
+        let api = Api::current();
 
         // Associate the dSYMs with the Info.plist data, if available
         if let Some(ref info_plist) = info_plist {

--- a/src/utils/system.rs
+++ b/src/utils/system.rs
@@ -8,6 +8,7 @@ use lazy_static::lazy_static;
 use regex::{Captures, Regex};
 
 use crate::config::Config;
+#[cfg(not(windows))]
 use crate::utils::xcode::launched_from_xcode;
 
 #[cfg(not(windows))]

--- a/src/utils/system.rs
+++ b/src/utils/system.rs
@@ -8,12 +8,19 @@ use lazy_static::lazy_static;
 use regex::{Captures, Regex};
 
 use crate::config::Config;
+use crate::utils::xcode::launched_from_xcode;
 
 #[cfg(not(windows))]
 pub fn run_or_interrupt<F>(f: F)
 where
     F: FnOnce() + Send + 'static,
 {
+    // See: https://github.com/getsentry/sentry-cli/pull/1104
+    if launched_from_xcode() {
+        f();
+        return;
+    }
+
     let (tx, rx) = crossbeam_channel::bounded(100);
     let mut signals = signal_hook::iterator::Signals::new(&[
         signal_hook::consts::SIGTERM,

--- a/src/utils/xcode.rs
+++ b/src/utils/xcode.rs
@@ -427,6 +427,12 @@ pub fn launched_from_xcode() -> bool {
     false
 }
 
+/// Returns true if we were invoked from xcode
+#[cfg(not(target_os = "macos"))]
+pub fn launched_from_xcode() -> bool {
+    false
+}
+
 /// Shows a dialog in xcode and blocks.  The dialog will have a title and a
 /// message as well as the buttons "Show details" and "Ignore".  Returns
 /// `true` if the `show details` button has been pressed.


### PR DESCRIPTION
In macOS 10.13, changes to Objective-C runtime forbid calling ObjC code before and after forking the process. If we want to do that, and we need to, due to moving `sentry-cli` process to the background during XCode artifacts upload, we need to perform all those calls *after* we daemonize ourselves. This forces us to not spawn any processes, nor call any ObjC-compiled code (like cURL) before we actually get to that branch.

The thing that's detaching us is `MayDetach::wrap` via `MayDetach::may_detach` function.

If we call any cURL code or spawn any process before-hand, it will result in the background process crashing with:

```
objc[80549]: +[__NSCFConstantString initialize] may have been in progress in another thread when fork() was called.
objc[80549]: +[__NSCFConstantString initialize] may have been in progress in another thread when fork() was called. We cannot safely call it or ignore it in the fork() child process. Crashing instead. Set a breakpoint on objc_initializeAfterForkError to debug.
```

This PR does the following:
- disable signal handling for processes spawned via XCode (prevent direct process spawning); we can afford that, as our upload process is a standalone `Build Script`, and not part of the larger mechanism, thus we never expect it to be interrupted.
- disable default built-in crash reporting (prevent process spawning in SDK transport constructors); this part was never used for years in the first place (see: https://github.com/getsentry/sentry-cli/commit/2b6bedbf7652682482e91cc7a526fc4d0b364a09) and it was always meant to be used for us to track CLI issues. Original initialization code was still in place though, so it was executed despite lacking the necessary DSN (it initialized empty client).
- move API initialization inside the wrapped function (prevent calling internal curl code);

ref: https://www.wefearchange.org/2018/11/forkmacos.rst.html
ref: http://sealiesoftware.com/blog/archive/2017/6/5/Objective-C_and_fork_in_macOS_1013.html