### PR TITLE
fix: Use first frame that has context-line in explain

### DIFF
--- a/tests/integration/_cases/sourcemaps/sourcemaps-explain-already-mapped.trycmd
+++ b/tests/integration/_cases/sourcemaps/sourcemaps-explain-already-mapped.trycmd
@@ -5,7 +5,7 @@ $ sentry-cli sourcemaps explain 43a57a55cd5a4207ac520c03e1dee1b4
 ✔ Event has release name: ytho-test
 ✔ Event has a valid exception present
 ✔ Event has a valid stacktrace present
-⚠ Exception is already source mapped and resolves to:
+⚠ Exception is already source mapped and first resolved frame points to:
 
   function foo(msg) {
     bar(msg);


### PR DESCRIPTION
When stacktrace frame is incorrectly marked as `inApp`, but it comes from the place that we cannot map (eg. built-in language SDK itself), then `print_mapped_frame` would fail, as despite being processed, this frame has no `context_line` that we can display.
This change filters through mapped frames and uses the first one that can be correctly printed.