### PR TITLE
feat: Add checksum validation for installed binaries

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -3,6 +3,7 @@
   "rules": {
     "class-methods-use-this": "off",
     "prefer-destructuring": "off",
-    "strict": "off"
+    "strict": "off",
+    "no-plusplus": "off"
   }
 }

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -136,6 +136,7 @@ jobs:
   node:
     name: NPM Package
     runs-on: ubuntu-latest
+    needs: [linux, macos, macos_universal, windows]
 
     steps:
       - uses: actions/checkout@v2
@@ -144,6 +145,17 @@ jobs:
         uses: actions/setup-node@v1
         with:
           node-version: 8.x
+
+      - name: Download compiled binaries
+        uses: actions/download-artifact@v2
+        with:
+          name: ${{ github.sha }}
+
+      - name: Calculate and store checksums
+        shell: bash
+        run: |
+          sha256sum sentry-cli-* | awk '{printf("%s=%s\n", $2, $1)}' > checksums.txt
+          cat checksums.txt
 
       - run: npm pack
 

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ target
 node_modules
 coverage
 dist
+checksums.txt
 
 /sentry-cli
 /sentry-cli.exe

--- a/.npmignore
+++ b/.npmignore
@@ -8,6 +8,7 @@
 !bin
 !js
 !scripts/install.js
+!checksums.txt
 
 # ignore JS tests
 __mocks__

--- a/scripts/install.js
+++ b/scripts/install.js
@@ -150,6 +150,43 @@ function getTempFile(cached) {
     .slice(2)}.tmp`;
 }
 
+function validateChecksum(tempPath, name) {
+  let storedHash;
+  try {
+    const checksums = fs.readFileSync(path.join(__dirname, '../checksums.txt'), 'utf8');
+    const entries = checksums.split('\n');
+    for (let i = 0; i < entries.length; i++) {
+      const [key, value] = entries[i].split('=');
+      if (key === name) {
+        storedHash = value;
+        break;
+      }
+    }
+  } catch (e) {
+    npmLog.info('Checksums are only available for npm published package. Skipping validation.');
+    return;
+  }
+
+  if (!storedHash) {
+    npmLog.info(`Checksum for ${name} not found, skipping validation.`);
+    return;
+  }
+
+  const currentHash = crypto
+    .createHash('sha256')
+    .update(fs.readFileSync(tempPath))
+    .digest('hex');
+
+  if (storedHash !== currentHash) {
+    fs.unlinkSync(tempPath);
+    throw new Error(
+      `Checksum validation for ${name} failed.\nExpected: ${storedHash}\nReceived: ${currentHash}`
+    );
+  } else {
+    npmLog.info('Checksum validation passed.');
+  }
+}
+
 function downloadBinary() {
   const arch = os.arch();
   const platform = os.platform();
@@ -217,6 +254,9 @@ function downloadBinary() {
           .on('error', e => reject(e))
           .on('close', () => resolve());
       }).then(() => {
+        if (process.env.SENTRYCLI_CHECKSUM_VALIDATION !== '1') {
+          validateChecksum(tempPath, name);
+        }
         fs.copyFileSync(tempPath, cachedPath);
         fs.copyFileSync(tempPath, outputPath);
         fs.unlinkSync(tempPath);


### PR DESCRIPTION
Checksum validation is performed only for newly downloaded binaries, not cached ones. It also bails out if a checksum was not found due to an incorrect name or some CI misconfiguration. It also contains a new `SENTRYCLI_CHECKSUM_VALIDATION` flag that allows you to skip it in case something goes wrong but you still want to proceed.
Those fail-safe mechanisms are there only in case something goes wrong, and we don't want to break people's stuff.