### PR TITLE
install: Silence progress bar in CI environments

### DIFF
--- a/scripts/install.js
+++ b/scripts/install.js
@@ -48,8 +48,9 @@ function shouldRenderProgressBar() {
   const silentFlag = process.argv.some(v => v === '--silent');
   const silentConfig = process.env.npm_config_loglevel === 'silent';
   const silentEnv = process.env.SENTRY_NO_PROGRESS_BAR;
+  const ciEnv = process.env.CI === 'true';
   // If any of possible options is set, skip rendering of progress bar
-  return !(silentFlag || silentConfig || silentEnv);
+  return !(silentFlag || silentConfig || silentEnv || ciEnv);
 }
 
 function getDownloadUrl(platform, arch) {


### PR DESCRIPTION
Closes #1121 by automatically quieting the progress bar if a CI environment is detected.

This saves end users from needing to set another env var when `CI: true` is already very widely implemented. GitHub, GitLab, CircleCI, Jenkins, Netlify, and others all set this by default.