### PR TITLE
ref: Make org and project flags position independent

### DIFF
--- a/src/commands/issues.rs
+++ b/src/commands/issues.rs
@@ -10,7 +10,7 @@ use crate::utils::args::ArgExt;
 pub fn make_app<'a, 'b: 'a>(app: App<'a, 'b>) -> App<'a, 'b> {
     app.about("Manage issues in Sentry.")
         .setting(AppSettings::SubcommandRequiredElseHelp)
-        .org_project_args()
+        .org_project_args(true)
         .arg(
             Arg::with_name("status")
                 .long("status")

--- a/src/commands/monitors.rs
+++ b/src/commands/monitors.rs
@@ -28,7 +28,7 @@ pub fn make_app<'a, 'b: 'a>(app: App<'a, 'b>) -> App<'a, 'b> {
     app.about("Manage monitors on Sentry.")
         .setting(AppSettings::SubcommandRequiredElseHelp)
         .setting(AppSettings::Hidden)
-        .org_arg()
+        .org_arg(true)
         .subcommand(App::new("list").about("List all monitors for an organization."))
         .subcommand(
             App::new("run")

--- a/src/commands/projects.rs
+++ b/src/commands/projects.rs
@@ -10,7 +10,7 @@ use crate::utils::formatting::Table;
 pub fn make_app<'a, 'b: 'a>(app: App<'a, 'b>) -> App<'a, 'b> {
     app.about("Manage projects on Sentry.")
         .setting(AppSettings::SubcommandRequiredElseHelp)
-        .org_arg()
+        .org_arg(true)
         .subcommand(App::new("list").about("List all projects for an organization."))
 }
 

--- a/src/commands/react_native_appcenter.rs
+++ b/src/commands/react_native_appcenter.rs
@@ -18,7 +18,7 @@ use crate::utils::sourcemaps::SourceMapProcessor;
 
 pub fn make_app<'a, 'b: 'a>(app: App<'a, 'b>) -> App<'a, 'b> {
     app.about("Upload react-native projects for AppCenter.")
-        .org_project_args()
+        .org_project_args(true)
         .arg(
             Arg::with_name("deployment")
                 .long("deployment")

--- a/src/commands/react_native_codepush.rs
+++ b/src/commands/react_native_codepush.rs
@@ -19,7 +19,7 @@ use crate::utils::sourcemaps::SourceMapProcessor;
 pub fn make_app<'a, 'b: 'a>(app: App<'a, 'b>) -> App<'a, 'b> {
     app.about("DEPRECATED: Upload react-native projects for CodePush.")
         .setting(AppSettings::Hidden)
-        .org_project_args()
+        .org_project_args(true)
         .arg(
             Arg::with_name("deployment")
                 .long("deployment")

--- a/src/commands/react_native_gradle.rs
+++ b/src/commands/react_native_gradle.rs
@@ -15,7 +15,7 @@ use crate::utils::sourcemaps::SourceMapProcessor;
 
 pub fn make_app<'a, 'b: 'a>(app: App<'a, 'b>) -> App<'a, 'b> {
     app.about("Upload react-native projects in a gradle build step.")
-        .org_project_args()
+        .org_project_args(true)
         .arg(
             Arg::with_name("sourcemap")
                 .long("sourcemap")

--- a/src/commands/react_native_xcode.rs
+++ b/src/commands/react_native_xcode.rs
@@ -29,7 +29,7 @@ struct SourceMapReport {
 
 pub fn make_app<'a, 'b: 'a>(app: App<'a, 'b>) -> App<'a, 'b> {
     app.about("Upload react-native projects in a Xcode build step.")
-        .org_project_args()
+        .org_project_args(true)
         // legacy parameter
         .arg(
             Arg::with_name("verbose")

--- a/src/commands/releases.rs
+++ b/src/commands/releases.rs
@@ -65,7 +65,7 @@ impl<'a> ReleaseContext<'a> {
 pub fn make_app<'a, 'b: 'a>(app: App<'a, 'b>) -> App<'a, 'b> {
     app.about("Manage releases on Sentry.")
         .setting(AppSettings::SubcommandRequiredElseHelp)
-        .org_project_args()
+        .org_project_args(true)
         .subcommand(App::new("new")
             .about("Create a new release.")
             .version_arg(1)

--- a/src/commands/repos.rs
+++ b/src/commands/repos.rs
@@ -10,7 +10,7 @@ use crate::utils::formatting::Table;
 pub fn make_app<'a, 'b: 'a>(app: App<'a, 'b>) -> App<'a, 'b> {
     app.about("Manage repositories on Sentry.")
         .setting(AppSettings::SubcommandRequiredElseHelp)
-        .org_arg()
+        .org_arg(true)
         .subcommand(App::new("list").about("List all repositories in your organization."))
 }
 

--- a/src/commands/upload_dif.rs
+++ b/src/commands/upload_dif.rs
@@ -23,7 +23,7 @@ static DERIVED_DATA: &str = "Library/Developer/Xcode/DerivedData";
 
 pub fn make_app<'a, 'b: 'a>(app: App<'a, 'b>) -> App<'a, 'b> {
     app.about("Upload debugging information files.")
-        .org_project_args()
+        .org_project_args(true)
         .arg(
             Arg::with_name("paths")
                 .value_name("PATH")

--- a/src/commands/upload_dsym.rs
+++ b/src/commands/upload_dsym.rs
@@ -8,7 +8,7 @@ use crate::utils::args::{validate_uuid, ArgExt};
 pub fn make_app<'a, 'b: 'a>(app: App<'a, 'b>) -> App<'a, 'b> {
     app.about("DEPRECATED: Upload Mac debug symbols to a project.")
         .setting(AppSettings::Hidden)
-        .org_project_args()
+        .org_project_args(true)
         .arg(
             Arg::with_name("paths")
                 .value_name("PATH")

--- a/src/commands/upload_proguard.rs
+++ b/src/commands/upload_proguard.rs
@@ -28,7 +28,7 @@ struct MappingRef {
 
 pub fn make_app<'a, 'b: 'a>(app: App<'a, 'b>) -> App<'a, 'b> {
     app.about("Upload ProGuard mapping files to a project.")
-        .org_project_args()
+        .org_project_args(true)
         .arg(
             Arg::with_name("paths")
                 .value_name("PATH")

--- a/src/utils/args.rs
+++ b/src/utils/args.rs
@@ -97,34 +97,36 @@ pub fn get_timestamp(value: &str) -> Result<DateTime<Utc>, Error> {
 }
 
 pub trait ArgExt: Sized {
-    fn org_arg(self) -> Self;
-    fn project_arg(self) -> Self;
+    fn org_arg(self, global: bool) -> Self;
+    fn project_arg(self, global: bool) -> Self;
     fn projects_arg(self) -> Self;
-    fn org_project_args(self) -> Self {
-        self.org_arg().project_arg()
+    fn org_project_args(self, global: bool) -> Self {
+        self.org_arg(global).project_arg(global)
     }
     fn version_arg(self, index: u64) -> Self;
 }
 
 impl<'a: 'b, 'b> ArgExt for clap::App<'a, 'b> {
-    fn org_arg(self) -> clap::App<'a, 'b> {
+    fn org_arg(self, global: bool) -> clap::App<'a, 'b> {
         self.arg(
             clap::Arg::with_name("org")
                 .value_name("ORG")
                 .long("org")
                 .short("o")
                 .validator(validate_org)
+                .global(global)
                 .help("The organization slug"),
         )
     }
 
-    fn project_arg(self) -> clap::App<'a, 'b> {
+    fn project_arg(self, global: bool) -> clap::App<'a, 'b> {
         self.arg(
             clap::Arg::with_name("project")
                 .value_name("PROJECT")
                 .long("project")
                 .short("p")
                 .validator(validate_project)
+                .global(global)
                 .help("The project slug"),
         )
     }
@@ -139,7 +141,7 @@ impl<'a: 'b, 'b> ArgExt for clap::App<'a, 'b> {
                 .number_of_values(1)
                 .required(false)
                 .validator(validate_project)
-                .help("The project slug.  This can be supplied multiple times."),
+                .help("The project slug. This can be supplied multiple times."),
         )
     }
 


### PR DESCRIPTION
`.global` is only propagating down, not up the command structure, so it will work for us perfectly.

Fixes https://github.com/getsentry/sentry-cli/issues/179