### PR TITLE
feat: Add --decompress option

### DIFF
--- a/js/__tests__/helper.test.js
+++ b/js/__tests__/helper.test.js
@@ -139,6 +139,15 @@ describe('SentryCli helper', () => {
         '?hash=1337',
       ]);
 
+      expect(helper.prepareCommand(command, SOURCEMAPS_OPTIONS, { decompress: true })).toEqual([
+        'releases',
+        'files',
+        'release',
+        'upload-sourcemaps',
+        '/dev/null',
+        '--decompress',
+      ]);
+
       expect(
         helper.prepareCommand(command, SOURCEMAPS_OPTIONS, { ignoreFile: '/js.ignore' })
       ).toEqual([

--- a/js/releases/index.js
+++ b/js/releases/index.js
@@ -146,7 +146,8 @@ class Releases {
    *   urlPrefix: '',             // add a prefix source map urls after stripping them
    *   urlSuffix: '',             // add a suffix source map urls after stripping them
    *   ext: ['js', 'map', 'jsbundle', 'bundle'],  // override file extensions to scan for
-   *   projects: ['node']        // provide a list of projects
+   *   projects: ['node'],        // provide a list of projects
+   *   decompress: false          // decompress gzip files before uploading
    * });
    *
    * @param {string} release Unique name of the release.

--- a/js/releases/options/uploadSourcemaps.js
+++ b/js/releases/options/uploadSourcemaps.js
@@ -11,6 +11,10 @@ module.exports = {
     param: '--dist',
     type: 'string',
   },
+  decompress: {
+    param: '--decompress',
+    type: 'boolean',
+  },
   rewrite: {
     param: '--rewrite',
     invertedParam: '--no-rewrite',


### PR DESCRIPTION
Adds the ability to pass the `--decompress` flag to the CLI from JS. Need this to deal with files compressed by gzip 

PR where the `--decompress` flag was added to the CLI: https://github.com/getsentry/sentry-cli/pull/1277

This PR is entirely based on this other PR: https://github.com/getsentry/sentry-cli/pull/373