### PR TITLE
fix: Windows binary location

### DIFF
--- a/js/helper.js
+++ b/js/helper.js
@@ -7,7 +7,7 @@ const childProcess = require('child_process');
  * @type {string}
  */
 let binaryPath = eval(
-  "require('path').resolve(__dirname, require('os').platform() === 'win32' ? '..\\sentry-cli.exe' : '../sentry-cli')"
+  "require('path').resolve(__dirname, require('os').platform() === 'win32' ? '../sentry-cli.exe' : '../sentry-cli')"
 );
 
 /**


### PR DESCRIPTION
It appears that `path.resolve` already caters for path separator differences so you can safely use forwards slashes and everything works.

Closes #1368 