### PR TITLE
feat: Bash hook tags and extra data

### DIFF
--- a/src/bashsupport.sh
+++ b/src/bashsupport.sh
@@ -32,7 +32,7 @@ _sentry_err_trap() {
   echo "@exit_code:${_exit_code}" >> "$_SENTRY_TRACEBACK_FILE"
 
   : >> "$_SENTRY_LOG_FILE"
-  export SENTRY_LAST_EVENT=$(___SENTRY_CLI___ bash-hook --send-event --traceback "$_SENTRY_TRACEBACK_FILE" --log "$_SENTRY_LOG_FILE" ___SENTRY_NO_ENVIRON___)
+  export SENTRY_LAST_EVENT=$(/usr/local/bin/sentry-cli bash-hook --send-event --traceback "$_SENTRY_TRACEBACK_FILE" --tag "job_name:$CI_JOB_NAME" -e "job_id:$CI_JOB_ID" -e "job_url:CI_JOB_URL" --log "$_SENTRY_LOG_FILE")
   rm -f "$_SENTRY_TRACEBACK_FILE" "$_SENTRY_LOG_FILE"
 }
 

--- a/src/bashsupport.sh
+++ b/src/bashsupport.sh
@@ -18,30 +18,6 @@ _sentry_exit_trap() {
   exit $_exit_code
 }
 
-_sentry_gather_tags() {
-    TAGS=' '
-    for tag in $SENTRY_TAGS
-    do
-        if [[ $tag =~ [A-Za-z0-9_-]:[A-Za-z0-9_-] ]]
-        then
-            TAGS+="--tag ${tag} "
-        fi
-    done
-    echo $TAGS
-}
-
-_sentry_gather_extra() {
-    EXTRA=' '
-    for ex in $SENTRY_EXTRA
-    do
-        if [[ $ex =~ [A-Za-z0-9_-]:[A-Za-z0-9_-] ]]
-        then
-            EXTRA+="--extra ${ex} "
-        fi
-    done
-    echo $EXTRA
-}
-
 _sentry_err_trap() {
   local _exit_code="$?"
   local _command="${BASH_COMMAND:-unknown}"
@@ -56,9 +32,7 @@ _sentry_err_trap() {
   echo "@exit_code:${_exit_code}" >> "$_SENTRY_TRACEBACK_FILE"
 
   : >> "$_SENTRY_LOG_FILE"
-  HOOK_TAGS="$(_sentry_gather_tags)"
-  HOOK_EXTRA="$(_sentry_gather_extra)"
-  export SENTRY_LAST_EVENT=$(___SENTRY_CLI___ bash-hook --send-event --traceback "$_SENTRY_TRACEBACK_FILE" $HOOK_TAGS $HOOK_EXTRA --log "$_SENTRY_LOG_FILE" ___SENTRY_NO_ENVIRON___)
+  export SENTRY_LAST_EVENT=$(___SENTRY_CLI___ bash-hook --send-event --traceback "$_SENTRY_TRACEBACK_FILE" ___SENTRY_TAGS___ ___SENTRY_EXTRA___ --log "$_SENTRY_LOG_FILE" ___SENTRY_NO_ENVIRON___)
   rm -f "$_SENTRY_TRACEBACK_FILE" "$_SENTRY_LOG_FILE"
 }
 

--- a/src/commands/bash_hook.rs
+++ b/src/commands/bash_hook.rs
@@ -239,13 +239,15 @@ pub fn execute(matches: &ArgMatches) -> Result<()> {
     let mut hook_tags = "".to_string();
     for tag in tags {
         hook_tags.push_str(&"-t ".to_string());
-        hook_tags.push_str(&tag.to_string());
+        let tag_value = format!("\"{}\"", tag.to_string());
+        hook_tags.push_str(&tag_value.to_string());
     }
 
     let mut hook_extra = "".to_string();
     for ex in extra {
         hook_extra.push_str(&"--extra ".to_string());
-        hook_extra.push_str(&ex.to_string());
+        let extra_value = format!("\"{}\"", ex.to_string());
+        hook_extra.push_str(&extra_value.to_string());
     }
 
     if hook_tags.is_empty() {


### PR DESCRIPTION
Allow sending tags and extra data with the bash-hook. Tags and extra data are gathered from an environment using reserved environment variables.

Example:

```
#!/bin/bash

export SENTRY_DSN=https://1c08*****************************86f@o2******6.ingest.sentry.io/56***17
eval "$(sentry-cli bash-hook -e extra_a:123-ars -t tag_a: qwfp-45)"
ls non_existing_dir

```
Closes: [#1067](https://github.com/getsentry/sentry-cli/issues/1067)