### PR TITLE
chore(backport): Replace `npmlog` dependency in order to avoid vulnerability

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,4 +90,8 @@ jobs:
         env:
           SENTRYCLI_LOCAL_CDNURL: "http://localhost:8999/"
 
+      # older node versions need an older nft
+      - run: npm install @vercel/nft@0.22.1
+        if: matrix.node-version == '10.x' || matrix.node-version == '12.x'
+
       - run: npm test

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -66,18 +66,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "arrayref"
-version = "0.3.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4c527152e37cf757a3f78aae5a06fbeefdb07ccc535c980a3208ee3060dd544"
-
-[[package]]
-name = "arrayvec"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23b62fc65de8e4e7f52534fb52b0f3ed04746ae267519eef2a83941e8085068b"
-
-[[package]]
 name = "arrayvec"
 version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -99,7 +87,7 @@ version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
 dependencies = [
- "hermit-abi",
+ "hermit-abi 0.1.19",
  "libc",
  "winapi 0.3.9",
 ]
@@ -116,7 +104,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9fe17f59a06fe8b87a6fc8bf53bb70b3aba76d7685f432487a68cd5552853625"
 dependencies = [
- "getrandom 0.2.4",
+ "getrandom",
  "instant",
  "rand",
 ]
@@ -170,17 +158,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "blake2b_simd"
-version = "0.5.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "afa748e348ad3be8263be728124b24a24f268266f6f5d58af9d75f6a40b5c587"
-dependencies = [
- "arrayref",
- "arrayvec 0.5.2",
- "constant_time_eq",
-]
-
-[[package]]
 name = "block-buffer"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -227,7 +204,7 @@ version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "030ea61398f34f1395ccbeb046fb68c87b631d1f34567fed0f0f11fa35d18d8d"
 dependencies = [
- "arrayvec 0.7.2",
+ "arrayvec",
 ]
 
 [[package]]
@@ -373,7 +350,7 @@ version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a28b32d32ca44b70c3e4acd7db1babf555fa026e385fb95f18028f88848b3c31"
 dependencies = [
- "encode_unicode",
+ "encode_unicode 0.3.6",
  "libc",
  "once_cell",
  "regex",
@@ -381,12 +358,6 @@ dependencies = [
  "unicode-width",
  "winapi 0.3.9",
 ]
-
-[[package]]
-name = "constant_time_eq"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "245097e9a4535ee1e3e3931fcfcd55a796a44c643e8596ff6566d68f09b87bbc"
 
 [[package]]
 name = "content_inspector"
@@ -529,22 +500,21 @@ dependencies = [
 
 [[package]]
 name = "dirs"
-version = "1.0.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fd78930633bd1c6e35c4b42b1df7b0cbc6bc191146e512bb3bedf243fcc3901"
-dependencies = [
- "libc",
- "redox_users 0.3.5",
- "winapi 0.3.9",
-]
-
-[[package]]
-name = "dirs"
 version = "3.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "30baa043103c9d0c2a57cf537cc2f35623889dc0d405e6c3cccfadbc81c71309"
 dependencies = [
  "dirs-sys",
+]
+
+[[package]]
+name = "dirs-next"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b98cf8ebf19c3d1b223e151f99a4f9f0690dca41414773390fc824184ac833e1"
+dependencies = [
+ "cfg-if",
+ "dirs-sys-next",
 ]
 
 [[package]]
@@ -554,7 +524,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "03d86534ed367a67548dc68113a0f5db55432fdfbb6e6f9d77704397d95d5780"
 dependencies = [
  "libc",
- "redox_users 0.4.0",
+ "redox_users",
+ "winapi 0.3.9",
+]
+
+[[package]]
+name = "dirs-sys-next"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ebda144c4fe02d1f7ea1a7d9641b6fc6b580adcfa024ae48797ecdeb6825b4d"
+dependencies = [
+ "libc",
+ "redox_users",
  "winapi 0.3.9",
 ]
 
@@ -616,6 +597,12 @@ name = "encode_unicode"
 version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a357d28ed41a50f9c765dbfe56cbc04a64e53e5fc58ba79fbc34c10ef3df831f"
+
+[[package]]
+name = "encode_unicode"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0"
 
 [[package]]
 name = "encoding"
@@ -682,6 +669,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a246d82be1c9d791c5dfde9a2bd045fc3cbba3fa2b11ad558f27d01712f00569"
 
 [[package]]
+name = "errno"
+version = "0.2.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f639046355ee4f37944e44f60642c6f3a7efa3cf6b78c78a0d989a8ce6c396a1"
+dependencies = [
+ "errno-dragonfly",
+ "libc",
+ "winapi 0.3.9",
+]
+
+[[package]]
+name = "errno-dragonfly"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa68f1b12764fab894d2755d2518754e71b4fd80ecfb822714a1206c2aab39bf"
+dependencies = [
+ "cc",
+ "libc",
+]
+
+[[package]]
 name = "failure"
 version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -732,7 +740,7 @@ checksum = "975ccf83d8d9d0d84682850a38c8169027be83368805971cc4f238c2b245bc98"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall 0.2.10",
+ "redox_syscall",
  "winapi 0.3.9",
 ]
 
@@ -790,24 +798,13 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.1.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fc3cb4d91f53b50155bdcfd23f6a4c39ae1969c2ae85982b135750cccaf5fce"
-dependencies = [
- "cfg-if",
- "libc",
- "wasi 0.9.0+wasi-snapshot-preview1",
-]
-
-[[package]]
-name = "getrandom"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "418d37c8b1d42553c93648be529cb70f920d3baf8ef469b74b9638df426e0b4c"
 dependencies = [
  "cfg-if",
  "libc",
- "wasi 0.10.0+wasi-snapshot-preview1",
+ "wasi",
 ]
 
 [[package]]
@@ -883,6 +880,15 @@ name = "hermit-abi"
 version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "hermit-abi"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee512640fe35acbfb4bb779db6f0d80704c2cacfa2e39b601ef3e3f47d1ae4c7"
 dependencies = [
  "libc",
 ]
@@ -1021,6 +1027,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "io-lifetimes"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7d6c6f8c91b4b9ed43484ad1a938e393caf35960fce7f82a040497207bd8e9e"
+dependencies = [
+ "libc",
+ "windows-sys 0.42.0",
+]
+
+[[package]]
+name = "is-terminal"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28dfb6c8100ccc63462345b67d1bbc3679177c75ee4bf59bf29c8b1d110b8189"
+dependencies = [
+ "hermit-abi 0.2.6",
+ "io-lifetimes",
+ "rustix",
+ "windows-sys 0.42.0",
+]
+
+[[package]]
 name = "itertools"
 version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1090,9 +1118,9 @@ checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "libc"
-version = "0.2.115"
+version = "0.2.139"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a8d982fa7a96a000f6ec4cfe966de9703eccde29750df2bb8949da91b0e818d"
+checksum = "201de327520df007757c1f0adce6e827fe8562fbc28bfd9c15571c66ca1f5f79"
 
 [[package]]
 name = "libgit2-sys"
@@ -1132,6 +1160,12 @@ name = "linked-hash-map"
 version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7fb9b38af92608140b86b693604b9ffcc5824240a484d1ecd4795bacb2fe88f3"
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f051f77a7c8e6957c0696eac88f26b0117e54f52d3fc682ab19397a8812846a4"
 
 [[package]]
 name = "lock_api"
@@ -1301,7 +1335,7 @@ version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19e64526ebdee182341572e50e9ad03965aa510cd94427a4549448f285e957a1"
 dependencies = [
- "hermit-abi",
+ "hermit-abi 0.1.19",
  "libc",
 ]
 
@@ -1451,7 +1485,7 @@ dependencies = [
  "cfg-if",
  "instant",
  "libc",
- "redox_syscall 0.2.10",
+ "redox_syscall",
  "smallvec",
  "winapi 0.3.9",
 ]
@@ -1464,9 +1498,9 @@ checksum = "28141e0cc4143da2443301914478dc976a61ffdb3f043058310c70df2fed8954"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall 0.2.10",
+ "redox_syscall",
  "smallvec",
- "windows-sys",
+ "windows-sys 0.32.0",
 ]
 
 [[package]]
@@ -1616,13 +1650,13 @@ checksum = "da1c2388b1513e1b605fcec39a95e0a9e8ef088f71443ef37099fa9ae6673fcb"
 
 [[package]]
 name = "prettytable-rs"
-version = "0.8.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fd04b170004fa2daccf418a7f8253aaf033c27760b5f225889024cf66d7ac2e"
+checksum = "eea25e07510aa6ab6547308ebe3c036016d162b8da920dbb079e3ba8acf3d95a"
 dependencies = [
- "atty",
  "csv",
- "encode_unicode",
+ "encode_unicode 1.0.0",
+ "is-terminal",
  "lazy_static",
  "term",
  "unicode-width",
@@ -1719,7 +1753,7 @@ version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d34f1408f55294453790c48b2f1ebbb1c5b4b7563eb1f418bcfcfdbb06ebb4e7"
 dependencies = [
- "getrandom 0.2.4",
+ "getrandom",
 ]
 
 [[package]]
@@ -1758,12 +1792,6 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.1.57"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41cc0f7e4d5d4544e8861606a285bb08d3e70712ccc7d2b84d7c0ccfaf4b05ce"
-
-[[package]]
-name = "redox_syscall"
 version = "0.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8383f39639269cde97d255a32bdb68c047337295414940c68bdd30c2e13203ff"
@@ -1773,23 +1801,12 @@ dependencies = [
 
 [[package]]
 name = "redox_users"
-version = "0.3.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de0737333e7a9502c789a36d7c7fa6092a49895d4faa31ca5df163857ded2e9d"
-dependencies = [
- "getrandom 0.1.16",
- "redox_syscall 0.1.57",
- "rust-argon2",
-]
-
-[[package]]
-name = "redox_users"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "528532f3d801c87aec9def2add9ca802fe569e44a544afe633765267840abe64"
 dependencies = [
- "getrandom 0.2.4",
- "redox_syscall 0.2.10",
+ "getrandom",
+ "redox_syscall",
 ]
 
 [[package]]
@@ -1835,18 +1852,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rust-argon2"
-version = "0.8.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b18820d944b33caa75a71378964ac46f58517c92b6ae5f762636247c09e78fb"
-dependencies = [
- "base64 0.13.0",
- "blake2b_simd",
- "constant_time_eq",
- "crossbeam-utils",
-]
-
-[[package]]
 name = "rust-ini"
 version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1870,6 +1875,26 @@ checksum = "138e3e0acb6c9fb258b19b67cb8abd63c00679d2851805ea151465464fe9030a"
 dependencies = [
  "semver 0.9.0",
 ]
+
+[[package]]
+name = "rustix"
+version = "0.36.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4fdebc4b395b7fbb9ab11e462e20ed9051e7b16e42d24042c776eca0ac81b03"
+dependencies = [
+ "bitflags",
+ "errno",
+ "io-lifetimes",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys 0.42.0",
+]
+
+[[package]]
+name = "rustversion"
+version = "1.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5583e89e108996506031660fe09baa5011b9dd0341b89029313006d1fb508d70"
 
 [[package]]
 name = "ryu"
@@ -2013,7 +2038,7 @@ dependencies = [
  "console",
  "crossbeam-channel",
  "curl",
- "dirs 3.0.2",
+ "dirs",
  "dotenv",
  "elementtree 0.5.0",
  "encoding",
@@ -2415,19 +2440,19 @@ dependencies = [
  "cfg-if",
  "fastrand",
  "libc",
- "redox_syscall 0.2.10",
+ "redox_syscall",
  "remove_dir_all",
  "winapi 0.3.9",
 ]
 
 [[package]]
 name = "term"
-version = "0.5.2"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edd106a334b7657c10b7c540a0106114feadeb4dc314513e97df481d5d966f42"
+checksum = "c59df8ac95d96ff9bede18eb7300b0fda5e5d8d90960e76f8e14ae765eedbf1f"
 dependencies = [
- "byteorder",
- "dirs 1.0.5",
+ "dirs-next",
+ "rustversion",
  "winapi 0.3.9",
 ]
 
@@ -2497,7 +2522,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6db9e6914ab8b1ae1c260a4ae7a49b6c5611b40328a735b21862567685e73255"
 dependencies = [
  "libc",
- "wasi 0.10.0+wasi-snapshot-preview1",
+ "wasi",
  "winapi 0.3.9",
 ]
 
@@ -2659,7 +2684,7 @@ version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bc5cf98d8186244414c848017f0e2676b3fcb46807f6668a97dfe67359a3c4b7"
 dependencies = [
- "getrandom 0.2.4",
+ "getrandom",
  "serde",
  "sha1",
 ]
@@ -2695,12 +2720,6 @@ dependencies = [
  "winapi 0.3.9",
  "winapi-util",
 ]
-
-[[package]]
-name = "wasi"
-version = "0.9.0+wasi-snapshot-preview1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519"
 
 [[package]]
 name = "wasi"
@@ -2784,12 +2803,33 @@ version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3df6e476185f92a12c072be4a189a0210dcdcf512a1891d6dff9edb874deadc6"
 dependencies = [
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_msvc",
+ "windows_aarch64_msvc 0.32.0",
+ "windows_i686_gnu 0.32.0",
+ "windows_i686_msvc 0.32.0",
+ "windows_x86_64_gnu 0.32.0",
+ "windows_x86_64_msvc 0.32.0",
 ]
+
+[[package]]
+name = "windows-sys"
+version = "0.42.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a3e1820f08b8513f676f7ab6c1f99ff312fb97b553d30ff4dd86f9f15728aa7"
+dependencies = [
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc 0.42.1",
+ "windows_i686_gnu 0.42.1",
+ "windows_i686_msvc 0.42.1",
+ "windows_x86_64_gnu 0.42.1",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc 0.42.1",
+]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.42.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c9864e83243fdec7fc9c5444389dcbbfd258f745e7853198f365e3c4968a608"
 
 [[package]]
 name = "windows_aarch64_msvc"
@@ -2798,10 +2838,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8e92753b1c443191654ec532f14c199742964a061be25d77d7a96f09db20bf5"
 
 [[package]]
+name = "windows_aarch64_msvc"
+version = "0.42.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c8b1b673ffc16c47a9ff48570a9d85e25d265735c503681332589af6253c6c7"
+
+[[package]]
 name = "windows_i686_gnu"
 version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a711c68811799e017b6038e0922cb27a5e2f43a2ddb609fe0b6f3eeda9de615"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.42.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de3887528ad530ba7bdbb1faa8275ec7a1155a45ffa57c37993960277145d640"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -2810,16 +2862,40 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "146c11bb1a02615db74680b32a68e2d61f553cc24c4eb5b4ca10311740e44172"
 
 [[package]]
+name = "windows_i686_msvc"
+version = "0.42.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf4d1122317eddd6ff351aa852118a2418ad4214e6613a50e0191f7004372605"
+
+[[package]]
 name = "windows_x86_64_gnu"
 version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c912b12f7454c6620635bbff3450962753834be2a594819bd5e945af18ec64bc"
 
 [[package]]
+name = "windows_x86_64_gnu"
+version = "0.42.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1040f221285e17ebccbc2591ffdc2d44ee1f9186324dd3e84e99ac68d699c45"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.42.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "628bfdf232daa22b0d64fdb62b09fcc36bb01f05a3939e20ab73aaf9470d0463"
+
+[[package]]
 name = "windows_x86_64_msvc"
 version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "504a2476202769977a040c6364301a3f65d0cc9e3fb08600b2bda150a0488316"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.42.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "447660ad36a13288b1db4d4248e857b510e8c3a225c822ba4fb748c0aafecffd"
 
 [[package]]
 name = "wyz"
@@ -2836,7 +2912,7 @@ version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a23fe958c70412687039c86f578938b4a0bb50ec788e96bce4d6ab00ddd5803"
 dependencies = [
- "dirs 3.0.2",
+ "dirs",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,7 +38,7 @@ open = "1.4.0"
 parking_lot = "0.11.2"
 percent-encoding = "2.1.0"
 plist = "1.3.1"
-prettytable-rs = "0.8.0"
+prettytable-rs = "0.10.0"
 proguard = { version = "4.1.1", features = ["uuid"] }
 r2d2 = "0.8.9"
 rayon = "1.5.1"

--- a/build.rs
+++ b/build.rs
@@ -6,7 +6,7 @@ use std::path::Path;
 fn main() {
     let out_dir = env::var("OUT_DIR").unwrap();
     let dest_path = Path::new(&out_dir).join("constants.gen.rs");
-    let mut f = File::create(&dest_path).unwrap();
+    let mut f = File::create(dest_path).unwrap();
 
     let target = env::var("TARGET").unwrap();
     let mut target_bits = target.split('-');
@@ -21,10 +21,10 @@ fn main() {
     }
 
     writeln!(f, "/// The platform identifier").ok();
-    writeln!(f, "pub const PLATFORM: &str = \"{}\";", platform).ok();
+    writeln!(f, "pub const PLATFORM: &str = \"{platform}\";").ok();
     writeln!(f, "/// The CPU architecture identifier").ok();
-    writeln!(f, "pub const ARCH: &str = \"{}\";", arch).ok();
+    writeln!(f, "pub const ARCH: &str = \"{arch}\";").ok();
     writeln!(f, "/// The user agent for sentry events").ok();
-    writeln!(f, "pub const USER_AGENT: &str = \"sentry-cli/{}\";", arch).ok();
+    writeln!(f, "pub const USER_AGENT: &str = \"sentry-cli/{arch}\";").ok();
     println!("cargo:rerun-if-changed=build.rs\n");
 }

--- a/js/logger.js
+++ b/js/logger.js
@@ -1,0 +1,14 @@
+'use strict';
+
+const format = require('util').format;
+
+module.exports = class Logger {
+  constructor(stream) {
+    this.stream = stream;
+  }
+
+  log() {
+    const message = format(...arguments);
+    this.stream.write(`[sentry-cli] ${message}\n`);
+  }
+};

--- a/package.json
+++ b/package.json
@@ -39,7 +39,6 @@
     "https-proxy-agent": "^5.0.0",
     "mkdirp": "^0.5.5",
     "node-fetch": "^2.6.7",
-    "npmlog": "^4.1.2",
     "progress": "^2.0.3",
     "proxy-from-env": "^1.1.0",
     "which": "^2.0.2"
@@ -54,14 +53,15 @@
     "npm-run-all": "^4.1.5",
     "prettier": "^1.19.1"
   },
-  "resolutions": {
-    "npmlog/**/ansi-regex": "^3.0.1"
-  },
   "jest": {
     "collectCoverage": true,
     "testEnvironment": "node",
     "testPathIgnorePatterns": [
       "src/utils"
     ]
+  },
+  "volta": {
+    "node": "10.24.1",
+    "yarn": "1.22.19"
   }
 }

--- a/src/api.rs
+++ b/src/api.rs
@@ -205,7 +205,7 @@ impl fmt::Display for SentryError {
             self.status
         )?;
         if let Some(ref extra) = self.extra {
-            write!(f, "\n  {:?}", extra)?;
+            write!(f, "\n  {extra:?}")?;
         }
         Ok(())
     }
@@ -648,9 +648,9 @@ impl Api {
         }
 
         if let Some(headers) = headers {
-            for &(ref key, ref value) in headers {
+            for (key, value) in headers {
                 form.part("header")
-                    .contents(format!("{}:{}", key, value).as_bytes())
+                    .contents(format!("{key}:{value}").as_bytes())
                     .add()?;
             }
         }
@@ -1593,12 +1593,12 @@ impl ApiRequest {
             Some(env) => {
                 debug!("pipeline: {}", env);
                 headers
-                    .append(&format!("User-Agent: sentry-cli/{} {}", VERSION, env))
+                    .append(&format!("User-Agent: sentry-cli/{VERSION} {env}"))
                     .ok();
             }
             None => {
                 headers
-                    .append(&format!("User-Agent: sentry-cli/{}", VERSION))
+                    .append(&format!("User-Agent: sentry-cli/{VERSION}"))
                     .ok();
             }
         }
@@ -1650,7 +1650,7 @@ impl ApiRequest {
             }
             Auth::Token(ref token) => {
                 debug!("using token authentication");
-                self.with_header("Authorization", &format!("Bearer {}", token))
+                self.with_header("Authorization", &format!("Bearer {token}"))
             }
         }
     }
@@ -1658,7 +1658,7 @@ impl ApiRequest {
     /// adds a specific header to the request
     pub fn with_header(mut self, key: &str, value: &str) -> ApiResult<Self> {
         let value = value.trim().lines().next().unwrap_or("");
-        self.headers.append(&format!("{}: {}", key, value))?;
+        self.headers.append(&format!("{key}: {value}"))?;
         Ok(self)
     }
 
@@ -1959,7 +1959,7 @@ pub struct Artifact {
 }
 
 impl Artifact {
-    pub fn get_header<'a, 'b>(&'a self, key: &'b str) -> Option<&'a str> {
+    pub fn get_header<'a>(&'a self, key: &str) -> Option<&'a str> {
         let ikey = key.to_lowercase();
         for (k, v) in &self.headers {
             if k.to_lowercase() == ikey {
@@ -2171,11 +2171,11 @@ impl IssueFilter {
                     return None;
                 }
                 for id in ids {
-                    rv.push(format!("id={}", id));
+                    rv.push(format!("id={id}"));
                 }
             }
             IssueFilter::Status(ref status) => {
-                rv.push(format!("status={}", status));
+                rv.push(format!("status={status}"));
             }
         }
         Some(rv.join("&"))
@@ -2266,7 +2266,7 @@ impl fmt::Display for Repo {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{}:{}", &self.provider.id, &self.id)?;
         if let Some(ref url) = self.url {
-            write!(f, " ({})", url)?;
+            write!(f, " ({url})")?;
         }
         Ok(())
     }

--- a/src/commands/bash_hook.rs
+++ b/src/commands/bash_hook.rs
@@ -158,7 +158,7 @@ fn send_event(traceback: &str, logfile: &str, environ: bool) -> Result<(), Error
 
     event.exception.values.push(Exception {
         ty: "BashError".into(),
-        value: Some(format!("command {} exited with status {}", cmd, exit_code)),
+        value: Some(format!("command {cmd} exited with status {exit_code}")),
         stacktrace: Some(Stacktrace {
             frames,
             ..Default::default()
@@ -167,7 +167,7 @@ fn send_event(traceback: &str, logfile: &str, environ: bool) -> Result<(), Error
     });
 
     let id = with_sentry_client(config.get_dsn()?, |c| c.capture_event(event, None));
-    println!("{}", id);
+    println!("{id}");
 
     Ok(())
 }
@@ -182,11 +182,11 @@ pub fn execute(matches: &ArgMatches<'_>) -> Result<(), Error> {
     }
 
     let path = env::temp_dir();
-    let log = path.join(&format!(
+    let log = path.join(format!(
         ".sentry-{}.out",
         Uuid::new_v4().to_hyphenated_ref()
     ));
-    let traceback = path.join(&format!(
+    let traceback = path.join(format!(
         ".sentry-{}.traceback",
         Uuid::new_v4().to_hyphenated_ref()
     ));
@@ -215,6 +215,6 @@ pub fn execute(matches: &ArgMatches<'_>) -> Result<(), Error> {
     if !matches.is_present("no_exit") {
         script.insert_str(0, "set -e\n\n");
     }
-    println!("{}", script);
+    println!("{script}");
     Ok(())
 }

--- a/src/commands/difutil_bundle_sources.rs
+++ b/src/commands/difutil_bundle_sources.rs
@@ -87,14 +87,14 @@ pub fn execute(matches: &ArgMatches<'_>) -> Result<(), Error> {
         for (index, object) in archive.get().objects().enumerate() {
             let object = object?;
             if object.has_sources() {
-                eprintln!("skipped {} (no source info)", orig_path);
+                eprintln!("skipped {orig_path} (no source info)");
                 continue;
             }
 
             let mut out = output_path.unwrap_or(parent_path).join(filename);
             match index {
                 0 => out.set_extension("src.zip"),
-                index => out.set_extension(&format!("{}.src.zip", index)),
+                index => out.set_extension(&format!("{index}.src.zip")),
             };
 
             fs::create_dir_all(out.parent().unwrap())?;
@@ -110,7 +110,7 @@ pub fn execute(matches: &ArgMatches<'_>) -> Result<(), Error> {
             )?;
 
             if !written {
-                eprintln!("skipped {} (no files found)", orig_path);
+                eprintln!("skipped {orig_path} (no files found)");
                 fs::remove_file(&out)?;
                 continue;
             } else {

--- a/src/commands/difutil_check.rs
+++ b/src/commands/difutil_check.rs
@@ -76,7 +76,7 @@ pub fn execute(matches: &ArgMatches<'_>) -> Result<(), Error> {
     println!("    > {}", dif.features());
 
     if let Some(msg) = dif.get_note() {
-        println!("  Note: {}", msg);
+        println!("  Note: {msg}");
     }
 
     if let Some(prob) = dif.get_problem() {

--- a/src/commands/difutil_id.rs
+++ b/src/commands/difutil_id.rs
@@ -54,7 +54,7 @@ pub fn execute(matches: &ArgMatches<'_>) -> Result<(), Error> {
 
     if !matches.is_present("json") {
         for id in f.ids() {
-            println!("{}", id);
+            println!("{id}");
         }
     } else if matches.is_present("json") {
         serde_json::to_writer_pretty(&mut io::stdout(), &f.ids())?;

--- a/src/commands/info.rs
+++ b/src/commands/info.rs
@@ -102,12 +102,12 @@ pub fn execute(matches: &ArgMatches<'_>) -> Result<(), Error> {
                     if let Some(ref auth) = info.auth {
                         println!("  Scopes:");
                         for scope in &auth.scopes {
-                            println!("    - {}", scope);
+                            println!("    - {scope}");
                         }
                     }
                 }
                 Err(err) => {
-                    println!("  (failure on authentication: {})", err);
+                    println!("  (failure on authentication: {err})");
                 }
             }
         }

--- a/src/commands/issues.rs
+++ b/src/commands/issues.rs
@@ -78,7 +78,7 @@ fn execute_change(
     if Api::current().bulk_update_issue(org, project, filter, changes)? {
         println!("Updated matching issues.");
         if let Some(status) = changes.new_status.as_ref() {
-            println!("  new status: {}", status);
+            println!("  new status: {status}");
         }
     } else {
         println!("No changes requested.");

--- a/src/commands/login.rs
+++ b/src/commands/login.rs
@@ -58,7 +58,7 @@ pub fn execute(matches: &ArgMatches<'_>) -> Result<(), Error> {
                 break;
             }
             Err(err) => {
-                println!("Invalid token: {}", err);
+                println!("Invalid token: {err}");
             }
         }
     }

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -182,7 +182,7 @@ impl<'a> fmt::Display for DebugArgs<'a> {
             if idx > 0 {
                 write!(f, " ")?;
             }
-            write!(f, "{:?}", arg)?;
+            write!(f, "{arg:?}")?;
         }
         Ok(())
     }

--- a/src/commands/monitors.rs
+++ b/src/commands/monitors.rs
@@ -71,7 +71,7 @@ pub fn execute(matches: &ArgMatches<'_>) -> Result<(), Error> {
     unreachable!();
 }
 
-fn execute_list<'a>(ctx: &MonitorContext, _matches: &ArgMatches<'a>) -> Result<(), Error> {
+fn execute_list(ctx: &MonitorContext, _matches: &ArgMatches) -> Result<(), Error> {
     let mut monitors = ctx.api.list_organization_monitors(ctx.get_org()?)?;
     monitors.sort_by_key(|p| (p.name.clone()));
 
@@ -91,7 +91,7 @@ fn execute_list<'a>(ctx: &MonitorContext, _matches: &ArgMatches<'a>) -> Result<(
     Ok(())
 }
 
-fn execute_run<'a>(ctx: &MonitorContext, matches: &ArgMatches<'a>) -> Result<(), Error> {
+fn execute_run(ctx: &MonitorContext, matches: &ArgMatches) -> Result<(), Error> {
     let monitor = matches
         .value_of("monitor")
         .unwrap()
@@ -134,7 +134,7 @@ fn execute_run<'a>(ctx: &MonitorContext, matches: &ArgMatches<'a>) -> Result<(),
         }
         Err(e) => {
             if allow_failure {
-                eprintln!("{}", e);
+                eprintln!("{e}");
             } else {
                 return Err(e.into());
             }

--- a/src/commands/react_native_appcenter.rs
+++ b/src/commands/react_native_appcenter.rs
@@ -125,7 +125,7 @@ pub fn execute(matches: &ArgMatches<'_>) -> Result<(), Error> {
         matches.value_of("release_name"),
     )?;
     if print_release_name {
-        println!("{}", release);
+        println!("{release}");
         return Ok(());
     }
 
@@ -144,7 +144,7 @@ pub fn execute(matches: &ArgMatches<'_>) -> Result<(), Error> {
                    ext == OsStr::new("map") ||
                    ext == OsStr::new("bundle");
                 then {
-                    let url = format!("~/{}", filename);
+                    let url = format!("~/{filename}");
                     processor.add(&url, ReleaseFileSearch::collect_file(entry.path())?)?;
                 }
             }

--- a/src/commands/react_native_codepush.rs
+++ b/src/commands/react_native_codepush.rs
@@ -99,7 +99,7 @@ pub fn execute(matches: &ArgMatches<'_>) -> Result<(), Error> {
     let release =
         get_react_native_codepush_release(&package, platform, matches.value_of("bundle_id"))?;
     if print_release_name {
-        println!("{}", release);
+        println!("{release}");
         return Ok(());
     }
 
@@ -118,7 +118,7 @@ pub fn execute(matches: &ArgMatches<'_>) -> Result<(), Error> {
                    ext == OsStr::new("map") ||
                    ext == OsStr::new("bundle");
                 then {
-                    let url = format!("~/{}", filename);
+                    let url = format!("~/{filename}");
                     processor.add(&url, ReleaseFileSearch::collect_file(entry.path())?)?;
                 }
             }

--- a/src/commands/react_native_xcode.rs
+++ b/src/commands/react_native_xcode.rs
@@ -198,11 +198,11 @@ pub fn execute(matches: &ArgMatches<'_>) -> Result<(), Error> {
             }
 
             api.download(
-                &format!("{}/index.ios.bundle?platform=ios&dev=true", url),
+                &format!("{url}/index.ios.bundle?platform=ios&dev=true"),
                 &mut bundle_file.open()?,
             )?;
             api.download(
-                &format!("{}/index.ios.map?platform=ios&dev=true", url),
+                &format!("{url}/index.ios.map?platform=ios&dev=true"),
                 &mut sourcemap_file.open()?,
             )?;
 

--- a/src/commands/releases.rs
+++ b/src/commands/releases.rs
@@ -50,7 +50,7 @@ impl<'a> ReleaseContext<'a> {
         self.get_projects(matches).map(|p| p[0].clone())
     }
 
-    pub fn get_projects(&'a self, matches: &ArgMatches<'a>) -> Result<Vec<String>, Error> {
+    pub fn get_projects(&'a self, matches: &ArgMatches) -> Result<Vec<String>, Error> {
         if let Some(projects) = matches.values_of("project") {
             Ok(projects.map(str::to_owned).collect())
         } else if let Some(project) = self.project_default {
@@ -444,7 +444,7 @@ fn path_as_url(path: &Path) -> String {
     path.display().to_string()
 }
 
-fn execute_new<'a>(ctx: &ReleaseContext<'_>, matches: &ArgMatches<'a>) -> Result<(), Error> {
+fn execute_new(ctx: &ReleaseContext<'_>, matches: &ArgMatches) -> Result<(), Error> {
     let version = matches.value_of("version").unwrap();
     ctx.api.new_release(
         ctx.get_org()?,
@@ -460,11 +460,11 @@ fn execute_new<'a>(ctx: &ReleaseContext<'_>, matches: &ArgMatches<'a>) -> Result
             },
         },
     )?;
-    println!("Created release {}.", version);
+    println!("Created release {version}.");
     Ok(())
 }
 
-fn execute_finalize<'a>(ctx: &ReleaseContext<'_>, matches: &ArgMatches<'a>) -> Result<(), Error> {
+fn execute_finalize(ctx: &ReleaseContext<'_>, matches: &ArgMatches) -> Result<(), Error> {
     fn get_date(value: Option<&str>, now_default: bool) -> Result<Option<DateTime<Utc>>, Error> {
         match value {
             None => Ok(if now_default { Some(Utc::now()) } else { None }),
@@ -484,7 +484,7 @@ fn execute_finalize<'a>(ctx: &ReleaseContext<'_>, matches: &ArgMatches<'a>) -> R
             ..Default::default()
         },
     )?;
-    println!("Finalized release {}.", version);
+    println!("Finalized release {version}.");
     Ok(())
 }
 
@@ -493,10 +493,7 @@ fn execute_propose_version() -> Result<(), Error> {
     Ok(())
 }
 
-fn execute_set_commits<'a>(
-    ctx: &ReleaseContext<'_>,
-    matches: &ArgMatches<'a>,
-) -> Result<(), Error> {
+fn execute_set_commits(ctx: &ReleaseContext<'_>, matches: &ArgMatches) -> Result<(), Error> {
     let version = matches.value_of("version").unwrap();
 
     let org = ctx.get_org()?;
@@ -624,30 +621,27 @@ fn execute_set_commits<'a>(
             },
         )?;
 
-        println!("Success! Set commits for release {}.", version);
+        println!("Success! Set commits for release {version}.");
     }
 
     Ok(())
 }
 
-fn execute_delete<'a>(ctx: &ReleaseContext<'_>, matches: &ArgMatches<'a>) -> Result<(), Error> {
+fn execute_delete(ctx: &ReleaseContext<'_>, matches: &ArgMatches) -> Result<(), Error> {
     let version = matches.value_of("version").unwrap();
     let project = ctx.get_project(matches).ok();
     if ctx
         .api
         .delete_release(ctx.get_org()?, project.as_deref(), version)?
     {
-        println!("Deleted release {}!", version);
+        println!("Deleted release {version}!");
     } else {
-        println!(
-            "Did nothing. Release with this version ({}) does not exist.",
-            version
-        );
+        println!("Did nothing. Release with this version ({version}) does not exist.");
     }
     Ok(())
 }
 
-fn execute_archive<'a>(ctx: &ReleaseContext<'_>, matches: &ArgMatches<'a>) -> Result<(), Error> {
+fn execute_archive(ctx: &ReleaseContext<'_>, matches: &ArgMatches) -> Result<(), Error> {
     let version = matches.value_of("version").unwrap();
     let info_rv = ctx.api.update_release(
         ctx.get_org()?,
@@ -663,7 +657,7 @@ fn execute_archive<'a>(ctx: &ReleaseContext<'_>, matches: &ArgMatches<'a>) -> Re
     Ok(())
 }
 
-fn execute_restore<'a>(ctx: &ReleaseContext<'_>, matches: &ArgMatches<'a>) -> Result<(), Error> {
+fn execute_restore(ctx: &ReleaseContext<'_>, matches: &ArgMatches) -> Result<(), Error> {
     let version = matches.value_of("version").unwrap();
     let info_rv = ctx.api.update_release(
         ctx.get_org()?,
@@ -679,7 +673,7 @@ fn execute_restore<'a>(ctx: &ReleaseContext<'_>, matches: &ArgMatches<'a>) -> Re
     Ok(())
 }
 
-fn execute_list<'a>(ctx: &ReleaseContext<'_>, matches: &ArgMatches<'a>) -> Result<(), Error> {
+fn execute_list(ctx: &ReleaseContext<'_>, matches: &ArgMatches) -> Result<(), Error> {
     let project = ctx.get_project(matches).ok();
     let releases = ctx.api.list_releases(ctx.get_org()?, project.as_deref())?;
 
@@ -690,7 +684,7 @@ fn execute_list<'a>(ctx: &ReleaseContext<'_>, matches: &ArgMatches<'a>) -> Resul
             .collect::<Vec<_>>()
             .join(matches.value_of("delimiter").unwrap_or("\n"));
 
-        println!("{}", versions);
+        println!("{versions}");
         return Ok(());
     }
 
@@ -738,7 +732,7 @@ fn execute_list<'a>(ctx: &ReleaseContext<'_>, matches: &ArgMatches<'a>) -> Resul
     Ok(())
 }
 
-fn execute_info<'a>(ctx: &ReleaseContext<'_>, matches: &ArgMatches<'a>) -> Result<(), Error> {
+fn execute_info(ctx: &ReleaseContext<'_>, matches: &ArgMatches) -> Result<(), Error> {
     let version = matches.value_of("version").unwrap();
     let org = ctx.get_org()?;
     let project = ctx.get_project(matches).ok();
@@ -771,7 +765,7 @@ fn execute_info<'a>(ctx: &ReleaseContext<'_>, matches: &ArgMatches<'a>) -> Resul
         let data_row = tbl
             .add_row()
             .add(&release.version)
-            .add(&release.date_created);
+            .add(release.date_created);
 
         if let Some(last_event) = release.last_event {
             data_row.add(last_event);
@@ -818,9 +812,9 @@ fn execute_info<'a>(ctx: &ReleaseContext<'_>, matches: &ArgMatches<'a>) -> Resul
     Ok(())
 }
 
-fn execute_files_list<'a>(
+fn execute_files_list(
     ctx: &ReleaseContext<'_>,
-    matches: &ArgMatches<'a>,
+    matches: &ArgMatches,
     release: &str,
 ) -> Result<(), Error> {
     let mut table = Table::new();
@@ -857,9 +851,9 @@ fn execute_files_list<'a>(
     Ok(())
 }
 
-fn execute_files_delete<'a>(
+fn execute_files_delete(
     ctx: &ReleaseContext<'_>,
-    matches: &ArgMatches<'a>,
+    matches: &ArgMatches,
     release: &str,
 ) -> Result<(), Error> {
     let org = ctx.get_org()?;
@@ -896,9 +890,9 @@ fn execute_files_delete<'a>(
     Ok(())
 }
 
-fn execute_files_upload<'a>(
+fn execute_files_upload(
     ctx: &ReleaseContext<'_>,
-    matches: &ArgMatches<'a>,
+    matches: &ArgMatches,
     version: &str,
 ) -> Result<(), Error> {
     let dist = matches.value_of("dist");
@@ -921,7 +915,7 @@ fn execute_files_upload<'a>(
         let ignore_file = matches.value_of("ignore_file").unwrap_or("");
         let ignores = matches
             .values_of("ignore")
-            .map(|ignores| ignores.map(|i| format!("!{}", i)).collect())
+            .map(|ignores| ignores.map(|i| format!("!{i}")).collect())
             .unwrap_or_else(Vec::new);
         let extensions = matches
             .values_of("extensions")
@@ -994,7 +988,7 @@ fn execute_files_upload<'a>(
     }
 }
 
-fn get_url_prefix_from_args<'a, 'b>(matches: &'b ArgMatches<'a>) -> &'b str {
+fn get_url_prefix_from_args<'a>(matches: &'a ArgMatches) -> &'a str {
     let mut rv = matches.value_of("url_prefix").unwrap_or("~");
     // remove a single slash from the end.  so ~/ becomes ~ and app:/// becomes app://
     if rv.ends_with('/') {
@@ -1003,11 +997,11 @@ fn get_url_prefix_from_args<'a, 'b>(matches: &'b ArgMatches<'a>) -> &'b str {
     rv
 }
 
-fn get_url_suffix_from_args<'a, 'b>(matches: &'b ArgMatches<'a>) -> &'b str {
+fn get_url_suffix_from_args<'a>(matches: &'a ArgMatches) -> &'a str {
     matches.value_of("url_suffix").unwrap_or("")
 }
 
-fn get_prefixes_from_args<'a, 'b>(matches: &'b ArgMatches<'a>) -> Vec<&'b str> {
+fn get_prefixes_from_args<'a>(matches: &'a ArgMatches) -> Vec<&'a str> {
     let mut prefixes: Vec<&str> = match matches.values_of("strip_prefix") {
         Some(paths) => paths.collect(),
         None => vec![],
@@ -1018,8 +1012,8 @@ fn get_prefixes_from_args<'a, 'b>(matches: &'b ArgMatches<'a>) -> Vec<&'b str> {
     prefixes
 }
 
-fn process_sources_from_bundle<'a>(
-    matches: &ArgMatches<'a>,
+fn process_sources_from_bundle(
+    matches: &ArgMatches,
     processor: &mut SourceMapProcessor,
 ) -> Result<(), Error> {
     let url_prefix = get_url_prefix_from_args(matches);
@@ -1077,8 +1071,8 @@ fn process_sources_from_bundle<'a>(
     Ok(())
 }
 
-fn process_sources_from_paths<'a>(
-    matches: &ArgMatches<'a>,
+fn process_sources_from_paths(
+    matches: &ArgMatches,
     processor: &mut SourceMapProcessor,
 ) -> Result<(), Error> {
     let paths = matches.values_of("paths").unwrap();
@@ -1089,7 +1083,7 @@ fn process_sources_from_paths<'a>(
         .unwrap_or_else(|| vec!["js", "map", "jsbundle", "bundle"]);
     let ignores = matches
         .values_of("ignore")
-        .map(|ignores| ignores.map(|i| format!("!{}", i)).collect())
+        .map(|ignores| ignores.map(|i| format!("!{i}")).collect())
         .unwrap_or_else(Vec::new);
 
     let opts = MatchOptions::new();
@@ -1144,9 +1138,9 @@ fn process_sources_from_paths<'a>(
     Ok(())
 }
 
-fn execute_files_upload_sourcemaps<'a>(
+fn execute_files_upload_sourcemaps(
     ctx: &ReleaseContext<'_>,
-    matches: &ArgMatches<'a>,
+    matches: &ArgMatches,
     version: &str,
 ) -> Result<(), Error> {
     let mut processor = SourceMapProcessor::new();
@@ -1181,7 +1175,7 @@ fn execute_files_upload_sourcemaps<'a>(
     Ok(())
 }
 
-fn execute_files<'a>(ctx: &ReleaseContext<'_>, matches: &ArgMatches<'a>) -> Result<(), Error> {
+fn execute_files(ctx: &ReleaseContext<'_>, matches: &ArgMatches) -> Result<(), Error> {
     let release = matches.value_of("version").unwrap();
     if let Some(sub_matches) = matches.subcommand_matches("list") {
         return execute_files_list(ctx, sub_matches, release);
@@ -1198,9 +1192,9 @@ fn execute_files<'a>(ctx: &ReleaseContext<'_>, matches: &ArgMatches<'a>) -> Resu
     unreachable!();
 }
 
-fn execute_deploys_new<'a>(
+fn execute_deploys_new(
     ctx: &ReleaseContext<'_>,
-    matches: &ArgMatches<'a>,
+    matches: &ArgMatches,
     version: &str,
 ) -> Result<(), Error> {
     let mut deploy = Deploy {
@@ -1233,9 +1227,9 @@ fn execute_deploys_new<'a>(
     Ok(())
 }
 
-fn execute_deploys_list<'a>(
+fn execute_deploys_list(
     ctx: &ReleaseContext<'_>,
-    _matches: &ArgMatches<'a>,
+    _matches: &ArgMatches,
     version: &str,
 ) -> Result<(), Error> {
     let mut table = Table::new();
@@ -1264,7 +1258,7 @@ fn execute_deploys_list<'a>(
     Ok(())
 }
 
-fn execute_deploys<'a>(ctx: &ReleaseContext<'_>, matches: &ArgMatches<'a>) -> Result<(), Error> {
+fn execute_deploys(ctx: &ReleaseContext<'_>, matches: &ArgMatches) -> Result<(), Error> {
     let release = matches.value_of("version").unwrap();
     if let Some(sub_matches) = matches.subcommand_matches("new") {
         return execute_deploys_new(ctx, sub_matches, release);

--- a/src/commands/repos.rs
+++ b/src/commands/repos.rs
@@ -29,7 +29,7 @@ pub fn execute(matches: &ArgMatches<'_>) -> Result<(), Error> {
             .add_row()
             .add(&repo.name)
             .add(&repo.provider.name)
-            .add(&repo.url.as_deref().unwrap_or("-"));
+            .add(repo.url.as_deref().unwrap_or("-"));
     }
 
     if table.is_empty() {

--- a/src/commands/send_event.rs
+++ b/src/commands/send_event.rs
@@ -282,7 +282,7 @@ pub fn execute(matches: &ArgMatches<'_>) -> Result<(), Error> {
     }
 
     let id = send_raw_event(event, dsn);
-    println!("Event dispatched: {}", id);
+    println!("Event dispatched: {id}");
 
     Ok(())
 }

--- a/src/commands/upload_dif.rs
+++ b/src/commands/upload_dif.rs
@@ -352,7 +352,7 @@ fn execute_internal(matches: &ArgMatches<'_>, legacy: bool) -> Result<(), Error>
                 eprintln!("{}", style("Error: Some symbols could not be found!").red());
                 eprintln!("The following symbols are still missing:");
                 for id in missing_ids {
-                    println!("  {}", id);
+                    println!("  {id}");
                 }
 
                 return Err(QuietExit(1).into());

--- a/src/commands/upload_proguard.rs
+++ b/src/commands/upload_proguard.rs
@@ -169,9 +169,8 @@ pub fn execute(matches: &ArgMatches<'_>) -> Result<(), Error> {
                 let mapping = ProguardMapping::new(&byteview);
                 if !mapping.has_line_info() {
                     eprintln!(
-                        "warning: proguard mapping '{}' was ignored because it \
-                         does not contain any line information.",
-                        path
+                        "warning: proguard mapping '{path}' was ignored because it \
+                         does not contain any line information."
                     );
                 } else {
                     let mut f = fs::File::open(path)?;
@@ -187,15 +186,14 @@ pub fn execute(matches: &ArgMatches<'_>) -> Result<(), Error> {
             }
             Err(ref err) if err.kind() == io::ErrorKind::NotFound => {
                 eprintln!(
-                    "warning: proguard mapping '{}' does not exist. This \
+                    "warning: proguard mapping '{path}' does not exist. This \
                      might be because the build process did not generate \
-                     one (for instance because -dontobfuscate is used)",
-                    path
+                     one (for instance because -dontobfuscate is used)"
                 );
             }
             Err(err) => {
                 return Err(Error::from(err)
-                    .context(format!("failed to open proguard mapping '{}'", path))
+                    .context(format!("failed to open proguard mapping '{path}'"))
                     .into());
             }
         }

--- a/src/utils/appcenter.rs
+++ b/src/utils/appcenter.rs
@@ -107,7 +107,7 @@ pub fn get_appcenter_deployment_history(
 
     if output.status.success() {
         Ok(serde_json::from_slice(&output.stdout).unwrap_or_else(|_| {
-            let err_msg = format!("Command `{} codepush deployment history {} --app {} --output json` failed to produce a valid JSON output.", appcenter_bin, deployment, app);
+            let err_msg = format!("Command `{appcenter_bin} codepush deployment history {deployment} --app {app} --output json` failed to produce a valid JSON output.");
             panic!("{}", err_msg);
         }))
     } else {

--- a/src/utils/chunks.rs
+++ b/src/utils/chunks.rs
@@ -35,7 +35,7 @@ where
     T: Into<u64> + Copy,
 {
     fn size(&self) -> u64 {
-        (*self).into() as u64
+        (*self).into()
     }
 }
 

--- a/src/utils/codepush.rs
+++ b/src/utils/codepush.rs
@@ -76,7 +76,7 @@ pub fn get_codepush_deployments(app: &str) -> Result<Vec<CodePushDeployment>, Er
 
     if output.status.success() {
         Ok(serde_json::from_slice(&output.stdout).unwrap_or_else(|_| {
-            let err_msg = format!("Command `{} deployment ls {} --format json` failed to produce a valid JSON output.", codepush_bin, app);
+            let err_msg = format!("Command `{codepush_bin} deployment ls {app} --format json` failed to produce a valid JSON output.");
             panic!("{}", err_msg);
         }))
     } else {

--- a/src/utils/file_search.rs
+++ b/src/utils/file_search.rs
@@ -119,7 +119,7 @@ impl ReleaseFileSearch {
             let mut types_builder = TypesBuilder::new();
             for ext in &self.extensions {
                 let ext_name = ext.replace('.', "__");
-                types_builder.add(&ext_name, &format!("*.{}", ext))?;
+                types_builder.add(&ext_name, &format!("*.{ext}"))?;
             }
             builder.types(types_builder.select("all").build()?);
         }

--- a/src/utils/file_upload.rs
+++ b/src/utils/file_upload.rs
@@ -354,14 +354,14 @@ fn url_to_bundle_path(url: &str) -> Result<String, Error> {
 
     let mut path = url.path().to_string();
     if let Some(fragment) = url.fragment() {
-        path = format!("{}#{}", path, fragment);
+        path = format!("{path}#{fragment}");
     }
     if path.starts_with('/') {
         path.remove(0);
     }
 
     Ok(match url.host_str() {
-        Some("~") => format!("_/_/{}", path),
+        Some("~") => format!("_/_/{path}"),
         Some(host) => format!("{}/{}/{}", url.scheme(), host, path),
         None => format!("{}/_/{}", url.scheme(), path),
     })

--- a/src/utils/formatting.rs
+++ b/src/utils/formatting.rs
@@ -95,7 +95,7 @@ impl Table {
         for row in &self.rows {
             tbl.add_row(row.make_row());
         }
-        tbl.print_tty(false);
+        tbl.print_tty(false).ok();
     }
 }
 

--- a/src/utils/fs.rs
+++ b/src/utils/fs.rs
@@ -73,7 +73,7 @@ impl TempFile {
             .create(true)
             .open(&self.path)?;
 
-        f.seek(SeekFrom::Start(0)).ok();
+        f.rewind().ok();
         Ok(f)
     }
 

--- a/src/utils/logging.rs
+++ b/src/utils/logging.rs
@@ -61,11 +61,11 @@ impl log::Log for Logger {
         let short_target = record.target().split("::").next().unwrap_or("");
         let msg = format!(
             "{} {} {}{}",
-            style(format!("  {}  ", level_name)).bg(level_color).black(),
+            style(format!("  {level_name}  ")).bg(level_color).black(),
             style(Local::now()).dim(),
             style(record.args()),
             style(if short_target != "sentry_cli" {
-                format!("  (from {})", short_target)
+                format!("  (from {short_target})")
             } else {
                 "".to_string()
             })
@@ -79,7 +79,7 @@ impl log::Log for Logger {
         if let Some(pb) = get_progress_bar() {
             pb.println(msg);
         } else {
-            writeln!(io::stderr(), "{}", msg).ok();
+            writeln!(io::stderr(), "{msg}").ok();
         }
     }
 

--- a/src/utils/sourcemaps.rs
+++ b/src/utils/sourcemaps.rs
@@ -27,11 +27,11 @@ fn is_likely_minified_js(code: &[u8]) -> bool {
 
 fn join_url(base_url: &str, url: &str) -> Result<String, Error> {
     if base_url.starts_with("~/") {
-        match Url::parse(&format!("http://{}", base_url))?.join(url) {
+        match Url::parse(&format!("http://{base_url}"))?.join(url) {
             Ok(url) => {
                 let rv = url.to_string();
                 if let Some(rest) = rv.strip_prefix("http://~/") {
-                    Ok(format!("~/{}", rest))
+                    Ok(format!("~/{rest}"))
                 } else {
                     Ok(rv)
                 }
@@ -72,7 +72,7 @@ fn unsplit_url(path: Option<&str>, basename: &str, ext: Option<&str>) -> String 
 
 pub fn get_sourcemap_ref_from_headers(file: &ReleaseFile) -> sourcemap::SourceMapRef {
     if let Some(sm_ref) =
-        get_sourcemap_reference_from_headers(file.headers.iter().map(|&(ref k, ref v)| (k, v)))
+        get_sourcemap_reference_from_headers(file.headers.iter().map(|(k, v)| (k, v)))
     {
         sourcemap::SourceMapRef::Ref(sm_ref.to_string())
     } else {
@@ -128,14 +128,14 @@ fn guess_sourcemap_reference(sourcemaps: &HashSet<String>, min_url: &str) -> Res
 
     if let Some(ext) = ext.as_ref() {
         // foo.min.js -> foo.min.js.map
-        let new_ext = format!("{}.{}", ext, map_ext);
+        let new_ext = format!("{ext}.{map_ext}");
         if sourcemaps.contains(&unsplit_url(path, basename, Some(&new_ext))) {
             return Ok(unsplit_url(None, basename, Some(&new_ext)));
         }
 
         // foo.min.js -> foo.js.map
         if let Some(rest) = ext.strip_prefix("min.") {
-            let new_ext = format!("{}.{}", rest, map_ext);
+            let new_ext = format!("{rest}.{map_ext}");
             if sourcemaps.contains(&unsplit_url(path, basename, Some(&new_ext))) {
                 return Ok(unsplit_url(None, basename, Some(&new_ext)));
             }
@@ -309,13 +309,13 @@ impl SourceMapProcessor {
             match source.ty {
                 SourceFileType::Source | SourceFileType::MinifiedSource => {
                     if let Err(err) = validate_script(source) {
-                        source.error(format!("failed to process: {}", err));
+                        source.error(format!("failed to process: {err}"));
                         failed = true;
                     }
                 }
                 SourceFileType::SourceMap => {
                     if let Err(err) = validate_sourcemap(&source_urls, source) {
-                        source.error(format!("failed to process: {}", err));
+                        source.error(format!("failed to process: {err}"));
                         failed = true;
                     }
                 }
@@ -408,7 +408,7 @@ impl SourceMapProcessor {
             );
 
             debug!("Inserting sourcemap for {}", name);
-            let sourcemap_name = format!("{}.map", name);
+            let sourcemap_name = format!("{name}.map");
             let sourcemap_url = join_url(bundle_source_url, &sourcemap_name)?;
             let mut sourcemap_content: Vec<u8> = vec![];
             sourcemap.to_writer(&mut sourcemap_content)?;
@@ -515,8 +515,7 @@ impl SourceMapProcessor {
                 }
                 Err(err) => {
                     source.warn(format!(
-                        "could not determine a source map reference ({})",
-                        err
+                        "could not determine a source map reference ({err})"
                     ));
                 }
             }
@@ -559,7 +558,7 @@ fn validate_regular(
         if sm.get_source_contents(idx).is_some() || source_urls.contains(source_url) {
             info!("validator found source ({})", source_url);
         } else {
-            source.warn(format!("missing sourcecode ({})", source_url));
+            source.warn(format!("missing sourcecode ({source_url})"));
         }
     }
 }

--- a/src/utils/system.rs
+++ b/src/utils/system.rs
@@ -23,7 +23,7 @@ where
     }
 
     let (tx, rx) = crossbeam_channel::bounded(100);
-    let mut signals = signal_hook::iterator::Signals::new(&[
+    let mut signals = signal_hook::iterator::Signals::new([
         signal_hook::consts::SIGTERM,
         signal_hook::consts::SIGINT,
     ])
@@ -172,7 +172,7 @@ pub fn init_backtrace() {
                     backtrace
                 );
             }
-            None => eprintln!("thread '{}' panicked at '{}'{:?}", thread, msg, backtrace),
+            None => eprintln!("thread '{thread}' panicked at '{msg}'{backtrace:?}"),
         }
 
         #[cfg(feature = "with_client_implementation")]

--- a/src/utils/ui.rs
+++ b/src/utils/ui.rs
@@ -6,7 +6,7 @@ use crate::utils::progress::{ProgressBar, ProgressStyle};
 /// Prints a message and loops until yes or no is entered.
 pub fn prompt_to_continue(message: &str) -> io::Result<bool> {
     loop {
-        print!("{} [y/n] ", message);
+        print!("{message} [y/n] ");
         io::stdout().flush()?;
 
         let mut buf = String::new();
@@ -25,7 +25,7 @@ pub fn prompt_to_continue(message: &str) -> io::Result<bool> {
 /// Prompts for input and returns it.
 pub fn prompt(message: &str) -> io::Result<String> {
     loop {
-        print!("{}: ", message);
+        print!("{message}: ");
         io::stdout().flush()?;
         let mut buf = String::new();
         io::stdin().read_line(&mut buf)?;

--- a/src/utils/update.rs
+++ b/src/utils/update.rs
@@ -55,11 +55,11 @@ fn rename_exe(exe: &Path, downloaded_path: &Path, elevate: bool) -> Result<(), E
     if elevate {
         println!("Need to sudo to overwrite {}", exe.display());
         runas::Command::new("mv")
-            .arg(&downloaded_path)
-            .arg(&exe)
+            .arg(downloaded_path)
+            .arg(exe)
             .status()?;
     } else {
-        fs::rename(&downloaded_path, &exe)?;
+        fs::rename(downloaded_path, exe)?;
     }
     Ok(())
 }

--- a/src/utils/vcs.rs
+++ b/src/utils/vcs.rs
@@ -20,8 +20,8 @@ pub enum GitReference<'a> {
 impl<'a> fmt::Display for GitReference<'a> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match *self {
-            GitReference::Commit(ref c) => write!(f, "{}", c),
-            GitReference::Symbolic(ref s) => write!(f, "{}", s),
+            GitReference::Commit(ref c) => write!(f, "{c}"),
+            GitReference::Symbolic(ref s) => write!(f, "{s}"),
         }
     }
 }
@@ -478,8 +478,7 @@ pub fn get_commits_from_git<'a>(
                 // Create a new release with default count if `--ignore-missing` is present
                 if ignore_missing {
                     println!(
-                        "Could not find the SHA of the previous release in the git history. Skipping previous release and creating a new one with {} commits.",
-                        default_count
+                        "Could not find the SHA of the previous release in the git history. Skipping previous release and creating a new one with {default_count} commits."
                     );
                     return get_default_commits_from_git(repo, default_count);
                 // Or throw an error and point to the right solution otherwise.
@@ -497,8 +496,7 @@ pub fn get_commits_from_git<'a>(
         Err(_) => {
             // If there is no previous commit, return the default number of commits
             println!(
-                "Could not find the previous commit. Creating a release with {} commits.",
-                default_count
+                "Could not find the previous commit. Creating a release with {default_count} commits."
             );
             get_default_commits_from_git(repo, default_count)
         }
@@ -854,7 +852,7 @@ fn test_url_normalization() {
 #[cfg(test)]
 fn git_initialize_repo(dir: &Path) {
     Command::new("git")
-        .args(&["init", "--quiet"])
+        .args(["init", "--quiet"])
         .current_dir(dir)
         .spawn()
         .expect("Failed to execute `git init`.")
@@ -862,7 +860,7 @@ fn git_initialize_repo(dir: &Path) {
         .expect("Failed to wait on git init.");
 
     Command::new("git")
-        .args(&["config", "--local", "user.name", "test"])
+        .args(["config", "--local", "user.name", "test"])
         .current_dir(dir)
         .spawn()
         .expect("Failed to execute `git config`.")
@@ -870,7 +868,7 @@ fn git_initialize_repo(dir: &Path) {
         .expect("Failed to wait on git config.");
 
     Command::new("git")
-        .args(&["config", "--local", "user.email", "test@example.com"])
+        .args(["config", "--local", "user.email", "test@example.com"])
         .current_dir(dir)
         .spawn()
         .expect("Failed to execute `git config`.")
@@ -878,7 +876,7 @@ fn git_initialize_repo(dir: &Path) {
         .expect("Failed to wait on git config.");
 
     Command::new("git")
-        .args(&[
+        .args([
             "remote",
             "add",
             "origin",
@@ -898,7 +896,7 @@ fn git_create_commit(dir: &Path, file_path: &str, content: &[u8], commit_message
     file.write_all(content).expect("Failed to execute.");
 
     let mut add = Command::new("git")
-        .args(&["add", "-A"])
+        .args(["add", "-A"])
         .current_dir(dir)
         .spawn()
         .expect("Failed to execute `git add .`");
@@ -906,7 +904,7 @@ fn git_create_commit(dir: &Path, file_path: &str, content: &[u8], commit_message
     add.wait().expect("Failed to wait on git add.");
 
     let mut commit = Command::new("git")
-        .args(&[
+        .args([
             "commit",
             "-am",
             commit_message,
@@ -940,7 +938,7 @@ fn git_create_tag(dir: &Path, tag_name: &str, annotated: bool) -> String {
     tag.wait().expect("Failed to wait on git tag.");
 
     let hash = Command::new("git")
-        .args(&["rev-list", "-n", "1", tag_name])
+        .args(["rev-list", "-n", "1", tag_name])
         .current_dir(dir)
         .output()
         .unwrap_or_else(|_| panic!("Failed to execute `git rev-list -n 1 {}`.", tag_name));
@@ -1088,7 +1086,7 @@ fn test_generate_patch_default_twenty() {
     );
 
     for n in 0..20 {
-        let file = format!("foo{}.js", n);
+        let file = format!("foo{n}.js");
         git_create_commit(
             dir.path(),
             &file,
@@ -1128,7 +1126,7 @@ fn test_generate_patch_ignore_missing() {
     );
 
     for n in 0..5 {
-        let file = format!("foo{}.js", n);
+        let file = format!("foo{n}.js");
         git_create_commit(
             dir.path(),
             &file,

--- a/src/utils/xcode.rs
+++ b/src/utils/xcode.rs
@@ -202,7 +202,7 @@ impl InfoPlist {
             if let Some(filename) = vars.get("INFOPLIST_FILE") {
                 let base = vars.get("PROJECT_DIR").map(String::as_str).unwrap_or(".");
                 let path = env::current_dir().unwrap().join(base).join(filename);
-                Ok(Some(InfoPlist::load_and_process(&path, &vars)?))
+                Ok(Some(InfoPlist::load_and_process(path, &vars)?))
             } else if let Ok(default_plist) = InfoPlist::from_xcode_env() {
                 Ok(Some(default_plist))
             } else {
@@ -260,12 +260,12 @@ impl InfoPlist {
             }
             if let Some(defs) = vars.get("INFOPLIST_PREPROCESSOR_DEFINITIONS") {
                 for token in defs.split_whitespace() {
-                    c.arg(format!("-D{}", token));
+                    c.arg(format!("-D{token}"));
                 }
             }
             c.arg(path.as_ref());
             let p = c.output()?;
-            InfoPlist::from_reader(&mut Cursor::new(&p.stdout[..]))?
+            InfoPlist::from_reader(Cursor::new(&p.stdout[..]))?
         } else {
             InfoPlist::from_path(path)?
         };
@@ -391,7 +391,7 @@ impl<'a> MayDetach<'a> {
                 if let Some(ref output_file) = md.output_file {
                     crate::utils::system::print_error(&err);
                     if md.show_critical_info()? {
-                        open::that(&output_file.path())?;
+                        open::that(output_file.path())?;
                         std::thread::sleep(Duration::from_millis(5000));
                     }
                 }

--- a/tests/integration/mod.rs
+++ b/tests/integration/mod.rs
@@ -14,7 +14,7 @@ pub fn register_test(path: &str) -> TestCases {
         .env("SENTRY_AUTH_TOKEN", "lolnope")
         .env("SENTRY_ORG", "wat-org")
         .env("SENTRY_PROJECT", "wat-project")
-        .case(format!("tests/integration/_cases/{}", path));
+        .case(format!("tests/integration/_cases/{path}"));
     test_case
 }
 pub struct EndpointOptions {
@@ -37,7 +37,7 @@ impl EndpointOptions {
     }
 
     pub fn with_response_file(mut self, path: &str) -> Self {
-        self.response_file = Some(format!("tests/integration/_api/{}", path));
+        self.response_file = Some(format!("tests/integration/_api/{path}"));
         self
     }
 

--- a/tests/integration/releases/new.rs
+++ b/tests/integration/releases/new.rs
@@ -66,7 +66,7 @@ fn creates_release_which_is_instantly_finalized() {
                     "version": "wat-release",
                     "projects": ["wat-project"],
                 })),
-                Matcher::Regex(format!(r#""dateReleased":"{}""#, UTC_DATE_FORMAT)),
+                Matcher::Regex(format!(r#""dateReleased":"{UTC_DATE_FORMAT}""#)),
             ])),
     );
     register_test("releases/releases-new-finalize.trycmd");

--- a/yarn.lock
+++ b/yarn.lock
@@ -667,17 +667,12 @@ ansi-escapes@^4.2.1:
   dependencies:
     type-fest "^0.21.3"
 
-ansi-regex@^2.0.0, ansi-regex@^3.0.1, ansi-regex@^5.0.1:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-3.0.1.tgz#123d6479e92ad45ad897d4054e3c7ca7db4944e1"
-  integrity sha512-+O9Jct8wf++lXxxFc4hc8LsjaSq0HFzzL7cVsw8pRDIPdjKD2mT4ytDZlLuSBZ4cLKZFXIrMGO7DbQCtMJJMKw==
-
 ansi-regex@^4.1.0:
-  version "4.1.0"
-  resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-4.1.0.tgz#8b9f8f08cf1acb843756a839ca8c7e3168c51997"
-  integrity sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-4.1.1.tgz#164daac87ab2d6f6db3a29875e2d1766582dabed"
+  integrity sha512-ILlv4k/3f6vfQ4OoP2AGvirOktlQ98ZEL1k9FaQjxa3L1abBgbuTDAdPOpvbGncC0BTVQrl+OM8xZGK6tWXt7g==
 
-ansi-regex@^5.0.0:
+ansi-regex@^5.0.0, ansi-regex@^5.0.1:
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-5.0.1.tgz#082cb2c89c9fe8659a311a53bd6a4dc5301db304"
   integrity sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==
@@ -712,11 +707,6 @@ anymatch@^3.0.3:
     normalize-path "^3.0.0"
     picomatch "^2.0.4"
 
-aproba@^1.0.3:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/aproba/-/aproba-1.2.0.tgz#6802e6264efd18c790a1b0d517f0f2627bf2c94a"
-  integrity sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==
-
 "aproba@^1.0.3 || ^2.0.0":
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/aproba/-/aproba-2.0.0.tgz#52520b8ae5b569215b354efc0caa3fe1e45a8adc"
@@ -729,14 +719,6 @@ are-we-there-yet@^2.0.0:
   dependencies:
     delegates "^1.0.0"
     readable-stream "^3.6.0"
-
-are-we-there-yet@~1.1.2:
-  version "1.1.7"
-  resolved "https://registry.yarnpkg.com/are-we-there-yet/-/are-we-there-yet-1.1.7.tgz#b15474a932adab4ff8a50d9adfa7e4e926f21146"
-  integrity sha512-nxwy40TuMiUGqMyRHgCSWZ9FM4VAoRP4xUYSTv5ImRog+h9yISPbVH7H8fASCIzYn9wlEv4zvFL7uKDMCFQm3g==
-  dependencies:
-    delegates "^1.0.0"
-    readable-stream "^2.0.6"
 
 argparse@^1.0.7:
   version "1.0.10"
@@ -1120,11 +1102,6 @@ co@^4.6.0:
   resolved "https://registry.yarnpkg.com/co/-/co-4.6.0.tgz#6ea6bdf3d853ae54ccb8e47bfa0bf3f9031fb184"
   integrity sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=
 
-code-point-at@^1.0.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/code-point-at/-/code-point-at-1.1.0.tgz#0d070b4d043a5bea33a2f1a40e2edb3d9a4ccf77"
-  integrity sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=
-
 collect-v8-coverage@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/collect-v8-coverage/-/collect-v8-coverage-1.0.1.tgz#cc2c8e94fc18bbdffe64d6534570c8a673b27f59"
@@ -1189,7 +1166,7 @@ confusing-browser-globals@^1.0.10:
   resolved "https://registry.yarnpkg.com/confusing-browser-globals/-/confusing-browser-globals-1.0.11.tgz#ae40e9b57cdd3915408a2805ebd3a5585608dc81"
   integrity sha512-JsPKdmh8ZkmnHxDk55FZ1TqVLvEQTvoByJZRN9jzI0UjxK/QgAmsphz7PGtqgPieQZ/CQcHWXCR7ATDNhGe+YA==
 
-console-control-strings@^1.0.0, console-control-strings@^1.1.0, console-control-strings@~1.1.0:
+console-control-strings@^1.0.0, console-control-strings@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/console-control-strings/-/console-control-strings-1.1.0.tgz#3d7cf4464db6446ea644bf4b39507f9851008e8e"
   integrity sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=
@@ -1210,11 +1187,6 @@ core-util-is@1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/core-util-is/-/core-util-is-1.0.2.tgz#b5fd54220aa2bc5ab57aab7140c940754503c1a7"
   integrity sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=
-
-core-util-is@~1.0.0:
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/core-util-is/-/core-util-is-1.0.3.tgz#a6042d3634c2b27e9328f837b965fac83808db85"
-  integrity sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==
 
 cross-spawn@^6.0.0, cross-spawn@^6.0.5:
   version "6.0.5"
@@ -1923,20 +1895,6 @@ gauge@^3.0.0:
     strip-ansi "^6.0.1"
     wide-align "^1.1.2"
 
-gauge@~2.7.3:
-  version "2.7.4"
-  resolved "https://registry.yarnpkg.com/gauge/-/gauge-2.7.4.tgz#2c03405c7538c39d7eb37b317022e325fb018bf7"
-  integrity sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=
-  dependencies:
-    aproba "^1.0.3"
-    console-control-strings "^1.0.0"
-    has-unicode "^2.0.0"
-    object-assign "^4.1.0"
-    signal-exit "^3.0.0"
-    string-width "^1.0.1"
-    strip-ansi "^3.0.1"
-    wide-align "^1.1.0"
-
 gensync@^1.0.0-beta.2:
   version "1.0.0-beta.2"
   resolved "https://registry.yarnpkg.com/gensync/-/gensync-1.0.0-beta.2.tgz#32a6ee76c3d7f52d46b2b1ae5d93fea8580a25e0"
@@ -2086,7 +2044,7 @@ has-tostringtag@^1.0.0:
   dependencies:
     has-symbols "^1.0.2"
 
-has-unicode@^2.0.0, has-unicode@^2.0.1:
+has-unicode@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/has-unicode/-/has-unicode-2.0.1.tgz#e0e6fe6a28cf51138855e086d1691e771de2a8b9"
   integrity sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=
@@ -2209,7 +2167,7 @@ inflight@^1.0.4:
     once "^1.3.0"
     wrappy "1"
 
-inherits@2, inherits@^2.0.3, inherits@~2.0.3:
+inherits@2, inherits@^2.0.3:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.4.tgz#0fa2c64f932917c3433a0ded55363aae37416b7c"
   integrity sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==
@@ -2366,13 +2324,6 @@ is-extglob@^2.1.1:
   resolved "https://registry.yarnpkg.com/is-extglob/-/is-extglob-2.1.1.tgz#a88c02535791f02ed37c76a1b9ea9773c833f8c2"
   integrity sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=
 
-is-fullwidth-code-point@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz#ef9e31386f031a7f0d643af82fde50c457ef00cb"
-  integrity sha1-754xOG8DGn8NZDr4L95QxFfvAMs=
-  dependencies:
-    number-is-nan "^1.0.0"
-
 is-fullwidth-code-point@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz#a3b30a5c4f199183167aaab93beefae3ddfb654f"
@@ -2487,7 +2438,7 @@ is-wsl@^2.1.1:
   dependencies:
     is-docker "^2.0.0"
 
-isarray@1.0.0, isarray@~1.0.0:
+isarray@1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/isarray/-/isarray-1.0.0.tgz#bb935d48582cba168c06834957a54a3e07124f11"
   integrity sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=
@@ -3400,16 +3351,6 @@ npm-run-path@^4.0.0:
   dependencies:
     path-key "^3.0.0"
 
-npmlog@^4.1.2:
-  version "4.1.2"
-  resolved "https://registry.yarnpkg.com/npmlog/-/npmlog-4.1.2.tgz#08a7f2a8bf734604779a9efa4ad5cc717abb954b"
-  integrity sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==
-  dependencies:
-    are-we-there-yet "~1.1.2"
-    console-control-strings "~1.1.0"
-    gauge "~2.7.3"
-    set-blocking "~2.0.0"
-
 npmlog@^5.0.1:
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/npmlog/-/npmlog-5.0.1.tgz#f06678e80e29419ad67ab964e0fa69959c1eb8b0"
@@ -3419,11 +3360,6 @@ npmlog@^5.0.1:
     console-control-strings "^1.1.0"
     gauge "^3.0.0"
     set-blocking "^2.0.0"
-
-number-is-nan@^1.0.0:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/number-is-nan/-/number-is-nan-1.0.1.tgz#097b602b53422a522c1afb8790318336941a011d"
-  integrity sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=
 
 nwsapi@^2.2.0:
   version "2.2.0"
@@ -3435,7 +3371,7 @@ oauth-sign@~0.9.0:
   resolved "https://registry.yarnpkg.com/oauth-sign/-/oauth-sign-0.9.0.tgz#47a7b016baa68b5fa0ecf3dee08a85c679ac6455"
   integrity sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ==
 
-object-assign@^4.1.0, object-assign@^4.1.1:
+object-assign@^4.1.1:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/object-assign/-/object-assign-4.1.1.tgz#2109adc7965887cfc05cbbd442cac8bfbb360863"
   integrity sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=
@@ -3724,11 +3660,6 @@ pretty-format@^25.5.0:
     ansi-styles "^4.0.0"
     react-is "^16.12.0"
 
-process-nextick-args@~2.0.0:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/process-nextick-args/-/process-nextick-args-2.0.1.tgz#7820d9b16120cc55ca9ae7792680ae7dba6d7fe2"
-  integrity sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==
-
 progress@^2.0.0, progress@^2.0.3:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/progress/-/progress-2.0.3.tgz#7e8cf8d8f5b8f239c1bc68beb4eb78567d572ef8"
@@ -3802,19 +3733,6 @@ read-pkg@^5.2.0:
     normalize-package-data "^2.5.0"
     parse-json "^5.0.0"
     type-fest "^0.6.0"
-
-readable-stream@^2.0.6:
-  version "2.3.7"
-  resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-2.3.7.tgz#1eca1cf711aef814c04f62252a36a62f6cb23b57"
-  integrity sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==
-  dependencies:
-    core-util-is "~1.0.0"
-    inherits "~2.0.3"
-    isarray "~1.0.0"
-    process-nextick-args "~2.0.0"
-    safe-buffer "~5.1.1"
-    string_decoder "~1.1.1"
-    util-deprecate "~1.0.1"
 
 readable-stream@^3.6.0:
   version "3.6.0"
@@ -4002,7 +3920,7 @@ safe-buffer@^5.0.1, safe-buffer@^5.1.2, safe-buffer@~5.2.0:
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.2.1.tgz#1eaf9fa9bdb1fdd4ec75f58f9cdb4e6b7827eec6"
   integrity sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==
 
-safe-buffer@~5.1.0, safe-buffer@~5.1.1:
+safe-buffer@~5.1.1:
   version "5.1.2"
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.1.2.tgz#991ec69d296e0313747d59bdfd2b745c35f8828d"
   integrity sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==
@@ -4058,7 +3976,7 @@ semver@^7.3.5:
   dependencies:
     lru-cache "^6.0.0"
 
-set-blocking@^2.0.0, set-blocking@~2.0.0:
+set-blocking@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/set-blocking/-/set-blocking-2.0.0.tgz#045f9782d011ae9a6803ddd382b24392b3d890f7"
   integrity sha1-BF+XgtARrppoA93TgrJDkrPYkPc=
@@ -4290,15 +4208,6 @@ string-length@^3.1.0:
     astral-regex "^1.0.0"
     strip-ansi "^5.2.0"
 
-string-width@^1.0.1:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/string-width/-/string-width-1.0.2.tgz#118bdf5b8cdc51a2a7e70d211e07e2b0b9b107d3"
-  integrity sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=
-  dependencies:
-    code-point-at "^1.0.0"
-    is-fullwidth-code-point "^1.0.0"
-    strip-ansi "^3.0.0"
-
 "string-width@^1.0.2 || 2 || 3 || 4", string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
@@ -4348,20 +4257,6 @@ string_decoder@^1.1.1:
   integrity sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==
   dependencies:
     safe-buffer "~5.2.0"
-
-string_decoder@~1.1.1:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/string_decoder/-/string_decoder-1.1.1.tgz#9cf1611ba62685d7030ae9e4ba34149c3af03fc8"
-  integrity sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==
-  dependencies:
-    safe-buffer "~5.1.0"
-
-strip-ansi@^3.0.0, strip-ansi@^3.0.1:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-3.0.1.tgz#6a385fb8853d952d5ff05d0e8aaf94278dc63dcf"
-  integrity sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=
-  dependencies:
-    ansi-regex "^2.0.0"
 
 strip-ansi@^5.1.0, strip-ansi@^5.2.0:
   version "5.2.0"
@@ -4672,7 +4567,7 @@ use@^3.1.0:
   resolved "https://registry.yarnpkg.com/use/-/use-3.1.1.tgz#d50c8cac79a19fbc20f2911f56eb973f4e10070f"
   integrity sha512-cwESVXlO3url9YWlFW/TA9cshCEhtu7IKJ/p5soJ/gGpj7vbvFrAY/eIioQ6Dw23KjZhYgiIo8HOs1nQ2vr/oQ==
 
-util-deprecate@^1.0.1, util-deprecate@~1.0.1:
+util-deprecate@^1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/util-deprecate/-/util-deprecate-1.0.2.tgz#450d4dc9fa70de732762fbd2d4a28981419a0ccf"
   integrity sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=
@@ -4805,7 +4700,7 @@ which@^2.0.1, which@^2.0.2:
   dependencies:
     isexe "^2.0.0"
 
-wide-align@^1.1.0, wide-align@^1.1.2:
+wide-align@^1.1.2:
   version "1.1.5"
   resolved "https://registry.yarnpkg.com/wide-align/-/wide-align-1.1.5.tgz#df1d4c206854369ecf3c9a4898f1b23fbd9d15d3"
   integrity sha512-eDMORYaPNZ4sQIuuYPDHdQvf4gyCF9rEEV/yPxGfwPkRodwEgiMUUXTx/dex+Me0wxx53S+NgUHaP7y3MGlDmg==


### PR DESCRIPTION
This is a backport of https://github.com/getsentry/sentry-cli/pull/1392, as we sadly still got some issues to figure out before we can update the webpack plugin to use v2 of sentry-cli.

We keep getting (every now and then) bumped on this security vulnerability, so we'd like to get this off our plate by backporting this fix and releasing it as 1.x.