### PR TITLE
fix: Remove fetch.FetchError usage in favor of catch-all clause

### DIFF
--- a/scripts/install.js
+++ b/scripts/install.js
@@ -230,13 +230,9 @@ async function downloadBinary() {
       redirect: 'follow',
     });
   } catch (error) {
-    if (error instanceof fetch.FetchError) {
-      throw new Error(
-        `Unable to download sentry-cli binary from ${downloadUrl}.\nError code: ${error.code}`
-      );
-    } else {
-      throw error;
-    }
+    throw new Error(
+      `Unable to download sentry-cli binary from ${downloadUrl}.\nError message: ${error.message}\nError code: ${error.code}`
+    );
   }
 
   if (!response.ok) {


### PR DESCRIPTION
We can do that, as according to https://github.com/node-fetch/node-fetch/blob/main/docs/ERROR-HANDLING.md

> All operational errors other than aborted requests are rejected with a FetchError.

And because we don't have abort logic, we don't need to handle that. 