### PR TITLE
build: Strip symbols and optimize for size

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -93,5 +93,6 @@ crossbeam-channel = "0.5.5"
 winapi = "0.3.9"
 
 [profile.release]
-opt-level = 3
+opt-level = "s"
+strip = "symbols"
 panic = "abort"


### PR DESCRIPTION
This changes the release builds to optimize for size and strip symbols. I don't think this is necessarily a good idea but I wonder how small the linux binaries get with that.

This should not be merged.