### PR TITLE
ref(monitors): Drop passing `SENTRY_TRACE_ID`

### DIFF
--- a/src/commands/monitors/run.rs
+++ b/src/commands/monitors/run.rs
@@ -1,5 +1,5 @@
+use std::process;
 use std::time::Instant;
-use std::{env, process};
 
 use anyhow::Result;
 use clap::{Arg, ArgMatches, Command};
@@ -57,11 +57,6 @@ pub fn execute(matches: &ArgMatches) -> Result<()> {
     let mut p = process::Command::new(args[0]);
     p.args(&args[1..]);
     p.env("SENTRY_MONITOR_ID", monitor.to_string());
-
-    // Inherit outer SENTRY_TRACE_ID if present
-    let trace_id = env::var_os("SENTRY_TRACE_ID")
-        .unwrap_or_else(|| Uuid::new_v4().simple().to_string().into());
-    p.env("SENTRY_TRACE_ID", trace_id);
 
     let (success, code) = match p.status() {
         Ok(status) => (status.success(), status.code()),

--- a/tests/integration/_cases/monitors/monitors-run-env.trycmd
+++ b/tests/integration/_cases/monitors/monitors-run-env.trycmd
@@ -1,7 +1,6 @@
 ```
-$ sentry-cli monitors run 85a34e5a-c0b6-11ec-9d64-0242ac120002 -- sh -c 'env | sort | grep -E "SENTRY_MONITOR_ID|SENTRY_TRACE_ID"'
+$ sentry-cli monitors run 85a34e5a-c0b6-11ec-9d64-0242ac120002 -- sh -c 'env | sort | grep -E "SENTRY_MONITOR_ID"'
 ? success
 SENTRY_MONITOR_ID=85a34e5a-c0b6-11ec-9d64-0242ac120002
-SENTRY_TRACE_ID=[..]
 
 ```


### PR DESCRIPTION
This will be implemented in a different way in the near future