### PR TITLE
feat: Add `headers` option on sentry cli js interface (#1354)

### DIFF
--- a/js/helper.js
+++ b/js/helper.js
@@ -164,6 +164,9 @@ async function execute(args, live, silent, configFile, config = {}) {
   }
   if (config.customHeader) {
     env.CUSTOM_HEADER = config.customHeader;
+  } else if (config.headers) {
+    const headers = Object.entries(config.headers).flatMap(([key, value]) => ['--header', `${key}:${value}`])
+    args = [...headers, ...args]
   }
   return new Promise((resolve, reject) => {
     if (live === true) {

--- a/js/helper.js
+++ b/js/helper.js
@@ -165,8 +165,8 @@ async function execute(args, live, silent, configFile, config = {}) {
   if (config.customHeader) {
     env.CUSTOM_HEADER = config.customHeader;
   } else if (config.headers) {
-    const headers = Object.entries(config.headers).flatMap(([key, value]) => ['--header', `${key}:${value}`])
-    args = [...headers, ...args]
+    const headers = Object.entries(config.headers).flatMap(([key, value]) => ['--header', `${key}:${value}`]);
+    args = [...headers, ...args];
   }
   return new Promise((resolve, reject) => {
     if (live === true) {

--- a/js/index.d.ts
+++ b/js/index.d.ts
@@ -47,6 +47,11 @@ declare module '@sentry/cli' {
      * This value will update `CUSTOM_HEADER` env variable.
      */
     customHeader?: string;
+    /**
+     * Headers added to every outgoing network request.
+     * This value does not set any env variable, and is overriden by `customHeader`.
+     */
+    headers?: Record<string, string>;
   }
 
   /**

--- a/js/index.d.ts
+++ b/js/index.d.ts
@@ -49,7 +49,7 @@ declare module '@sentry/cli' {
     customHeader?: string;
     /**
      * Headers added to every outgoing network request.
-     * This value does not set any env variable, and is overriden by `customHeader`.
+     * This value does not set any env variable, and is overridden by `customHeader`.
      */
     headers?: Record<string, string>;
   }


### PR DESCRIPTION
Allow multiple headers to be passed to sentry-cli when usingy the JS interface.

Fixes https://github.com/getsentry/sentry-cli/issues/1354