### PR TITLE
fix: Allow hyphenated release names with any flags position

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,6 @@ on:
     branches:
       - master
       - 1.x
-      - 2.x
       - release/**
 
   pull_request:
@@ -90,6 +89,6 @@ jobs:
 
       - run: npm install
         env:
-          SENTRYCLI_LOCAL_CDNURL: "http://localhost:8999/"
+          SENTRYCLI_LOCAL_CDNURL: 'http://localhost:8999/'
 
       - run: npm test

--- a/src/commands/releases/archive.rs
+++ b/src/commands/releases/archive.rs
@@ -6,7 +6,10 @@ use crate::config::Config;
 use crate::utils::args::ArgExt;
 
 pub fn make_command(command: Command) -> Command {
-    command.about("Archive a release.").version_arg()
+    command
+        .about("Archive a release.")
+        .allow_hyphen_values(true)
+        .version_arg()
 }
 
 pub fn execute(matches: &ArgMatches) -> Result<()> {

--- a/src/commands/releases/delete.rs
+++ b/src/commands/releases/delete.rs
@@ -6,7 +6,10 @@ use crate::config::Config;
 use crate::utils::args::ArgExt;
 
 pub fn make_command(command: Command) -> Command {
-    command.about("Delete a release.").version_arg()
+    command
+        .about("Delete a release.")
+        .allow_hyphen_values(true)
+        .version_arg()
 }
 
 pub fn execute(matches: &ArgMatches) -> Result<()> {

--- a/src/commands/releases/finalize.rs
+++ b/src/commands/releases/finalize.rs
@@ -9,6 +9,7 @@ use crate::utils::args::{get_timestamp, validate_timestamp, ArgExt};
 pub fn make_command(command: Command) -> Command {
     command
         .about("Mark a release as finalized and released.")
+        .allow_hyphen_values(true)
         .version_arg()
         .arg(
             Arg::new("url")

--- a/src/commands/releases/info.rs
+++ b/src/commands/releases/info.rs
@@ -11,6 +11,7 @@ use crate::utils::system::QuietExit;
 pub fn make_command(command: Command) -> Command {
     command
         .about("Print information about a release.")
+        .allow_hyphen_values(true)
         .version_arg()
         .arg(
             Arg::new("show_projects")

--- a/src/commands/releases/mod.rs
+++ b/src/commands/releases/mod.rs
@@ -45,12 +45,14 @@ pub fn make_command(mut command: Command) -> Command {
         // Backward compatibility with `releases files <VERSION>` commands.
         .subcommand(
             crate::commands::files::make_command(Command::new("files"))
+                .allow_hyphen_values(true)
                 .version_arg()
                 .hide(true),
         )
         // Backward compatibility with `releases deploys <VERSION>` commands.
         .subcommand(
             crate::commands::deploys::make_command(Command::new("deploys"))
+                .allow_hyphen_values(true)
                 .version_arg()
                 .hide(true),
         );

--- a/src/commands/releases/new.rs
+++ b/src/commands/releases/new.rs
@@ -9,6 +9,7 @@ use crate::utils::args::ArgExt;
 pub fn make_command(command: Command) -> Command {
     command
         .about("Create a new release.")
+        .allow_hyphen_values(true)
         .version_arg()
         .arg(
             Arg::new("url")

--- a/src/commands/releases/restore.rs
+++ b/src/commands/releases/restore.rs
@@ -6,7 +6,10 @@ use crate::config::Config;
 use crate::utils::args::ArgExt;
 
 pub fn make_command(command: Command) -> Command {
-    command.about("Restore a release.").version_arg()
+    command
+        .about("Restore a release.")
+        .allow_hyphen_values(true)
+        .version_arg()
 }
 
 pub fn execute(matches: &ArgMatches) -> Result<()> {

--- a/src/commands/releases/set_commits.rs
+++ b/src/commands/releases/set_commits.rs
@@ -14,6 +14,7 @@ use crate::utils::vcs::{
 pub fn make_command(command: Command) -> Command {
     command
         .about("Set commits of a release.")
+        .allow_hyphen_values(true)
         .version_arg()
         .arg(Arg::new("clear")
             .long("clear")

--- a/src/utils/args.rs
+++ b/src/utils/args.rs
@@ -145,7 +145,6 @@ impl<'a: 'b, 'b> ArgExt for Command<'a> {
             Arg::new("version")
                 .value_name("VERSION")
                 .required(true)
-                .allow_hyphen_values(true)
                 .validator(validate_release)
                 .help("The version of the release"),
         )

--- a/tests/integration/_cases/releases/releases-new-help.trycmd
+++ b/tests/integration/_cases/releases/releases-new-help.trycmd
@@ -1,0 +1,26 @@
+```
+$ sentry-cli[..] releases new -h
+? success
+sentry-cli[..]-releases-new 
+Create a new release.
+
+USAGE:
+    sentry-cli releases new [OPTIONS] <VERSION>
+
+ARGS:
+    <VERSION>    The version of the release
+
+OPTIONS:
+        --auth-token <AUTH_TOKEN>    Use the given Sentry auth token.
+        --finalize                   Immediately finalize the release. (sets it to released)
+    -h, --help                       Print help information
+        --log-level <LOG_LEVEL>      Set the log output verbosity. [possible values: trace, debug,
+                                     info, warn, error]
+    -o, --org <ORG>                  The organization slug
+    -p, --project <PROJECT>          The project slug.
+        --quiet                      Do not print any output while preserving correct exit code.
+                                     This flag is currently implemented only for selected
+                                     subcommands. [aliases: silent]
+        --url <URL>                  Optional URL to the release for information purposes.
+
+```

--- a/tests/integration/_cases/releases/releases-new-with-project-hyphen.trycmd
+++ b/tests/integration/_cases/releases/releases-new-with-project-hyphen.trycmd
@@ -1,0 +1,6 @@
+```
+$ sentry-cli releases new -p wat-project -hyphenated-release
+? success
+Created release -hyphenated-release.
+
+```

--- a/tests/integration/_cases/releases/releases-new-with-project.trycmd
+++ b/tests/integration/_cases/releases/releases-new-with-project.trycmd
@@ -1,0 +1,6 @@
+```
+$ sentry-cli releases new -p wat-project new-release
+? success
+Created release new-release.
+
+```

--- a/tests/integration/releases/new.rs
+++ b/tests/integration/releases/new.rs
@@ -4,6 +4,11 @@ use serde_json::json;
 use crate::integration::{mock_endpoint, register_test, EndpointOptions, UTC_DATE_FORMAT};
 
 #[test]
+fn command_releases_new_help() {
+    register_test("releases/releases-new-help.trycmd");
+}
+
+#[test]
 fn creates_release() {
     let _server = mock_endpoint(
         EndpointOptions::new("POST", "/api/0/projects/wat-org/wat-project/releases/", 201)
@@ -27,6 +32,32 @@ fn allows_for_release_to_start_with_hyphen() {
             }))),
     );
     register_test("releases/releases-new-hyphen.trycmd");
+}
+
+#[test]
+fn creates_release_with_project() {
+    let _server = mock_endpoint(
+        EndpointOptions::new("POST", "/api/0/projects/wat-org/wat-project/releases/", 201)
+            .with_response_file("releases/get-release.json")
+            .with_matcher(Matcher::PartialJson(json!({
+                "version": "new-release",
+                "projects": ["wat-project"],
+            }))),
+    );
+    register_test("releases/releases-new-with-project.trycmd");
+}
+
+#[test]
+fn allows_for_release_with_project_to_start_with_hyphen() {
+    let _server = mock_endpoint(
+        EndpointOptions::new("POST", "/api/0/projects/wat-org/wat-project/releases/", 201)
+            .with_response_file("releases/get-release.json")
+            .with_matcher(Matcher::PartialJson(json!({
+                "version": "-hyphenated-release",
+                "projects": ["wat-project"],
+            }))),
+    );
+    register_test("releases/releases-new-with-project-hyphen.trycmd");
 }
 
 #[test]


### PR DESCRIPTION
Moves `allow_hyphen_values` from the argument to the command itself. This makes it understand that `-p` is indeed a short flag and not a release name.

Added appropriate tests to cover this case.

Fixes https://github.com/getsentry/sentry-cli/issues/1186
