### PR TITLE
feat: Allow for specifying global --header options to config requests

### DIFF
--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -115,6 +115,11 @@ fn configure_args(config: &mut Config, matches: &ArgMatches<'_>) -> Result<(), E
         config.set_base_url(url);
     }
 
+    if let Some(headers) = matches.values_of("headers") {
+        let headers = headers.map(|h| h.to_owned()).collect();
+        config.set_headers(headers);
+    }
+
     if let Some(api_key) = matches.value_of("api_key") {
         config.set_auth(Auth::Key(api_key.to_owned()));
     }
@@ -212,6 +217,17 @@ pub fn execute(args: &[String]) -> Result<(), Error> {
             "Fully qualified URL to the Sentry server.{n}\
              [defaults to https://sentry.io/]",
         ))
+        .arg(
+            Arg::with_name("headers")
+                .long("header")
+                .short("h")
+                .value_name("HEADERS")
+                .multiple(true)
+                .number_of_values(1)
+                .help(
+                    "Custom headers that should be attached to all requests in key:value format.",
+                ),
+        )
         .arg(
             Arg::with_name("auth_token")
                 .value_name("AUTH_TOKEN")


### PR DESCRIPTION
Back in the https://github.com/getsentry/sentry-cli/pull/970 `CUSTOM_HEADER` env variable and `defaults.custom_header` config option were introduced. This however was limited to a single header being passed.

In this PR, I add `--header/-h` flag as a global option that can be provided multiple times, and will be propagated down to every request.

This still plays nicely with the old solution and fallbacks to their values if configured.

Note: In v2, I'll change `CUSTOM_HEADER` to `SENTRY_HEADER` and `defaults.custom_header` to `default.header` to make it more unified.

Closes https://github.com/getsentry/sentry-cli/issues/1142

cc @mathew-cf