### PR TITLE
ref: Use more concrete [EXE] matcher from trycmd

### DIFF
--- a/tests/integration/_cases/debug_files/debug_files-help.trycmd
+++ b/tests/integration/_cases/debug_files/debug_files-help.trycmd
@@ -1,11 +1,11 @@
 ```
 $ sentry-cli debug-files --help
 ? success
-sentry-cli[..]-debug-files 
+sentry-cli[EXE]-debug-files 
 Locate, analyze or upload debug information files.
 
 USAGE:
-    sentry-cli[..] debug-files [OPTIONS] <SUBCOMMAND>
+    sentry-cli[EXE] debug-files [OPTIONS] <SUBCOMMAND>
 
 OPTIONS:
         --auth-token <AUTH_TOKEN>    Use the given Sentry auth token.

--- a/tests/integration/_cases/debug_files/debug_files-no-subcommand.trycmd
+++ b/tests/integration/_cases/debug_files/debug_files-no-subcommand.trycmd
@@ -1,11 +1,11 @@
 ```
 $ sentry-cli debug-files
 ? failed
-sentry-cli[..]-debug-files 
+sentry-cli[EXE]-debug-files 
 Locate, analyze or upload debug information files.
 
 USAGE:
-    sentry-cli[..] debug-files [OPTIONS] <SUBCOMMAND>
+    sentry-cli[EXE] debug-files [OPTIONS] <SUBCOMMAND>
 
 OPTIONS:
         --auth-token <AUTH_TOKEN>    Use the given Sentry auth token.

--- a/tests/integration/_cases/debug_files/debug_files-upload-help.trycmd
+++ b/tests/integration/_cases/debug_files/debug_files-upload-help.trycmd
@@ -1,11 +1,11 @@
 ```
 $ sentry-cli debug-files upload --help
 ? success
-sentry-cli[..]-debug-files-upload 
+sentry-cli[EXE]-debug-files-upload 
 Upload debugging information files.
 
 USAGE:
-    sentry-cli[..] debug-files upload [OPTIONS] [PATH]...
+    sentry-cli[EXE] debug-files upload [OPTIONS] [PATH]...
 
 ARGS:
     <PATH>...    A path to search recursively for symbol files.

--- a/tests/integration/_cases/deploys/deploys-help.trycmd
+++ b/tests/integration/_cases/deploys/deploys-help.trycmd
@@ -1,11 +1,11 @@
 ```
 $ sentry-cli deploys --help
 ? success
-sentry-cli[..]-deploys 
+sentry-cli[EXE]-deploys 
 Manage deployments for Sentry releases.
 
 USAGE:
-    sentry-cli[..] deploys [OPTIONS] <SUBCOMMAND>
+    sentry-cli[EXE] deploys [OPTIONS] <SUBCOMMAND>
 
 OPTIONS:
         --auth-token <AUTH_TOKEN>    Use the given Sentry auth token.

--- a/tests/integration/_cases/deploys/deploys-no-subcommand.trycmd
+++ b/tests/integration/_cases/deploys/deploys-no-subcommand.trycmd
@@ -1,11 +1,11 @@
 ```
 $ sentry-cli deploys
 ? failed
-sentry-cli[..]-deploys 
+sentry-cli[EXE]-deploys 
 Manage deployments for Sentry releases.
 
 USAGE:
-    sentry-cli[..] deploys [OPTIONS] <SUBCOMMAND>
+    sentry-cli[EXE] deploys [OPTIONS] <SUBCOMMAND>
 
 OPTIONS:
         --auth-token <AUTH_TOKEN>    Use the given Sentry auth token.

--- a/tests/integration/_cases/info/info-help.trycmd
+++ b/tests/integration/_cases/info/info-help.trycmd
@@ -1,11 +1,11 @@
 ```
 $ sentry-cli info --help
 ? success
-sentry-cli[..]-info 
+sentry-cli[EXE]-info 
 Print information about the Sentry server.
 
 USAGE:
-    sentry-cli[..] info [OPTIONS]
+    sentry-cli[EXE] info [OPTIONS]
 
 OPTIONS:
         --auth-token <AUTH_TOKEN>    Use the given Sentry auth token.

--- a/tests/integration/_cases/login/login-help.trycmd
+++ b/tests/integration/_cases/login/login-help.trycmd
@@ -1,11 +1,11 @@
 ```
 $ sentry-cli login --help
 ? success
-sentry-cli[..]-login 
+sentry-cli[EXE]-login 
 Authenticate with the Sentry server.
 
 USAGE:
-    sentry-cli[..] login [OPTIONS]
+    sentry-cli[EXE] login [OPTIONS]
 
 OPTIONS:
         --auth-token <AUTH_TOKEN>    Use the given Sentry auth token.

--- a/tests/integration/_cases/releases/releases-help.trycmd
+++ b/tests/integration/_cases/releases/releases-help.trycmd
@@ -1,11 +1,11 @@
 ```
 $ sentry-cli releases --help
 ? success
-sentry-cli[..]-releases 
+sentry-cli[EXE]-releases 
 Manage releases on Sentry.
 
 USAGE:
-    sentry-cli[..] releases [OPTIONS] <SUBCOMMAND>
+    sentry-cli[EXE] releases [OPTIONS] <SUBCOMMAND>
 
 OPTIONS:
         --auth-token <AUTH_TOKEN>    Use the given Sentry auth token.

--- a/tests/integration/_cases/releases/releases-new-help.trycmd
+++ b/tests/integration/_cases/releases/releases-new-help.trycmd
@@ -1,7 +1,7 @@
 ```
-$ sentry-cli[..] releases new -h
+$ sentry-cli[EXE] releases new -h
 ? success
-sentry-cli[..]-releases-new 
+sentry-cli[EXE]-releases-new 
 Create a new release.
 
 USAGE:

--- a/tests/integration/_cases/releases/releases-no-subcommand.trycmd
+++ b/tests/integration/_cases/releases/releases-no-subcommand.trycmd
@@ -1,11 +1,11 @@
 ```
 $ sentry-cli releases
 ? failed
-sentry-cli[..]-releases 
+sentry-cli[EXE]-releases 
 Manage releases on Sentry.
 
 USAGE:
-    sentry-cli[..] releases [OPTIONS] <SUBCOMMAND>
+    sentry-cli[EXE] releases [OPTIONS] <SUBCOMMAND>
 
 OPTIONS:
         --auth-token <AUTH_TOKEN>    Use the given Sentry auth token.

--- a/tests/integration/_cases/send_event/send_event-help.trycmd
+++ b/tests/integration/_cases/send_event/send_event-help.trycmd
@@ -1,14 +1,14 @@
 ```
 $ sentry-cli send-event --help
 ? success
-sentry-cli[..]-send-event 
+sentry-cli[EXE]-send-event 
 Send a manual event to Sentry.{n}{n}This command will validate input parameters and attempt to send
 an event to Sentry. Due to network errors, rate limits or sampling the event is not guaranteed to
 actually arrive. Check debug output for transmission errors by passing --log-level=debug or setting
 `SENTRY_LOG_LEVEL=debug`.
 
 USAGE:
-    sentry-cli[..] send-event [OPTIONS] [PATH]
+    sentry-cli[EXE] send-event [OPTIONS] [PATH]
 
 ARGS:
     <PATH>

--- a/tests/integration/_cases/sourcemaps/sourcemaps-help.trycmd
+++ b/tests/integration/_cases/sourcemaps/sourcemaps-help.trycmd
@@ -1,11 +1,11 @@
 ```
 $ sentry-cli sourcemaps --help
 ? success
-sentry-cli[..]-sourcemaps 
+sentry-cli[EXE]-sourcemaps 
 Manage sourcemaps for Sentry releases.
 
 USAGE:
-    sentry-cli[..] sourcemaps [OPTIONS] <SUBCOMMAND>
+    sentry-cli[EXE] sourcemaps [OPTIONS] <SUBCOMMAND>
 
 OPTIONS:
         --auth-token <AUTH_TOKEN>    Use the given Sentry auth token.

--- a/tests/integration/_cases/sourcemaps/sourcemaps-no-subcommand.trycmd
+++ b/tests/integration/_cases/sourcemaps/sourcemaps-no-subcommand.trycmd
@@ -1,11 +1,11 @@
 ```
 $ sentry-cli sourcemaps
 ? failed
-sentry-cli[..]-sourcemaps 
+sentry-cli[EXE]-sourcemaps 
 Manage sourcemaps for Sentry releases.
 
 USAGE:
-    sentry-cli[..] sourcemaps [OPTIONS] <SUBCOMMAND>
+    sentry-cli[EXE] sourcemaps [OPTIONS] <SUBCOMMAND>
 
 OPTIONS:
         --auth-token <AUTH_TOKEN>    Use the given Sentry auth token.

--- a/tests/integration/_cases/sourcemaps/sourcemaps-resolve-help.trycmd
+++ b/tests/integration/_cases/sourcemaps/sourcemaps-resolve-help.trycmd
@@ -1,11 +1,11 @@
 ```
 $ sentry-cli sourcemaps resolve --help
 ? success
-sentry-cli[..]-sourcemaps-resolve 
+sentry-cli[EXE]-sourcemaps-resolve 
 Resolve sourcemap for a given line/column position.
 
 USAGE:
-    sentry-cli[..] sourcemaps resolve [OPTIONS] [PATH]
+    sentry-cli[EXE] sourcemaps resolve [OPTIONS] [PATH]
 
 ARGS:
     <PATH>    The sourcemap to resolve.

--- a/tests/integration/_cases/uninstall/uninstall-help.trycmd
+++ b/tests/integration/_cases/uninstall/uninstall-help.trycmd
@@ -1,11 +1,11 @@
 ```
 $ sentry-cli uninstall --help
 ? success
-sentry-cli[..]-uninstall 
+sentry-cli[EXE]-uninstall 
 Uninstall the sentry-cli executable.
 
 USAGE:
-    sentry-cli[..] uninstall [OPTIONS]
+    sentry-cli[EXE] uninstall [OPTIONS]
 
 OPTIONS:
         --auth-token <AUTH_TOKEN>    Use the given Sentry auth token.

--- a/tests/integration/_cases/update/update-help.trycmd
+++ b/tests/integration/_cases/update/update-help.trycmd
@@ -1,11 +1,11 @@
 ```
 $ sentry-cli update --help
 ? success
-sentry-cli[..]-update 
+sentry-cli[EXE]-update 
 Update the sentry-cli executable.
 
 USAGE:
-    sentry-cli[..] update [OPTIONS]
+    sentry-cli[EXE] update [OPTIONS]
 
 OPTIONS:
         --auth-token <AUTH_TOKEN>    Use the given Sentry auth token.

--- a/tests/integration/_cases/upload_dif/upload_dif-help.trycmd
+++ b/tests/integration/_cases/upload_dif/upload_dif-help.trycmd
@@ -1,11 +1,11 @@
 ```
 $ sentry-cli upload-dif --help
 ? success
-sentry-cli[..]-upload-dif 
+sentry-cli[EXE]-upload-dif 
 Upload debugging information files.
 
 USAGE:
-    sentry-cli[..] upload-dif [OPTIONS] [PATH]...
+    sentry-cli[EXE] upload-dif [OPTIONS] [PATH]...
 
 ARGS:
     <PATH>...    A path to search recursively for symbol files.

--- a/tests/integration/_cases/upload_dsym/upload_dsym-help.trycmd
+++ b/tests/integration/_cases/upload_dsym/upload_dsym-help.trycmd
@@ -1,11 +1,11 @@
 ```
 $ sentry-cli upload-dsym --help
 ? success
-sentry-cli[..]-upload-dsym 
+sentry-cli[EXE]-upload-dsym 
 Upload debugging information files.
 
 USAGE:
-    sentry-cli[..] upload-dsym [OPTIONS] [PATH]...
+    sentry-cli[EXE] upload-dsym [OPTIONS] [PATH]...
 
 ARGS:
     <PATH>...    A path to search recursively for symbol files.

--- a/tests/integration/_cases/upload_proguard/upload_proguard-help.trycmd
+++ b/tests/integration/_cases/upload_proguard/upload_proguard-help.trycmd
@@ -1,11 +1,11 @@
 ```
 $ sentry-cli upload-proguard --help
 ? success
-sentry-cli[..]-upload-proguard 
+sentry-cli[EXE]-upload-proguard 
 Upload ProGuard mapping files to a project.
 
 USAGE:
-    sentry-cli[..] upload-proguard [OPTIONS] [PATH]...
+    sentry-cli[EXE] upload-proguard [OPTIONS] [PATH]...
 
 ARGS:
     <PATH>...    The path to the mapping files.


### PR DESCRIPTION
Use
> [EXE] as part of the line: On Windows, matches .exe, ignored otherwise

instead of
> [..] as part of a line: match any characters. This is equivalent of [^\n]*?.

https://docs.rs/trycmd/latest/trycmd/index.html

#skip-changelog