### PR TITLE
ref: Rework find_matching_rev tests to not use our real repo history

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,10 +52,6 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-        with:
-          # FIXME: Some VCS tests are parsing the history of the repository itself.
-          # Because of that, we need an access to all previous commits. Should't be like that.
-          fetch-depth: 0
 
       - uses: actions-rs/toolchain@v1
         with:


### PR DESCRIPTION
This change allows us to remove `fetch-depth` from the CI, as the tests are now fully isolated.