### PR TITLE
feat: Allow specifying env for set-commits command

### DIFF
--- a/src/api.rs
+++ b/src/api.rs
@@ -905,12 +905,23 @@ impl Api {
         &self,
         org: &str,
         version: &str,
+        env: Option<&str>,
     ) -> ApiResult<OptionalReleaseInfo> {
-        let path = format!(
-            "/organizations/{}/releases/{}/previous-with-commits/",
-            PathArg(org),
-            PathArg(version)
-        );
+        let path = if let Some(env) = env {
+            format!(
+                "/organizations/{}/releases/{}/previous-with-commits/?env={}",
+                PathArg(org),
+                PathArg(version),
+                PathArg(env)
+            )
+        } else {
+            format!(
+                "/organizations/{}/releases/{}/previous-with-commits/",
+                PathArg(org),
+                PathArg(version)
+            )
+        };
+
         let resp = self.get(&path)?;
         if resp.status() == 404 {
             Ok(OptionalReleaseInfo::None(NoneReleaseInfo {}))


### PR DESCRIPTION
This is blocked by https://github.com/getsentry/sentry/issues/32618

Closes https://github.com/getsentry/sentry-cli/issues/1076