### PR TITLE
feat: Add support for Portable PDB debug files

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2416,7 +2416,9 @@ checksum = "6bdef32e8150c2a081110b42772ffe7d7c9032b606bc226c8260fd97e0976601"
 
 [[package]]
 name = "symbolic"
-version = "9.2.1"
+version = "10.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d91aea6f2208ce7853a0b61750b217ea7da5c5e46c2eeb52a9bf8a025b707859"
 dependencies = [
  "symbolic-common",
  "symbolic-debuginfo",
@@ -2426,7 +2428,9 @@ dependencies = [
 
 [[package]]
 name = "symbolic-common"
-version = "9.2.1"
+version = "10.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "753f48b7c2399e03be394c2ac68537871cc122eb0c3c9890ad700f6a0ed75867"
 dependencies = [
  "debugid",
  "memmap2",
@@ -2437,7 +2441,9 @@ dependencies = [
 
 [[package]]
 name = "symbolic-debuginfo"
-version = "9.2.1"
+version = "10.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff25b3ee88ee0a1bf2b3350ae5b61f15e25d3338f7a3b7b4b0c7a45f0f0d76c6"
 dependencies = [
  "bitvec",
  "dmsort",
@@ -2467,7 +2473,9 @@ dependencies = [
 
 [[package]]
 name = "symbolic-il2cpp"
-version = "9.2.1"
+version = "10.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a78ce9c1fb893dada8ef3e12b1fc5add3d5f1f6e9e332528c7c5b4da8e86dd38"
 dependencies = [
  "indexmap",
  "serde_json",
@@ -2477,7 +2485,9 @@ dependencies = [
 
 [[package]]
 name = "symbolic-ppdb"
-version = "9.2.1"
+version = "10.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d04703a3a0798d61ec00115565cc77d64fa6253c77695c937aaf8a8adcfe4097"
 dependencies = [
  "indexmap",
  "symbolic-common",
@@ -2488,7 +2498,9 @@ dependencies = [
 
 [[package]]
 name = "symbolic-symcache"
-version = "9.2.1"
+version = "10.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "caaeb234a94403271759121fc99236d8bc4d2dbeadd4eada1ba4b65f4878cce1"
 dependencies = [
  "indexmap",
  "symbolic-common",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1163,6 +1163,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
+name = "leb128"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "884e2677b40cc8c339eaefcb701c32ef1fd2493d71118dc0ca4b6a736c93bd67"
+
+[[package]]
 name = "libc"
 version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2410,9 +2416,7 @@ checksum = "6bdef32e8150c2a081110b42772ffe7d7c9032b606bc226c8260fd97e0976601"
 
 [[package]]
 name = "symbolic"
-version = "9.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a25d209528aa05da204db74a60a04c3a7afd2b36c51c252eaf58b2b7e0cdf4a8"
+version = "9.2.1"
 dependencies = [
  "symbolic-common",
  "symbolic-debuginfo",
@@ -2422,9 +2426,7 @@ dependencies = [
 
 [[package]]
 name = "symbolic-common"
-version = "9.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d431a4117e17192ca2d46b9261919bc34561b7dd2dcba4ab4c93801826fcbd33"
+version = "9.2.1"
 dependencies = [
  "debugid",
  "memmap2",
@@ -2435,9 +2437,7 @@ dependencies = [
 
 [[package]]
 name = "symbolic-debuginfo"
-version = "9.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "084052554bfcf55a5df749b0bf98209cdc3b48e584229f41431a45809c13f179"
+version = "9.2.1"
 dependencies = [
  "bitvec",
  "dmsort",
@@ -2459,6 +2459,7 @@ dependencies = [
  "serde_json",
  "smallvec",
  "symbolic-common",
+ "symbolic-ppdb",
  "thiserror",
  "wasmparser",
  "zip",
@@ -2466,9 +2467,7 @@ dependencies = [
 
 [[package]]
 name = "symbolic-il2cpp"
-version = "9.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f241a432cc325fd6324d6b34c991cd00b67b5b036d8d81d1406de5e610c8556f"
+version = "9.2.1"
 dependencies = [
  "indexmap",
  "serde_json",
@@ -2477,10 +2476,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "symbolic-ppdb"
+version = "9.2.1"
+dependencies = [
+ "indexmap",
+ "symbolic-common",
+ "thiserror",
+ "uuid",
+ "watto",
+]
+
+[[package]]
 name = "symbolic-symcache"
-version = "9.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "438d1b2f67a390fd1f899030254e70d9fc9a52746e77f814c8840344effc5e33"
+version = "9.2.1"
 dependencies = [
  "indexmap",
  "symbolic-common",
@@ -2488,6 +2496,7 @@ dependencies = [
  "symbolic-il2cpp",
  "thiserror",
  "tracing",
+ "watto",
 ]
 
 [[package]]
@@ -2553,18 +2562,18 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.31"
+version = "1.0.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd829fe32373d27f76265620b5309d0340cb8550f523c1dda251d6298069069a"
+checksum = "10deb33631e3c9018b9baf9dcbbc4f737320d2b576bac10f6aefa048fa407e3e"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.31"
+version = "1.0.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0396bc89e626244658bef819e22d0cc459e795a5ebe878e6ec336d1674a8d79a"
+checksum = "982d17546b47146b28f7c22e3d08465f6b8903d0ea13c1660d9d84a6e7adcdbb"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2823,6 +2832,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b62c8d843f4423efee314dc75a1049886deba3214f7e7f9ff0e4e58b4d618581"
 dependencies = [
  "indexmap",
+]
+
+[[package]]
+name = "watto"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6746b5315e417144282a047ebb82260d45c92d09bf653fa9ec975e3809be942b"
+dependencies = [
+ "leb128",
+ "thiserror",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,7 +50,7 @@ serde = { version = "1.0.137", features = ["derive"] }
 serde_json = "1.0.81"
 sha1_smol = { version = "1.0.0", features = ["serde"] }
 sourcemap = { version = "6.0.2", features = ["ram_bundle"] }
-symbolic = { version = "9.1.4", features = ["debuginfo-serde", "il2cpp"] }
+symbolic = { path = "../symbolic/symbolic", features = ["debuginfo-serde", "il2cpp"] }
 thiserror = "1.0.31"
 url = "2.2.2"
 username = "0.2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,7 +50,7 @@ serde = { version = "1.0.137", features = ["derive"] }
 serde_json = "1.0.81"
 sha1_smol = { version = "1.0.0", features = ["serde"] }
 sourcemap = { version = "6.0.2", features = ["ram_bundle"] }
-symbolic = { path = "../symbolic/symbolic", features = ["debuginfo-serde", "il2cpp"] }
+symbolic = { version = "10.0.0", features = ["debuginfo-serde", "il2cpp"] }
 thiserror = "1.0.31"
 url = "2.2.2"
 username = "0.2.0"

--- a/src/api.rs
+++ b/src/api.rs
@@ -2516,6 +2516,9 @@ pub enum ChunkUploadCapability {
     /// Upload of PDBs and debug id overrides
     Pdbs,
 
+    /// Upload of Portable PDBs
+    PortablePdbs,
+
     /// Uploads of source archives
     Sources,
 
@@ -2538,6 +2541,7 @@ impl<'de> Deserialize<'de> for ChunkUploadCapability {
             "debug_files" => ChunkUploadCapability::DebugFiles,
             "release_files" => ChunkUploadCapability::ReleaseFiles,
             "pdbs" => ChunkUploadCapability::Pdbs,
+            "portablepdbs" => ChunkUploadCapability::PortablePdbs,
             "sources" => ChunkUploadCapability::Sources,
             "bcsymbolmaps" => ChunkUploadCapability::BcSymbolmap,
             "il2cpp" => ChunkUploadCapability::Il2Cpp,

--- a/src/commands/debug_files/check.rs
+++ b/src/commands/debug_files/check.rs
@@ -5,7 +5,7 @@ use anyhow::Result;
 use clap::{Arg, ArgMatches, Command};
 use console::style;
 
-use crate::utils::dif::DifFile;
+use crate::utils::dif::{DifFile, DifType};
 use crate::utils::logging::is_quiet_mode;
 use crate::utils::system::QuietExit;
 
@@ -26,7 +26,7 @@ pub fn make_command(command: Command) -> Command {
                 .long("type")
                 .short('t')
                 .value_name("TYPE")
-                .possible_values(&["dsym", "elf", "proguard", "breakpad"])
+                .possible_values(DifType::all_names())
                 .help(
                     "Explicitly set the type of the debug info file. \
                      This should not be needed as files are auto detected.",

--- a/src/commands/debug_files/find.rs
+++ b/src/commands/debug_files/find.rs
@@ -47,15 +47,7 @@ pub fn make_command(command: Command) -> Command {
                 .short('t')
                 .value_name("TYPE")
                 .multiple_occurrences(true)
-                .possible_values(&[
-                    "dsym",
-                    "elf",
-                    "pe",
-                    "pdb",
-                    "proguard",
-                    "breakpad",
-                    "sourcebundle",
-                ])
+                .possible_values(DifType::all_names())
                 .help(
                     "Only consider debug information files of the given \
                      type.  By default all types are considered.",
@@ -341,12 +333,7 @@ pub fn execute(matches: &ArgMatches) -> Result<()> {
             types.insert(ty.parse().unwrap());
         }
     } else {
-        types.insert(DifType::Dsym);
-        types.insert(DifType::Pdb);
-        types.insert(DifType::Pe);
-        types.insert(DifType::Proguard);
-        types.insert(DifType::SourceBundle);
-        types.insert(DifType::Breakpad);
+        types.extend(DifType::all());
     }
 
     let with_well_known = !matches.is_present("no_well_known");

--- a/src/commands/debug_files/find.rs
+++ b/src/commands/debug_files/find.rs
@@ -147,6 +147,7 @@ fn find_ids(
                 DifType::Elf => find_ids_for_elf(&dirent, &remaining),
                 DifType::Pe => find_ids_for_pe(&dirent, &remaining),
                 DifType::Pdb => find_ids_for_pdb(&dirent, &remaining),
+                DifType::PortablePdb => find_ids_for_portablepdb(&dirent, &remaining),
                 DifType::SourceBundle => find_ids_for_sourcebundle(&dirent, &remaining),
                 DifType::Breakpad => find_ids_for_breakpad(&dirent, &remaining),
                 DifType::Proguard => find_ids_for_proguard(&dirent, &proguard_uuids),
@@ -267,6 +268,20 @@ fn find_ids_for_pdb(
         if let Ok(dif) = DifFile::open_path(dirent.path(), Some(DifType::Pdb));
         then {
             return Some(extract_remaining_ids(&dif.ids(), remaining, DifType::Pdb))
+        }
+    }
+    None
+}
+
+fn find_ids_for_portablepdb(
+    dirent: &DirEntry,
+    remaining: &HashSet<DebugId>,
+) -> Option<Vec<(DebugId, DifType)>> {
+    if_chain! {
+        if dirent.path().extension() == Some(OsStr::new("pdb"));
+        if let Ok(dif) = DifFile::open_path(dirent.path(), Some(DifType::PortablePdb));
+        then {
+            return Some(extract_remaining_ids(&dif.ids(), remaining, DifType::PortablePdb))
         }
     }
     None

--- a/src/commands/debug_files/upload.rs
+++ b/src/commands/debug_files/upload.rs
@@ -11,7 +11,7 @@ use symbolic::debuginfo::FileFormat;
 use crate::api::Api;
 use crate::config::Config;
 use crate::utils::args::{validate_id, ArgExt};
-use crate::utils::dif::ObjectDifFeatures;
+use crate::utils::dif::{DifType, ObjectDifFeatures};
 use crate::utils::dif_upload::{DifFormat, DifUpload};
 use crate::utils::progress::{ProgressBar, ProgressStyle};
 use crate::utils::system::QuietExit;
@@ -20,6 +20,9 @@ use crate::utils::xcode::{InfoPlist, MayDetach};
 static DERIVED_DATA_FOLDER: &str = "Library/Developer/Xcode/DerivedData";
 
 pub fn make_command(command: Command) -> Command {
+    let mut types = vec!["bcsymbolmap"];
+    types.extend(DifType::all_names());
+
     command
         .about("Upload debugging information files.")
         .org_arg()
@@ -36,15 +39,7 @@ pub fn make_command(command: Command) -> Command {
                 .short('t')
                 .value_name("TYPE")
                 .multiple_occurrences(true)
-                .possible_values(&[
-                    "dsym",
-                    "elf",
-                    "breakpad",
-                    "pdb",
-                    "pe",
-                    "sourcebundle",
-                    "bcsymbolmap",
-                ])
+                .possible_values(types)
                 .help(
                     "Only consider debug information files of the given \
                     type.  By default, all types are considered.",

--- a/src/commands/debug_files/upload.rs
+++ b/src/commands/debug_files/upload.rs
@@ -200,6 +200,7 @@ pub fn execute(matches: &ArgMatches) -> Result<()> {
             "pdb" => upload.filter_format(DifFormat::Object(FileFormat::Pdb)),
             "pe" => upload.filter_format(DifFormat::Object(FileFormat::Pe)),
             "sourcebundle" => upload.filter_format(DifFormat::Object(FileFormat::SourceBundle)),
+            "portablepdb" => upload.filter_format(DifFormat::Object(FileFormat::PortablePdb)),
             "bcsymbolmap" => {
                 upload.filter_format(DifFormat::BcSymbolMap);
                 upload.filter_format(DifFormat::PList)

--- a/src/utils/dif.rs
+++ b/src/utils/dif.rs
@@ -19,6 +19,7 @@ pub enum DifType {
     SourceBundle,
     Pe,
     Pdb,
+    PortablePdb,
     Wasm,
 }
 
@@ -29,6 +30,7 @@ impl DifType {
             DifType::Elf => "elf",
             DifType::Pe => "pe",
             DifType::Pdb => "pdb",
+            DifType::PortablePdb => "portablepdb",
             DifType::SourceBundle => "sourcebundle",
             DifType::Breakpad => "breakpad",
             DifType::Proguard => "proguard",
@@ -52,6 +54,7 @@ impl str::FromStr for DifType {
             "elf" => Ok(DifType::Elf),
             "pe" => Ok(DifType::Pe),
             "pdb" => Ok(DifType::Pdb),
+            "portablepdb" => Ok(DifType::PortablePdb),
             "sourcebundle" => Ok(DifType::SourceBundle),
             "breakpad" => Ok(DifType::Breakpad),
             "proguard" => Ok(DifType::Proguard),
@@ -191,6 +194,7 @@ impl DifFile<'static> {
                 | FileFormat::Elf
                 | FileFormat::Pe
                 | FileFormat::Pdb
+                | FileFormat::PortablePdb
                 | FileFormat::Breakpad
                 | FileFormat::Wasm
                 | FileFormat::SourceBundle => return DifFile::from_archive(archive),
@@ -214,6 +218,7 @@ impl DifFile<'static> {
             Some(DifType::Elf) => DifFile::open_object(path, FileFormat::Elf),
             Some(DifType::Pe) => DifFile::open_object(path, FileFormat::Pe),
             Some(DifType::Pdb) => DifFile::open_object(path, FileFormat::Pdb),
+            Some(DifType::PortablePdb) => DifFile::open_object(path, FileFormat::PortablePdb),
             Some(DifType::SourceBundle) => DifFile::open_object(path, FileFormat::SourceBundle),
             Some(DifType::Wasm) => DifFile::open_object(path, FileFormat::Wasm),
             Some(DifType::Breakpad) => DifFile::open_object(path, FileFormat::Breakpad),
@@ -246,6 +251,7 @@ impl<'a> DifFile<'a> {
                 FileFormat::Breakpad => DifType::Breakpad,
                 FileFormat::Elf => DifType::Elf,
                 FileFormat::Pdb => DifType::Pdb,
+                FileFormat::PortablePdb => DifType::PortablePdb,
                 FileFormat::Pe => DifType::Pe,
                 FileFormat::Wasm => DifType::Wasm,
                 FileFormat::SourceBundle => DifType::SourceBundle,

--- a/src/utils/dif.rs
+++ b/src/utils/dif.rs
@@ -37,6 +37,34 @@ impl DifType {
             DifType::Wasm => "wasm",
         }
     }
+
+    pub fn all() -> &'static [DifType] {
+        &[
+            DifType::Dsym,
+            DifType::Elf,
+            DifType::Pe,
+            DifType::Pdb,
+            DifType::PortablePdb,
+            DifType::SourceBundle,
+            DifType::Breakpad,
+            DifType::Proguard,
+            DifType::Wasm,
+        ]
+    }
+
+    pub fn all_names() -> &'static [&'static str] {
+        &[
+            "dsym",
+            "elf",
+            "pe",
+            "pdb",
+            "portablepdb",
+            "sourcebundle",
+            "breakpad",
+            "proguard",
+            "wasm",
+        ]
+    }
 }
 
 impl fmt::Display for DifType {

--- a/src/utils/fs.rs
+++ b/src/utils/fs.rs
@@ -204,7 +204,7 @@ pub fn decompress_gzip_content(slice: &[u8]) -> Result<Vec<u8>> {
 
 #[cfg(windows)]
 pub fn path_as_url(path: &Path) -> String {
-    path.display().to_string().replace("\\", "/")
+    path.display().to_string().replace('\\', "/")
 }
 
 #[cfg(not(windows))]

--- a/src/utils/system.rs
+++ b/src/utils/system.rs
@@ -53,7 +53,7 @@ where
 #[cfg(windows)]
 pub fn run_or_interrupt<F>(f: F)
 where
-    F: FnOnce() -> (),
+    F: FnOnce(),
     F: Send + 'static,
 {
     f();

--- a/tests/integration/_cases/debug_files/debug_files-upload-help.trycmd
+++ b/tests/integration/_cases/debug_files/debug_files-upload-help.trycmd
@@ -69,8 +69,9 @@ OPTIONS:
                                      without this option if they are found in the PATH searched for
                                      symbol files.
     -t, --type <TYPE>                Only consider debug information files of the given type.  By
-                                     default, all types are considered. [possible values: dsym, elf,
-                                     breakpad, pdb, pe, sourcebundle, bcsymbolmap]
+                                     default, all types are considered. [possible values:
+                                     bcsymbolmap, dsym, elf, pe, pdb, portablepdb, sourcebundle,
+                                     breakpad, proguard, wasm]
         --wait                       Wait for the server to fully process uploaded files. Errors can
                                      only be displayed if --wait is specified, but this will
                                      significantly slow down the upload process.

--- a/tests/integration/_cases/upload_dif/upload_dif-help.trycmd
+++ b/tests/integration/_cases/upload_dif/upload_dif-help.trycmd
@@ -69,8 +69,9 @@ OPTIONS:
                                      without this option if they are found in the PATH searched for
                                      symbol files.
     -t, --type <TYPE>                Only consider debug information files of the given type.  By
-                                     default, all types are considered. [possible values: dsym, elf,
-                                     breakpad, pdb, pe, sourcebundle, bcsymbolmap]
+                                     default, all types are considered. [possible values:
+                                     bcsymbolmap, dsym, elf, pe, pdb, portablepdb, sourcebundle,
+                                     breakpad, proguard, wasm]
         --wait                       Wait for the server to fully process uploaded files. Errors can
                                      only be displayed if --wait is specified, but this will
                                      significantly slow down the upload process.


### PR DESCRIPTION
This adds support to the `debug-files` subcommand to check, find and upload Portable PDB files.

The actual upload still depends on properly exposing this in sentry.