### PR TITLE
ref: Fix typo in upload_proguard

### DIFF
--- a/src/commands/upload_proguard.rs
+++ b/src/commands/upload_proguard.rs
@@ -66,8 +66,8 @@ pub fn make_command(command: Command) -> Command {
                 .requires("version")
                 .help(
                     "Optionally associate the mapping files with an application \
-                     ID.{n}If you have multiple apps in one sentry project you can \
-                     then easlier tell them apart.",
+                     ID.{n}If you have multiple apps in one sentry project, you can \
+                     then easily tell them apart.",
                 ),
         )
         .arg(

--- a/tests/integration/_cases/upload_proguard/upload_proguard-help.trycmd
+++ b/tests/integration/_cases/upload_proguard/upload_proguard-help.trycmd
@@ -16,7 +16,7 @@ OPTIONS:
 
         --app-id <APP_ID>
             Optionally associate the mapping files with an application ID.
-            If you have multiple apps in one sentry project you can then easlier tell them apart.
+            If you have multiple apps in one sentry project, you can then easily tell them apart.
 
         --auth-token <AUTH_TOKEN>
             Use the given Sentry auth token.


### PR DESCRIPTION
I think easlier is not a common English word. Fixed it by replacing it with easily and added a missing comma.

#skip-changelog