### PR TITLE
feat: Allow for selecting frame in sourcemaps explain

### DIFF
--- a/tests/integration/_cases/sourcemaps/sourcemaps-explain-frame-malformed-abspath.trycmd
+++ b/tests/integration/_cases/sourcemaps/sourcemaps-explain-frame-malformed-abspath.trycmd
@@ -5,6 +5,6 @@ $ sentry-cli sourcemaps explain 43a57a55cd5a4207ac520c03e1dee1b4
 ✔ Event has release name: ytho-test
 ✔ Event has a valid exception present
 ✔ Event has a valid stacktrace present
-✖ Event exception stacktrace top frame has incorrect abs_path (valid url is required). Found okboomer
+✖ Event exception stacktrace selected frame (0) has incorrect abs_path (valid url is required). Found okboomer
 
 ```

--- a/tests/integration/_cases/sourcemaps/sourcemaps-explain-frame-no-extension.trycmd
+++ b/tests/integration/_cases/sourcemaps/sourcemaps-explain-frame-no-extension.trycmd
@@ -5,6 +5,6 @@ $ sentry-cli sourcemaps explain 43a57a55cd5a4207ac520c03e1dee1b4
 ✔ Event has release name: ytho-test
 ✔ Event has a valid exception present
 ✔ Event has a valid stacktrace present
-✖ Top frame of event exception originates from the <script> tag, its not possible to resolve source maps
+✖ Selected frame (0) of event exception originates from the <script> tag, its not possible to resolve source maps
 
 ```

--- a/tests/integration/_cases/sourcemaps/sourcemaps-explain-help.trycmd
+++ b/tests/integration/_cases/sourcemaps/sourcemaps-explain-help.trycmd
@@ -14,6 +14,8 @@ OPTIONS:
         --auth-token <AUTH_TOKEN>    Use the given Sentry auth token.
     -f, --force                      Force full validation flow, even when event is already source
                                      mapped.
+        --frame <frame>              Position of the frame that should be used for source map
+                                     resolution. [default: 0]
     -h, --help                       Print help information
         --header <KEY:VALUE>         Custom headers that should be attached to all requests
                                      in key:value format.

--- a/tests/integration/_cases/sourcemaps/sourcemaps-explain-select-frame-out-of-range.trycmd
+++ b/tests/integration/_cases/sourcemaps/sourcemaps-explain-select-frame-out-of-range.trycmd
@@ -1,10 +1,10 @@
 ```
-$ sentry-cli sourcemaps explain 43a57a55cd5a4207ac520c03e1dee1b4
+$ sentry-cli sourcemaps explain 43a57a55cd5a4207ac520c03e1dee1b4 --frame 42
 ? failed
 ✔ Fetched data for event: 43a57a55cd5a4207ac520c03e1dee1b4
 ✔ Event has release name: ytho-test
 ✔ Event has a valid exception present
 ✔ Event has a valid stacktrace present
-✖ Selected frame (0) is missing an abs_path
+✖ Selected frame (42) is missing.
 
 ```

--- a/tests/integration/_cases/sourcemaps/sourcemaps-explain-select-frame.trycmd
+++ b/tests/integration/_cases/sourcemaps/sourcemaps-explain-select-frame.trycmd
@@ -1,10 +1,10 @@
 ```
-$ sentry-cli sourcemaps explain 43a57a55cd5a4207ac520c03e1dee1b4
+$ sentry-cli sourcemaps explain 43a57a55cd5a4207ac520c03e1dee1b4 --frame 2
 ? failed
 ✔ Fetched data for event: 43a57a55cd5a4207ac520c03e1dee1b4
 ✔ Event has release name: ytho-test
 ✔ Event has a valid exception present
 ✔ Event has a valid stacktrace present
-✖ Selected frame (0) is missing an abs_path
+✖ Event exception stacktrace selected frame (2) has incorrect abs_path (valid url is required). Found wrongabspath
 
 ```

--- a/tests/integration/_responses/sourcemaps/get-event-select-frame.json
+++ b/tests/integration/_responses/sourcemaps/get-event-select-frame.json
@@ -1,0 +1,51 @@
+{
+  "event_id": "43a57a55cd5a4207ac520c03e1dee1b4",
+  "project": 5334254,
+  "release": "ytho-test",
+  "dist": null,
+  "exception": {
+    "values": [
+      {
+        "type": "Error",
+        "value": "whoops",
+        "stacktrace": {
+          "frames": [
+            {
+              "filename": "/dist/bundle.min.js",
+              "abs_path": "wrongabspath",
+              "lineno": 1,
+              "colno": 456,
+              "context_line": "{snip} tps://5b0e5845265a472ba9c269bbfa0c8388@o333688.ingest.sentry.io/5334254\",release:\"ytho-test\"}),function(t){throw new Error(\"whoops\")}()})();",
+              "post_context": [
+                "//# sourceMappingURL=bundle.min.js.map"
+              ],
+              "in_app": true
+            },
+            {
+              "filename": "/dist/bundle.min.js",
+              "abs_path": "http://localhost:5000/dist/bundle.min.js",
+              "lineno": 1,
+              "colno": 452,
+              "context_line": "{snip} tps://5b0e5845265a472ba9c269bbfa0c8388@o333688.ingest.sentry.io/5334254\",release:\"ytho-test\"}),function(t){throw new Error(\"whoops\")}()})();",
+              "post_context": [
+                "//# sourceMappingURL=bundle.min.js.map"
+              ],
+              "in_app": true
+            },
+            {
+              "filename": "/dist/bundle.min.js",
+              "abs_path": "http://localhost:5000/dist/bundle.min.js",
+              "lineno": 1,
+              "colno": 432,
+              "context_line": "{snip} tps://5b0e5845265a472ba9c269bbfa0c8388@o333688.ingest.sentry.io/5334254\",release:\"ytho-test\"}),function(t){throw new Error(\"whoops\")}()})();",
+              "post_context": [
+                "//# sourceMappingURL=bundle.min.js.map"
+              ],
+              "in_app": true
+            }
+          ]
+        }
+      }
+    ]
+  }
+}

--- a/tests/integration/sourcemaps/explain.rs
+++ b/tests/integration/sourcemaps/explain.rs
@@ -385,3 +385,29 @@ fn command_sourcemaps_explain_print_sourcemap() {
 
     register_test("sourcemaps/sourcemaps-explain-print-sourcemap.trycmd");
 }
+
+#[test]
+fn command_sourcemaps_explain_select_frame() {
+    let _event = mock_endpoint(
+        EndpointOptions::new(
+            "GET",
+            "/api/0/projects/wat-org/wat-project/events/43a57a55cd5a4207ac520c03e1dee1b4/json/",
+            200,
+        )
+        .with_response_file("sourcemaps/get-event-select-frame.json"),
+    );
+    register_test("sourcemaps/sourcemaps-explain-select-frame.trycmd");
+}
+
+#[test]
+fn command_sourcemaps_explain_select_frame_out_of_range() {
+    let _event = mock_endpoint(
+        EndpointOptions::new(
+            "GET",
+            "/api/0/projects/wat-org/wat-project/events/43a57a55cd5a4207ac520c03e1dee1b4/json/",
+            200,
+        )
+        .with_response_file("sourcemaps/get-event-select-frame.json"),
+    );
+    register_test("sourcemaps/sourcemaps-explain-select-frame-out-of-range.trycmd");
+}


### PR DESCRIPTION
This allows us to select other frames that might be for some reason not resolved. It's 0-indexed.

```terminal
sentry-cli sourcemaps explain <id> --frame 2
```