### PR TITLE
build: Move to rust edition 2021 and msrv to 1.65

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -70,9 +70,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.68"
+version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2cb2f989d18dd141ab8ae82f64d1a8cdd37e0840f73a406896cf5e99502fab61"
+checksum = "224afbd727c3d6e4b90103ece64b8d1b67fbb1973b1046c2281eed3f3803f800"
 dependencies = [
  "backtrace",
 ]
@@ -801,15 +801,6 @@ checksum = "aa68f1b12764fab894d2755d2518754e71b4fd80ecfb822714a1206c2aab39bf"
 dependencies = [
  "cc",
  "libc",
-]
-
-[[package]]
-name = "failure"
-version = "0.1.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d32e9bd16cc02eae7db7ef620b392808b89f6a5e16bb3497d159c6b92a0f4f86"
-dependencies = [
- "backtrace",
 ]
 
 [[package]]
@@ -1988,12 +1979,12 @@ dependencies = [
 
 [[package]]
 name = "runas"
-version = "0.2.1"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a620b0994a180cdfa25c0439e6d58c0628272571501880d626ffff58e96a0799"
+checksum = "ed87390fefd18965ff20baae5aeb9913bcf82d2b59dc04c0f6d8f17f7be56ff2"
 dependencies = [
  "cc",
- "which 3.1.1",
+ "which",
 ]
 
 [[package]]
@@ -2263,7 +2254,7 @@ dependencies = [
  "username",
  "uuid",
  "walkdir",
- "which 4.4.0",
+ "which",
  "winapi 0.3.9",
  "zip",
 ]
@@ -2334,12 +2325,21 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.91"
+version = "1.0.93"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "877c235533714907a8c2464236f5c4b2a17262ef1bd71f38f35ea592c8da6883"
+checksum = "cad406b69c91885b5107daf2c29572f6c8cdb3c66826821e286c533490c0bc76"
 dependencies = [
  "itoa 1.0.5",
  "ryu",
+ "serde",
+]
+
+[[package]]
+name = "serde_spanned"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0efd8caf556a6cebd3b285caf480045fcc1ac04f6bd786b09a6f11af30c4fcf4"
+dependencies = [
  "serde",
 ]
 
@@ -2394,9 +2394,9 @@ checksum = "43b2853a4d09f215c24cc5489c992ce46052d359b5109343cbafbf26bc62f8a3"
 
 [[package]]
 name = "signal-hook"
-version = "0.3.14"
+version = "0.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a253b5e89e2698464fc26b545c9edceb338e18a89effeeecfea192c3025be29d"
+checksum = "732768f1176d21d09e076c23a93123d40bba92d50c4058da34d45c8de8e682b9"
 dependencies = [
  "libc",
  "signal-hook-registry",
@@ -2767,23 +2767,23 @@ checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 
 [[package]]
 name = "toml_datetime"
-version = "0.5.1"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4553f467ac8e3d374bc9a177a26801e5d0f9b211aa1673fb137a403afd1c9cf5"
+checksum = "3ab8ed2edee10b50132aed5f331333428b011c99402b5a534154ed15746f9622"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "toml_edit"
-version = "0.17.1"
+version = "0.19.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a34cc558345efd7e88b9eda9626df2138b80bb46a7606f695e751c892bc7dac6"
+checksum = "5e6a7712b49e1775fb9a7b998de6635b299237f48b404dde71704f2e0e7f37e5"
 dependencies = [
  "indexmap",
- "itertools",
  "nom8",
  "serde",
+ "serde_spanned",
  "toml_datetime",
 ]
 
@@ -2821,9 +2821,9 @@ dependencies = [
 
 [[package]]
 name = "trycmd"
-version = "0.14.10"
+version = "0.14.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01662d21325d18cd4acae7e1dc9f29a2a88b7fbb7f9bc427c4a692aaec5773ac"
+checksum = "522dcafb4bf113bcf83e4f47a0499ea1f6798877439e6a0e96cf087a2abe97dc"
 dependencies = [
  "glob",
  "humantime",
@@ -2922,9 +2922,9 @@ dependencies = [
 
 [[package]]
 name = "uuid"
-version = "1.2.2"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "422ee0de9031b5b948b97a8fc04e3aa35230001a722ddd27943e0be31564ce4c"
+checksum = "1674845326ee10d37ca60470760d4288a6f80f304007d92e5c53bab78c9cfd79"
 dependencies = [
  "getrandom",
  "serde",
@@ -3047,16 +3047,6 @@ checksum = "6746b5315e417144282a047ebb82260d45c92d09bf653fa9ec975e3809be942b"
 dependencies = [
  "leb128",
  "thiserror",
-]
-
-[[package]]
-name = "which"
-version = "3.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d011071ae14a2f6671d0b74080ae0cd8ebf3a6f8c9589a2cd45f23126fe29724"
-dependencies = [
- "failure",
- "libc",
 ]
 
 [[package]]
@@ -3196,9 +3186,9 @@ checksum = "09041cd90cf85f7f8b2df60c646f853b7f535ce68f85244eb6731cf89fa498ec"
 
 [[package]]
 name = "zip"
-version = "0.6.3"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "537ce7411d25e54e8ae21a7ce0b15840e7bfcff15b51d697ec3266cc76bdf080"
+checksum = "0445d0fbc924bb93539b4316c11afb121ea39296f99a3c4c9edad09e3658cdef"
 dependencies = [
  "aes",
  "byteorder",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,11 +3,12 @@ authors = ["Armin Ronacher <armin.ronacher@active-4.com>"]
 build = "build.rs"
 name = "sentry-cli"
 version = "2.12.0"
-edition = "2018"
+edition = "2021"
+rust-version = "1.65"
 
 [dependencies]
 anylog = "0.6.3"
-anyhow = { version = "1.0.68", features = ["backtrace"] }
+anyhow = { version = "1.0.69", features = ["backtrace"] }
 backoff = "0.4.0"
 backtrace = "0.3.67"
 brotli2 = "0.3.2"
@@ -49,7 +50,7 @@ proguard = { version = "5.0.0", features = ["uuid"] }
 r2d2 = "0.8.10"
 rayon = "1.6.1"
 regex = "1.7.1"
-runas = "0.2.1"
+runas = "1.0.0"
 rust-ini = "0.18.0"
 semver = "1.0.16"
 sentry = { version = "0.29.3", default-features = false, features = [
@@ -58,24 +59,24 @@ sentry = { version = "0.29.3", default-features = false, features = [
   "contexts",
 ] }
 serde = { version = "1.0.152", features = ["derive"] }
-serde_json = "1.0.91"
+serde_json = "1.0.93"
 sha1_smol = { version = "1.0.0", features = ["serde"] }
 sourcemap = { version = "6.2.1", features = ["ram_bundle"] }
 symbolic = { version = "11.1.0", features = ["debuginfo-serde", "il2cpp"] }
 thiserror = "1.0.38"
 url = "2.3.1"
 username = "0.2.0"
-uuid = { version = "1.2.2", features = ["v4", "serde"] }
+uuid = { version = "1.3.0", features = ["v4", "serde"] }
 walkdir = "2.3.2"
 which = "4.4.0"
-zip = "0.6.3"
+zip = "0.6.4"
 
 [dev-dependencies]
 insta = { version = "1.26.0", features = ["redactions", "yaml"] }
 mockito = "0.31.1"
 predicates = "2.1.5"
 tempfile = "3.3.0"
-trycmd = "0.14.10"
+trycmd = "0.14.11"
 
 [features]
 default = []
@@ -95,7 +96,7 @@ unix-daemonize = "0.1.2"
 
 [target."cfg(unix)".dependencies]
 openssl-probe = "0.1.5"
-signal-hook = "0.3.14"
+signal-hook = "0.3.15"
 crossbeam-channel = "0.5.6"
 
 [target."cfg(windows)"]

--- a/src/utils/vcs.rs
+++ b/src/utils/vcs.rs
@@ -937,7 +937,7 @@ fn git_create_tag(dir: &Path, tag_name: &str, annotated: bool) -> String {
         .args(tag_cmd)
         .current_dir(dir)
         .spawn()
-        .unwrap_or_else(|_| panic!("Failed to execute `git tag {}`", tag_name));
+        .unwrap_or_else(|_| panic!("Failed to execute `git tag {tag_name}`"));
 
     tag.wait().expect("Failed to wait on git tag.");
 
@@ -945,7 +945,7 @@ fn git_create_tag(dir: &Path, tag_name: &str, annotated: bool) -> String {
         .args(["rev-list", "-n", "1", tag_name])
         .current_dir(dir)
         .output()
-        .unwrap_or_else(|_| panic!("Failed to execute `git rev-list -n 1 {}`.", tag_name));
+        .unwrap_or_else(|_| panic!("Failed to execute `git rev-list -n 1 {tag_name}`."));
 
     String::from_utf8(hash.stdout)
         .map(|s| s.trim().to_string())


### PR DESCRIPTION
`1.65` is the first stable release that supports `let-else` that we use in `sentry-rust`.