### PR TITLE
ref: Restore and hide legacy aliases from 1.x for backward compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,28 +30,22 @@ Breaking changes are denotated with _(breaking)_ tag, and appropriate required c
 
 ### Removed APIs
 
-- ref: Remove `difutil id` subcommand (use `debug-files check` instead) _(breaking)_
 - ref: Remove `monitors` command (support for this feature has been dropped) _(breaking)_
 - ref: Remove `react-native codepush` subcommand (use `react-native appcenter` instead) _(breaking)_
 - ref: Remove `react-native-gradle` and `react-native-xcode` commands (use `react-native gradle` and `react-native xcode` instead) _(breaking)_
-- ref: Remove `upload-dsym` command (use `debug-files upload` instead) _(breaking)_
-- ref: Remove deprecated and hidden flags from commands (remove listed flags usage) _(breaking)_
-  - `react-native xcode --verbose`
-  - `releases new --ref`
-  - `releases list --no-abbrev`
-  - `releases upload-sourcemaps --verbose`
-  - `releases upload-sourcemaps --rewrite` (it's a default behavior now)
-  - `upload-dif --upload-symbol-maps`
 - ref: Remove `bash-hook` command (use `1.x` if you still need the functionality; it will eventually be ported as a separate repository - https://github.com/getsentry/sentry-cli-bash-hook) _(breaking)_
 - ref: Remove `crash_reporting` related code and `with_crash_reporting` crate feature (no required changes) _(breaking)_
 - ref: Remove `SENTRY_NO_PROGRESS_BAR` env var in favor of `SENTRYCLI_NO_PROGRESS_BAR` (rename env variable) _(breaking)_
+- ref: Hide `difutil id` subcommand (use `debug-files check` instead)
+- ref: Hide `upload-dsym` command (use `debug-files upload` instead)
+- ref: Make `releases upload-sourcemaps --rewrite` a default behavior now
 
 ### Breaking Changes
 
 - ref: Update minimal required `node` version to `v12` (update node version) _(breaking)_
 - ref: Rename `--header` argument of `releases files upload` command to `--file-header` (rename flag) _(breaking)_
 - ref: Rename `CUSTOM_HEADER` to `SENTRY_HEADER` and `defaults.custom_header` to `http.header` (rename env variable or update config file) _(breaking)_
-- ref: Make `ignore-empty` for `releases set-commits` a default behavior and remove `--ignore-empty` flag (remove `--ignore-empty` usage) _(breaking)_
+- ref: Make `ignore-empty` for `releases set-commits` a default behavior and hide `--ignore-empty` flag (remove `--ignore-empty` usage) _(breaking)_
 
 ### Various fixes & improvements
 

--- a/src/commands/debug_files/check.rs
+++ b/src/commands/debug_files/check.rs
@@ -12,6 +12,10 @@ use crate::utils::system::QuietExit;
 pub fn make_command(command: Command) -> Command {
     command
         .about("Check the debug info file at a given path.")
+        // Legacy name, left hidden for backward compatibility
+        .alias("id")
+        // Legacy name, left hidden for backward compatibility
+        .alias("uuid")
         .arg(
             Arg::new("path")
                 .required(true)

--- a/src/commands/debug_files/upload.rs
+++ b/src/commands/debug_files/upload.rs
@@ -157,6 +157,12 @@ pub fn make_command(command: Command) -> Command {
             can only be displayed if --wait is specified, but this will \
             significantly slow down the upload process.",
         ))
+        // Legacy flag that has no effect, left hidden for backward compatibility
+        .arg(
+            Arg::new("upload_symbol_maps")
+                .long("upload-symbol-maps")
+                .hide(true),
+        )
 }
 
 pub fn execute(matches: &ArgMatches) -> Result<()> {

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -34,6 +34,7 @@ macro_rules! each_subcommand {
         #[cfg(not(feature = "managed"))]
         $mac!(update);
         $mac!(upload_dif);
+        $mac!(upload_dsym);
         $mac!(upload_proguard);
     };
 }

--- a/src/commands/releases/list.rs
+++ b/src/commands/releases/list.rs
@@ -29,6 +29,8 @@ pub fn make_command(command: Command) -> Command {
                 .requires("raw")
                 .help("Delimiter for the --raw flag"),
         )
+        // Legacy flag that has no effect, left hidden for backward compatibility
+        .arg(Arg::new("no_abbrev").long("no-abbrev").hide(true))
 }
 
 pub fn execute(matches: &ArgMatches) -> Result<()> {

--- a/src/commands/releases/new.rs
+++ b/src/commands/releases/new.rs
@@ -22,6 +22,8 @@ pub fn make_command(command: Command) -> Command {
                 .long("finalize")
                 .help("Immediately finalize the release. (sets it to released)"),
         )
+        // Legacy flag that has no effect, left hidden for backward compatibility
+        .arg(Arg::new("ref").long("ref").hide(true))
 }
 
 pub fn execute(matches: &ArgMatches) -> Result<()> {

--- a/src/commands/releases/set_commits.rs
+++ b/src/commands/releases/set_commits.rs
@@ -61,6 +61,9 @@ pub fn make_command(command: Command) -> Command {
                     the current commit of the repository at the given PATH is \
                     assumed.  To override the revision `@REV` can be appended \
                     which will force the revision to a certain value."))
+        // Legacy flag that has no effect, left hidden for backward compatibility
+        .arg(Arg::new("ignore-empty")
+            .long("ignore-empty").hide(true))
 }
 
 fn strip_sha(sha: &str) -> &str {

--- a/src/commands/sourcemaps/upload.rs
+++ b/src/commands/sourcemaps/upload.rs
@@ -145,6 +145,10 @@ pub fn make_command(command: Command) -> Command {
                     Defaults to: `--ext=js --ext=map --ext=jsbundle --ext=bundle`",
                 ),
         )
+        // Legacy flag that has no effect, left hidden for backward compatibility
+        .arg(Arg::new("rewrite").long("rewrite").hide(true))
+        // Legacy flag that has no effect, left hidden for backward compatibility
+        .arg(Arg::new("verbose").long("verbose").short('v').hide(true))
 }
 
 fn get_prefixes_from_args(matches: &ArgMatches) -> Vec<&str> {

--- a/src/commands/upload_dsym.rs
+++ b/src/commands/upload_dsym.rs
@@ -1,0 +1,12 @@
+// upload-dsym is a backward compatible, hidden alias for `debug-files upload`.
+
+use anyhow::Result;
+use clap::{ArgMatches, Command};
+
+pub fn make_command(command: Command) -> Command {
+    crate::commands::debug_files::upload::make_command(command).hide(true)
+}
+
+pub fn execute(matches: &ArgMatches) -> Result<()> {
+    crate::commands::debug_files::upload::execute(matches)
+}

--- a/tests/integration/_cases/upload_dsym/upload_dsym-help.trycmd
+++ b/tests/integration/_cases/upload_dsym/upload_dsym-help.trycmd
@@ -1,0 +1,74 @@
+```
+$ sentry-cli upload-dsym --help
+? success
+sentry-cli[..]-upload-dsym 
+Upload debugging information files.
+
+USAGE:
+    sentry-cli[..] upload-dsym [OPTIONS] [PATH]...
+
+ARGS:
+    <PATH>...    A path to search recursively for symbol files.
+
+OPTIONS:
+        --auth-token <AUTH_TOKEN>    Use the given Sentry auth token.
+        --derived-data               Search for debug symbols in Xcode's derived data.
+        --force-foreground           Wait for the process to finish.
+                                     By default, the upload process will detach and continue in the
+                                     background when triggered from Xcode.  When an error happens, a
+                                     dialog is shown.  If this parameter is passed Xcode will wait
+                                     for the process to finish before the build finishes and output
+                                     will be shown in the Xcode build output.
+    -h, --help                       Print help information
+        --id <ID>                    Search for specific debug identifiers.
+        --include-sources            Include sources from the local file system and upload them as
+                                     source bundles.
+        --info-plist <PATH>          Optional path to the Info.plist.
+                                     We will try to find this automatically if run from Xcode.
+                                     Providing this information will associate the debug symbols
+                                     with a specific ITC application and build in Sentry.  Note that
+                                     if you provide the plist explicitly it must already be
+                                     processed.
+        --log-level <LOG_LEVEL>      Set the log output verbosity. [possible values: trace, debug,
+                                     info, warn, error]
+        --no-debug                   Do not scan for debugging information. This will usually
+                                     exclude debug companion files. They might still be uploaded, if
+                                     they contain additional processable information (see other
+                                     flags).
+        --no-reprocessing            Do not trigger reprocessing after uploading.
+        --no-sources                 Do not scan for source information. This will usually exclude
+                                     source bundle files. They might still be uploaded, if they
+                                     contain additional processable information (see other flags).
+        --no-unwind                  Do not scan for stack unwinding information. Specify this flag
+                                     for builds with disabled FPO, or when stackwalking occurs on
+                                     the device. This usually excludes executables and dynamic
+                                     libraries. They might still be uploaded, if they contain
+                                     additional processable information (see other flags).
+        --no-upload                  Disable the actual upload.
+                                     This runs all steps for the processing but does not trigger the
+                                     upload (this also automatically disables reprocessing).  This
+                                     is useful if you just want to verify the setup or skip the
+                                     upload in tests.
+        --no-zips                    Do not search in ZIP files.
+    -o, --org <ORG>                  The organization slug
+    -p, --project <PROJECT>          The project slug.
+        --quiet                      Do not print any output while preserving correct exit code.
+                                     This flag is currently implemented only for selected
+                                     subcommands. [aliases: silent]
+        --require-all                Errors if not all identifiers specified with --id could be
+                                     found.
+        --symbol-maps <PATH>         Optional path to BCSymbolMap files which are used to resolve
+                                     hidden symbols in dSYM files downloaded from iTunes Connect.
+                                     This requires the dsymutil tool to be available.  This should
+                                     not be used when using the App Store Connect integration, the
+                                     .bcsymbolmap files needed for the integration are uploaded
+                                     without this option if they are found in the PATH searched for
+                                     symbol files.
+    -t, --type <TYPE>                Only consider debug information files of the given type.  By
+                                     default, all types are considered. [possible values: dsym, elf,
+                                     breakpad, pdb, pe, sourcebundle, bcsymbolmap]
+        --wait                       Wait for the server to fully process uploaded files. Errors can
+                                     only be displayed if --wait is specified, but this will
+                                     significantly slow down the upload process.
+
+```

--- a/tests/integration/upload_dsym.rs
+++ b/tests/integration/upload_dsym.rs
@@ -1,0 +1,11 @@
+#[cfg(not(windows))]
+use crate::integration::register_test;
+
+// I have no idea why this is timing out on Windows.
+// I verified it manually, and this command works just fine. — Kamil
+// TODO: Fix windows timeout.
+#[cfg(not(windows))]
+#[test]
+fn command_upload_dsym_help() {
+    register_test("upload_sym/upload_sym-help.trycmd");
+}


### PR DESCRIPTION
Fixes https://github.com/getsentry/sentry-fastlane-plugin/pull/119
Fixes https://github.com/getsentry/sentry-cli/issues/1190
Fixes https://github.com/getsentry/sentry-cli/issues/1188#issuecomment-1096806402