### PR TITLE
ci: Remove danger.js workflow

### DIFF
--- a/.github/workflows/danger.yml
+++ b/.github/workflows/danger.yml
@@ -1,9 +1,0 @@
-name: Danger
-
-on:
-  pull_request:
-    types: [opened, synchronize, reopened, edited, ready_for_review]
-
-jobs:
-  danger:
-    uses: getsentry/github-workflows/.github/workflows/danger.yml@v2


### PR DESCRIPTION
I maintain this repo using `changelogPolicy: auto` and use appropriate PR titles and `skip-changelog` tags as I go. This way I don't have to ever remember about the changelog being up to date, as it's generated automatically for me, in the desirable format.

#skip-changelog