### PR TITLE
fix: Break out of the loop when we reach cursor limit for list_release_files

### DIFF
--- a/src/utils/xcode.rs
+++ b/src/utils/xcode.rs
@@ -182,12 +182,10 @@ impl XcodeProjectInfo {
     /// Returns the config with a certain name
     pub fn get_configuration(&self, name: &str) -> Option<&str> {
         let name = name.to_lowercase();
-        for cfg in &self.configurations {
-            if cfg.to_lowercase() == name {
-                return Some(cfg);
-            }
-        }
-        None
+        self.configurations
+            .iter()
+            .find(|&cfg| cfg.to_lowercase() == name)
+            .map(|v| v.as_ref())
     }
 }
 


### PR DESCRIPTION
Workaround for the small regression introduced in https://github.com/getsentry/sentry-cli/pull/1275 that happens in usecases where over 20k of files are uploaded for a single release.

Potential improvement is explained in the comment:
> Instead of breaking out of the loop here when we reach the limit
> (200 pages of 100 items, for a total of 20_000 files), we should send a list of hashes
> to the server, perform an intersection there, and change the upload mechanism
> to leave out only those files that were gave back to us by the server.
> This would also limit number of API requests for deduping from `N=[1:200]` to 1.

Related DIFs functionality that we can reuse here:

1. https://github.com/getsentry/sentry/blob/f9bf16e7d663c780c1e0c0378ae92f2a93aa326b/src/sentry/api/urls.py#L1941-L1945
2. https://github.com/getsentry/sentry/blob/f9bf16e7d663c780c1e0c0378ae92f2a93aa326b/src/sentry/api/endpoints/debug_files.py#L248-L255
3. https://github.com/getsentry/sentry-cli/blob/2cac02b7e3a1139f941c6aa9842ca1119e64bc7d/src/api.rs#L1005-L1030


Fixes https://github.com/getsentry/sentry-cli/issues/1306