### PR TITLE
ci: update and pin GHA to commit hash

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -62,7 +62,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - uses: actions-rs/toolchain@v1
+      - uses: actions-rs/toolchain@16499b5e05bf2e26879000db0c1d13f7e13fa3af # pin@v1
         with:
           toolchain: stable
           target: ${{ matrix.target }}
@@ -70,7 +70,7 @@ jobs:
           override: true
 
       - name: Run Cargo Build
-        uses: actions-rs/cargo@v1
+        uses: actions-rs/cargo@844f36862e911db73fe0815f00a4a2602c279505 # pin@v1
         with:
           command: build
           args: --target=${{ matrix.target }} --release --locked
@@ -119,14 +119,14 @@ jobs:
         shell: bash
         run: rustup set auto-self-update disable
 
-      - uses: actions-rs/toolchain@v1
+      - uses: actions-rs/toolchain@16499b5e05bf2e26879000db0c1d13f7e13fa3af # pin@v1
         with:
           toolchain: stable-${{ matrix.arch }}-pc-windows-msvc
           profile: minimal
           override: true
 
       - name: Run Cargo Build
-        uses: actions-rs/cargo@v1
+        uses: actions-rs/cargo@844f36862e911db73fe0815f00a4a2602c279505 # pin@v1
         with:
           command: build
           args: --release --locked

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,25 +19,25 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - uses: actions-rs/toolchain@v1
+      - uses: actions-rs/toolchain@16499b5e05bf2e26879000db0c1d13f7e13fa3af # pin@v1
         with:
           toolchain: stable
           profile: minimal
           components: clippy, rustfmt
           override: true
 
-      - uses: swatinem/rust-cache@v1
+      - uses: swatinem/rust-cache@81d053bdb0871dcd3f10763c8cc60d0adc41762b # pin@v1
         with:
           key: ${{ github.job }}
 
       - name: Run Rustfmt
-        uses: actions-rs/cargo@v1
+        uses: actions-rs/cargo@844f36862e911db73fe0815f00a4a2602c279505 # pin@v1
         with:
           command: fmt
           args: --all -- --check
 
       - name: Run Clippy
-        uses: actions-rs/cargo@v1
+        uses: actions-rs/cargo@844f36862e911db73fe0815f00a4a2602c279505 # pin@v1
         with:
           command: clippy
           args: --workspace --all-features --tests -- -D clippy::all
@@ -54,18 +54,18 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - uses: actions-rs/toolchain@v1
+      - uses: actions-rs/toolchain@16499b5e05bf2e26879000db0c1d13f7e13fa3af # pin@v1
         with:
           toolchain: stable
           profile: minimal
           override: true
 
-      - uses: swatinem/rust-cache@v1
+      - uses: swatinem/rust-cache@81d053bdb0871dcd3f10763c8cc60d0adc41762b # pin@v1
         with:
           key: ${{ github.job }}
 
       - name: Run Cargo Tests
-        uses: actions-rs/cargo@v1
+        uses: actions-rs/cargo@844f36862e911db73fe0815f00a4a2602c279505 # pin@v1
         with:
           command: test
           args: --all

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -9,14 +9,14 @@
 # the `language` matrix defined below to confirm you have the correct set of
 # supported CodeQL languages.
 #
-name: "CodeQL"
+name: 'CodeQL'
 
 on:
   push:
-    branches: [ master ]
+    branches: [master]
   pull_request:
     # The branches below must be a subset of the branches above
-    branches: [ master ]
+    branches: [master]
   schedule:
     - cron: '32 17 * * 4'
 
@@ -28,40 +28,37 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        language: [ 'javascript' ]
+        language: ['javascript']
         # CodeQL supports [ 'cpp', 'csharp', 'go', 'java', 'javascript', 'python' ]
         # Learn more:
         # https://docs.github.com/en/free-pro-team@latest/github/finding-security-vulnerabilities-and-errors-in-your-code/configuring-code-scanning#changing-the-languages-that-are-analyzed
 
     steps:
-    - name: Checkout repository
-      uses: actions/checkout@v2
+      - name: Checkout repository
+        uses: actions/checkout@v2
 
-    # Initializes the CodeQL tools for scanning.
-    - name: Initialize CodeQL
-      uses: github/codeql-action/init@v1
-      with:
-        languages: ${{ matrix.language }}
-        # If you wish to specify custom queries, you can do so here or in a config file.
-        # By default, queries listed here will override any specified in a config file.
-        # Prefix the list here with "+" to use these queries and those in the config file.
-        # queries: ./path/to/local/query, your-org/your-repo/queries@main
+      # Initializes the CodeQL tools for scanning.
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@e0e5ded33cabb451ae0a9768fc7b0410bad9ad44 # pin@v2
+        with:
+          languages: ${{ matrix.language }}
+          # If you wish to specify custom queries, you can do so here or in a config file.
+          # By default, queries listed here will override any specified in a config file.
+          # Prefix the list here with "+" to use these queries and those in the config file.
+          # queries: ./path/to/local/query, your-org/your-repo/queries@main
 
-    # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
-    # If this step fails, then you should remove it and run the build manually (see below)
-    - name: Autobuild
-      uses: github/codeql-action/autobuild@v1
+      # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
+      # If this step fails, then you should remove it and run the build manually (see below)
+      - name: Autobuild
+        uses: github/codeql-action/autobuild@e0e5ded33cabb451ae0a9768fc7b0410bad9ad44 # pin@v2
 
-    # ℹ️ Command-line programs to run using the OS shell.
-    # 📚 https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions
-
-    # ✏️ If the Autobuild fails above, remove it and uncomment the following three lines
-    #    and modify them (or add more) to build your code if your project
-    #    uses a compiled language
-
-    #- run: |
-    #   make bootstrap
-    #   make release
-
-    - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v1
+      # ℹ️ Command-line programs to run using the OS shell.
+      # 📚 https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions
+      # ✏️ If the Autobuild fails above, remove it and uncomment the following three lines
+      #    and modify them (or add more) to build your code if your project
+      #    uses a compiled language
+      #- run: |
+      #   make bootstrap
+      #   make release
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@e0e5ded33cabb451ae0a9768fc7b0410bad9ad44 # pin@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,15 +16,15 @@ jobs:
     runs-on: ubuntu-latest
     name: 'Release a new version'
     steps:
-     - uses: actions/checkout@v2
-       with:
+      - uses: actions/checkout@v2
+        with:
           token: ${{ secrets.GH_RELEASE_PAT }}
           fetch-depth: 0
-     - name: Prepare release
-       uses: getsentry/action-prepare-release@v1
-       env:
-         GITHUB_TOKEN: ${{ secrets.GH_RELEASE_PAT }}
-       with:
-         version: ${{ github.event.inputs.version }}
-         force: ${{ github.event.inputs.force }}
-         merge_target: ${{ github.event.inputs.merge_target }}
+      - name: Prepare release
+        uses: getsentry/action-prepare-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GH_RELEASE_PAT }}
+        with:
+          version: ${{ github.event.inputs.version }}
+          force: ${{ github.event.inputs.force }}
+          merge_target: ${{ github.event.inputs.merge_target }}

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -12,14 +12,14 @@ jobs:
           repo-token: ${{ github.token }}
           days-before-stale: 21
           days-before-close: 7
-          only-labels: ""
+          only-labels: ''
           operations-per-run: 100
           remove-stale-when-updated: true
           debug-only: false
           ascending: false
 
-          exempt-issue-labels: "Status: Backlog,Status: In Progress"
-          stale-issue-label: "Status: Stale"
+          exempt-issue-labels: 'Status: Backlog,Status: In Progress'
+          stale-issue-label: 'Status: Stale'
           stale-issue-message: |-
             This issue has gone three weeks without activity. In another week, I will close it.
 
@@ -29,11 +29,11 @@ jobs:
 
             "A weed is but an unloved flower." ― _Ella Wheeler Wilcox_ 🥀
           skip-stale-issue-message: false
-          close-issue-label: ""
-          close-issue-message: ""
+          close-issue-label: ''
+          close-issue-message: ''
 
-          exempt-pr-labels: "Status: Backlog,Status: In Progress"
-          stale-pr-label: "Status: Stale"
+          exempt-pr-labels: 'Status: Backlog,Status: In Progress'
+          stale-pr-label: 'Status: Stale'
           stale-pr-message: |-
             This pull request has gone three weeks without activity. In another week, I will close it.
 
@@ -44,4 +44,4 @@ jobs:
             "A weed is but an unloved flower." ― _Ella Wheeler Wilcox_ 🥀
           skip-stale-pr-message: false
           close-pr-label:
-          close-pr-message: ""
+          close-pr-message: ''


### PR DESCRIPTION
Used `Get-ChildItem . -Filter *.yml | Foreach-Object { pin-github-action --allow 'actions/*,getsentry/*' $_.FullName }` and manually reverted the most disturbing formatting changes it's making (line breaks on long lines)...

There should be no need to do this again + new PRs will automatically get a failure through Danger.

#skip-changelog