### PR TITLE
chore: fix recommended VS Code extension name

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -8,7 +8,7 @@
         // TOML language support
         "bungcip.better-toml",
         // Rust language server
-        "matklad.rust-analyzer",
+        "rust-lang.rust-analyzer",
         // Crates.io dependency versions
         "serayuzgur.crates",
         // Debugger support for Rust and native


### PR DESCRIPTION
mutklad.rust-analyzer moved to rust-lang: https://github.com/rust-lang/rust-analyzer/graphs/contributors