### PR TITLE
chore: Add resolution to bump ansi-regex to version ^3.0.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,6 +52,9 @@
     "npm-run-all": "^4.1.5",
     "prettier": "^1.19.1"
   },
+  "resolutions": {
+    "npmlog/**/ansi-regex": "^3.0.1"
+  },
   "jest": {
     "collectCoverage": true,
     "testEnvironment": "node",

--- a/src/commands/releases.rs
+++ b/src/commands/releases.rs
@@ -908,9 +908,7 @@ fn execute_files_upload<'a>(
             if !header.contains(':') {
                 bail!("Invalid header. Needs to be in key:value format");
             }
-            let mut iter = header.splitn(2, ':');
-            let key = iter.next().unwrap();
-            let value = iter.next().unwrap();
+            let (key, value) = header.split_once(':').unwrap();
             headers.push((key.trim().to_string(), value.trim().to_string()));
         }
     };

--- a/src/utils/formatting.rs
+++ b/src/utils/formatting.rs
@@ -5,7 +5,7 @@ use chrono::Duration;
 /// Helper for formatting durations.
 pub struct HumanDuration(pub Duration);
 
-impl<'a> fmt::Display for HumanDuration {
+impl fmt::Display for HumanDuration {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         macro_rules! try_write {
             ($num:expr, $str:expr) => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -625,17 +625,17 @@ ansi-escapes@^4.2.1:
   dependencies:
     type-fest "^0.21.3"
 
-ansi-regex@^2.0.0:
-  version "2.1.1"
-  resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-2.1.1.tgz#c3b33ab5ee360d86e0e628f0468ae7ef27d654df"
-  integrity sha1-w7M6te42DYbg5ijwRorn7yfWVN8=
+ansi-regex@^2.0.0, ansi-regex@^3.0.1, ansi-regex@^5.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-3.0.1.tgz#123d6479e92ad45ad897d4054e3c7ca7db4944e1"
+  integrity sha512-+O9Jct8wf++lXxxFc4hc8LsjaSq0HFzzL7cVsw8pRDIPdjKD2mT4ytDZlLuSBZ4cLKZFXIrMGO7DbQCtMJJMKw==
 
 ansi-regex@^4.1.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-4.1.0.tgz#8b9f8f08cf1acb843756a839ca8c7e3168c51997"
   integrity sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==
 
-ansi-regex@^5.0.0, ansi-regex@^5.0.1:
+ansi-regex@^5.0.0:
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-5.0.1.tgz#082cb2c89c9fe8659a311a53bd6a4dc5301db304"
   integrity sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==


### PR DESCRIPTION
Should fix a vulnerability mentioned in https://github.com/getsentry/sentry-javascript/issues/5415 and #1079 in v1 of the CLI

CI seems happy and building/installing works locally for me. Feel free to close if this PR seems like a bad idea.

Changes in `releases.rs` and `formatting.rs` were purely made to make the linter happy