### PR TITLE
fix: Add + to reserved query characters in url encoding

### DIFF
--- a/src/api.rs
+++ b/src/api.rs
@@ -50,7 +50,13 @@ use crate::utils::xcode::InfoPlist;
 // Based on https://docs.rs/percent-encoding/1.0.1/src/percent_encoding/lib.rs.html#104
 // WHATWG Spec: https://url.spec.whatwg.org/#percent-encoded-bytes
 // RFC3986 Reserved Characters: https://www.rfc-editor.org/rfc/rfc3986#section-2.2
-const QUERY_ENCODE_SET: AsciiSet = CONTROLS.add(b' ').add(b'"').add(b'#').add(b'<').add(b'>');
+const QUERY_ENCODE_SET: AsciiSet = CONTROLS
+    .add(b' ')
+    .add(b'"')
+    .add(b'#')
+    .add(b'<')
+    .add(b'>')
+    .add(b'+');
 const PATH_SEGMENT_ENCODE_SET: AsciiSet = QUERY_ENCODE_SET
     .add(b'`')
     .add(b'?')


### PR DESCRIPTION
Fixes https://github.com/getsentry/sentry/issues/40307

However, at this point, I'm not sure if we couldn't just encode all reserved characters.
Our `validate_release` is very loose, so it'd make sense. Or would it be too much?
It looks like our own UI does just that. For example `foo.bar@4.2+1337` is encoded as `foo.bar%404.2%2B1337` (delete all artifacts call below)

```
Request URL: https://sentry.io/api/0/projects/kamil-test/test-1/files/source-maps/?name=foo.bar%404.2%2B1337
Request Method: DELETE
```

If we follow https://www.rfc-editor.org/rfc/rfc3986#section-2.2 then it'd change the code to:

```rust
// RFC3986 Reserved Characters: https://www.rfc-editor.org/rfc/rfc3986#section-2.2
const ENCODE_SET: AsciiSet = CONTROLS
    .add(b':')
    .add(b'/')
    .add(b'?')
    .add(b'#')
    .add(b'[')
    .add(b']')
    .add(b'@')
    .add(b'!')
    .add(b'$')
    .add(b'&')
    .add(b'\'')
    .add(b'(')
    .add(b')')
    .add(b'*')
    .add(b'+')
    .add(b',')
    .add(b';')
    .add(b'=');
```