### PR TITLE
ref: Print better error when processing appcenter paths

### DIFF
--- a/src/commands/react_native/appcenter.rs
+++ b/src/commands/react_native/appcenter.rs
@@ -2,7 +2,7 @@ use std::env;
 use std::ffi::OsStr;
 use std::fs;
 
-use anyhow::Result;
+use anyhow::{anyhow, Result};
 use clap::{Arg, ArgMatches, Command};
 use console::style;
 use if_chain::if_chain;
@@ -134,7 +134,10 @@ pub fn execute(matches: &ArgMatches) -> Result<()> {
     let mut processor = SourceMapProcessor::new();
 
     for path in matches.values_of("paths").unwrap() {
-        for entry in (fs::read_dir(path)?).flatten() {
+        let entries = fs::read_dir(path)
+            .map_err(|e| anyhow!(e).context(format!("Failed processing path: \"{}\"", &path)))?;
+
+        for entry in entries.flatten() {
             if_chain! {
                 if let Some(filename) = entry.file_name().to_str();
                 if let Some(ext) = entry.path().extension();


### PR DESCRIPTION
**Before:**

```
> Fetching latest AppCenter deployment info
> Processing react-native AppCenter sourcemaps
error: No such file or directory (os error 2)
```

**After:**

```
> Fetching latest AppCenter deployment info
> Processing react-native AppCenter sourcemaps
error: Failed processing path: "./src/missing_dir"
  caused by: No such file or directory (os error 2)
```

Fixes https://github.com/getsentry/sentry-cli/issues/1286