### PR TITLE
Retrieve the events list for a project for v2

### DIFF
--- a/src/api.rs
+++ b/src/api.rs
@@ -1419,9 +1419,11 @@ impl Api {
         &self,
         org: &str,
         project: &str,
+        limit: u16,
     ) -> ApiResult<Vec<Event>> {
         let mut rv = vec![];
         let mut cursor = "".to_string();
+        let mut _limit = limit;
 
         loop {
             let resp = self.get(&format!(
@@ -1440,6 +1442,12 @@ impl Api {
             }
             let pagination = resp.pagination();
             rv.extend(resp.convert::<Vec<Event>>()?.into_iter());
+
+            _limit -= 1;
+            if _limit == 0 {
+                break;
+            }
+
             if let Some(next) = pagination.into_next_cursor() {
                 cursor = next;
             } else {

--- a/src/commands/events/list.rs
+++ b/src/commands/events/list.rs
@@ -1,57 +1,94 @@
 use anyhow::Result;
-use clap::{ArgMatches, Command};
+use clap::{Arg, ArgMatches, Command};
 
 use crate::api::Api;
 use crate::config::Config;
 use crate::utils::formatting::Table;
 
 pub fn make_command(command: Command) -> Command {
-    command.about("List all events in your organization.")
+    command
+        .about("List all events in your organization.")
+        .arg(
+            Arg::with_name("show_user")
+                .long("show-user")
+                .short('U')
+                .help("Display the Users column."),
+        )
+        .arg(
+            Arg::with_name("show_tags")
+                .long("show-tags")
+                .short('T')
+                .help("Display the Tags column."),
+        )
+        .arg(
+            Arg::new("max_rows")
+                .long("max-rows")
+                .value_name("MAX_ROWS")
+                .value_parser(clap::value_parser!(usize))
+                .help("Maximum number of rows to print."),
+        )
+        .arg(
+            Arg::new("pages")
+                .long("pages")
+                .value_name("PAGES")
+                .default_value("5")
+                .value_parser(clap::value_parser!(usize))
+                .help("Maximum number of pages to fetch (100 events/page)."),
+        )
 }
 
 pub fn execute(matches: &ArgMatches) -> Result<()> {
-    let api = Api::current();
-
     let config = Config::current();
     let org = config.get_org(matches)?;
     let project = config.get_project(matches)?;
-    let limit = matches.value_of("limit").unwrap();
+    let pages = *matches.get_one("pages").unwrap();
+    let api = Api::current();
 
-    let events =
-        api.list_organization_project_events(&org, &project, limit.parse::<u16>().unwrap())?;
+    let events = api.list_organization_project_events(&org, &project, pages)?;
 
     let mut table = Table::new();
-    let row = table.title_row().add("Event ID").add("Date").add("Title");
-    if matches.is_present("user") {
-        row.add("User");
+    let title_row = table.title_row().add("Event ID").add("Date").add("Title");
+
+    if matches.is_present("show_user") {
+        title_row.add("User");
     }
 
-    if matches.is_present("tags") {
-        row.add("Tags");
+    if matches.is_present("show_tags") {
+        title_row.add("Tags");
     }
 
-    let max_rows = if matches.is_present("max-rows") {
-        matches
-            .value_of("max-rows")
-            .unwrap()
-            .parse::<usize>()
-            .unwrap()
-    } else {
-        events.len()
-    };
+    let max_rows = std::cmp::min(
+        events.len(),
+        *matches.get_one("max_rows").unwrap_or(&std::usize::MAX),
+    );
 
-    for event in &events[..max_rows] {
-        let row = table.add_row();
-        row.add(&event.event_id)
-            .add(&event.date_created)
-            .add(&event.title);
+    if let Some(events) = events.get(..max_rows) {
+        for event in events {
+            let row = table.add_row();
+            row.add(&event.event_id)
+                .add(&event.date_created)
+                .add(&event.title);
 
-        if matches.is_present("user") {
-            row.add(&event.user);
-        }
+            if matches.is_present("show_user") {
+                if let Some(user) = &event.user {
+                    row.add(user);
+                } else {
+                    row.add("-");
+                }
+            }
 
-        if matches.is_present("tags") {
-            row.add(&event.tags);
+            if matches.is_present("show_tags") {
+                if let Some(tags) = &event.tags {
+                    row.add(
+                        tags.iter()
+                            .map(|t| t.to_string())
+                            .collect::<Vec<_>>()
+                            .join("\n"),
+                    );
+                } else {
+                    row.add("-");
+                }
+            }
         }
     }
 

--- a/src/commands/events/list.rs
+++ b/src/commands/events/list.rs
@@ -1,0 +1,52 @@
+use anyhow::Result;
+use clap::{ArgMatches, Command};
+
+use crate::api::Api;
+use crate::config::Config;
+use crate::utils::formatting::Table;
+
+pub fn make_command(command: Command) -> Command {
+    command.about("List all events in your organization.")
+}
+
+pub fn execute(matches: &ArgMatches) -> Result<()> {
+    let api = Api::current();
+
+    let config = Config::current();
+    let org = config.get_org(matches)?;
+    let project = config.get_project(matches)?;
+    let events = api.list_organization_project_events(&org, &project)?;
+
+    let mut table = Table::new();
+    let row = table.title_row().add("Event ID").add("Date").add("Title");
+    if matches.is_present("user") {
+        row.add("User");
+    }
+
+    if matches.is_present("tags") {
+        row.add("Tags");
+    }
+
+    for event in &events {
+        let row = table.add_row();
+        row.add(&event.event_id)
+            .add(&event.date_created)
+            .add(&event.title);
+
+        if matches.is_present("user") {
+            row.add(&event.user);
+        }
+
+        if matches.is_present("tags") {
+            row.add(&event.tags);
+        }
+    }
+
+    if table.is_empty() {
+        println!("No events found");
+    } else {
+        table.print();
+    }
+
+    Ok(())
+}

--- a/src/commands/events/list.rs
+++ b/src/commands/events/list.rs
@@ -15,7 +15,10 @@ pub fn execute(matches: &ArgMatches) -> Result<()> {
     let config = Config::current();
     let org = config.get_org(matches)?;
     let project = config.get_project(matches)?;
-    let events = api.list_organization_project_events(&org, &project)?;
+    let limit = matches.value_of("limit").unwrap();
+
+    let events =
+        api.list_organization_project_events(&org, &project, limit.parse::<u16>().unwrap())?;
 
     let mut table = Table::new();
     let row = table.title_row().add("Event ID").add("Date").add("Title");
@@ -27,7 +30,17 @@ pub fn execute(matches: &ArgMatches) -> Result<()> {
         row.add("Tags");
     }
 
-    for event in &events {
+    let max_rows = if matches.is_present("max-rows") {
+        matches
+            .value_of("max-rows")
+            .unwrap()
+            .parse::<usize>()
+            .unwrap()
+    } else {
+        events.len()
+    };
+
+    for event in &events[..max_rows] {
         let row = table.add_row();
         row.add(&event.event_id)
             .add(&event.date_created)

--- a/src/commands/events/mod.rs
+++ b/src/commands/events/mod.rs
@@ -1,0 +1,59 @@
+use anyhow::Result;
+use clap::{Arg, ArgMatches, Command};
+
+use crate::utils::args::ArgExt;
+
+pub mod list;
+
+macro_rules! each_subcommand {
+    ($mac:ident) => {
+        $mac!(list);
+    };
+}
+
+pub fn make_command(mut command: Command) -> Command {
+    macro_rules! add_subcommand {
+        ($name:ident) => {{
+            command = command.subcommand(crate::commands::events::$name::make_command(
+                Command::new(stringify!($name).replace('_', "-")),
+            ));
+        }};
+    }
+
+    command = command
+        .about("Manage events on Sentry.")
+        .subcommand_required(true)
+        .arg_required_else_help(true)
+        .org_arg()
+        .project_arg(true)
+        .arg(
+            Arg::with_name("user")
+                .long("user")
+                .short('u')
+                .global(true)
+                .help("Include user's info into the list."),
+        )
+        .arg(
+            Arg::with_name("tags")
+                .long("tags")
+                .short('t')
+                .global(true)
+                .help("Include tags into the list."),
+        );
+    each_subcommand!(add_subcommand);
+    command
+}
+
+pub fn execute(matches: &ArgMatches) -> Result<()> {
+    macro_rules! execute_subcommand {
+        ($name:ident) => {{
+            if let Some(sub_matches) =
+                matches.subcommand_matches(&stringify!($name).replace('_', "-"))
+            {
+                return crate::commands::events::$name::execute(&sub_matches);
+            }
+        }};
+    }
+    each_subcommand!(execute_subcommand);
+    unreachable!();
+}

--- a/src/commands/events/mod.rs
+++ b/src/commands/events/mod.rs
@@ -1,5 +1,5 @@
 use anyhow::Result;
-use clap::{Arg, ArgMatches, Command};
+use clap::{ArgMatches, Command};
 
 use crate::utils::args::ArgExt;
 
@@ -25,36 +25,7 @@ pub fn make_command(mut command: Command) -> Command {
         .subcommand_required(true)
         .arg_required_else_help(true)
         .org_arg()
-        .project_arg(true)
-        .arg(
-            Arg::with_name("user")
-                .long("user")
-                .short('u')
-                .global(true)
-                .help("Include user's info into the list."),
-        )
-        .arg(
-            Arg::with_name("tags")
-                .long("tags")
-                .short('t')
-                .global(true)
-                .help("Include tags into the list."),
-        )
-        .arg(
-            Arg::new("max-rows")
-                .long("max-rows")
-                .value_name("MAX-ROWS")
-                .global(true)
-                .help("Max of rows for a table."),
-        )
-        .arg(
-            Arg::new("limit")
-                .long("limit")
-                .global(true)
-                .value_name("LIMIT")
-                .default_value("10")
-                .help("Limit of requests."),
-        );
+        .project_arg(true);
     each_subcommand!(add_subcommand);
     command
 }

--- a/src/commands/events/mod.rs
+++ b/src/commands/events/mod.rs
@@ -43,6 +43,7 @@ pub fn make_command(mut command: Command) -> Command {
         .arg(
             Arg::new("max-rows")
                 .long("max-rows")
+                .value_name("MAX-ROWS")
                 .global(true)
                 .help("Max of rows for a table."),
         )
@@ -50,6 +51,7 @@ pub fn make_command(mut command: Command) -> Command {
             Arg::new("limit")
                 .long("limit")
                 .global(true)
+                .value_name("LIMIT")
                 .default_value("10")
                 .help("Limit of requests."),
         );

--- a/src/commands/events/mod.rs
+++ b/src/commands/events/mod.rs
@@ -39,6 +39,19 @@ pub fn make_command(mut command: Command) -> Command {
                 .short('t')
                 .global(true)
                 .help("Include tags into the list."),
+        )
+        .arg(
+            Arg::new("max-rows")
+                .long("max-rows")
+                .global(true)
+                .help("Max of rows for a table."),
+        )
+        .arg(
+            Arg::new("limit")
+                .long("limit")
+                .global(true)
+                .default_value("10")
+                .help("Limit of requests."),
         );
     each_subcommand!(add_subcommand);
     command

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -20,6 +20,7 @@ macro_rules! each_subcommand {
         $mac!(bash_hook);
         $mac!(debug_files);
         $mac!(deploys);
+        $mac!(events);
         $mac!(files);
         $mac!(info);
         $mac!(issues);
@@ -62,6 +63,7 @@ to learn more about them.";
 const UPDATE_NAGGER_CMDS: &[&str] = &[
     "debug-files",
     "deploys",
+    "events",
     "files",
     "info",
     "issues",

--- a/tests/integration/_cases/events/events-help.trycmd
+++ b/tests/integration/_cases/events/events-help.trycmd
@@ -1,0 +1,27 @@
+```
+$ sentry-cli events --help
+? success
+sentry-cli[EXE]-events 
+Manage events on Sentry.
+
+USAGE:
+    sentry-cli[EXE] events [OPTIONS] <SUBCOMMAND>
+
+OPTIONS:
+        --auth-token <AUTH_TOKEN>    Use the given Sentry auth token.
+    -h, --help                       Print help information
+        --header <KEY:VALUE>         Custom headers that should be attached to all requests
+                                     in key:value format.
+        --log-level <LOG_LEVEL>      Set the log output verbosity. [possible values: trace, debug,
+                                     info, warn, error]
+    -o, --org <ORG>                  The organization slug
+    -p, --project <PROJECT>          The project slug.
+        --quiet                      Do not print any output while preserving correct exit code.
+                                     This flag is currently implemented only for selected
+                                     subcommands. [aliases: silent]
+
+SUBCOMMANDS:
+    help    Print this message or the help of the given subcommand(s)
+    list    List all events in your organization.
+
+```

--- a/tests/integration/_cases/events/events-list-empty.trycmd
+++ b/tests/integration/_cases/events/events-list-empty.trycmd
@@ -1,0 +1,6 @@
+```
+$ sentry-cli events list
+? success
+No events found
+
+```

--- a/tests/integration/_cases/events/events-list-help.trycmd
+++ b/tests/integration/_cases/events/events-list-help.trycmd
@@ -1,0 +1,28 @@
+```
+$ sentry-cli events list --help
+? success
+sentry-cli[EXE]-events-list 
+List all events in your organization.
+
+USAGE:
+    sentry-cli[EXE] events list [OPTIONS]
+
+OPTIONS:
+        --auth-token <AUTH_TOKEN>    Use the given Sentry auth token.
+    -h, --help                       Print help information
+        --header <KEY:VALUE>         Custom headers that should be attached to all requests
+                                     in key:value format.
+        --log-level <LOG_LEVEL>      Set the log output verbosity. [possible values: trace, debug,
+                                     info, warn, error]
+        --max-rows <MAX_ROWS>        Maximum number of rows to print.
+    -o, --org <ORG>                  The organization slug
+    -p, --project <PROJECT>          The project slug.
+        --pages <PAGES>              Maximum number of pages to fetch (100 events/page). [default:
+                                     5]
+        --quiet                      Do not print any output while preserving correct exit code.
+                                     This flag is currently implemented only for selected
+                                     subcommands. [aliases: silent]
+    -T, --show-tags                  Display the Tags column.
+    -U, --show-user                  Display the Users column.
+
+```

--- a/tests/integration/_cases/events/events-no-subcommand.trycmd
+++ b/tests/integration/_cases/events/events-no-subcommand.trycmd
@@ -1,0 +1,27 @@
+```
+$ sentry-cli events
+? failed
+sentry-cli[EXE]-events 
+Manage events on Sentry.
+
+USAGE:
+    sentry-cli[EXE] events [OPTIONS] <SUBCOMMAND>
+
+OPTIONS:
+        --auth-token <AUTH_TOKEN>    Use the given Sentry auth token.
+    -h, --help                       Print help information
+        --header <KEY:VALUE>         Custom headers that should be attached to all requests
+                                     in key:value format.
+        --log-level <LOG_LEVEL>      Set the log output verbosity. [possible values: trace, debug,
+                                     info, warn, error]
+    -o, --org <ORG>                  The organization slug
+    -p, --project <PROJECT>          The project slug.
+        --quiet                      Do not print any output while preserving correct exit code.
+                                     This flag is currently implemented only for selected
+                                     subcommands. [aliases: silent]
+
+SUBCOMMANDS:
+    help    Print this message or the help of the given subcommand(s)
+    list    List all events in your organization.
+
+```

--- a/tests/integration/_cases/help/help-windows.trycmd
+++ b/tests/integration/_cases/help/help-windows.trycmd
@@ -30,6 +30,7 @@ OPTIONS:
 SUBCOMMANDS:
     debug-files        Locate, analyze or upload debug information files. [aliases: dif]
     deploys            Manage deployments for Sentry releases.
+    events             Manage events on Sentry.
     files              Manage release artifacts.
     help               Print this message or the help of the given subcommand(s)
     info               Print information about the Sentry server.

--- a/tests/integration/_cases/help/help.trycmd
+++ b/tests/integration/_cases/help/help.trycmd
@@ -30,6 +30,7 @@ OPTIONS:
 SUBCOMMANDS:
     debug-files        Locate, analyze or upload debug information files. [aliases: dif]
     deploys            Manage deployments for Sentry releases.
+    events             Manage events on Sentry.
     files              Manage release artifacts.
     help               Print this message or the help of the given subcommand(s)
     info               Print information about the Sentry server.

--- a/tests/integration/events/list.rs
+++ b/tests/integration/events/list.rs
@@ -1,0 +1,19 @@
+use crate::integration::{mock_endpoint, register_test, EndpointOptions};
+
+#[test]
+fn command_events_list_help() {
+    register_test("events/events-list-help.trycmd");
+}
+
+#[test]
+fn doesnt_fail_with_empty_response() {
+    let _server = mock_endpoint(
+        EndpointOptions::new(
+            "GET",
+            "/api/0/projects/wat-org/wat-project/events/?cursor=",
+            200,
+        )
+        .with_response_body("[]"),
+    );
+    register_test("events/events-list-empty.trycmd");
+}

--- a/tests/integration/events/mod.rs
+++ b/tests/integration/events/mod.rs
@@ -1,0 +1,13 @@
+use crate::integration::register_test;
+
+mod list;
+
+#[test]
+fn command_events_help() {
+    register_test("events/events-help.trycmd");
+}
+
+#[test]
+fn command_events_no_subcommand() {
+    register_test("events/events-no-subcommand.trycmd");
+}

--- a/tests/integration/mod.rs
+++ b/tests/integration/mod.rs
@@ -1,6 +1,7 @@
 mod bash_hook;
 mod debug_files;
 mod deploys;
+mod events;
 mod help;
 mod info;
 mod login;


### PR DESCRIPTION
Sorry to re-open a PR for the same feat, but I can't re-open #1047. This PR adds
```
Manage events on Sentry.

USAGE:
    sentry-cli events [OPTIONS] <SUBCOMMAND>

OPTIONS:
        --auth-token <AUTH_TOKEN>    Use the given Sentry auth token.
    -h, --help                       Print help information
        --header <KEY:VALUE>         Custom headers that should be attached to all requests
                                     in key:value format.
        --limit <LIMIT>              Limit of requests [default: 10]
        --log-level <LOG_LEVEL>      Set the log output verbosity. [possible values: trace, debug,
                                     info, warn, error]
        --max-rows <MAX-ROWS>        Max of rows for a table.
    -o, --org <ORG>                  The organization slug
    -p, --project <PROJECT>          The project slug.
        --quiet                      Do not print any output while preserving correct exit code.
                                     This flag is currently implemented only for selected
                                     subcommands. [aliases: silent]
    -t, --tags                       Include tags into the list.
    -u, --user                       Include user's info into the list.

SUBCOMMANDS:
    help    Print this message or the help of the given subcommand(s)
    list    List all events in your organization.
```

As requested on [this comment](https://github.com/getsentry/sentry-cli/pull/1047#issuecomment-1095021293) I added two flags:
- `limit` is the limit of API requests
- `max_rows` is the limit of events the table will print (default is all)

I'm not really sure about the last flag but I think it is the closets thing to "per-page" as `cursor` moves 100 items at a time.

---

@kamilogorek sorry if I could only work on it now but I was a bit busy :sweat_smile: 