### PR TITLE
Increase TempFile robustness on Windows

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2063,6 +2063,7 @@ dependencies = [
  "uuid",
  "walkdir",
  "which 4.2.4",
+ "winapi 0.3.9",
  "zip",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,6 +59,9 @@ walkdir = "2.3.2"
 which = "4.2.4"
 zip = "0.5.13"
 
+[target.'cfg(windows)'.dependencies]
+winapi = "0.3.9"
+
 [dev-dependencies]
 insta = { version = "1.12.0", features = ["redactions"] }
 mockito = "0.31.0"

--- a/src/utils/fs.rs
+++ b/src/utils/fs.rs
@@ -105,7 +105,6 @@ impl Drop for TempFile {
     fn drop(&mut self) {
         // On Windows, we open the file handle to set "FILE_FLAG_DELETE_ON_CLOSE" so that it will be closed
         // when the last open handle to this file is gone.
-        extern crate winapi;
         use std::os::windows::prelude::*;
         use winapi::um::winbase::FILE_FLAG_DELETE_ON_CLOSE;
         let result = fs::OpenOptions::new()


### PR DESCRIPTION
This addresses GH-1250 -- it replaces the `Drop` implementation of `TempFile` with one that uses `FILE_FLAG_DELETE_ON_CLOSE` to defer deletion until the last handle is closed on Windows.

This also adds some error logging when `TempFile`'s `drop` fails -- not sure if that's appropriate? It'll help catch issues like this.