### PR TITLE
feat(monitors): Pass SENTRY_TRACE_ID down execution path

### DIFF
--- a/src/commands/monitors/run.rs
+++ b/src/commands/monitors/run.rs
@@ -43,8 +43,6 @@ pub fn execute(matches: &ArgMatches) -> Result<()> {
         .map(|x| x.parse::<Uuid>().unwrap())
         .unwrap();
 
-    let trace_id = Uuid::new_v4();
-
     let allow_failure = matches.is_present("allow_failure");
     let args: Vec<_> = matches.values_of("args").unwrap().collect();
 
@@ -61,9 +59,9 @@ pub fn execute(matches: &ArgMatches) -> Result<()> {
     p.env("SENTRY_MONITOR_ID", monitor.to_string());
 
     // Inherit outer SENTRY_TRACE_ID if present
-    if env::var_os("SENTRY_TRACE_ID").is_none() {
-        p.env("SENTRY_TRACE_ID", trace_id.to_string().replace("-", ""));
-    }
+    let trace_id = env::var_os("SENTRY_TRACE_ID")
+        .unwrap_or_else(|| Uuid::new_v4().simple().to_string().into());
+    p.env("SENTRY_TRACE_ID", trace_id);
 
     let (success, code) = match p.status() {
         Ok(status) => (status.success(), status.code()),

--- a/tests/integration/_cases/monitors/monitors-run-env.trycmd
+++ b/tests/integration/_cases/monitors/monitors-run-env.trycmd
@@ -1,6 +1,7 @@
 ```
-$ sentry-cli monitors run 85a34e5a-c0b6-11ec-9d64-0242ac120002 -- sh -c 'env | grep SENTRY_MONITOR_ID'
+$ sentry-cli monitors run 85a34e5a-c0b6-11ec-9d64-0242ac120002 -- sh -c 'env | grep -E "SENTRY_MONITOR_ID|SENTRY_TRACE_ID"'
 ? success
 SENTRY_MONITOR_ID=85a34e5a-c0b6-11ec-9d64-0242ac120002
+SENTRY_TRACE_ID=[..]
 
 ```

--- a/tests/integration/_cases/monitors/monitors-run-env.trycmd
+++ b/tests/integration/_cases/monitors/monitors-run-env.trycmd
@@ -1,5 +1,5 @@
 ```
-$ sentry-cli monitors run 85a34e5a-c0b6-11ec-9d64-0242ac120002 -- sh -c 'env | grep -E "SENTRY_MONITOR_ID|SENTRY_TRACE_ID"'
+$ sentry-cli monitors run 85a34e5a-c0b6-11ec-9d64-0242ac120002 -- sh -c 'env | sort | grep -E "SENTRY_MONITOR_ID|SENTRY_TRACE_ID"'
 ? success
 SENTRY_MONITOR_ID=85a34e5a-c0b6-11ec-9d64-0242ac120002
 SENTRY_TRACE_ID=[..]


### PR DESCRIPTION
This adds `SENTRY_TRACE_ID` to the environ of the executing command.

This is in support of https://github.com/getsentry/sentry/issues/43647
and will allow SDKs embedded in the executing command to associate the
monitor checkin to any events produced by the SDK.

This is the second part of #1438 