### PR TITLE
fix: detect SENTRYCLI_NO_PROGRESS_BAR instead of SENTRY_NO_PROGRESS_BAR

### DIFF
--- a/src/utils/progress.rs
+++ b/src/utils/progress.rs
@@ -8,7 +8,7 @@ use crate::utils::logging;
 pub use indicatif::{ProgressDrawTarget, ProgressStyle};
 
 pub fn is_progress_bar_visible() -> bool {
-    env::var("SENTRY_NO_PROGRESS_BAR") != Ok("1".into())
+    env::var("SENTRYCLI_NO_PROGRESS_BAR") != Ok("1".into())
 }
 
 pub struct ProgressBar {


### PR DESCRIPTION
According to the [CHANGELOG](https://github.com/getsentry/sentry-cli/blob/master/CHANGELOG.md#removed-apis), `SENTRY_NO_PROGRESS_BAR` was replaced with `SENTRYCLI_NO_PROGRESS_BAR`, but a reference was left in the progress bar code.