### PR TITLE
feat: Allow for adding sourcemaps refs to non-minified JS sources

### DIFF
--- a/js/index.d.ts
+++ b/js/index.d.ts
@@ -86,9 +86,9 @@ declare module '@sentry/cli' {
      */
     sourceMapReference?: boolean;
     /**
-     * Enables adding sourcemaps references to non-minified sources.
+     * Enables adding sourcemap references to non-minified sources.
      * This is useful for compile-to-JS languages/frameworks,
-     * that does not perform minification, but still produce source-maps.
+     * that do not perform minification, but still produce source-maps.
      */
     processNonminified?: boolean;
     /**

--- a/js/index.d.ts
+++ b/js/index.d.ts
@@ -86,6 +86,12 @@ declare module '@sentry/cli' {
      */
     sourceMapReference?: boolean;
     /**
+     * Enables adding sourcemaps references to non-minified sources.
+     * This is useful for compile-to-JS languages/frameworks,
+     * that does not perform minification, but still produce source-maps.
+     */
+    processNonminified?: boolean;
+    /**
      * When paired with the rewrite option this will remove a prefix from uploaded files.
      * For instance you can use this to remove a path that is build machine specific.
      */

--- a/js/releases/index.js
+++ b/js/releases/index.js
@@ -145,6 +145,7 @@ class Releases {
    *   ignoreFile: null,          // path to a file with ignore rules
    *   rewrite: false,            // preprocess sourcemaps before uploading
    *   sourceMapReference: true,  // add a source map reference to source files
+   *   processNonminified: false, // add a source map reference to non-minified source files
    *   stripPrefix: [],           // remove certain prefices from filenames
    *   stripCommonPrefix: false,  // guess common prefices to remove from filenames
    *   validate: false,           // validate source maps and cancel the upload on error

--- a/js/releases/options/uploadSourcemaps.js
+++ b/js/releases/options/uploadSourcemaps.js
@@ -20,6 +20,10 @@ module.exports = {
     invertedParam: '--no-sourcemap-reference',
     type: 'boolean',
   },
+  processNonminified: {
+    param: '--process-nonminified',
+    type: 'boolean',
+  },
   stripPrefix: {
     param: '--strip-prefix',
     type: 'array',

--- a/src/commands/releases.rs
+++ b/src/commands/releases.rs
@@ -289,9 +289,9 @@ pub fn make_app<'a, 'b: 'a>(app: App<'a, 'b>) -> App<'a, 'b> {
                     .help("Wait for the server to fully process uploaded files."))
                 .arg(Arg::with_name("process_nonminified")
                     .long("process-nonminified")
-                    .help("Enables adding sourcemaps references to non-minified sources.{n}\
+                    .help("Enables adding sourcemap references to non-minified sources.{n}\
                            This is useful for compile-to-JS languages/frameworks, \
-                           that does not perform minification, but still produce source-maps.")
+                           that do not perform minification, but still produce source-maps.")
                     .conflicts_with("no_sourcemap_reference"))
                 .arg(Arg::with_name("no_sourcemap_reference")
                     .long("no-sourcemap-reference")

--- a/src/commands/releases.rs
+++ b/src/commands/releases.rs
@@ -287,6 +287,12 @@ pub fn make_app<'a, 'b: 'a>(app: App<'a, 'b>) -> App<'a, 'b> {
                 .arg(Arg::with_name("wait")
                     .long("wait")
                     .help("Wait for the server to fully process uploaded files."))
+                .arg(Arg::with_name("process_nonminified")
+                    .long("process-nonminified")
+                    .help("Enables adding sourcemaps references to non-minified sources.{n}\
+                           This is useful for compile-to-JS languages/frameworks, \
+                           that does not perform minification, but still produce source-maps.")
+                    .conflicts_with("no_sourcemap_reference"))
                 .arg(Arg::with_name("no_sourcemap_reference")
                     .long("no-sourcemap-reference")
                     .help("Disable emitting of automatic sourcemap references.{n}\
@@ -1080,6 +1086,10 @@ fn execute_files_upload_sourcemaps<'a>(
     version: &str,
 ) -> Result<(), Error> {
     let mut processor = SourceMapProcessor::new();
+
+    if matches.is_present("process_nonminified") {
+        processor.process_nonminified(true);
+    }
 
     if matches.is_present("bundle") && matches.is_present("bundle_sourcemap") {
         process_sources_from_bundle(matches, &mut processor)?;

--- a/src/utils/sourcemaps.rs
+++ b/src/utils/sourcemaps.rs
@@ -183,7 +183,7 @@ impl SourceMapProcessor {
     }
 
     /// Set whether we should add sourcemap references to non-minified sources.
-    /// This is useful for compile-to-JS languages/frameworks, that does not perform minification,
+    /// This is useful for compile-to-JS languages/frameworks, that do not perform minification,
     /// but still produce sourcemaps.
     ///
     /// Defaults to `false`.


### PR DESCRIPTION
This flag allows for adding sourcemaps references to non-minified sources. This is useful for compile-to-JS languages/frameworks, that does not perform minification, but still produce source-maps.

From what I discussed with @lobsterkatie, this is the behavior that Next.js has with it's server-side code, that's compiled with SWC from TypeScript down to JavaScript.
The problem there is that we don't have a control over filenames, thus we cannot use the `.min.js` branch for detecting whether code is minified - https://github.com/getsentry/sentry-cli/blob/405a6fee86107daac0122afc717b131428c70e47/src/utils/sourcemaps.rs#L218 and compiled code is not detected as such by the heuristics in `might_be_minified`,

Still to be discussed whether it's a reasonable solution.