### PR TITLE
Prevent Sentry from attempting to access unbound variables

### DIFF
--- a/src/bashsupport.sh
+++ b/src/bashsupport.sh
@@ -21,10 +21,10 @@ _sentry_exit_trap() {
 _sentry_err_trap() {
   local _exit_code="$?"
   local _command="${BASH_COMMAND:-unknown}"
-  if [ "x$1" != x ]; then
+  if [ $# -ge 1 ] && [ "x$1" != x ]; then
     _command="$1"
   fi
-  if [ "x$2" != x ]; then
+  if [ $# -ge 2 ] && [ "x$2" != x ]; then
     _exit_code="$2"
   fi
   _sentry_traceback 1

--- a/tests/integration/_cases/bash_hook/bash_hook.trycmd
+++ b/tests/integration/_cases/bash_hook/bash_hook.trycmd
@@ -26,10 +26,10 @@ _sentry_exit_trap() {
 _sentry_err_trap() {
   local _exit_code="$?"
   local _command="${BASH_COMMAND:-unknown}"
-  if [ "x$1" != x ]; then
+  if [ $# -ge 1 ] && [ "x$1" != x ]; then
     _command="$1"
   fi
-  if [ "x$2" != x ]; then
+  if [ $# -ge 2 ] && [ "x$2" != x ]; then
     _exit_code="$2"
   fi
   _sentry_traceback 1


### PR DESCRIPTION
Bash has a nifty feature `set -u` to error on unbound variables. This is also trappable (like with `set -e`), so Sentry can catch this.

However, Sentry itself may attempt to access arguments via `$1` and `$2`, which may not be set, which will trigger a bash error if `set -u` is used. This will create an error output: `./my_script.sh: line 42: $1: unbound variable`.

The proposed fix here will check for existence of `$1...$n` via the argument count `$#`, without accessing `$1...$n`, making it possible to use Sentry for bash scripts with `set -u`