### PR TITLE
chore: Add test for install script

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,7 +74,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: [10.x, 12.x, 14.x, 16.x]
+        node-version: [10.x, 12.x, 14.x, 16.x, 18.x]
 
     name: Test Node ${{ matrix.node-version }}
     runs-on: ubuntu-latest
@@ -92,3 +92,40 @@ jobs:
           SENTRYCLI_LOCAL_CDNURL: 'http://localhost:8999/'
 
       - run: npm test
+
+  test_install:
+    strategy:
+      fail-fast: false
+      matrix:
+        node-version: [10.x, 12.x, 14.x, 16.x, 18.x]
+
+    name: Test install script on Node ${{ matrix.node-version }}
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          path: sentry-cli-dep
+
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v1
+        with:
+          node-version: ${{ matrix.node-version }}
+
+      - name: Setup empty test app
+        run:  mkdir test-app && cd test-app && npm init --yes
+
+      - name: Install @sentry/cli
+        run: npm install ../sentry-cli-dep --install-links
+        working-directory: ./test-app
+
+      - name: Ensure binary is installed locally
+        run: npm run sentry-cli help
+        working-directory: ./test-app
+
+      - name: Ensure binary can be called from paths
+        run: |
+          node_modules/.bin/sentry-cli help
+          node_modules/@sentry/cli/sentry-cli help
+        working-directory: ./test-app
+

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -119,13 +119,15 @@ jobs:
         run: npm install ../sentry-cli-dep --install-links
         working-directory: ./test-app
 
-      - name: Ensure binary is installed locally
-        run: npm run sentry-cli help
-        working-directory: ./test-app
-
       - name: Ensure binary can be called from paths
         run: |
           node_modules/.bin/sentry-cli help
           node_modules/@sentry/cli/sentry-cli help
         working-directory: ./test-app
+
+      - name: Install @sentry/cli globally
+        run: npm install ./sentry-cli-dep --install-links -g
+
+      - name: Ensure binary is installed globally
+        run: sentry-cli help
 


### PR DESCRIPTION
While working on the install script, I noticed there aren't really any tests covering the install script (which made it hard to verify if everything works on different versions of node).

This PR adds a very basic test on CI that:

* Checks out the branch
* Creates a new, empty npm app
* Installs sentry-cli from the checked out branch
* Verifies the binary exists

I _hope_ the binary check is correct for what the install.js script does (it passes at least). But it should give at least a bit more security about changes to the install script!

Note that I also extended the test matrix to node 18, which is also LTS by now.