### PR TITLE
feat: aarch64 windows release support

### DIFF
--- a/.craft.yml
+++ b/.craft.yml
@@ -73,3 +73,4 @@ requireNames:
   - /^sentry-cli-Linux-aarch64$/
   - /^sentry-cli-Windows-i686.exe$/
   - /^sentry-cli-Windows-x86_64.exe$/
+  - /^sentry-cli-Windows-aarch64.exe$/

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -105,7 +105,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        arch: [i686, x86_64]
+        arch: [i686, x86_64, aarch64]
 
     name: Windows ${{ matrix.arch }}
     runs-on: windows-2019


### PR DESCRIPTION
Closes #1426

Note: this is likely not going to work because winapi doesn't seem to have an aarch64 target
Also, there doesn't seem to be a way to test this at the moment...