### PR TITLE
feat(sourcemaps): Add no-dedupe flag for skipping deduplication

### DIFF
--- a/src/utils/sourcemaps.rs
+++ b/src/utils/sourcemaps.rs
@@ -548,6 +548,12 @@ impl SourceMapProcessor {
     }
 
     fn flag_uploaded_sources(&mut self) {
+        // There is no point in going through all the sources if nothing was uploaded,
+        // or we did not collect uploaded files.
+        if self.already_uploaded_sources.is_empty() {
+            return;
+        }
+
         for source in self.sources.values_mut() {
             if let Ok(checksum) = &source.checksum() {
                 if self.already_uploaded_sources.contains(checksum) {

--- a/tests/integration/_cases/sourcemaps/sourcemaps-upload-help.trycmd
+++ b/tests/integration/_cases/sourcemaps/sourcemaps-upload-help.trycmd
@@ -42,6 +42,10 @@ OPTIONS:
         --log-level <LOG_LEVEL>
             Set the log output verbosity. [possible values: trace, debug, info, warn, error]
 
+        --no-dedupe
+            Skip artifacts deduplication prior to uploading. This will force all artifacts to be
+            uploaded, no matter whether they are already present on the server.
+
         --no-rewrite
             Disables rewriting of matching sourcemaps. By default the tool will rewrite sources, so
             that indexed maps are flattened and missing sources are inlined if possible.

--- a/tests/integration/_cases/sourcemaps/sourcemaps-upload-no-dedupe.trycmd
+++ b/tests/integration/_cases/sourcemaps/sourcemaps-upload-no-dedupe.trycmd
@@ -1,5 +1,5 @@
 ```
-$ sentry-cli sourcemaps upload tests/integration/_fixtures/bundle.min.js.map tests/integration/_fixtures/vendor.min.js.map --release=wat-release
+$ sentry-cli sourcemaps upload tests/integration/_fixtures/bundle.min.js.map tests/integration/_fixtures/vendor.min.js.map --release=wat-release --no-dedupe
 ? success
 > Found 1 release file
 > Found 1 release file
@@ -17,6 +17,6 @@ $ sentry-cli sourcemaps upload tests/integration/_fixtures/bundle.min.js.map tes
 Source Map Upload Report
   Source Maps
     ~/bundle.min.js.map
-    ~/vendor.min.js.map (skipped; already uploaded)
+    ~/vendor.min.js.map
 
 ```

--- a/tests/integration/_fixtures/vendor.min.js.map
+++ b/tests/integration/_fixtures/vendor.min.js.map
@@ -1,0 +1,1 @@
+{"version":3,"file":"vendor.min.js","mappings":"CAIA,SAAaA,GACX,MAAM,IAAIC,MAGR,UAPFC","sources":["webpack://webpack-plugin/./src/app.js"],"sourcesContent":["function foo(msg) {\n  bar(msg);\n}\n\nfunction bar(msg) {\n  throw new Error(msg);\n}\n\nfoo(\"whoops\");\n"],"names":["msg","Error","bar"],"sourceRoot":""}

--- a/tests/integration/sourcemaps/upload.rs
+++ b/tests/integration/sourcemaps/upload.rs
@@ -38,16 +38,40 @@ fn command_sourcemaps_upload_skip_already_uploaded() {
         .with_response_body(
             r#"[{
                 "id": "1337",
-                "name": "~/bundle.min.js.map",
+                "name": "~/vendor.min.js.map",
                 "headers": {},
                 "size": 1522,
-                "sha1": "38ed853073df85147960ea3a5bced6170ec389b0",
+                "sha1": "f3673e2cea68bcb86bb74254a9efaa381d74929f",
                 "dateCreated": "2022-05-12T11:08:01.496220Z"
             }]"#,
         ),
     );
 
     register_test("sourcemaps/sourcemaps-upload-skip-already-uploaded.trycmd");
+}
+
+#[test]
+fn command_sourcemaps_upload_no_dedupe() {
+    let _upload_endpoints = mock_common_upload_endpoints();
+    let _files = mock_endpoint(
+        EndpointOptions::new(
+            "GET",
+            "/api/0/projects/wat-org/wat-project/releases/wat-release/files/?cursor=",
+            200,
+        )
+        .with_response_body(
+            r#"[{
+                "id": "1337",
+                "name": "~/vendor.min.js.map",
+                "headers": {},
+                "size": 1522,
+                "sha1": "f3673e2cea68bcb86bb74254a9efaa381d74929f",
+                "dateCreated": "2022-05-12T11:08:01.496220Z"
+            }]"#,
+        ),
+    );
+
+    register_test("sourcemaps/sourcemaps-upload-no-dedupe.trycmd");
 }
 
 // Endpoints need to be bound, as they need to live long enough for test to finish


### PR DESCRIPTION
Some people prefer not to use it, as it "costs" sometimes quite a lot of requests (our release artifacts paging is 20 items each afair), that count toward API quota.

Resolves https://github.com/getsentry/sentry-cli/issues/1322