### PR TITLE
deps: Update all Rust dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -249,9 +249,9 @@ dependencies = [
 
 [[package]]
 name = "brownstone"
-version = "1.1.0"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "030ea61398f34f1395ccbeb046fb68c87b631d1f34567fed0f0f11fa35d18d8d"
+checksum = "c5839ee4f953e811bfdcf223f509cb2c6a3e1447959b0bff459405575bc17f22"
 dependencies = [
  "arrayvec 0.7.2",
 ]
@@ -353,9 +353,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "3.2.6"
+version = "3.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f1fe12880bae935d142c8702d500c63a4e8634b6c3c57ad72bf978fc7b6249a"
+checksum = "5b7b16274bb247b45177db843202209b12191b631a14a9d06e41b3777d6ecf14"
 dependencies = [
  "bitflags",
  "clap_lex",
@@ -367,9 +367,9 @@ dependencies = [
 
 [[package]]
 name = "clap_lex"
-version = "0.2.3"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87eba3c8c7f42ef17f6c659fc7416d0f4758cd3e58861ee63c5fa4a4dde649e4"
+checksum = "2850f2f5a82cbf437dd5af4d49848fbdfc27c157c3d010345776f952765261c5"
 dependencies = [
  "os_str_bytes",
 ]
@@ -569,22 +569,12 @@ dependencies = [
 
 [[package]]
 name = "debugid"
-version = "0.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6ee87af31d84ef885378aebca32be3d682b0e0dc119d5b4860a2c5bb5046730"
-dependencies = [
- "serde",
- "uuid 0.8.2",
-]
-
-[[package]]
-name = "debugid"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef552e6f588e446098f6ba40d89ac146c8c7b64aade83c051ee00bb5d2bc18d"
 dependencies = [
  "serde",
- "uuid 1.1.2",
+ "uuid",
 ]
 
 [[package]]
@@ -1310,9 +1300,9 @@ dependencies = [
 
 [[package]]
 name = "nom-supreme"
-version = "0.6.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aadc66631948f6b65da03be4c4cd8bd104d481697ecbb9bbd65719b1ec60bc9f"
+checksum = "2bd3ae6c901f1959588759ff51c95d24b491ecb9ff91aa9c2ef4acc5b1dcab27"
 dependencies = [
  "brownstone",
  "indent_write",
@@ -1401,9 +1391,9 @@ checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 
 [[package]]
 name = "open"
-version = "2.1.3"
+version = "3.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2423ffbf445b82e58c3b1543655968923dd06f85432f10be2bb4f1b7122f98c"
+checksum = "360bcc8316bf6363aa3954c3ccc4de8add167b087e0259190a043c9514f910fe"
 dependencies = [
  "pathdiff",
  "windows-sys",
@@ -1529,13 +1519,13 @@ dependencies = [
 
 [[package]]
 name = "pdb"
-version = "0.7.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13f4d162ecaaa1467de5afbe62d597757b674b51da8bb4e587430c5fdb2af7aa"
+checksum = "82040a392923abe6279c00ab4aff62d5250d1c8555dc780e4b02783a7aa74863"
 dependencies = [
  "fallible-iterator",
- "scroll 0.10.2",
- "uuid 0.8.2",
+ "scroll 0.11.0",
+ "uuid",
 ]
 
 [[package]]
@@ -1679,12 +1669,12 @@ dependencies = [
 
 [[package]]
 name = "proguard"
-version = "4.1.1"
+version = "5.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e2aaf95c3580a3560f1b5695920df195a7a9e2bed69762f9fa919d3443cd918"
+checksum = "9ea52ab74a4eeffa17e7ab1fefd1416bd49e88afe8d214cdc164efef1bde4525"
 dependencies = [
  "lazy_static",
- "uuid 0.8.2",
+ "uuid",
 ]
 
 [[package]]
@@ -1980,9 +1970,9 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "1.0.10"
+version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a41d061efea015927ac527063765e73601444cdc344ba855bc7bd44578b25e1c"
+checksum = "3d92beeab217753479be2f74e54187a6aed4c125ff0703a866c3147a02f0c6dd"
 
 [[package]]
 name = "semver-parser"
@@ -2073,7 +2063,7 @@ dependencies = [
  "regex",
  "runas",
  "rust-ini",
- "semver 1.0.10",
+ "semver 1.0.11",
  "sentry",
  "serde",
  "serde_json",
@@ -2087,11 +2077,11 @@ dependencies = [
  "unix-daemonize",
  "url",
  "username",
- "uuid 0.8.2",
+ "uuid",
  "walkdir",
  "which 4.2.5",
  "winapi 0.3.9",
- "zip 0.6.2",
+ "zip",
 ]
 
 [[package]]
@@ -2113,7 +2103,7 @@ version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "823923ae5f54a729159d720aa12181673044ee5c79cbda3be09e56f885e5468f"
 dependencies = [
- "debugid 0.8.0",
+ "debugid",
  "getrandom 0.2.7",
  "hex",
  "serde",
@@ -2121,7 +2111,7 @@ dependencies = [
  "thiserror",
  "time 0.3.11",
  "url",
- "uuid 1.1.2",
+ "uuid",
 ]
 
 [[package]]
@@ -2189,15 +2179,6 @@ dependencies = [
  "digest 0.8.1",
  "fake-simd",
  "opaque-debug 0.2.3",
-]
-
-[[package]]
-name = "sha1"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1da05c97445caa12d05e848c4a4fcbbea29e748ac28f7e80e9b010392063770"
-dependencies = [
- "sha1_smol",
 ]
 
 [[package]]
@@ -2361,9 +2342,9 @@ checksum = "6bdef32e8150c2a081110b42772ffe7d7c9032b606bc226c8260fd97e0976601"
 
 [[package]]
 name = "symbolic"
-version = "8.8.0"
+version = "9.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b49345d083b1103e25c8c10e5e52cff254d33e70e29307c2bc4777074a25258"
+checksum = "2cfa96ac23f7d031f3c10a7ac9a6365938e78c0dae68721cd205350eaf051521"
 dependencies = [
  "symbolic-common",
  "symbolic-debuginfo",
@@ -2373,22 +2354,22 @@ dependencies = [
 
 [[package]]
 name = "symbolic-common"
-version = "8.8.0"
+version = "9.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f551f902d5642e58039aee6a9021a61037926af96e071816361644983966f540"
+checksum = "9ea2ab8b85d27d49d184438b4b77fbd521b385cc9c5c802f60e784f2df25a03d"
 dependencies = [
- "debugid 0.7.3",
+ "debugid",
  "memmap2",
  "serde",
  "stable_deref_trait",
- "uuid 0.8.2",
+ "uuid",
 ]
 
 [[package]]
 name = "symbolic-debuginfo"
-version = "8.8.0"
+version = "9.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1165dabf9fc1d6bb6819c2c0e27c8dd0e3068d2c53cf186d319788e96517f0d6"
+checksum = "2ae53696d978c5b188348a1c20137b2ea70627cc600b4857bad5bd0492cfbf27"
 dependencies = [
  "bitvec",
  "dmsort",
@@ -2411,14 +2392,14 @@ dependencies = [
  "symbolic-common",
  "thiserror",
  "wasmparser",
- "zip 0.5.13",
+ "zip",
 ]
 
 [[package]]
 name = "symbolic-il2cpp"
-version = "8.8.0"
+version = "9.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e87460a7057edee737f12ce11efd7b10f66630a496895d2618d29154ba14e80"
+checksum = "376a4d1201b9895d899fdaa15e6687dfb541e5914a347211dab134f3522b1c57"
 dependencies = [
  "anyhow",
  "gimli",
@@ -2433,9 +2414,9 @@ dependencies = [
 
 [[package]]
 name = "symbolic-symcache"
-version = "8.8.0"
+version = "9.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9660ab728a9b400c195865453a5b516805cb6e5615e30044c59af6a4f675806b"
+checksum = "df2d7059fe1d882df610339240489a64b947c3d48e87637dc7cf5d66aa561aab"
 dependencies = [
  "dmsort",
  "fnv",
@@ -2681,23 +2662,13 @@ dependencies = [
 
 [[package]]
 name = "uuid"
-version = "0.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc5cf98d8186244414c848017f0e2676b3fcb46807f6668a97dfe67359a3c4b7"
-dependencies = [
- "getrandom 0.2.7",
- "serde",
- "sha1 0.6.1",
-]
-
-[[package]]
-name = "uuid"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd6469f4314d5f1ffec476e05f17cc9a78bc7a27a6a857842170bdf8d6f98d2f"
 dependencies = [
  "getrandom 0.2.7",
  "serde",
+ "sha1_smol",
 ]
 
 [[package]]
@@ -2752,9 +2723,12 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasmparser"
-version = "0.83.0"
+version = "0.84.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "718ed7c55c2add6548cca3ddd6383d738cd73b892df400e96b9aa876f0141d7a"
+checksum = "77dc97c22bb5ce49a47b745bed8812d30206eff5ef3af31424f2c1820c0974b2"
+dependencies = [
+ "indexmap",
+]
 
 [[package]]
 name = "which"
@@ -2895,18 +2869,6 @@ checksum = "09041cd90cf85f7f8b2df60c646f853b7f535ce68f85244eb6731cf89fa498ec"
 
 [[package]]
 name = "zip"
-version = "0.5.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93ab48844d61251bb3835145c521d88aa4031d7139e8485990f60ca911fa0815"
-dependencies = [
- "byteorder",
- "crc32fast",
- "flate2",
- "thiserror",
-]
-
-[[package]]
-name = "zip"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf225bcf73bb52cbb496e70475c7bd7a3f769df699c0020f6c7bd9a96dcf0b8d"
@@ -2920,7 +2882,7 @@ dependencies = [
  "flate2",
  "hmac",
  "pbkdf2",
- "sha1 0.10.1",
+ "sha1",
  "time 0.3.11",
  "zstd",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,9 +7,9 @@ edition = "2018"
 
 [dependencies]
 anylog = "0.6.1"
-anyhow = { version = "1.0.56", features = ["backtrace"] }
+anyhow = { version = "1.0.58", features = ["backtrace"] }
 backoff = "0.4.0"
-backtrace = "0.3.64"
+backtrace = "0.3.65"
 brotli2 = "0.3.2"
 chardet = "0.2.4"
 chrono = { version = "0.4.19", features = ["serde"] }
@@ -20,8 +20,8 @@ dirs = "4.0.0"
 dotenv = "0.15.0"
 elementtree = "0.7.0"
 encoding = "0.2.33"
-flate2 = { version = "1.0.22", default-features = false, features = ["rust_backend"] }
-git2 = { version = "0.14.2", default-features = false }
+flate2 = { version = "1.0.24", default-features = false, features = ["rust_backend"] }
+git2 = { version = "0.14.4", default-features = false }
 glob = "0.3.0"
 if_chain = "1.0.2"
 ignore = "0.4.18"
@@ -30,41 +30,41 @@ indicatif = "0.14.0"
 itertools = "0.10.3"
 java-properties = "1.4.1"
 lazy_static = "1.4.0"
-libc = "0.2.121"
-log = { version = "0.4.16", features = ["std"] }
+libc = "0.2.126"
+log = { version = "0.4.17", features = ["std"] }
 might-be-minified = "0.3.0"
-open = "2.1.1"
-parking_lot = "0.12.0"
+open = "3.0.1"
+parking_lot = "0.12.1"
 percent-encoding = "2.1.0"
 plist = "1.3.1"
 prettytable-rs = "0.8.0"
-proguard = { version = "4.1.1", features = ["uuid"] }
-r2d2 = "0.8.9"
-rayon = "1.5.1"
-regex = "1.5.5"
+proguard = { version = "5.0.0", features = ["uuid"] }
+r2d2 = "0.8.10"
+rayon = "1.5.3"
+regex = "1.5.6"
 runas = "0.2.1"
 rust-ini = "0.18.0"
-semver = "1.0.7"
+semver = "1.0.11"
 sentry = { version = "0.27.0", default-features = false, features = ["anyhow", "curl"] }
-serde = { version = "1.0.136", features = ["derive"] }
-serde_json = "1.0.79"
+serde = { version = "1.0.137", features = ["derive"] }
+serde_json = "1.0.81"
 sha1_smol = { version = "1.0.0", features = ["serde"] }
-sourcemap = { version = "6.0.1", features = ["ram_bundle"] }
-symbolic = { version = "8.8.0", features = ["debuginfo-serde", "il2cpp"] }
-thiserror = "1.0.30"
+sourcemap = { version = "6.0.2", features = ["ram_bundle"] }
+symbolic = { version = "9.0.0", features = ["debuginfo-serde", "il2cpp"] }
+thiserror = "1.0.31"
 url = "2.2.2"
 username = "0.2.0"
-uuid = { version = "0.8.2", features = ["v4", "serde"] }
+uuid = { version = "1.1.2", features = ["v4", "serde"] }
 walkdir = "2.3.2"
 which = "4.2.5"
 zip = "0.6.2"
 
 [dev-dependencies]
-insta = { version = "1.14.0", features = ["redactions"] }
+insta = { version = "1.15.0", features = ["redactions"] }
 mockito = "0.31.0"
 predicates = "2.1.1"
 tempfile = "3.3.0"
-trycmd = "0.13.3"
+trycmd = "0.13.4"
 
 [features]
 default = []
@@ -84,8 +84,8 @@ unix-daemonize = "0.1.2"
 
 [target."cfg(unix)".dependencies]
 openssl-probe = "0.1.5"
-signal-hook = "0.3.13"
-crossbeam-channel = "0.5.4"
+signal-hook = "0.3.14"
+crossbeam-channel = "0.5.5"
 
 [target."cfg(windows)"]
 

--- a/src/commands/bash_hook.rs
+++ b/src/commands/bash_hook.rs
@@ -180,13 +180,10 @@ pub fn execute(matches: &ArgMatches) -> Result<()> {
     }
 
     let path = env::temp_dir();
-    let log = path.join(&format!(
-        ".sentry-{}.out",
-        Uuid::new_v4().to_hyphenated_ref()
-    ));
+    let log = path.join(&format!(".sentry-{}.out", Uuid::new_v4().as_hyphenated()));
     let traceback = path.join(&format!(
         ".sentry-{}.traceback",
-        Uuid::new_v4().to_hyphenated_ref()
+        Uuid::new_v4().as_hyphenated()
     ));
     let mut script = BASH_SCRIPT
         .replace(

--- a/src/utils/dif_upload.rs
+++ b/src/utils/dif_upload.rs
@@ -628,7 +628,7 @@ fn find_uuid_plists(
     //        ├─ 1C228684-3EE5-472B-AB8D-29B3FBF63A70.plist
     //        └─ DWARF
     //           └─ App
-    let plist_name = format!("{:X}.plist", uuid.to_hyphenated_ref());
+    let plist_name = format!("{:X}.plist", uuid.as_hyphenated());
     let plist = match source.get_relative(format!("../{}", &plist_name)) {
         Some(plist) => plist,
         None => return None,

--- a/src/utils/fs.rs
+++ b/src/utils/fs.rs
@@ -22,7 +22,7 @@ impl TempDir {
     /// Creates a new tempdir
     pub fn create() -> io::Result<Self> {
         let mut path = env::temp_dir();
-        path.push(Uuid::new_v4().to_hyphenated_ref().to_string());
+        path.push(Uuid::new_v4().as_hyphenated().to_string());
         fs::create_dir(&path)?;
         Ok(TempDir { path })
     }
@@ -49,7 +49,7 @@ impl TempFile {
     /// Creates a new tempfile.
     pub fn create() -> io::Result<Self> {
         let mut path = env::temp_dir();
-        path.push(Uuid::new_v4().to_hyphenated_ref().to_string());
+        path.push(Uuid::new_v4().as_hyphenated().to_string());
 
         let tf = TempFile { path };
         tf.open()?;
@@ -59,7 +59,7 @@ impl TempFile {
     /// Assumes ownership over an existing file and moves it to a temp location.
     pub fn take<P: AsRef<Path>>(path: P) -> io::Result<TempFile> {
         let mut destination = env::temp_dir();
-        destination.push(Uuid::new_v4().to_hyphenated_ref().to_string());
+        destination.push(Uuid::new_v4().as_hyphenated().to_string());
 
         fs::rename(&path, &destination)?;
         Ok(TempFile { path: destination })


### PR DESCRIPTION
Except `clap` and `indicatif`, because reasons.

(`clap` has breaking changes, don't want to spend time on them now, `indicatif` has an unidentified bug we cannot solve, see comment in `Cargo.toml`).

Major bumps of:
- `open`
- `proguard`
- `symbolic`
- `uuid`