### PR TITLE
test: fixcommand_monitors_run test on windows

### DIFF
--- a/tests/integration/_cases/monitors/monitors-run-win.trycmd
+++ b/tests/integration/_cases/monitors/monitors-run-win.trycmd
@@ -1,0 +1,6 @@
+```
+$ sentry-cli monitors run 85a34e5a-c0b6-11ec-9d64-0242ac120002 -- cmd.exe /C echo 123
+? success
+123
+
+```

--- a/tests/integration/monitors/run.rs
+++ b/tests/integration/monitors/run.rs
@@ -10,7 +10,11 @@ fn command_monitors_run() {
         )
         .with_response_file("monitors/post-monitors.json"),
     );
-    register_test("monitors/monitors-run.trycmd");
+    if cfg!(windows) {
+        register_test("monitors/monitors-run-win.trycmd");
+    } else {
+        register_test("monitors/monitors-run.trycmd");
+    }
 }
 
 #[test]


### PR DESCRIPTION
Currently fails with the following error when run on Windows

```
Testing tests/integration/_cases/monitors/monitors-run.trycmd:2 ... failed
Expected success, was 1

---- expected: stdout
++++ actual:   stdout
   1      - 123
        1 + error could not invoke program 'echo': program not found
stderr:

```