### PR TITLE
feat(monitors): Report spawn failures

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -6,7 +6,7 @@ use std::path::Path;
 fn main() {
     let out_dir = env::var("OUT_DIR").unwrap();
     let dest_path = Path::new(&out_dir).join("constants.gen.rs");
-    let mut f = File::create(&dest_path).unwrap();
+    let mut f = File::create(dest_path).unwrap();
 
     let target = env::var("TARGET").unwrap();
     let mut target_bits = target.split('-');

--- a/src/commands/bash_hook.rs
+++ b/src/commands/bash_hook.rs
@@ -180,8 +180,8 @@ pub fn execute(matches: &ArgMatches) -> Result<()> {
     }
 
     let path = env::temp_dir();
-    let log = path.join(&format!(".sentry-{}.out", Uuid::new_v4().as_hyphenated()));
-    let traceback = path.join(&format!(
+    let log = path.join(format!(".sentry-{}.out", Uuid::new_v4().as_hyphenated()));
+    let traceback = path.join(format!(
         ".sentry-{}.traceback",
         Uuid::new_v4().as_hyphenated()
     ));

--- a/src/utils/appcenter.rs
+++ b/src/utils/appcenter.rs
@@ -174,7 +174,7 @@ pub fn get_react_native_appcenter_release(
         opts.case_sensitive = false;
 
         for entry in (glob_with("ios/*.xcodeproj", opts)?).flatten() {
-            let pi = XcodeProjectInfo::from_path(&entry)?;
+            let pi = XcodeProjectInfo::from_path(entry)?;
             if let Some(ipl) = InfoPlist::from_project_info(&pi)? {
                 if let Some(release_name) = get_xcode_release_name(Some(ipl))? {
                     let vec: Vec<&str> = release_name.split('@').collect();

--- a/src/utils/chunks.rs
+++ b/src/utils/chunks.rs
@@ -36,7 +36,7 @@ where
     T: Into<u64> + Copy,
 {
     fn size(&self) -> u64 {
-        (*self).into() as u64
+        (*self).into()
     }
 }
 

--- a/src/utils/codepush.rs
+++ b/src/utils/codepush.rs
@@ -113,7 +113,7 @@ pub fn get_react_native_codepush_release(
         let mut opts = MatchOptions::new();
         opts.case_sensitive = false;
         for entry in (glob_with("ios/*.xcodeproj", opts)?).flatten() {
-            let pi = XcodeProjectInfo::from_path(&entry)?;
+            let pi = XcodeProjectInfo::from_path(entry)?;
             if let Some(ipl) = InfoPlist::from_project_info(&pi)? {
                 if let Some(release_name) = get_xcode_release_name(Some(ipl))? {
                     return Ok(format!("{}+codepush:{}", release_name, package.label));

--- a/src/utils/xcode.rs
+++ b/src/utils/xcode.rs
@@ -199,7 +199,7 @@ impl InfoPlist {
             if let Some(filename) = vars.get("INFOPLIST_FILE") {
                 let base = vars.get("PROJECT_DIR").map(String::as_str).unwrap_or(".");
                 let path = env::current_dir().unwrap().join(base).join(filename);
-                Ok(Some(InfoPlist::load_and_process(&path, &vars)?))
+                Ok(Some(InfoPlist::load_and_process(path, &vars)?))
             } else if let Ok(default_plist) = InfoPlist::from_env_vars(&vars) {
                 Ok(Some(default_plist))
             } else {
@@ -236,7 +236,7 @@ impl InfoPlist {
                     let base = vars.get("PROJECT_DIR").map(Path::new)
                         .unwrap_or_else(|| pi.base_path());
                     let path = base.join(path);
-                    return Ok(Some(InfoPlist::load_and_process(&path, &vars)?))
+                    return Ok(Some(InfoPlist::load_and_process(path, &vars)?))
                 }
             }
         }
@@ -264,7 +264,7 @@ impl InfoPlist {
             }
             c.arg(path.as_ref());
             let p = c.output()?;
-            InfoPlist::from_reader(&mut Cursor::new(&p.stdout[..]))
+            InfoPlist::from_reader(Cursor::new(&p.stdout[..]))
         } else {
             InfoPlist::from_path(path).or_else(|err| {
                 /*


### PR DESCRIPTION
Previously if a monitor run tried to invoke a non existing binary the status of the monitor check-in remained as `in_progress`. With this change it will properly report as `error`.