### PR TITLE
feat: Add show-projects and show-commits flags to 'releases info' command

### DIFF
--- a/src/api.rs
+++ b/src/api.rs
@@ -899,6 +899,36 @@ impl Api {
         }
     }
 
+    /// Looks up a release commits and returns it.  If it does not exist `None`
+    /// will be returned.
+    pub fn get_release_commits(
+        &self,
+        org: &str,
+        project: Option<&str>,
+        version: &str,
+    ) -> ApiResult<Option<Vec<ReleaseCommit>>> {
+        let path = if let Some(project) = project {
+            format!(
+                "/projects/{}/{}/releases/{}/commits/",
+                PathArg(org),
+                PathArg(project),
+                PathArg(version)
+            )
+        } else {
+            format!(
+                "/organizations/{}/releases/{}/commits/",
+                PathArg(org),
+                PathArg(version)
+            )
+        };
+        let resp = self.get(&path)?;
+        if resp.status() == 404 {
+            Ok(None)
+        } else {
+            resp.convert()
+        }
+    }
+
     // Finds the most recent release with commits and returns it.
     // If it does not exist `None` will be returned.
     pub fn get_previous_release_with_commits(
@@ -2015,7 +2045,7 @@ pub struct ReleaseInfo {
         rename = "lastCommit",
         skip_serializing_if = "Option::is_none"
     )]
-    pub last_commit: Option<LastCommit>,
+    pub last_commit: Option<ReleaseCommit>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -2030,7 +2060,7 @@ pub enum OptionalReleaseInfo {
 pub struct NoneReleaseInfo {}
 
 #[derive(Debug, Deserialize)]
-pub struct LastCommit {
+pub struct ReleaseCommit {
     pub id: String,
 }
 

--- a/tests/commands/releases_info.rs
+++ b/tests/commands/releases_info.rs
@@ -20,9 +20,48 @@ fn shows_release_details() {
         .assert()
         .success()
         .stdout(
-            contains("| Version      | wat-release                    |").and(contains(
-                "| Date created | 2020-06-29 11:36:59.612687 UTC |",
-            )),
+            contains("| Version     | Date created                   |")
+                .and(contains("| wat-release | 2020-06-29 11:36:59.612687 UTC |")),
+        );
+}
+
+#[test]
+fn shows_release_details_with_projects_and_commits() {
+    let _server = mock("GET", "/api/0/projects/wat-org/wat-project/releases/wat-release/")
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(r#"{"dateReleased":"2020-06-29T12:16:49.368667Z","newGroups":0,"commitCount":0,"url":null,"data":{},"lastDeploy":null,"deployCount":0,"dateCreated":"2020-06-29T11:36:59.612687Z","lastEvent":null,"version":"wat-release","firstEvent":null,"lastCommit":null,"shortVersion":"wat-release","authors":[],"owner":null,"versionInfo":{"buildHash":null,"version":{"raw":"wat-release"},"description":"wat-release","package":null},"ref":null,"projects":[{"name":"test","platform":"javascript","slug":"test","platforms":["javascript"],"newGroups":0,"id":1861017}]}"#)
+        .create();
+
+    let _commits = mock(
+        "GET",
+        "/api/0/projects/wat-org/wat-project/releases/wat-release/commits/",
+    )
+    .with_status(200)
+    .with_header("content-type", "application/json")
+    .with_body(r#"[{"id":"iddqd"},{"id":"idkfa"}]"#)
+    .create();
+
+    Command::cargo_bin("sentry-cli")
+        .unwrap()
+        .envs(common::get_base_env())
+        .args(vec![
+            "releases",
+            "info",
+            "wat-release",
+            "--show-commits",
+            "--show-projects",
+        ])
+        .assert()
+        .success()
+        .stdout(
+            contains("| Version     | Date created                   | Projects | Commits |")
+                .and(contains(
+                    "| wat-release | 2020-06-29 11:36:59.612687 UTC | test     | iddqd   |",
+                ))
+                .and(contains(
+                    "|             |                                |          | idkfa   |",
+                )),
         );
 }
 


### PR DESCRIPTION
Closes https://github.com/getsentry/sentry-cli/issues/954

Note: these tests will be redone using snapshot testing, so its fine if they are like this right now.