### PR TITLE
build: Update symbolic to 8.6.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,7 +51,7 @@ serde = { version = "1.0.136", features = ["derive"] }
 serde_json = "1.0.78"
 sha1 = { version = "0.6.0", features = ["serde"] }
 sourcemap = { version = "5.0.0", features = ["ram_bundle"] }
-symbolic = { version = "8.5.0", features = ["debuginfo-serde"] }
+symbolic = { version = "8.6.0", features = ["debuginfo-serde"] }
 url = "2.2.2"
 username = "0.2.0"
 uuid = { version = "0.8.2", features = ["v4", "serde"] }


### PR DESCRIPTION
Fixes a panic when inspecting debug files larger than 4GB.

