### PR TITLE
feat: Remove all release files instantaneously with --all flag

### DIFF
--- a/src/api.rs
+++ b/src/api.rs
@@ -568,6 +568,37 @@ impl Api {
         }
     }
 
+    /// Deletes all release files.  Returns `true` if files were
+    /// deleted or `false` otherwise.
+    pub fn delete_release_files(
+        &self,
+        org: &str,
+        project: Option<&str>,
+        version: &str,
+    ) -> ApiResult<bool> {
+        let path = if let Some(project) = project {
+            format!(
+                "/projects/{}/{}/files/source-maps/?name={}",
+                PathArg(org),
+                PathArg(project),
+                PathArg(version)
+            )
+        } else {
+            format!(
+                "/organizations/{}/files/source-maps/?name={}",
+                PathArg(org),
+                PathArg(version)
+            )
+        };
+
+        let resp = self.delete(&path)?;
+        if resp.status() == 404 {
+            Ok(false)
+        } else {
+            resp.into_result().map(|_| true)
+        }
+    }
+
     /// Uploads a new release file.  The file is loaded directly from the file
     /// system and uploaded as `name`.
     // TODO: Simplify this function interface

--- a/src/commands/releases.rs
+++ b/src/commands/releases.rs
@@ -801,17 +801,28 @@ fn execute_files_delete<'a>(
     matches: &ArgMatches<'a>,
     release: &str,
 ) -> Result<(), Error> {
+    let org = ctx.get_org()?;
+    let project = ctx.get_project_default().ok();
+
+    if matches.is_present("all") {
+        if ctx
+            .api
+            .delete_release_files(org, project.as_deref(), release)?
+        {
+            println!("All files deleted.");
+        }
+        return Ok(());
+    }
+
     let files: HashSet<String> = match matches.values_of("names") {
         Some(paths) => paths.map(|x| x.into()).collect(),
         None => HashSet::new(),
     };
-    let org = ctx.get_org()?;
-    let project = ctx.get_project_default().ok();
     for file in ctx
         .api
         .list_release_files(org, project.as_deref(), release)?
     {
-        if !(matches.is_present("all") || files.contains(&file.name)) {
+        if !files.contains(&file.name) {
             continue;
         }
         if ctx


### PR DESCRIPTION
Previously we fetched a list of files and iterated over them for a one-by-one removal.
We do however have an endpoint that allows for bulk removal, which we can use in our `--all` flag case.