### PR TITLE
feat(monitors): Pass SENTRY_MONITOR_ID to executing process

### DIFF
--- a/src/commands/monitors/run.rs
+++ b/src/commands/monitors/run.rs
@@ -56,6 +56,8 @@ pub fn execute(matches: &ArgMatches) -> Result<()> {
     let started = Instant::now();
     let mut p = process::Command::new(args[0]);
     p.args(&args[1..]);
+    p.env("SENTRY_MONITOR_ID", monitor.to_string());
+
     let (success, code) = match p.status() {
         Ok(status) => (status.success(), status.code()),
         Err(err) => {

--- a/tests/integration/_cases/monitors/monitors-run-env.trycmd
+++ b/tests/integration/_cases/monitors/monitors-run-env.trycmd
@@ -1,0 +1,6 @@
+```
+$ sentry-cli monitors run 85a34e5a-c0b6-11ec-9d64-0242ac120002 -- sh -c 'env | grep SENTRY_MONITOR_ID'
+? success
+SENTRY_MONITOR_ID=85a34e5a-c0b6-11ec-9d64-0242ac120002
+
+```

--- a/tests/integration/monitors/run.rs
+++ b/tests/integration/monitors/run.rs
@@ -14,6 +14,19 @@ fn command_monitors_run() {
 }
 
 #[test]
+fn command_monitors_run_env() {
+    let _server = mock_endpoint(
+        EndpointOptions::new(
+            "POST",
+            "/api/0/monitors/85a34e5a-c0b6-11ec-9d64-0242ac120002/checkins/",
+            200,
+        )
+        .with_response_file("monitors/post-monitors.json"),
+    );
+    register_test("monitors/monitors-run-env.trycmd");
+}
+
+#[test]
 fn command_monitors_run_invalid_uuid() {
     register_test("monitors/monitors-run-invalid-uuid.trycmd");
 }


### PR DESCRIPTION
This adds `SENTRY_MONITOR_ID` to the environ of the executing command.

This is in support of https://github.com/getsentry/sentry/issues/43647
and will allow SDKs embedded in the executing command to associate the
monitor context to any events produced by the SDK.