### PR TITLE
meta(changelog): Update CHANGELOG for 2.13.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,14 @@
 
 ## Unreleased
 
-### Various fixes & improvements
+## 2.13.0
 
 - feat: Added the `--raw` flag to `send-envelope` to allow sending envelopes without parsing or validation. (#1468)
+- feat: extract and upload embedded Portable PDB from PE (#1463)
+- ref(monitors): Drop passing `SENTRY_TRACE_ID` (#1472)
+- ref(monitors): Rename MonitorStatus -> MonitorCheckinStatus (#1471)
+- ref: Deduplicate artifacts upload using queried checksums (#1456)
+- ref: Add better debug message for malformed config files (#1450)
 
 ## 2.12.0
 


### PR DESCRIPTION
Not 100% sure about the `ref` entires, they do seem kind of relevant for the changelog maybe, but not sure?

Note: Make sure to publish this _after_ https://github.com/getsentry/sentry-cli/pull/1474.