### PR TITLE
ref(monitors): Rename MonitorStatus -> MonitorCheckinStatus

### DIFF
--- a/src/api.rs
+++ b/src/api.rs
@@ -2388,7 +2388,7 @@ pub struct Monitor {
 
 #[derive(Debug, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
-pub enum MonitorStatus {
+pub enum MonitorCheckinStatus {
     Unknown,
     Ok,
     InProgress,
@@ -2398,19 +2398,19 @@ pub enum MonitorStatus {
 #[derive(Debug, Deserialize)]
 pub struct MonitorCheckIn {
     pub id: Uuid,
-    pub status: MonitorStatus,
+    pub status: MonitorCheckinStatus,
     pub duration: Option<u64>,
 }
 
 #[derive(Debug, Serialize)]
 pub struct CreateMonitorCheckIn {
-    pub status: MonitorStatus,
+    pub status: MonitorCheckinStatus,
 }
 
 #[derive(Debug, Serialize, Default)]
 pub struct UpdateMonitorCheckIn {
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub status: Option<MonitorStatus>,
+    pub status: Option<MonitorCheckinStatus>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub duration: Option<u64>,
 }

--- a/src/commands/monitors/run.rs
+++ b/src/commands/monitors/run.rs
@@ -6,7 +6,7 @@ use clap::{Arg, ArgMatches, Command};
 use console::style;
 use uuid::Uuid;
 
-use crate::api::{Api, CreateMonitorCheckIn, MonitorStatus, UpdateMonitorCheckIn};
+use crate::api::{Api, CreateMonitorCheckIn, MonitorCheckinStatus, UpdateMonitorCheckIn};
 use crate::utils::args::validate_uuid;
 use crate::utils::system::{print_error, QuietExit};
 
@@ -49,7 +49,7 @@ pub fn execute(matches: &ArgMatches) -> Result<()> {
     let monitor_checkin = api.create_monitor_checkin(
         &monitor,
         &CreateMonitorCheckIn {
-            status: MonitorStatus::InProgress,
+            status: MonitorCheckinStatus::InProgress,
         },
     );
 
@@ -83,9 +83,9 @@ pub fn execute(matches: &ArgMatches) -> Result<()> {
                 &checkin.id,
                 &UpdateMonitorCheckIn {
                     status: Some(if success {
-                        MonitorStatus::Ok
+                        MonitorCheckinStatus::Ok
                     } else {
-                        MonitorStatus::Error
+                        MonitorCheckinStatus::Error
                     }),
                     duration: Some({
                         let elapsed = started.elapsed();


### PR DESCRIPTION
This is consistent with the sentry codebase