### PR TITLE
ref: Dont run install script using node binary

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "sentry-cli": "bin/sentry-cli"
   },
   "scripts": {
-    "install": "node scripts/install.js",
+    "install": "./scripts/install.js",
     "fix": "npm-run-all fix:eslint fix:prettier",
     "fix:eslint": "eslint --fix bin/* scripts/**/*.js js/**/*.js",
     "fix:prettier": "prettier --write bin/* scripts/**/*.js js/**/*.js",


### PR DESCRIPTION
Instead of relying on some random `node`, which is decided by the `npm` on runtime (eg. `npm` adds everything from `node_modules/.bin` to `$PATH` for its lifecycle-scripts), let `#!/usr/bin/env node` from scripts itself decide. `./install/script.js` has all `-x` chmod flags set correctly, so it won't be a problem executing it.