### PR TITLE
deps: Update git2 crate to 0.14.1 to support custom git extensions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -788,9 +788,9 @@ dependencies = [
 
 [[package]]
 name = "git2"
-version = "0.13.25"
+version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f29229cc1b24c0e6062f6e742aa3e256492a5323365e5ed3413599f8a5eff7d6"
+checksum = "6e7d3b96ec1fcaa8431cf04a4f1ef5caafe58d5cf7bcc31f09c1626adddb0ffe"
 dependencies = [
  "bitflags",
  "libc",
@@ -1037,9 +1037,9 @@ checksum = "0a8d982fa7a96a000f6ec4cfe966de9703eccde29750df2bb8949da91b0e818d"
 
 [[package]]
 name = "libgit2-sys"
-version = "0.12.26+1.3.0"
+version = "0.13.1+1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19e1c899248e606fbfe68dcb31d8b0176ebab833b103824af31bddf4b7457494"
+checksum = "43e598aa7a4faedf1ea1b4608f582b06f0f40211eec551b7ef36019ae3f62def"
 dependencies = [
  "cc",
  "libc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ elementtree = "0.5.0"
 encoding = "0.2.33"
 failure = { version = "0.1.8", features = ["derive"] }
 flate2 = { version = "1.0.22", default-features = false, features = ["rust_backend"] }
-git2 = { version = "0.13.25", default-features = false }
+git2 = { version = "0.14.1", default-features = false }
 glob = "0.3.0"
 if_chain = "1.0.2"
 ignore = "0.4.18"


### PR DESCRIPTION
Closes https://github.com/getsentry/sentry-cli/issues/1068
Ref https://github.com/rust-lang/git2-rs/pull/791
Ref https://github.com/rust-lang/git2-rs/commit/c55bd6dbdba52f90788150180ef124ef6c90daa6