### PR TITLE
Replace `npmlog` dependency in order to support Node 10+

### DIFF
--- a/js/logger.js
+++ b/js/logger.js
@@ -1,0 +1,7 @@
+class Logger {
+  info() {
+    this.stream.write(Array.from(arguments).join(' '));
+  }
+}
+
+module.exports = new Logger();

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "author": "Sentry",
   "license": "BSD-3-Clause",
   "engines": {
-    "node": ">= 12"
+    "node": ">= 10"
   },
   "main": "js/index.js",
   "types": "js/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   "dependencies": {
     "https-proxy-agent": "^5.0.0",
     "node-fetch": "^2.6.7",
-    "npmlog": "^6.0.1",
+    "npmlog": "^5.0.1",
     "progress": "^2.0.3",
     "proxy-from-env": "^1.1.0",
     "which": "^2.0.2"

--- a/package.json
+++ b/package.json
@@ -17,7 +17,6 @@
   "dependencies": {
     "https-proxy-agent": "^5.0.0",
     "node-fetch": "^2.6.7",
-    "npmlog": "^5.0.1",
     "progress": "^2.0.3",
     "proxy-from-env": "^1.1.0",
     "which": "^2.0.2"

--- a/package.json
+++ b/package.json
@@ -48,5 +48,9 @@
     "testPathIgnorePatterns": [
       "<rootDir>/src"
     ]
+  },
+  "volta": {
+    "node": "12.22.12",
+    "yarn": "1.22.19"
   }
 }

--- a/scripts/install.js
+++ b/scripts/install.js
@@ -15,11 +15,11 @@ const fetch = require('node-fetch');
 const HttpsProxyAgent = require('https-proxy-agent');
 const ProgressBar = require('progress');
 const Proxy = require('proxy-from-env');
-const npmLog = require('npmlog');
 const which = require('which');
 
 const helper = require('../js/helper');
 const pkgInfo = require('../package.json');
+const logger = require('../js/logger');
 
 const CDN_URL =
   process.env.SENTRYCLI_LOCAL_CDNURL ||
@@ -157,14 +157,14 @@ function validateChecksum(tempPath, name) {
       }
     }
   } catch (e) {
-    npmLog.info(
+    logger.info(
       'Checksums are generated when the package is published to npm. They are not available directly in the source repository. Skipping validation.'
     );
     return;
   }
 
   if (!storedHash) {
-    npmLog.info(`Checksum for ${name} not found, skipping validation.`);
+    logger.info(`Checksum for ${name} not found, skipping validation.`);
     return;
   }
 
@@ -176,7 +176,7 @@ function validateChecksum(tempPath, name) {
       `Checksum validation for ${name} failed.\nExpected: ${storedHash}\nReceived: ${currentHash}`
     );
   } else {
-    npmLog.info('Checksum validation passed.');
+    logger.info('Checksum validation passed.');
   }
 }
 
@@ -188,7 +188,7 @@ async function downloadBinary() {
   if (process.env.SENTRYCLI_USE_LOCAL === '1') {
     try {
       const binPath = which.sync('sentry-cli');
-      npmLog.info('sentry-cli', `Using local binary: ${binPath}`);
+      logger.info('sentry-cli', `Using local binary: ${binPath}`);
       fs.copyFileSync(binPath, outputPath);
       return Promise.resolve();
     } catch (e) {
@@ -206,7 +206,7 @@ async function downloadBinary() {
 
   const cachedPath = getCachedPath(downloadUrl);
   if (fs.existsSync(cachedPath)) {
-    npmLog.info('sentry-cli', `Using cached binary: ${cachedPath}`);
+    logger.info('sentry-cli', `Using cached binary: ${cachedPath}`);
     fs.copyFileSync(cachedPath, outputPath);
     return;
   }
@@ -214,10 +214,10 @@ async function downloadBinary() {
   const proxyUrl = Proxy.getProxyForUrl(downloadUrl);
   const agent = proxyUrl ? new HttpsProxyAgent(proxyUrl) : null;
 
-  npmLog.info('sentry-cli', `Downloading from ${downloadUrl}`);
+  logger.info('sentry-cli', `Downloading from ${downloadUrl}`);
 
   if (proxyUrl) {
-    npmLog.info('sentry-cli', `Using proxy URL: ${proxyUrl}`);
+    logger.info('sentry-cli', `Using proxy URL: ${proxyUrl}`);
   }
 
   let response;
@@ -316,10 +316,10 @@ if (process.env.SENTRYCLI_LOCAL_CDNURL) {
   process.on('exit', () => server.close());
 }
 
-npmLog.stream = getLogStream('stderr');
+logger.stream = getLogStream('stderr');
 
 if (process.env.SENTRYCLI_SKIP_DOWNLOAD === '1') {
-  npmLog.info('sentry-cli', `Skipping download because SENTRYCLI_SKIP_DOWNLOAD=1 detected.`);
+  logger.info('sentry-cli', `Skipping download because SENTRYCLI_SKIP_DOWNLOAD=1 detected.`);
   process.exit(0);
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -749,14 +749,6 @@ are-we-there-yet@^2.0.0:
     delegates "^1.0.0"
     readable-stream "^3.6.0"
 
-are-we-there-yet@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/are-we-there-yet/-/are-we-there-yet-3.0.0.tgz#ba20bd6b553e31d62fc8c31bd23d22b95734390d"
-  integrity sha512-0GWpv50YSOcLXaN6/FAKY3vfRbllXWV2xvfA/oKJF8pzFhWXPV+yjhJXDBbjscDYowv7Yw1A3uigpzn5iEGTyw==
-  dependencies:
-    delegates "^1.0.0"
-    readable-stream "^3.6.0"
-
 argparse@^1.0.7:
   version "1.0.10"
   resolved "https://registry.yarnpkg.com/argparse/-/argparse-1.0.10.tgz#bcd6791ea5ae09725e17e5ad988134cd40b3d911"
@@ -1497,21 +1489,6 @@ gauge@^3.0.0:
     console-control-strings "^1.0.0"
     has-unicode "^2.0.1"
     object-assign "^4.1.1"
-    signal-exit "^3.0.0"
-    string-width "^4.2.3"
-    strip-ansi "^6.0.1"
-    wide-align "^1.1.2"
-
-gauge@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/gauge/-/gauge-4.0.0.tgz#afba07aa0374a93c6219603b1fb83eaa2264d8f8"
-  integrity sha512-F8sU45yQpjQjxKkm1UOAhf0U/O0aFt//Fl7hsrNVto+patMHjs7dPI9mFOGUKbhrgKm0S3EjW3scMFuQmWSROw==
-  dependencies:
-    ansi-regex "^5.0.1"
-    aproba "^1.0.3 || ^2.0.0"
-    color-support "^1.1.2"
-    console-control-strings "^1.0.0"
-    has-unicode "^2.0.1"
     signal-exit "^3.0.0"
     string-width "^4.2.3"
     strip-ansi "^6.0.1"
@@ -2630,16 +2607,6 @@ npmlog@^5.0.1:
     are-we-there-yet "^2.0.0"
     console-control-strings "^1.1.0"
     gauge "^3.0.0"
-    set-blocking "^2.0.0"
-
-npmlog@^6.0.1:
-  version "6.0.1"
-  resolved "https://registry.yarnpkg.com/npmlog/-/npmlog-6.0.1.tgz#06f1344a174c06e8de9c6c70834cfba2964bba17"
-  integrity sha512-BTHDvY6nrRHuRfyjt1MAufLxYdVXZfd099H4+i1f0lPywNQyI4foeNXJRObB/uy+TYqUW0vAD9gbdSOXPst7Eg==
-  dependencies:
-    are-we-there-yet "^3.0.0"
-    console-control-strings "^1.1.0"
-    gauge "^4.0.0"
     set-blocking "^2.0.0"
 
 nwsapi@^2.2.0:


### PR DESCRIPTION
This PR replaces the npmlog dependency with a super simple logger. We actually only use very limited stuff from npmlog, so we can drop this dependency, which, as far as I can tell, is the only thing blocking us from supporting node 10.

This _does_ loose some coloring in the generated logs, but IMHO that is not that important - if we'd really want to, we can still bring this back with something like `chalk`.

Closes https://github.com/getsentry/sentry-cli/issues/1391