### PR TITLE
fix: fixing 'no-zips' option.

### DIFF
--- a/src/utils/dif_upload.rs
+++ b/src/utils/dif_upload.rs
@@ -529,20 +529,22 @@ where
         }
 
         let path = entry.path();
-        match try_open_zip(path) {
-            Ok(Some(zip)) => {
-                debug!("searching zip archive {}", path.display());
-                walk_difs_zip(zip, options, &mut func)?;
-                debug!("finished zip archive {}", path.display());
-                continue;
-            }
-            Err(e) => {
-                debug!("skipping zip archive {}", path.display());
-                debug!("error: {}", e);
-                continue;
-            }
-            Ok(None) => {
-                // this is not a zip archive
+        if options.zips_allowed {
+            match try_open_zip(path) {
+                Ok(Some(zip)) => {
+                    debug!("searching zip archive {}", path.display());
+                    walk_difs_zip(zip, options, &mut func)?;
+                    debug!("finished zip archive {}", path.display());
+                    continue;
+                }
+                Err(e) => {
+                    debug!("skipping zip archive {}", path.display());
+                    debug!("error: {}", e);
+                    continue;
+                }
+                Ok(None) => {
+                    // this is not a zip archive
+                }
             }
         }
 


### PR DESCRIPTION
Looks like 'no-zips' option is broken.
Actually we need it due to a bug with pwd protected zips (https://github.com/getsentry/sentry-cli/issues/1238)