### PR TITLE
fix: Set bash as the interpretter for bash-hook command

### DIFF
--- a/src/bashsupport.sh
+++ b/src/bashsupport.sh
@@ -1,3 +1,7 @@
+#!/usr/bin/env bash
+
+set -e
+
 _SENTRY_TRACEBACK_FILE="___SENTRY_TRACEBACK_FILE___"
 _SENTRY_LOG_FILE="___SENTRY_LOG_FILE___"
 

--- a/src/commands/bash_hook.rs
+++ b/src/commands/bash_hook.rs
@@ -210,9 +210,10 @@ pub fn execute(matches: &ArgMatches) -> Result<()> {
         script = script.replace("___SENTRY_NO_ENVIRON___", "");
     }
 
-    if !matches.is_present("no_exit") {
-        script.insert_str(0, "set -e\n\n");
+    if matches.is_present("no_exit") {
+        script = script.replace("set -e\n\n", "");
     }
+
     println!("{}", script);
     Ok(())
 }

--- a/tests/integration/_cases/bash_hook/bash_hook-flags.trycmd
+++ b/tests/integration/_cases/bash_hook/bash_hook-flags.trycmd
@@ -1,9 +1,7 @@
 ```
-$ sentry-cli bash-hook
+$ sentry-cli bash-hook --no-exit --no-environ --cli=/foo/bar
 ? success
 #!/usr/bin/env bash
-
-set -e
 
 _SENTRY_TRACEBACK_FILE="[..].traceback"
 _SENTRY_LOG_FILE="[..].out"
@@ -39,7 +37,7 @@ _sentry_err_trap() {
   echo "@exit_code:${_exit_code}" >> "$_SENTRY_TRACEBACK_FILE"
 
   : >> "$_SENTRY_LOG_FILE"
-  export SENTRY_LAST_EVENT=$([CWD]/target/debug/sentry-cli[EXE] bash-hook --send-event --traceback "$_SENTRY_TRACEBACK_FILE" --log "$_SENTRY_LOG_FILE" )
+  export SENTRY_LAST_EVENT=$(/foo/bar bash-hook --send-event --traceback "$_SENTRY_TRACEBACK_FILE" --log "$_SENTRY_LOG_FILE" --no-environ)
   rm -f "$_SENTRY_TRACEBACK_FILE" "$_SENTRY_LOG_FILE"
 }
 

--- a/tests/integration/bash_hook.rs
+++ b/tests/integration/bash_hook.rs
@@ -9,3 +9,8 @@ fn command_bash_hook_help() {
 fn command_bash_hook() {
     register_test("bash_hook/bash_hook.trycmd");
 }
+
+#[test]
+fn command_bash_hook_flags() {
+    register_test("bash_hook/bash_hook-flags.trycmd");
+}


### PR DESCRIPTION
Shell script produced by `bash-hook` was missing a shebang, which caused it to be executed by `sh` in some environments. And because `sh` has no process substitution (https://www.shellcheck.net/wiki/SC3001) it failed with a syntax error.

Fixes https://github.com/getsentry/sentry-cli/issues/1260