### PR TITLE
feat: Allow for using local binary through SENTRYCLI_USE_LOCAL env

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,8 @@
     "node-fetch": "^2.6.7",
     "npmlog": "^4.1.2",
     "progress": "^2.0.3",
-    "proxy-from-env": "^1.1.0"
+    "proxy-from-env": "^1.1.0",
+    "which": "^2.0.2"
   },
   "devDependencies": {
     "eslint": "^6.8.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3158,7 +3158,7 @@ nice-try@^1.0.4:
   resolved "https://registry.yarnpkg.com/nice-try/-/nice-try-1.0.5.tgz#a3378a7696ce7d223e88fc9b764bd7ef1089e366"
   integrity sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==
 
-node-fetch@^2.6.0:
+node-fetch@^2.6.7:
   version "2.6.7"
   resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.7.tgz#24de9fba827e3b4ae44dc8b20256a379160052ad"
   integrity sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==


### PR DESCRIPTION
Keep in mind that it will still error if installed version won’t match the one required by the `package.json`, and we should not change that.

Closes https://github.com/getsentry/sentry-cli/issues/835

Note: I'll update docs with all the new `SENTRYCLI_` options soon.