### PR TITLE
ref: Remove confusing ending dots from command logs

### DIFF
--- a/src/commands/releases/archive.rs
+++ b/src/commands/releases/archive.rs
@@ -28,6 +28,6 @@ pub fn execute(matches: &ArgMatches) -> Result<()> {
         },
     )?;
 
-    println!("Archived release {}.", info_rv.version);
+    println!("Archived release {}", info_rv.version);
     Ok(())
 }

--- a/src/commands/releases/finalize.rs
+++ b/src/commands/releases/finalize.rs
@@ -57,6 +57,6 @@ pub fn execute(matches: &ArgMatches) -> Result<()> {
         },
     )?;
 
-    println!("Finalized release {}.", version);
+    println!("Finalized release {}", version);
     Ok(())
 }

--- a/src/commands/releases/new.rs
+++ b/src/commands/releases/new.rs
@@ -46,6 +46,6 @@ pub fn execute(matches: &ArgMatches) -> Result<()> {
         },
     )?;
 
-    println!("Created release {}.", version);
+    println!("Created release {}", version);
     Ok(())
 }

--- a/src/commands/releases/restore.rs
+++ b/src/commands/releases/restore.rs
@@ -28,6 +28,6 @@ pub fn execute(matches: &ArgMatches) -> Result<()> {
         },
     )?;
 
-    println!("Restored release {}.", info_rv.version);
+    println!("Restored release {}", info_rv.version);
     Ok(())
 }

--- a/src/commands/releases/set_commits.rs
+++ b/src/commands/releases/set_commits.rs
@@ -198,7 +198,7 @@ pub fn execute(matches: &ArgMatches) -> Result<()> {
             },
         )?;
 
-        println!("Success! Set commits for release {}.", version);
+        println!("Success! Set commits for release {}", version);
     }
 
     Ok(())

--- a/src/utils/sourcemaps.rs
+++ b/src/utils/sourcemaps.rs
@@ -142,10 +142,7 @@ fn guess_sourcemap_reference(sourcemaps: &HashSet<String>, min_url: &str) -> Res
         }
     }
 
-    bail!(
-        "Could not auto-detect referenced sourcemap for {}.",
-        min_url
-    );
+    bail!("Could not auto-detect referenced sourcemap for {}", min_url);
 }
 
 pub struct SourceMapProcessor {

--- a/tests/integration/_cases/releases/releases-finalize-dates.trycmd
+++ b/tests/integration/_cases/releases/releases-finalize-dates.trycmd
@@ -1,6 +1,6 @@
 ```
 $ sentry-cli releases finalize wat-release --started 1431648100 --released 1431648000
 ? success
-Finalized release wat-release.
+Finalized release wat-release
 
 ```

--- a/tests/integration/_cases/releases/releases-finalize-hyphen.trycmd
+++ b/tests/integration/_cases/releases/releases-finalize-hyphen.trycmd
@@ -1,6 +1,6 @@
 ```
 $ sentry-cli releases finalize -hyphenated-release
 ? success
-Finalized release -hyphenated-release.
+Finalized release -hyphenated-release
 
 ```

--- a/tests/integration/_cases/releases/releases-finalize.trycmd
+++ b/tests/integration/_cases/releases/releases-finalize.trycmd
@@ -1,6 +1,6 @@
 ```
 $ sentry-cli releases finalize wat-release
 ? success
-Finalized release wat-release.
+Finalized release wat-release
 
 ```

--- a/tests/integration/_cases/releases/releases-new-existing.trycmd
+++ b/tests/integration/_cases/releases/releases-new-existing.trycmd
@@ -1,6 +1,6 @@
 ```
 $ sentry-cli releases new wat-release
 ? success
-Created release wat-release.
+Created release wat-release
 
 ```

--- a/tests/integration/_cases/releases/releases-new-finalize.trycmd
+++ b/tests/integration/_cases/releases/releases-new-finalize.trycmd
@@ -1,6 +1,6 @@
 ```
 $ sentry-cli releases new wat-release --finalize
 ? success
-Created release wat-release.
+Created release wat-release
 
 ```

--- a/tests/integration/_cases/releases/releases-new-hyphen.trycmd
+++ b/tests/integration/_cases/releases/releases-new-hyphen.trycmd
@@ -1,6 +1,6 @@
 ```
 $ sentry-cli releases new -hyphenated-release
 ? success
-Created release -hyphenated-release.
+Created release -hyphenated-release
 
 ```

--- a/tests/integration/_cases/releases/releases-new-url.trycmd
+++ b/tests/integration/_cases/releases/releases-new-url.trycmd
@@ -1,6 +1,6 @@
 ```
 $ sentry-cli releases new wat-release --url https://oh.rly
 ? success
-Created release wat-release.
+Created release wat-release
 
 ```

--- a/tests/integration/_cases/releases/releases-new-with-project-hyphen.trycmd
+++ b/tests/integration/_cases/releases/releases-new-with-project-hyphen.trycmd
@@ -1,6 +1,6 @@
 ```
 $ sentry-cli releases new -p wat-project -hyphenated-release
 ? success
-Created release -hyphenated-release.
+Created release -hyphenated-release
 
 ```

--- a/tests/integration/_cases/releases/releases-new-with-project.trycmd
+++ b/tests/integration/_cases/releases/releases-new-with-project.trycmd
@@ -1,6 +1,6 @@
 ```
 $ sentry-cli releases new -p wat-project new-release
 ? success
-Created release new-release.
+Created release new-release
 
 ```

--- a/tests/integration/_cases/releases/releases-new.trycmd
+++ b/tests/integration/_cases/releases/releases-new.trycmd
@@ -1,6 +1,6 @@
 ```
 $ sentry-cli releases new new-release
 ? success
-Created release new-release.
+Created release new-release
 
 ```


### PR DESCRIPTION
Because last "word" is always the value itself, it can be confusing whether dot is the part of user-provided value or not. Especially in paths/urls.