### PR TITLE
fix: move dist option to SentryCliUploadSourceMapsOptions

### DIFF
--- a/js/index.d.ts
+++ b/js/index.d.ts
@@ -39,11 +39,6 @@ declare module '@sentry/cli' {
      */
     vcsRemote?: string;
     /**
-     * Unique identifier for the distribution, used to further segment your release.
-     * Usually your build number.
-     */
-    dist?: string;
-    /**
      * If true, all logs are suppressed.
      */
     silent?: boolean;
@@ -116,6 +111,11 @@ declare module '@sentry/cli' {
      * By default the following file extensions are processed: js, map, jsbundle and bundle.
      */
     ext?: string[];
+    /**
+     * Unique identifier for the distribution, used to further segment your release.
+     * Usually your build number.
+     */
+    dist?: string;
   }
 
   export interface SentryCliNewDeployOptions {


### PR DESCRIPTION
Hello!

It seems that the `dist` is wrongly placed at main settings, while (according to [this sourcecode](https://github.com/getsentry/sentry-cli/blob/master/js/releases/options/uploadSourcemaps.js#L10)) it need to be placed in source maps settings (_passing dist option to new SentryCli(path, opts) doesnt do anything, while passing it to uploadSourceMaps works_).

This PR moves `dist` from `SentryCliOptions` to `SentryCliUploadSourceMapsOptions`