### PR TITLE
ref: Use better artifacts url resolution for sourcemaps explain

### DIFF
--- a/tests/integration/_cases/sourcemaps/sourcemaps-explain-detect-from-file-content.trycmd
+++ b/tests/integration/_cases/sourcemaps/sourcemaps-explain-detect-from-file-content.trycmd
@@ -9,7 +9,8 @@ $ sentry-cli sourcemaps explain 43a57a55cd5a4207ac520c03e1dee1b4
 ✔ Release artifact distribution matched. Event: [none], Artifact: [none]
 ✔ Successfully fetched ~/dist/bundle.min.js file metadata from the server.
 ✔ Successfully fetched ~/dist/bundle.min.js file from the server.
-✔ Found source map location: dist/bundle.min.js.map
+✔ Found source map location: bundle.min.js.map
+✔ Resolved source map url: ~/dist/bundle.min.js.map
 ✖ Uploaded artifacts do not include entry: ~/dist/bundle.min.js.map
 
 ```

--- a/tests/integration/_cases/sourcemaps/sourcemaps-explain-detect-from-sourcemap-header.trycmd
+++ b/tests/integration/_cases/sourcemaps/sourcemaps-explain-detect-from-sourcemap-header.trycmd
@@ -8,7 +8,8 @@ $ sentry-cli sourcemaps explain 43a57a55cd5a4207ac520c03e1dee1b4
 ✔ Artifact ~/dist/bundle.min.js found.
 ✔ Release artifact distribution matched. Event: [none], Artifact: [none]
 ✔ Successfully fetched ~/dist/bundle.min.js file metadata from the server.
-✔ Found source map location: dist/bundle.min.js.map
+✔ Found source map location: bundle.min.js.map
+✔ Resolved source map url: ~/dist/bundle.min.js.map
 ✖ Uploaded artifacts do not include entry: ~/dist/bundle.min.js.map
 
 ```

--- a/tests/integration/_cases/sourcemaps/sourcemaps-explain-detect-from-xsourcemap-header.trycmd
+++ b/tests/integration/_cases/sourcemaps/sourcemaps-explain-detect-from-xsourcemap-header.trycmd
@@ -9,6 +9,7 @@ $ sentry-cli sourcemaps explain 43a57a55cd5a4207ac520c03e1dee1b4
 ✔ Release artifact distribution matched. Event: [none], Artifact: [none]
 ✔ Successfully fetched ~/dist/bundle.min.js file metadata from the server.
 ✔ Found source map location: bundle.min.js.map
-✖ Uploaded artifacts do not include entry: ~/bundle.min.js.map
+✔ Resolved source map url: ~/dist/bundle.min.js.map
+✖ Uploaded artifacts do not include entry: ~/dist/bundle.min.js.map
 
 ```

--- a/tests/integration/_cases/sourcemaps/sourcemaps-explain-print-sourcemap.trycmd
+++ b/tests/integration/_cases/sourcemaps/sourcemaps-explain-print-sourcemap.trycmd
@@ -8,7 +8,8 @@ $ sentry-cli sourcemaps explain 43a57a55cd5a4207ac520c03e1dee1b4
 ✔ Artifact ~/dist/bundle.min.js found.
 ✔ Release artifact distribution matched. Event: [none], Artifact: [none]
 ✔ Successfully fetched ~/dist/bundle.min.js file metadata from the server.
-✔ Found source map location: dist/bundle.min.js.map
+✔ Found source map location: bundle.min.js.map
+✔ Resolved source map url: ~/dist/bundle.min.js.map
 ✔ Artifact ~/dist/bundle.min.js.map found.
 ✔ Release artifact distribution matched. Event: [none], Artifact: [none]
 ✔ Successfully fetched ~/dist/bundle.min.js.map file from the server.

--- a/tests/integration/_responses/sourcemaps/get-file-metadata-sourcemap-header.json
+++ b/tests/integration/_responses/sourcemaps/get-file-metadata-sourcemap-header.json
@@ -3,7 +3,7 @@
   "name": "~/dist/bundle.min.js",
   "dist": null,
   "headers": {
-    "Sourcemap": "dist/bundle.min.js.map"
+    "Sourcemap": "bundle.min.js.map"
   },
   "size": 497,
   "sha1": "2fb719956748ab7ec5ae9bcb47606733f5589b72",

--- a/tests/integration/_responses/sourcemaps/get-file.js
+++ b/tests/integration/_responses/sourcemaps/get-file.js
@@ -455,4 +455,4 @@ class _ {
   }
 }
 export { d as Scope, _ as Session };
-//# sourceMappingURL=dist/bundle.min.js.map
+//# sourceMappingURL=bundle.min.js.map


### PR DESCRIPTION
This better mimics the behavior of https://github.com/getsentry/sentry/blob/72e351082168f68cbaa5700a51e8ed577222e887/src/sentry/lang/javascript/processor.py#L984 and our internal release fetching mechanism.

Based on https://docs.google.com/document/d/1U1RGAehQwRypUTovF1KRlpiOFze0b-_2gc6fAH0KY0k/edit#heading=h.lmz475t4mvbx the sourcemap url should be relative to the path the JS file was loaded from.
Thos `http://whatever.com/static/js/bundle.js` with `sourceMappingURL=foo.js` should point to `http://whatever.com/static/js/foo.js` and not just `http://whatever.com/foo.js`.

Also fixes https://github.com/getsentry/sentry-cli/issues/1313 along the way.