### PR TITLE
ref: Dont panic on malformed xcodeproj directories

### DIFF
--- a/src/utils/update.rs
+++ b/src/utils/update.rs
@@ -205,12 +205,11 @@ fn update_nagger_impl() -> Result<(), Error> {
         .with_context(|_| "Could not get cache folder")?;
     path.push("updatecheck");
 
-    let mut check: LastUpdateCheck;
-    if let Ok(f) = fs::File::open(&path) {
-        check = serde_json::from_reader(io::BufReader::new(f))?;
+    let mut check: LastUpdateCheck = if let Ok(f) = fs::File::open(&path) {
+        serde_json::from_reader(io::BufReader::new(f))?
     } else {
-        check = Default::default();
-    }
+        Default::default()
+    };
 
     if check.should_run_check() {
         info!("Running update nagger update check");

--- a/src/utils/xcode.rs
+++ b/src/utils/xcode.rs
@@ -101,10 +101,10 @@ fn get_xcode_project_info(path: &Path) -> Result<Option<XcodeProjectInfo>, Error
     }
 
     if projects.len() == 1 {
-        return match XcodeProjectInfo::from_path(&projects[0]) {
+        match XcodeProjectInfo::from_path(&projects[0]) {
             Ok(info) => Ok(Some(info)),
             _ => Ok(None),
-        };
+        }
     } else {
         Ok(None)
     }
@@ -129,7 +129,7 @@ impl XcodeProjectInfo {
                 Ok(rv.project)
             }
             Err(e) => {
-                warn!("Command `xcodebuild -list -json -project {}` failed to produce a valid JSON output. Your .xcodeproj might be malformed.", path.as_ref().display());
+                warn!("Your .xcodeproj might be malformed. Command `xcodebuild -list -json -project {}` failed to produce a valid JSON output.", path.as_ref().display());
                 Err(e.into())
             }
         }


### PR DESCRIPTION
There are scenarios like the one lined below, where `xcodeproj` directories does not contain all the required files for `xcodebuild` to give us a proper data. In that case, instead of panicking, we can bail out with a warning, and let the command proceed, as it's possible to do that without associating dSYMs just fine - https://github.com/getsentry/sentry-cli/blob/765f26ac55987c6ceeeae5fdc2e6befbc2abc7ea/src/commands/upload_dif.rs#L302-L329

Fixes https://github.com/getsentry/sentry-cli/issues/1126