### PR TITLE
ref: Deduplicate artifacts upload using queried checksums

### DIFF
--- a/src/commands/files/delete.rs
+++ b/src/commands/files/delete.rs
@@ -43,7 +43,7 @@ pub fn execute(matches: &ArgMatches) -> Result<()> {
         Some(paths) => paths.map(|x| x.into()).collect(),
         None => HashSet::new(),
     };
-    for file in api.list_release_files(&org, project.as_deref(), &release)? {
+    for file in api.list_release_files(&org, project.as_deref(), &release, None)? {
         if !files.contains(&file.name) {
             continue;
         }

--- a/src/commands/files/list.rs
+++ b/src/commands/files/list.rs
@@ -26,7 +26,7 @@ pub fn execute(matches: &ArgMatches) -> Result<()> {
         .add("Source Map")
         .add("Size");
 
-    for artifact in api.list_release_files(&org, project.as_deref(), &release)? {
+    for artifact in api.list_release_files(&org, project.as_deref(), &release, None)? {
         let row = table.add_row();
         row.add(&artifact.name);
         if let Some(ref dist) = artifact.dist {

--- a/src/commands/files/upload.rs
+++ b/src/commands/files/upload.rs
@@ -127,6 +127,7 @@ pub fn execute(matches: &ArgMatches) -> Result<()> {
         release: &release,
         dist,
         wait: matches.is_present("wait"),
+        ..Default::default()
     };
 
     let path = Path::new(matches.value_of("path").unwrap());

--- a/src/commands/react_native/appcenter.rs
+++ b/src/commands/react_native/appcenter.rs
@@ -178,6 +178,7 @@ pub fn execute(matches: &ArgMatches) -> Result<()> {
                 release: &release.version,
                 dist: None,
                 wait: matches.is_present("wait"),
+                ..Default::default()
             })?;
         }
         Some(dists) => {
@@ -193,6 +194,7 @@ pub fn execute(matches: &ArgMatches) -> Result<()> {
                     release: &release.version,
                     dist: Some(dist),
                     wait: matches.is_present("wait"),
+                    ..Default::default()
                 })?;
             }
         }

--- a/src/commands/react_native/gradle.rs
+++ b/src/commands/react_native/gradle.rs
@@ -119,6 +119,7 @@ pub fn execute(matches: &ArgMatches) -> Result<()> {
             release: &release.version,
             dist: Some(dist),
             wait: matches.is_present("wait"),
+            ..Default::default()
         })?;
     }
 

--- a/src/commands/react_native/xcode.rs
+++ b/src/commands/react_native/xcode.rs
@@ -286,6 +286,7 @@ pub fn execute(matches: &ArgMatches) -> Result<()> {
                     release: &release.version,
                     dist: Some(&dist),
                     wait: matches.is_present("wait"),
+                    ..Default::default()
                 })?;
             }
             Some(dists) => {
@@ -296,6 +297,7 @@ pub fn execute(matches: &ArgMatches) -> Result<()> {
                         release: &release.version,
                         dist: Some(dist),
                         wait: matches.is_present("wait"),
+                        ..Default::default()
                     })?;
                 }
             }

--- a/src/commands/sourcemaps/explain.rs
+++ b/src/commands/sourcemaps/explain.rs
@@ -120,7 +120,7 @@ fn extract_nth_frame(stacktrace: &Stacktrace, position: usize) -> Result<&Frame>
 }
 
 fn fetch_release_artifacts(org: &str, project: &str, release: &str) -> Result<Vec<Artifact>> {
-    Api::current().list_release_files(org, Some(project), release).map(|artifacts| {
+    Api::current().list_release_files(org, Some(project), release, None).map(|artifacts| {
         if artifacts.is_empty() {
             error("Release has no artifacts uploaded");
             tip("https://docs.sentry.io/platforms/javascript/sourcemaps/troubleshooting_js/#verify-artifacts-are-uploaded");

--- a/tests/integration/_cases/sourcemaps/sourcemaps-upload-skip-already-uploaded.trycmd
+++ b/tests/integration/_cases/sourcemaps/sourcemaps-upload-skip-already-uploaded.trycmd
@@ -6,7 +6,7 @@ $ sentry-cli sourcemaps upload tests/integration/_fixtures/bundle.min.js.map tes
 > Analyzing 2 sources
 > Rewriting sources
 > Adding source map references
-> Bundled 2 files for upload
+> Bundled 1 file for upload
 > Uploaded release files to Sentry
 > File upload complete (processing pending on server)
 > Organization: wat-org

--- a/tests/integration/sourcemaps/upload.rs
+++ b/tests/integration/sourcemaps/upload.rs
@@ -32,7 +32,7 @@ fn command_sourcemaps_upload_skip_already_uploaded() {
     let _files = mock_endpoint(
         EndpointOptions::new(
             "GET",
-            "/api/0/projects/wat-org/wat-project/releases/wat-release/files/?cursor=",
+            "/api/0/projects/wat-org/wat-project/releases/wat-release/files/?cursor=&checksum=38ed853073df85147960ea3a5bced6170ec389b0&checksum=f3673e2cea68bcb86bb74254a9efaa381d74929f",
             200,
         )
         .with_response_body(


### PR DESCRIPTION
Tbh I just realized that this feature was doing basically nothing other than marking those uploaded... they were still archived and delivered, as `insert` into `this.sources` was never guarded 😢 