### PR TITLE
feat: Use checksum to dedupe uploaded release artifacts

### DIFF
--- a/src/commands/files/upload.rs
+++ b/src/commands/files/upload.rs
@@ -151,6 +151,7 @@ pub fn execute(matches: &ArgMatches) -> Result<()> {
                         ty: SourceFileType::Source,
                         headers: headers.clone(),
                         messages: vec![],
+                        already_uploaded: false,
                     },
                 )
             })

--- a/src/commands/sourcemaps/upload.rs
+++ b/src/commands/sourcemaps/upload.rs
@@ -309,7 +309,7 @@ pub fn execute(matches: &ArgMatches) -> Result<()> {
         let checksum = Digest::from_str(&artifact.sha1)
             .map_err(|_| format_err!("Invalid artifact checksum"))?;
 
-        processor.add_already_uploaded_source(checksum)?;
+        processor.add_already_uploaded_source(checksum);
     }
 
     if matches.is_present("bundle") && matches.is_present("bundle_sourcemap") {

--- a/src/commands/sourcemaps/upload.rs
+++ b/src/commands/sourcemaps/upload.rs
@@ -1,9 +1,11 @@
 use std::path::PathBuf;
+use std::str::FromStr;
 
-use anyhow::Result;
+use anyhow::{format_err, Result};
 use clap::{Arg, ArgMatches, Command};
 use glob::{glob_with, MatchOptions};
 use log::{debug, warn};
+use sha1_smol::Digest;
 
 use crate::api::{Api, NewRelease};
 use crate::config::Config;
@@ -302,6 +304,13 @@ pub fn execute(matches: &ArgMatches) -> Result<()> {
     let (org, project) = config.get_org_and_project(matches)?;
     let api = Api::current();
     let mut processor = SourceMapProcessor::new();
+
+    for artifact in api.list_release_files(&org, Some(&project), &version)? {
+        let checksum = Digest::from_str(&artifact.sha1)
+            .map_err(|_| format_err!("Invalid artifact checksum"))?;
+
+        processor.add_already_uploaded_source(checksum)?;
+    }
 
     if matches.is_present("bundle") && matches.is_present("bundle_sourcemap") {
         process_sources_from_bundle(matches, &mut processor)?;

--- a/src/utils/sourcemaps.rs
+++ b/src/utils/sourcemaps.rs
@@ -176,9 +176,8 @@ impl SourceMapProcessor {
     }
 
     /// Adds an already uploaded sources checksum.
-    pub fn add_already_uploaded_source(&mut self, checksum: Digest) -> Result<()> {
+    pub fn add_already_uploaded_source(&mut self, checksum: Digest) {
         self.already_uploaded_sources.push(checksum);
-        Ok(())
     }
 
     fn flush_pending_sources(&mut self) {

--- a/src/utils/sourcemaps.rs
+++ b/src/utils/sourcemaps.rs
@@ -9,6 +9,7 @@ use anyhow::{bail, Error, Result};
 use console::style;
 use indicatif::ProgressStyle;
 use log::{debug, info, warn};
+use sha1_smol::Digest;
 use symbolic::debuginfo::sourcebundle::SourceFileType;
 use url::Url;
 
@@ -147,6 +148,7 @@ fn guess_sourcemap_reference(sourcemaps: &HashSet<String>, min_url: &str) -> Res
 
 pub struct SourceMapProcessor {
     pending_sources: HashSet<(String, ReleaseFileMatch)>,
+    already_uploaded_sources: Vec<Digest>,
     sources: ReleaseFiles,
 }
 
@@ -162,6 +164,7 @@ impl SourceMapProcessor {
     pub fn new() -> SourceMapProcessor {
         SourceMapProcessor {
             pending_sources: HashSet::new(),
+            already_uploaded_sources: Vec::new(),
             sources: HashMap::new(),
         }
     }
@@ -169,6 +172,12 @@ impl SourceMapProcessor {
     /// Adds a new file for processing.
     pub fn add(&mut self, url: &str, file: ReleaseFileMatch) -> Result<()> {
         self.pending_sources.insert((url.to_string(), file));
+        Ok(())
+    }
+
+    /// Adds an already uploaded sources checksum.
+    pub fn add_already_uploaded_source(&mut self, checksum: Digest) -> Result<()> {
+        self.already_uploaded_sources.push(checksum);
         Ok(())
     }
 
@@ -191,6 +200,7 @@ impl SourceMapProcessor {
         );
         for (url, mut file) in self.pending_sources.drain() {
             pb.set_message(&url);
+
             let ty = if sourcemap::is_sourcemap_slice(&file.contents) {
                 SourceFileType::SourceMap
             } else if file
@@ -232,6 +242,7 @@ impl SourceMapProcessor {
                     ty,
                     headers: vec![],
                     messages: vec![],
+                    already_uploaded: false,
                 },
             );
             pb.inc(1);
@@ -266,6 +277,14 @@ impl SourceMapProcessor {
                     .bold()
                 );
                 sect = Some(source.ty);
+            }
+
+            if source.already_uploaded {
+                println!(
+                    "    {}",
+                    style(format!("{} (skipped; already uploaded)", &source.url)).yellow()
+                );
+                continue;
             }
 
             if source.ty == SourceFileType::MinifiedSource {
@@ -401,6 +420,7 @@ impl SourceMapProcessor {
                     ty: SourceFileType::MinifiedSource,
                     headers: vec![],
                     messages: vec![],
+                    already_uploaded: false,
                 },
             );
 
@@ -418,6 +438,7 @@ impl SourceMapProcessor {
                     ty: SourceFileType::SourceMap,
                     headers: vec![],
                     messages: vec![],
+                    already_uploaded: false,
                 },
             );
         }
@@ -527,9 +548,20 @@ impl SourceMapProcessor {
         Ok(())
     }
 
+    fn flag_uploaded_sources(&mut self) {
+        for source in self.sources.values_mut() {
+            if let Ok(checksum) = &source.checksum() {
+                if self.already_uploaded_sources.contains(checksum) {
+                    source.already_uploaded = true;
+                }
+            }
+        }
+    }
+
     /// Uploads all files
     pub fn upload(&mut self, context: &UploadContext<'_>) -> Result<()> {
         self.flush_pending_sources();
+        self.flag_uploaded_sources();
         let mut uploader = ReleaseFileUpload::new(context);
         uploader.files(&self.sources);
         uploader.upload()?;

--- a/tests/integration/_cases/sourcemaps/sourcemaps-upload-help.trycmd
+++ b/tests/integration/_cases/sourcemaps/sourcemaps-upload-help.trycmd
@@ -1,0 +1,96 @@
+```
+$ sentry-cli sourcemaps upload --help
+? success
+sentry-cli[EXE]-sourcemaps-upload 
+Upload sourcemaps for a release.
+
+USAGE:
+    sentry-cli[EXE] sourcemaps upload [OPTIONS] [PATHS]...
+
+ARGS:
+    <PATHS>...    The files to upload.
+
+OPTIONS:
+        --auth-token <AUTH_TOKEN>
+            Use the given Sentry auth token.
+
+        --bundle <BUNDLE>
+            Path to the application bundle (indexed, file, or regular)
+
+        --bundle-sourcemap <BUNDLE_SOURCEMAP>
+            Path to the bundle sourcemap
+
+    -d, --dist <DISTRIBUTION>
+            Optional distribution identifier for the sourcemaps.
+
+    -h, --help
+            Print help information
+
+        --header <KEY:VALUE>
+            Custom headers that should be attached to all requests
+            in key:value format.
+
+    -i, --ignore <IGNORE>
+            Ignores all files and folders matching the given glob
+
+    -I, --ignore-file <IGNORE_FILE>
+            Ignore all files and folders specified in the given ignore file, e.g. .gitignore.
+
+        --log-level <LOG_LEVEL>
+            Set the log output verbosity. [possible values: trace, debug, info, warn, error]
+
+        --no-rewrite
+            Disables rewriting of matching sourcemaps. By default the tool will rewrite sources, so
+            that indexed maps are flattened and missing sources are inlined if possible.
+            This fundamentally changes the upload process to be based on sourcemaps and minified
+            files exclusively and comes in handy for setups like react-native that generate
+            sourcemaps that would otherwise not work for sentry.
+
+        --no-sourcemap-reference
+            Disable emitting of automatic sourcemap references.
+            By default the tool will store a 'Sourcemap' header with minified files so that
+            sourcemaps are located automatically if the tool can detect a link. If this causes
+            issues it can be disabled.
+
+    -o, --org <ORG>
+            The organization slug
+
+    -p, --project <PROJECT>
+            The project slug.
+
+        --quiet
+            Do not print any output while preserving correct exit code. This flag is currently
+            implemented only for selected subcommands. [aliases: silent]
+
+    -r, --release <RELEASE>
+            The release slug.
+
+        --strip-common-prefix
+            Similar to --strip-prefix but strips the most common prefix on all sources references.
+
+        --strip-prefix <PREFIX>
+            Strips the given prefix from all sources references inside the upload sourcemaps (paths
+            used within the sourcemap content, to map minified code to it's original source). Only
+            sources that start with the given prefix will be stripped.
+            This will not modify the uploaded sources paths. To do that, point the upload or
+            upload-sourcemaps command to a more precise directory instead.
+
+    -u, --url-prefix <PREFIX>
+            The URL prefix to prepend to all filenames.
+
+        --url-suffix <SUFFIX>
+            The URL suffix to append to all filenames.
+
+        --validate
+            Enable basic sourcemap validation.
+
+        --wait
+            Wait for the server to fully process uploaded files.
+
+    -x, --ext <EXT>
+            Set the file extensions that are considered for upload. This overrides the default
+            extensions. To add an extension, all default extensions must be repeated. Specify once
+            per extension.
+            Defaults to: `--ext=js --ext=map --ext=jsbundle --ext=bundle`
+
+```

--- a/tests/integration/_cases/sourcemaps/sourcemaps-upload-skip-already-uploaded.trycmd
+++ b/tests/integration/_cases/sourcemaps/sourcemaps-upload-skip-already-uploaded.trycmd
@@ -1,0 +1,20 @@
+```
+$ sentry-cli sourcemaps upload tests/integration/_fixtures/bundle.min.js.map --release=wat-release
+? success
+> Found 1 release file
+> Analyzing 1 sources
+> Rewriting sources
+> Adding source map references
+> Bundled 1 file for upload
+> Uploaded release files to Sentry
+> File upload complete (processing pending on server)
+> Organization: wat-org
+> Project: wat-project
+> Release: wat-release
+> Dist: None
+
+Source Map Upload Report
+  Source Maps
+    ~/bundle.min.js.map (skipped; already uploaded)
+
+```

--- a/tests/integration/_cases/sourcemaps/sourcemaps-upload-successfully-upload-file.trycmd
+++ b/tests/integration/_cases/sourcemaps/sourcemaps-upload-successfully-upload-file.trycmd
@@ -1,0 +1,20 @@
+```
+$ sentry-cli sourcemaps upload tests/integration/_fixtures/bundle.min.js.map --release=wat-release
+? success
+> Found 1 release file
+> Analyzing 1 sources
+> Rewriting sources
+> Adding source map references
+> Bundled 1 file for upload
+> Uploaded release files to Sentry
+> File upload complete (processing pending on server)
+> Organization: wat-org
+> Project: wat-project
+> Release: wat-release
+> Dist: None
+
+Source Map Upload Report
+  Source Maps
+    ~/bundle.min.js.map
+
+```

--- a/tests/integration/_cases/sourcemaps/sourcemaps-upload.trycmd
+++ b/tests/integration/_cases/sourcemaps/sourcemaps-upload.trycmd
@@ -1,0 +1,12 @@
+```
+$ sentry-cli sourcemaps upload
+? failed
+error: The following required arguments were not provided:
+    <PATHS>...
+
+USAGE:
+    sentry-cli[EXE] sourcemaps upload <PATHS>...
+
+For more information try --help
+
+```

--- a/tests/integration/sourcemaps/mod.rs
+++ b/tests/integration/sourcemaps/mod.rs
@@ -2,6 +2,7 @@ use crate::integration::register_test;
 
 mod explain;
 mod resolve;
+mod upload;
 
 #[test]
 fn command_sourcemaps_help() {

--- a/tests/integration/sourcemaps/upload.rs
+++ b/tests/integration/sourcemaps/upload.rs
@@ -1,0 +1,92 @@
+use crate::integration::{mock_endpoint, register_test, EndpointOptions};
+use mockito::{server_url, Mock};
+
+#[test]
+fn command_sourcemaps_upload_help() {
+    register_test("sourcemaps/sourcemaps-upload-help.trycmd");
+}
+
+#[test]
+fn command_sourcemaps_upload() {
+    register_test("sourcemaps/sourcemaps-upload.trycmd");
+}
+
+#[test]
+fn command_sourcemaps_upload_successfully_upload_file() {
+    let _upload_endpoints = mock_common_upload_endpoints();
+    let _files = mock_endpoint(
+        EndpointOptions::new(
+            "GET",
+            "/api/0/projects/wat-org/wat-project/releases/wat-release/files/?cursor=",
+            200,
+        )
+        .with_response_body("[]"),
+    );
+
+    register_test("sourcemaps/sourcemaps-upload-successfully-upload-file.trycmd");
+}
+
+#[test]
+fn command_sourcemaps_upload_skip_already_uploaded() {
+    let _upload_endpoints = mock_common_upload_endpoints();
+    let _files = mock_endpoint(
+        EndpointOptions::new(
+            "GET",
+            "/api/0/projects/wat-org/wat-project/releases/wat-release/files/?cursor=",
+            200,
+        )
+        .with_response_body(
+            r#"[{
+                "id": "1337",
+                "name": "~/bundle.min.js.map",
+                "headers": {},
+                "size": 1522,
+                "sha1": "38ed853073df85147960ea3a5bced6170ec389b0",
+                "dateCreated": "2022-05-12T11:08:01.496220Z"
+            }]"#,
+        ),
+    );
+
+    register_test("sourcemaps/sourcemaps-upload-skip-already-uploaded.trycmd");
+}
+
+// Endpoints need to be bound, as they need to live long enough for test to finish
+fn mock_common_upload_endpoints() -> Vec<Mock> {
+    let chunk_upload_response = format!(
+        "{{
+            \"url\": \"{}/api/0/organizations/wat-org/chunk-upload/\",
+            \"chunkSize\": 8388608,
+            \"chunksPerRequest\": 64,
+            \"maxRequestSize\": 33554432,
+            \"concurrency\": 8,
+            \"hashAlgorithm\": \"sha1\",
+            \"accept\": [
+              \"release_files\"
+            ]
+          }}",
+        server_url()
+    );
+
+    vec![
+        mock_endpoint(
+            EndpointOptions::new("POST", "/api/0/projects/wat-org/wat-project/releases/", 208)
+                .with_response_file("releases/get-release.json"),
+        ),
+        mock_endpoint(
+            EndpointOptions::new("GET", "/api/0/organizations/wat-org/chunk-upload/", 200)
+                .with_response_body(chunk_upload_response),
+        ),
+        mock_endpoint(
+            EndpointOptions::new("POST", "/api/0/organizations/wat-org/chunk-upload/", 200)
+                .with_response_body("[]"),
+        ),
+        mock_endpoint(
+            EndpointOptions::new(
+                "POST",
+                "/api/0/organizations/wat-org/releases/wat-release/assemble/",
+                200,
+            )
+            .with_response_body(r#"{"state":"created","missingChunks":[]}"#),
+        ),
+    ]
+}


### PR DESCRIPTION
This change will make `sentry-cli` skip the upload of files that are already present for the given release.
It's using `sha1` checksum for comparison, as we already have this data for every file that was uploaded to our servers.
When skipped, an appropriate message is added to the upload report.
The same behavior already exists for all other debug files formats.