### PR TITLE
fix: paths argument for debug-files find should take a value

### DIFF
--- a/src/commands/debug_files/find.rs
+++ b/src/commands/debug_files/find.rs
@@ -75,6 +75,7 @@ pub fn make_command(command: Command) -> Command {
             Arg::new("paths")
                 .long("path")
                 .short('p')
+                .value_name("PATH")
                 .multiple_occurrences(true)
                 .help("Add a path to search recursively for debug info files."),
         )


### PR DESCRIPTION
NOTE: `takes_name` implicitly sets `Arg::takes_value(true)`

Whoops.

#no-changelog