### PR TITLE
chore: update clap deprecations

### DIFF
--- a/src/api.rs
+++ b/src/api.rs
@@ -2326,7 +2326,7 @@ impl IssueFilter {
     }
 
     pub fn get_filter_from_matches(matches: &ArgMatches) -> Result<IssueFilter> {
-        if matches.is_present("all") {
+        if matches.contains_id("all") {
             return Ok(IssueFilter::All);
         }
         if let Some(status) = matches.get_one::<String>("status") {

--- a/src/api.rs
+++ b/src/api.rs
@@ -2329,7 +2329,7 @@ impl IssueFilter {
         if matches.is_present("all") {
             return Ok(IssueFilter::All);
         }
-        if let Some(status) = matches.value_of("status") {
+        if let Some(status) = matches.get_one::<String>("status") {
             return Ok(IssueFilter::Status(status.into()));
         }
         let mut ids = vec![];

--- a/src/api.rs
+++ b/src/api.rs
@@ -2333,7 +2333,7 @@ impl IssueFilter {
             return Ok(IssueFilter::Status(status.into()));
         }
         let mut ids = vec![];
-        if let Some(values) = matches.values_of("id") {
+        if let Some(values) = matches.get_many::<String>("id") {
             for value in values {
                 ids.push(value.parse::<u64>().context("Invalid issue ID")?);
             }

--- a/src/commands/bash_hook.rs
+++ b/src/commands/bash_hook.rs
@@ -173,8 +173,8 @@ fn send_event(traceback: &str, logfile: &str, environ: bool) -> Result<()> {
 pub fn execute(matches: &ArgMatches) -> Result<()> {
     if matches.is_present("send_event") {
         return send_event(
-            matches.value_of("traceback").unwrap(),
-            matches.value_of("log").unwrap(),
+            matches.get_one::<String>("traceback").unwrap(),
+            matches.get_one::<String>("log").unwrap(),
             !matches.is_present("no_environ"),
         );
     }
@@ -193,7 +193,10 @@ pub fn execute(matches: &ArgMatches) -> Result<()> {
         .replace("___SENTRY_LOG_FILE___", &log.display().to_string());
 
     if matches.is_present("cli") {
-        script = script.replace("___SENTRY_CLI___", matches.value_of("cli").unwrap());
+        script = script.replace(
+            "___SENTRY_CLI___",
+            matches.get_one::<String>("cli").unwrap(),
+        );
     } else {
         script = script.replace(
             "___SENTRY_CLI___",

--- a/src/commands/bash_hook.rs
+++ b/src/commands/bash_hook.rs
@@ -171,11 +171,11 @@ fn send_event(traceback: &str, logfile: &str, environ: bool) -> Result<()> {
 }
 
 pub fn execute(matches: &ArgMatches) -> Result<()> {
-    if matches.is_present("send_event") {
+    if matches.contains_id("send_event") {
         return send_event(
             matches.get_one::<String>("traceback").unwrap(),
             matches.get_one::<String>("log").unwrap(),
-            !matches.is_present("no_environ"),
+            !matches.contains_id("no_environ"),
         );
     }
 
@@ -192,7 +192,7 @@ pub fn execute(matches: &ArgMatches) -> Result<()> {
         )
         .replace("___SENTRY_LOG_FILE___", &log.display().to_string());
 
-    if matches.is_present("cli") {
+    if matches.contains_id("cli") {
         script = script.replace(
             "___SENTRY_CLI___",
             matches.get_one::<String>("cli").unwrap(),
@@ -204,13 +204,13 @@ pub fn execute(matches: &ArgMatches) -> Result<()> {
         );
     }
 
-    if matches.is_present("no_environ") {
+    if matches.contains_id("no_environ") {
         script = script.replace("___SENTRY_NO_ENVIRON___", "--no-environ");
     } else {
         script = script.replace("___SENTRY_NO_ENVIRON___", "");
     }
 
-    if !matches.is_present("no_exit") {
+    if !matches.contains_id("no_exit") {
         script.insert_str(0, "set -e\n\n");
     }
     println!("{script}");

--- a/src/commands/bash_hook.rs
+++ b/src/commands/bash_hook.rs
@@ -192,17 +192,16 @@ pub fn execute(matches: &ArgMatches) -> Result<()> {
         )
         .replace("___SENTRY_LOG_FILE___", &log.display().to_string());
 
-    if matches.contains_id("cli") {
-        script = script.replace(
-            "___SENTRY_CLI___",
-            matches.get_one::<String>("cli").unwrap(),
-        );
-    } else {
-        script = script.replace(
-            "___SENTRY_CLI___",
-            &env::current_exe().unwrap().display().to_string(),
-        );
-    }
+    script = script.replace(
+        "___SENTRY_CLI___",
+        matches
+            .get_one::<String>("cli")
+            .map_or_else(
+                || env::current_exe().unwrap().display().to_string(),
+                String::clone,
+            )
+            .as_str(),
+    );
 
     if matches.contains_id("no_environ") {
         script = script.replace("___SENTRY_NO_ENVIRON___", "--no-environ");

--- a/src/commands/debug_files/bundle_sources.rs
+++ b/src/commands/debug_files/bundle_sources.rs
@@ -67,7 +67,7 @@ fn get_canonical_path<P: AsRef<Path>>(path: P) -> Result<PathBuf> {
 }
 
 pub fn execute(matches: &ArgMatches) -> Result<()> {
-    let output_path = matches.value_of("output").map(Path::new);
+    let output_path = matches.get_one::<String>("output").map(Path::new);
 
     for orig_path in matches.values_of("paths").unwrap() {
         let canonical_path = get_canonical_path(orig_path)?;

--- a/src/commands/debug_files/bundle_sources.rs
+++ b/src/commands/debug_files/bundle_sources.rs
@@ -69,7 +69,7 @@ fn get_canonical_path<P: AsRef<Path>>(path: P) -> Result<PathBuf> {
 pub fn execute(matches: &ArgMatches) -> Result<()> {
     let output_path = matches.get_one::<String>("output").map(Path::new);
 
-    for orig_path in matches.values_of("paths").unwrap() {
+    for orig_path in matches.get_many::<String>("paths").unwrap() {
         let canonical_path = get_canonical_path(orig_path)?;
 
         let archive = match DifFile::open_path(&canonical_path, None)? {

--- a/src/commands/debug_files/bundle_sources.rs
+++ b/src/commands/debug_files/bundle_sources.rs
@@ -2,7 +2,7 @@ use std::fs;
 use std::path::{Path, PathBuf};
 
 use anyhow::Result;
-use clap::{Arg, ArgMatches, Command};
+use clap::{Arg, ArgAction, ArgMatches, Command};
 use log::warn;
 use symbolic::debuginfo::sourcebundle::SourceBundleWriter;
 
@@ -15,7 +15,8 @@ pub fn make_command(command: Command) -> Command {
         .arg(
             Arg::new("paths")
                 .required(true)
-                .multiple_occurrences(true)
+                .multiple_values(true)
+                .action(ArgAction::Append)
                 .help("The path to the input debug info files."),
         )
         .arg(

--- a/src/commands/debug_files/check.rs
+++ b/src/commands/debug_files/check.rs
@@ -2,8 +2,7 @@ use std::io;
 use std::path::Path;
 
 use anyhow::Result;
-use clap::builder::PossibleValuesParser;
-use clap::{Arg, ArgMatches, Command};
+use clap::{builder::PossibleValuesParser, Arg, ArgMatches, Command};
 use console::style;
 
 use crate::utils::dif::{DifFile, DifType};

--- a/src/commands/debug_files/check.rs
+++ b/src/commands/debug_files/check.rs
@@ -48,12 +48,12 @@ pub fn execute(matches: &ArgMatches) -> Result<()> {
         .map(|t| t.parse().unwrap());
     let dif = DifFile::open_path(path, ty)?;
 
-    if matches.is_present("json") {
+    if matches.contains_id("json") {
         serde_json::to_writer_pretty(&mut io::stdout(), &dif)?;
         println!();
     }
 
-    if matches.is_present("json") || is_quiet_mode() {
+    if matches.contains_id("json") || is_quiet_mode() {
         return if dif.is_usable() {
             Ok(())
         } else {

--- a/src/commands/debug_files/check.rs
+++ b/src/commands/debug_files/check.rs
@@ -40,10 +40,12 @@ pub fn make_command(command: Command) -> Command {
 }
 
 pub fn execute(matches: &ArgMatches) -> Result<()> {
-    let path = Path::new(matches.value_of("path").unwrap());
+    let path = Path::new(matches.get_one::<String>("path").unwrap());
 
     // which types should we consider?
-    let ty = matches.value_of("type").map(|t| t.parse().unwrap());
+    let ty = matches
+        .get_one::<String>("type")
+        .map(|t| t.parse().unwrap());
     let dif = DifFile::open_path(path, ty)?;
 
     if matches.is_present("json") {

--- a/src/commands/debug_files/check.rs
+++ b/src/commands/debug_files/check.rs
@@ -2,6 +2,7 @@ use std::io;
 use std::path::Path;
 
 use anyhow::Result;
+use clap::builder::PossibleValuesParser;
 use clap::{Arg, ArgMatches, Command};
 use console::style;
 
@@ -26,7 +27,7 @@ pub fn make_command(command: Command) -> Command {
                 .long("type")
                 .short('t')
                 .value_name("TYPE")
-                .possible_values(DifType::all_names())
+                .value_parser(PossibleValuesParser::new(DifType::all_names()))
                 .help(
                     "Explicitly set the type of the debug info file. \
                      This should not be needed as files are auto detected.",

--- a/src/commands/debug_files/find.rs
+++ b/src/commands/debug_files/find.rs
@@ -7,8 +7,7 @@ use std::path::PathBuf;
 use std::str::FromStr;
 
 use anyhow::Result;
-use clap::builder::PossibleValuesParser;
-use clap::{Arg, ArgAction, ArgMatches, Command};
+use clap::{builder::PossibleValuesParser, Arg, ArgAction, ArgMatches, Command};
 use console::style;
 use if_chain::if_chain;
 use proguard::ProguardMapping;

--- a/src/commands/debug_files/find.rs
+++ b/src/commands/debug_files/find.rs
@@ -7,7 +7,8 @@ use std::path::PathBuf;
 use std::str::FromStr;
 
 use anyhow::Result;
-use clap::{Arg, ArgMatches, Command, ArgAction};
+use clap::builder::PossibleValuesParser;
+use clap::{Arg, ArgAction, ArgMatches, Command};
 use console::style;
 use if_chain::if_chain;
 use proguard::ProguardMapping;
@@ -50,7 +51,7 @@ pub fn make_command(command: Command) -> Command {
                 .value_name("TYPE")
                 .multiple_values(true)
                 .action(ArgAction::Append)
-                .possible_values(DifType::all_names())
+                .value_parser(PossibleValuesParser::new(DifType::all_names()))
                 .help(
                     "Only consider debug information files of the given \
                      type.  By default all types are considered.",

--- a/src/commands/debug_files/find.rs
+++ b/src/commands/debug_files/find.rs
@@ -337,8 +337,8 @@ pub fn execute(matches: &ArgMatches) -> Result<()> {
         types.extend(DifType::all());
     }
 
-    let with_well_known = !matches.is_present("no_well_known");
-    let with_cwd = !matches.is_present("no_cwd");
+    let with_well_known = !matches.contains_id("no_well_known");
+    let with_cwd = !matches.contains_id("no_cwd");
 
     // start adding well known locations
     if_chain! {
@@ -376,7 +376,7 @@ pub fn execute(matches: &ArgMatches) -> Result<()> {
         return Ok(());
     }
 
-    if !find_ids(&paths, &types, &ids, matches.is_present("json"))? {
+    if !find_ids(&paths, &types, &ids, matches.contains_id("json"))? {
         return Err(QuietExit(1).into());
     }
 

--- a/src/commands/debug_files/find.rs
+++ b/src/commands/debug_files/find.rs
@@ -1,8 +1,10 @@
 use std::collections::HashSet;
 use std::env;
 use std::ffi::OsStr;
+use std::fmt::Debug;
 use std::io;
 use std::path::PathBuf;
+use std::str::FromStr;
 
 use anyhow::Result;
 use clap::{Arg, ArgMatches, Command};
@@ -14,7 +16,6 @@ use symbolic::common::{ByteView, DebugId};
 use uuid::{Uuid, Version as UuidVersion};
 use walkdir::{DirEntry, WalkDir};
 
-use crate::utils::args::validate_id;
 use crate::utils::dif::{DifFile, DifType};
 use crate::utils::progress::{ProgressBar, ProgressStyle};
 use crate::utils::system::QuietExit;
@@ -38,7 +39,7 @@ pub fn make_command(command: Command) -> Command {
             Arg::new("ids")
                 .value_name("ID")
                 .help("The debug identifiers of the files to search for.")
-                .validator(validate_id)
+                .value_parser(DebugId::from_str)
                 .multiple_occurrences(true),
         )
         .arg(
@@ -368,9 +369,9 @@ pub fn execute(matches: &ArgMatches) -> Result<()> {
     }
 
     // which ids are we looking for?
-    if let Some(i) = matches.get_many::<String>("ids") {
+    if let Some(i) = matches.get_many::<DebugId>("ids") {
         for id in i {
-            ids.insert(id.parse().unwrap());
+            ids.insert(*id);
         }
     } else {
         return Ok(());

--- a/src/commands/debug_files/find.rs
+++ b/src/commands/debug_files/find.rs
@@ -7,7 +7,7 @@ use std::path::PathBuf;
 use std::str::FromStr;
 
 use anyhow::Result;
-use clap::{Arg, ArgMatches, Command};
+use clap::{Arg, ArgMatches, Command, ArgAction};
 use console::style;
 use if_chain::if_chain;
 use proguard::ProguardMapping;
@@ -40,14 +40,16 @@ pub fn make_command(command: Command) -> Command {
                 .value_name("ID")
                 .help("The debug identifiers of the files to search for.")
                 .value_parser(DebugId::from_str)
-                .multiple_occurrences(true),
+                .multiple_values(true)
+                .action(ArgAction::Append),
         )
         .arg(
             Arg::new("types")
                 .long("type")
                 .short('t')
                 .value_name("TYPE")
-                .multiple_occurrences(true)
+                .multiple_values(true)
+                .action(ArgAction::Append)
                 .possible_values(DifType::all_names())
                 .help(
                     "Only consider debug information files of the given \
@@ -69,7 +71,7 @@ pub fn make_command(command: Command) -> Command {
                 .long("path")
                 .short('p')
                 .value_name("PATH")
-                .multiple_occurrences(true)
+                .action(ArgAction::Append)
                 .help("Add a path to search recursively for debug info files."),
         )
         .arg(

--- a/src/commands/debug_files/find.rs
+++ b/src/commands/debug_files/find.rs
@@ -49,7 +49,6 @@ pub fn make_command(command: Command) -> Command {
                 .long("type")
                 .short('t')
                 .value_name("TYPE")
-                .multiple_values(true)
                 .action(ArgAction::Append)
                 .value_parser(PossibleValuesParser::new(DifType::all_names()))
                 .help(

--- a/src/commands/debug_files/find.rs
+++ b/src/commands/debug_files/find.rs
@@ -329,7 +329,7 @@ pub fn execute(matches: &ArgMatches) -> Result<()> {
     let mut ids = HashSet::new();
 
     // which types should we consider?
-    if let Some(t) = matches.values_of("types") {
+    if let Some(t) = matches.get_many::<String>("types") {
         for ty in t {
             types.insert(ty.parse().unwrap());
         }
@@ -361,14 +361,14 @@ pub fn execute(matches: &ArgMatches) -> Result<()> {
     }
 
     // extra paths
-    if let Some(p) = matches.values_of("paths") {
+    if let Some(p) = matches.get_many::<String>("paths") {
         for path in p {
             paths.insert(PathBuf::from(path));
         }
     }
 
     // which ids are we looking for?
-    if let Some(i) = matches.values_of("ids") {
+    if let Some(i) = matches.get_many::<String>("ids") {
         for id in i {
             ids.insert(id.parse().unwrap());
         }

--- a/src/commands/debug_files/print_sources.rs
+++ b/src/commands/debug_files/print_sources.rs
@@ -16,7 +16,7 @@ pub fn make_command(command: Command) -> Command {
 }
 
 pub fn execute(matches: &ArgMatches) -> Result<()> {
-    let path = Path::new(matches.value_of("path").unwrap());
+    let path = Path::new(matches.get_one::<String>("path").unwrap());
 
     // which types should we consider?
     let data = ByteView::open(path)?;

--- a/src/commands/debug_files/upload.rs
+++ b/src/commands/debug_files/upload.rs
@@ -2,7 +2,7 @@ use std::collections::BTreeSet;
 use std::str::{self, FromStr};
 
 use anyhow::{bail, format_err, Result};
-use clap::{Arg, ArgMatches, Command};
+use clap::{Arg, ArgMatches, Command, ArgAction};
 use console::style;
 use log::info;
 use symbolic::common::DebugId;
@@ -31,14 +31,16 @@ pub fn make_command(command: Command) -> Command {
             Arg::new("paths")
                 .value_name("PATH")
                 .help("A path to search recursively for symbol files.")
-                .multiple_occurrences(true),
+                .multiple_values(true)
+                .action(ArgAction::Append),
         )
         .arg(
             Arg::new("types")
                 .long("type")
                 .short('t')
                 .value_name("TYPE")
-                .multiple_occurrences(true)
+                .multiple_values(true)
+                .action(ArgAction::Append)
                 .possible_values(types)
                 .help(
                     "Only consider debug information files of the given \
@@ -81,7 +83,8 @@ pub fn make_command(command: Command) -> Command {
                 .long("id")
                 .help("Search for specific debug identifiers.")
                 .value_parser(DebugId::from_str)
-                .multiple_occurrences(true),
+                .multiple_values(true)
+                .action(ArgAction::Append),
         )
         .arg(
             Arg::new("require_all")

--- a/src/commands/debug_files/upload.rs
+++ b/src/commands/debug_files/upload.rs
@@ -169,7 +169,7 @@ pub fn execute(matches: &ArgMatches) -> Result<()> {
     let (org, project) = config.get_org_and_project(matches)?;
 
     let ids = matches
-        .values_of("ids")
+        .get_many::<String>("ids")
         .unwrap_or_default()
         .filter_map(|s| DebugId::from_str(s).ok());
 
@@ -182,12 +182,12 @@ pub fn execute(matches: &ArgMatches) -> Result<()> {
     let mut upload = DifUpload::new(org.clone(), project.clone());
     upload
         .wait(matches.contains_id("wait"))
-        .search_paths(matches.values_of("paths").unwrap_or_default())
+        .search_paths(matches.get_many::<String>("paths").unwrap_or_default())
         .allow_zips(!matches.contains_id("no_zips"))
         .filter_ids(ids);
 
     // Restrict symbol types, if specified by the user
-    for ty in matches.values_of("types").unwrap_or_default() {
+    for ty in matches.get_many::<String>("types").unwrap_or_default().map(String::as_str) {
         match ty {
             "dsym" => upload.filter_format(DifFormat::Object(FileFormat::MachO)),
             "elf" => upload.filter_format(DifFormat::Object(FileFormat::Elf)),
@@ -297,7 +297,7 @@ pub fn execute(matches: &ArgMatches) -> Result<()> {
         // Did we miss explicitly requested symbols?
         if matches.contains_id("require_all") {
             let required_ids: BTreeSet<_> = matches
-                .values_of("ids")
+                .get_many::<String>("ids")
                 .unwrap_or_default()
                 .filter_map(|s| DebugId::from_str(s).ok())
                 .collect();

--- a/src/commands/debug_files/upload.rs
+++ b/src/commands/debug_files/upload.rs
@@ -221,7 +221,7 @@ pub fn execute(matches: &ArgMatches) -> Result<()> {
     upload.il2cpp_mapping(matches.is_present("il2cpp_mapping"));
 
     // Configure BCSymbolMap resolution, if possible
-    if let Some(symbol_map) = matches.value_of("symbol_maps") {
+    if let Some(symbol_map) = matches.get_one::<String>("symbol_maps") {
         upload
             .symbol_map(symbol_map)
             .map_err(|_| format_err!("--symbol-maps requires Apple dsymutil to be available."))?;
@@ -238,7 +238,7 @@ pub fn execute(matches: &ArgMatches) -> Result<()> {
     }
 
     // Try to resolve the Info.plist either by path or from Xcode
-    let info_plist = match matches.value_of("info_plist") {
+    let info_plist = match matches.get_one::<String>("info_plist") {
         Some(path) => Some(InfoPlist::from_path(path)?),
         None => InfoPlist::discover_from_env()?,
     };

--- a/src/commands/debug_files/upload.rs
+++ b/src/commands/debug_files/upload.rs
@@ -2,8 +2,7 @@ use std::collections::BTreeSet;
 use std::str::{self, FromStr};
 
 use anyhow::{bail, format_err, Result};
-use clap::builder::PossibleValuesParser;
-use clap::{Arg, ArgAction, ArgMatches, Command};
+use clap::{builder::PossibleValuesParser, Arg, ArgAction, ArgMatches, Command};
 use console::style;
 use log::info;
 use symbolic::common::DebugId;
@@ -305,7 +304,7 @@ pub fn execute(matches: &ArgMatches) -> Result<()> {
             let required_ids: BTreeSet<DebugId> = matches
                 .get_many::<DebugId>("ids")
                 .unwrap_or_default()
-                .map(DebugId::clone)
+                .cloned()
                 .collect();
 
             let found_ids = uploaded.into_iter().map(|dif| dif.id()).collect();

--- a/src/commands/debug_files/upload.rs
+++ b/src/commands/debug_files/upload.rs
@@ -3,7 +3,7 @@ use std::str::{self, FromStr};
 
 use anyhow::{bail, format_err, Result};
 use clap::builder::PossibleValuesParser;
-use clap::{Arg, ArgMatches, Command, ArgAction};
+use clap::{Arg, ArgAction, ArgMatches, Command};
 use console::style;
 use log::info;
 use symbolic::common::DebugId;
@@ -40,7 +40,6 @@ pub fn make_command(command: Command) -> Command {
                 .long("type")
                 .short('t')
                 .value_name("TYPE")
-                .multiple_values(true)
                 .action(ArgAction::Append)
                 .value_parser(PossibleValuesParser::new(types))
                 .help(
@@ -84,7 +83,6 @@ pub fn make_command(command: Command) -> Command {
                 .long("id")
                 .help("Search for specific debug identifiers.")
                 .value_parser(DebugId::from_str)
-                .multiple_values(true)
                 .action(ArgAction::Append),
         )
         .arg(

--- a/src/commands/debug_files/upload.rs
+++ b/src/commands/debug_files/upload.rs
@@ -2,6 +2,7 @@ use std::collections::BTreeSet;
 use std::str::{self, FromStr};
 
 use anyhow::{bail, format_err, Result};
+use clap::builder::PossibleValuesParser;
 use clap::{Arg, ArgMatches, Command, ArgAction};
 use console::style;
 use log::info;
@@ -41,7 +42,7 @@ pub fn make_command(command: Command) -> Command {
                 .value_name("TYPE")
                 .multiple_values(true)
                 .action(ArgAction::Append)
-                .possible_values(types)
+                .value_parser(PossibleValuesParser::new(types))
                 .help(
                     "Only consider debug information files of the given \
                     type.  By default, all types are considered.",

--- a/src/commands/deploys/new.rs
+++ b/src/commands/deploys/new.rs
@@ -69,8 +69,8 @@ pub fn execute(matches: &ArgMatches) -> Result<()> {
     let version = config.get_release_with_legacy_fallback(matches)?;
     let mut deploy = Deploy {
         env: matches.get_one::<String>("env").unwrap().to_string(),
-        name: matches.get_one::<String>("name").map(String::clone),
-        url: matches.get_one::<String>("url").map(String::clone),
+        name: matches.get_one::<String>("name").cloned(),
+        url: matches.get_one::<String>("url").cloned(),
         ..Default::default()
     };
 

--- a/src/commands/deploys/new.rs
+++ b/src/commands/deploys/new.rs
@@ -68,23 +68,23 @@ pub fn execute(matches: &ArgMatches) -> Result<()> {
     let api = Api::current();
     let version = config.get_release_with_legacy_fallback(matches)?;
     let mut deploy = Deploy {
-        env: matches.value_of("env").unwrap().to_string(),
-        name: matches.value_of("name").map(str::to_owned),
-        url: matches.value_of("url").map(str::to_owned),
+        env: matches.get_one::<String>("env").unwrap().to_string(),
+        name: matches.get_one::<String>("name").map(String::clone),
+        url: matches.get_one::<String>("url").map(String::clone),
         ..Default::default()
     };
 
-    if let Some(value) = matches.value_of("time") {
+    if let Some(value) = matches.get_one::<String>("time") {
         let finished = Utc::now();
         deploy.finished = Some(finished);
         deploy.started = Some(finished - Duration::seconds(value.parse().unwrap()));
     } else {
-        if let Some(finished_str) = matches.value_of("finished") {
+        if let Some(finished_str) = matches.get_one::<String>("finished") {
             deploy.finished = Some(get_timestamp(finished_str)?);
         } else {
             deploy.finished = Some(Utc::now());
         }
-        if let Some(started_str) = matches.value_of("started") {
+        if let Some(started_str) = matches.get_one::<String>("started") {
             deploy.started = Some(get_timestamp(started_str)?);
         }
     }

--- a/src/commands/events/list.rs
+++ b/src/commands/events/list.rs
@@ -9,13 +9,13 @@ pub fn make_command(command: Command) -> Command {
     command
         .about("List all events in your organization.")
         .arg(
-            Arg::with_name("show_user")
+            Arg::new("show_user")
                 .long("show-user")
                 .short('U')
                 .help("Display the Users column."),
         )
         .arg(
-            Arg::with_name("show_tags")
+            Arg::new("show_tags")
                 .long("show-tags")
                 .short('T')
                 .help("Display the Tags column."),

--- a/src/commands/events/list.rs
+++ b/src/commands/events/list.rs
@@ -49,11 +49,11 @@ pub fn execute(matches: &ArgMatches) -> Result<()> {
     let mut table = Table::new();
     let title_row = table.title_row().add("Event ID").add("Date").add("Title");
 
-    if matches.is_present("show_user") {
+    if matches.contains_id("show_user") {
         title_row.add("User");
     }
 
-    if matches.is_present("show_tags") {
+    if matches.contains_id("show_tags") {
         title_row.add("Tags");
     }
 
@@ -69,7 +69,7 @@ pub fn execute(matches: &ArgMatches) -> Result<()> {
                 .add(&event.date_created)
                 .add(&event.title);
 
-            if matches.is_present("show_user") {
+            if matches.contains_id("show_user") {
                 if let Some(user) = &event.user {
                     row.add(user);
                 } else {
@@ -77,7 +77,7 @@ pub fn execute(matches: &ArgMatches) -> Result<()> {
                 }
             }
 
-            if matches.is_present("show_tags") {
+            if matches.contains_id("show_tags") {
                 if let Some(tags) = &event.tags {
                     row.add(
                         tags.iter()

--- a/src/commands/files/delete.rs
+++ b/src/commands/files/delete.rs
@@ -1,7 +1,7 @@
 use std::collections::HashSet;
 
 use anyhow::Result;
-use clap::{Arg, ArgMatches, Command};
+use clap::{Arg, ArgMatches, Command, ArgAction};
 
 use crate::api::Api;
 use crate::config::Config;
@@ -14,7 +14,8 @@ pub fn make_command(command: Command) -> Command {
         .arg(
             Arg::new("names")
                 .value_name("NAMES")
-                .multiple_occurrences(true)
+                .multiple_values(true)
+                .action(ArgAction::Append)
                 .help("Filenames to delete."),
         )
         .arg(

--- a/src/commands/files/delete.rs
+++ b/src/commands/files/delete.rs
@@ -32,7 +32,7 @@ pub fn execute(matches: &ArgMatches) -> Result<()> {
     let project = config.get_project(matches).ok();
     let api = Api::current();
 
-    if matches.is_present("all") {
+    if matches.contains_id("all") {
         if api.delete_release_files(&org, project.as_deref(), &release)? {
             println!("All files deleted.");
         }

--- a/src/commands/files/delete.rs
+++ b/src/commands/files/delete.rs
@@ -39,7 +39,7 @@ pub fn execute(matches: &ArgMatches) -> Result<()> {
         return Ok(());
     }
 
-    let files: HashSet<String> = match matches.values_of("names") {
+    let files: HashSet<String> = match matches.get_many::<String>("names") {
         Some(paths) => paths.map(|x| x.into()).collect(),
         None => HashSet::new(),
     };

--- a/src/commands/files/upload.rs
+++ b/src/commands/files/upload.rs
@@ -111,7 +111,7 @@ pub fn execute(matches: &ArgMatches) -> Result<()> {
 
     let dist = matches.get_one::<String>("dist").map(String::as_str);
     let mut headers = vec![];
-    if let Some(header_list) = matches.values_of("file-headers") {
+    if let Some(header_list) = matches.get_many::<String>("file-headers") {
         for header in header_list {
             if !header.contains(':') {
                 bail!("Invalid header. Needs to be in key:value format");
@@ -138,11 +138,11 @@ pub fn execute(matches: &ArgMatches) -> Result<()> {
             .map(String::as_str)
             .unwrap_or_default();
         let ignores = matches
-            .values_of("ignore")
+            .get_many::<String>("ignore")
             .map(|ignores| ignores.map(|i| format!("!{i}")).collect())
             .unwrap_or_else(Vec::new);
         let extensions = matches
-            .values_of("extensions")
+            .get_many::<String>("extensions")
             .map(|extensions| extensions.map(|ext| ext.trim_start_matches('.')).collect())
             .unwrap_or_else(Vec::new);
 

--- a/src/commands/files/upload.rs
+++ b/src/commands/files/upload.rs
@@ -109,7 +109,7 @@ pub fn execute(matches: &ArgMatches) -> Result<()> {
     let project = config.get_project(matches).ok();
     let api = Api::current();
 
-    let dist = matches.value_of("dist");
+    let dist = matches.get_one::<String>("dist").map(String::as_str);
     let mut headers = vec![];
     if let Some(header_list) = matches.values_of("file-headers") {
         for header in header_list {
@@ -130,10 +130,13 @@ pub fn execute(matches: &ArgMatches) -> Result<()> {
         ..Default::default()
     };
 
-    let path = Path::new(matches.value_of("path").unwrap());
+    let path = Path::new(matches.get_one::<String>("path").unwrap());
     // Batch files upload
     if path.is_dir() {
-        let ignore_file = matches.value_of("ignore_file").unwrap_or("");
+        let ignore_file = matches
+            .get_one::<String>("ignore_file")
+            .map(String::as_str)
+            .unwrap_or_default();
         let ignores = matches
             .values_of("ignore")
             .map(|ignores| ignores.map(|i| format!("!{i}")).collect())
@@ -150,8 +153,14 @@ pub fn execute(matches: &ArgMatches) -> Result<()> {
             .decompress(matches.is_present("decompress"))
             .collect_files()?;
 
-        let url_suffix = matches.value_of("url_suffix").unwrap_or("");
-        let mut url_prefix = matches.value_of("url_prefix").unwrap_or("~");
+        let url_suffix = matches
+            .get_one::<String>("url_suffix")
+            .map(String::as_str)
+            .unwrap_or_default();
+        let mut url_prefix = matches
+            .get_one::<String>("url_prefix")
+            .map(String::as_str)
+            .unwrap_or("~");
         // remove a single slash from the end.  so ~/ becomes ~ and app:/// becomes app://
         if url_prefix.ends_with('/') {
             url_prefix = &url_prefix[..url_prefix.len() - 1];
@@ -181,7 +190,7 @@ pub fn execute(matches: &ArgMatches) -> Result<()> {
     }
     // Single file upload
     else {
-        let name = match matches.value_of("name") {
+        let name = match matches.get_one::<String>("name") {
             Some(name) => name,
             None => Path::new(path)
                 .file_name()

--- a/src/commands/files/upload.rs
+++ b/src/commands/files/upload.rs
@@ -4,7 +4,7 @@ use std::io::Read;
 use std::path::Path;
 
 use anyhow::{bail, format_err, Result};
-use clap::{Arg, ArgMatches, Command};
+use clap::{Arg, ArgMatches, Command, ArgAction};
 use log::warn;
 use symbolic::debuginfo::sourcebundle::SourceFileType;
 
@@ -54,7 +54,8 @@ pub fn make_command(command: Command) -> Command {
                 .long("file-header")
                 .short('H')
                 .value_name("KEY VALUE")
-                .multiple_occurrences(true)
+                .multiple_values(true)
+                .action(ArgAction::Append)
                 .help("Store a header with this file."),
         )
         .arg(
@@ -75,7 +76,8 @@ pub fn make_command(command: Command) -> Command {
                 .long("ignore")
                 .short('i')
                 .value_name("IGNORE")
-                .multiple_occurrences(true)
+                .multiple_values(true)
+                .action(ArgAction::Append)
                 .help("Ignores all files and folders matching the given glob"),
         )
         .arg(
@@ -93,7 +95,8 @@ pub fn make_command(command: Command) -> Command {
                 .long("ext")
                 .short('x')
                 .value_name("EXT")
-                .multiple_occurrences(true)
+                .multiple_values(true)
+                .action(ArgAction::Append)
                 .help(
                     "Set the file extensions that are considered for upload. \
                     This overrides the default extensions. To add an extension, all default \

--- a/src/commands/files/upload.rs
+++ b/src/commands/files/upload.rs
@@ -36,7 +36,7 @@ pub fn make_command(command: Command) -> Command {
                 .long("dist")
                 .short('d')
                 .value_name("DISTRIBUTION")
-                .validator(validate_distribution)
+                .value_parser(validate_distribution)
                 .help("Optional distribution identifier for this file."),
         )
         .arg(

--- a/src/commands/files/upload.rs
+++ b/src/commands/files/upload.rs
@@ -126,7 +126,7 @@ pub fn execute(matches: &ArgMatches) -> Result<()> {
         project: project.as_deref(),
         release: &release,
         dist,
-        wait: matches.is_present("wait"),
+        wait: matches.contains_id("wait"),
         ..Default::default()
     };
 
@@ -150,7 +150,7 @@ pub fn execute(matches: &ArgMatches) -> Result<()> {
             .ignore_file(ignore_file)
             .ignores(ignores)
             .extensions(extensions)
-            .decompress(matches.is_present("decompress"))
+            .decompress(matches.contains_id("decompress"))
             .collect_files()?;
 
         let url_suffix = matches
@@ -202,7 +202,7 @@ pub fn execute(matches: &ArgMatches) -> Result<()> {
         let mut contents = Vec::new();
         f.read_to_end(&mut contents)?;
 
-        if matches.is_present("decompress") && is_gzip_compressed(&contents) {
+        if matches.contains_id("decompress") && is_gzip_compressed(&contents) {
             contents = decompress_gzip_content(&contents).unwrap_or_else(|_| {
                 warn!("Could not decompress: {}", name);
                 contents

--- a/src/commands/files/upload.rs
+++ b/src/commands/files/upload.rs
@@ -54,7 +54,6 @@ pub fn make_command(command: Command) -> Command {
                 .long("file-header")
                 .short('H')
                 .value_name("KEY VALUE")
-                .multiple_values(true)
                 .action(ArgAction::Append)
                 .help("Store a header with this file."),
         )
@@ -76,7 +75,6 @@ pub fn make_command(command: Command) -> Command {
                 .long("ignore")
                 .short('i')
                 .value_name("IGNORE")
-                .multiple_values(true)
                 .action(ArgAction::Append)
                 .help("Ignores all files and folders matching the given glob"),
         )
@@ -95,7 +93,6 @@ pub fn make_command(command: Command) -> Command {
                 .long("ext")
                 .short('x')
                 .value_name("EXT")
-                .multiple_values(true)
                 .action(ArgAction::Append)
                 .help(
                     "Set the file extensions that are considered for upload. \

--- a/src/commands/info.rs
+++ b/src/commands/info.rs
@@ -79,7 +79,7 @@ fn get_config_status_json() -> Result<()> {
 }
 
 pub fn execute(matches: &ArgMatches) -> Result<()> {
-    if matches.is_present("config_status_json") {
+    if matches.contains_id("config_status_json") {
         return get_config_status_json();
     }
 
@@ -91,7 +91,7 @@ pub fn execute(matches: &ArgMatches) -> Result<()> {
     let mut errors = config.get_auth().is_none() || info_rv.is_err();
 
     // If `no-defaults` is present, only authentication should be verified.
-    if !matches.is_present("no_defaults") {
+    if !matches.contains_id("no_defaults") {
         errors = errors || project.is_none() || org.is_none();
     }
 
@@ -105,7 +105,7 @@ pub fn execute(matches: &ArgMatches) -> Result<()> {
 
     println!("Sentry Server: {}", config.get_base_url().unwrap_or("-"));
 
-    if !matches.is_present("no_defaults") {
+    if !matches.contains_id("no_defaults") {
         println!(
             "Default Organization: {}",
             org.unwrap_or_else(|| "-".into())

--- a/src/commands/issues/mod.rs
+++ b/src/commands/issues/mod.rs
@@ -1,5 +1,5 @@
 use anyhow::Result;
-use clap::{Arg, ArgMatches, Command, ArgAction};
+use clap::{Arg, ArgAction, ArgMatches, Command};
 
 use crate::utils::args::ArgExt;
 
@@ -36,7 +36,7 @@ pub fn make_command(mut command: Command) -> Command {
                 .short('s')
                 .value_name("STATUS")
                 .global(true)
-                .possible_values(["resolved", "muted", "unresolved"])
+                .value_parser(["resolved", "muted", "unresolved"])
                 .help("Select all issues matching a given status."),
         )
         .arg(

--- a/src/commands/issues/mod.rs
+++ b/src/commands/issues/mod.rs
@@ -1,5 +1,5 @@
 use anyhow::Result;
-use clap::{Arg, ArgMatches, Command};
+use clap::{Arg, ArgMatches, Command, ArgAction};
 
 use crate::utils::args::ArgExt;
 
@@ -48,7 +48,8 @@ pub fn make_command(mut command: Command) -> Command {
         )
         .arg(
             Arg::new("id")
-                .multiple_occurrences(true)
+                .multiple_values(true)
+                .action(ArgAction::Append)
                 .long("id")
                 .short('i')
                 .value_name("ID")

--- a/src/commands/issues/mod.rs
+++ b/src/commands/issues/mod.rs
@@ -48,11 +48,10 @@ pub fn make_command(mut command: Command) -> Command {
         )
         .arg(
             Arg::new("id")
-                .multiple_values(true)
-                .action(ArgAction::Append)
                 .long("id")
                 .short('i')
                 .value_name("ID")
+                .action(ArgAction::Append)
                 .global(true)
                 .help("Select the issue with the given ID."),
         );

--- a/src/commands/issues/resolve.rs
+++ b/src/commands/issues/resolve.rs
@@ -25,7 +25,7 @@ pub fn execute(matches: &ArgMatches) -> Result<()> {
         org, project
     );
 
-    if matches.is_present("next_release") {
+    if matches.contains_id("next_release") {
         changes.new_status = Some("resolvedInNextRelease".into());
     } else {
         changes.new_status = Some("resolved".into());

--- a/src/commands/login.rs
+++ b/src/commands/login.rs
@@ -27,7 +27,7 @@ fn update_config(config: &Config, token: &str) -> Result<()> {
 pub fn execute(matches: &ArgMatches) -> Result<()> {
     let config = Config::current();
     let token_url = format!("{}/api/", config.get_base_url()?);
-    let predefined_token = matches.value_of("auth_token");
+    let predefined_token = matches.get_one::<String>("auth_token");
     let has_predefined_token = predefined_token.is_some();
 
     println!("This helps you signing in your sentry-cli with an authentication token.");

--- a/src/commands/login.rs
+++ b/src/commands/login.rs
@@ -85,7 +85,7 @@ pub fn execute(matches: &ArgMatches) -> Result<()> {
         }
     }
 
-    let config_to_update = if matches.is_present("global") {
+    let config_to_update = if matches.contains_id("global") {
         Config::global()?
     } else {
         Config::from_cli_config()?

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -230,7 +230,7 @@ pub fn execute() -> Result<()> {
     app = add_commands(app);
     let matches = app.get_matches();
     configure_args(&mut config, &matches)?;
-    set_quiet_mode(matches.is_present("quiet"));
+    set_quiet_mode(matches.contains_id("quiet"));
 
     // bind the config to the process and fetch an immutable reference to it
     config.bind_to_process();

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -101,7 +101,7 @@ fn configure_args(config: &mut Config, matches: &ArgMatches) -> Result<()> {
         config.set_base_url(url);
     }
 
-    if let Some(headers) = matches.values_of("headers") {
+    if let Some(headers) = matches.get_many::<String>("headers") {
         let headers = headers.map(|h| h.to_owned()).collect();
         config.set_headers(headers);
     }

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -4,6 +4,7 @@ use std::env;
 use std::process;
 
 use anyhow::{bail, Result};
+use clap::ArgAction;
 use clap::{Arg, ArgMatches, Command};
 use log::{debug, info, set_logger, set_max_level, LevelFilter};
 
@@ -143,7 +144,7 @@ fn app() -> Command<'static> {
             Arg::new("headers")
                 .long("header")
                 .value_name("KEY:VALUE")
-                .multiple_occurrences(true)
+                .action(ArgAction::Append)
                 .global(true)
                 .help(
                     "Custom headers that should be attached to all requests{n}in key:value format.",

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -97,7 +97,7 @@ fn preexecute_hooks() -> Result<bool> {
 }
 
 fn configure_args(config: &mut Config, matches: &ArgMatches) -> Result<()> {
-    if let Some(url) = matches.value_of("url") {
+    if let Some(url) = matches.get_one::<String>("url") {
         config.set_base_url(url);
     }
 
@@ -106,15 +106,15 @@ fn configure_args(config: &mut Config, matches: &ArgMatches) -> Result<()> {
         config.set_headers(headers);
     }
 
-    if let Some(api_key) = matches.value_of("api_key") {
+    if let Some(api_key) = matches.get_one::<String>("api_key") {
         config.set_auth(Auth::Key(api_key.to_owned()));
     }
 
-    if let Some(auth_token) = matches.value_of("auth_token") {
+    if let Some(auth_token) = matches.get_one::<String>("auth_token") {
         config.set_auth(Auth::Token(auth_token.to_owned()));
     }
 
-    if let Some(level_str) = matches.value_of("log_level") {
+    if let Some(level_str) = matches.get_one::<String>("log_level") {
         match level_str.parse() {
             Ok(level) => {
                 config.set_log_level(level);

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -167,7 +167,7 @@ fn app() -> Command<'static> {
             Arg::new("log_level")
                 .value_name("LOG_LEVEL")
                 .long("log-level")
-                .possible_values(["trace", "debug", "info", "warn", "error"])
+                .value_parser(["trace", "debug", "info", "warn", "error"])
                 .ignore_case(true)
                 .global(true)
                 .help("Set the log output verbosity."),

--- a/src/commands/monitors/run.rs
+++ b/src/commands/monitors/run.rs
@@ -44,7 +44,7 @@ pub fn execute(matches: &ArgMatches) -> Result<()> {
         .unwrap();
 
     let allow_failure = matches.contains_id("allow_failure");
-    let args: Vec<_> = matches.values_of("args").unwrap().collect();
+    let args: Vec<_> = matches.get_many::<String>("args").unwrap().collect();
 
     let monitor_checkin = api.create_monitor_checkin(
         &monitor,

--- a/src/commands/monitors/run.rs
+++ b/src/commands/monitors/run.rs
@@ -39,7 +39,7 @@ pub fn execute(matches: &ArgMatches) -> Result<()> {
     let api = Api::current();
 
     let monitor = matches
-        .value_of("monitor")
+        .get_one::<String>("monitor")
         .map(|x| x.parse::<Uuid>().unwrap())
         .unwrap();
 

--- a/src/commands/monitors/run.rs
+++ b/src/commands/monitors/run.rs
@@ -43,7 +43,7 @@ pub fn execute(matches: &ArgMatches) -> Result<()> {
         .map(|x| x.parse::<Uuid>().unwrap())
         .unwrap();
 
-    let allow_failure = matches.is_present("allow_failure");
+    let allow_failure = matches.contains_id("allow_failure");
     let args: Vec<_> = matches.values_of("args").unwrap().collect();
 
     let monitor_checkin = api.create_monitor_checkin(

--- a/src/commands/monitors/run.rs
+++ b/src/commands/monitors/run.rs
@@ -7,7 +7,6 @@ use console::style;
 use uuid::Uuid;
 
 use crate::api::{Api, CreateMonitorCheckIn, MonitorCheckinStatus, UpdateMonitorCheckIn};
-use crate::utils::args::validate_uuid;
 use crate::utils::system::{print_error, QuietExit};
 
 pub fn make_command(command: Command) -> Command {
@@ -17,7 +16,7 @@ pub fn make_command(command: Command) -> Command {
             Arg::new("monitor")
                 .help("The monitor ID")
                 .required(true)
-                .validator(validate_uuid),
+                .value_parser(Uuid::parse_str),
         )
         .arg(
             Arg::new("allow_failure")
@@ -38,16 +37,13 @@ pub fn make_command(command: Command) -> Command {
 pub fn execute(matches: &ArgMatches) -> Result<()> {
     let api = Api::current();
 
-    let monitor = matches
-        .get_one::<String>("monitor")
-        .map(|x| x.parse::<Uuid>().unwrap())
-        .unwrap();
+    let monitor = matches.get_one::<Uuid>("monitor").unwrap();
 
     let allow_failure = matches.contains_id("allow_failure");
     let args: Vec<_> = matches.get_many::<String>("args").unwrap().collect();
 
     let monitor_checkin = api.create_monitor_checkin(
-        &monitor,
+        monitor,
         &CreateMonitorCheckIn {
             status: MonitorCheckinStatus::InProgress,
         },
@@ -74,7 +70,7 @@ pub fn execute(matches: &ArgMatches) -> Result<()> {
     match monitor_checkin {
         Ok(checkin) => {
             api.update_monitor_checkin(
-                &monitor,
+                monitor,
                 &checkin.id,
                 &UpdateMonitorCheckIn {
                     status: Some(if success {

--- a/src/commands/react_native/appcenter.rs
+++ b/src/commands/react_native/appcenter.rs
@@ -50,7 +50,7 @@ pub fn make_command(command: Command) -> Command {
                 .long("dist")
                 .value_name("DISTRIBUTION")
                 .multiple_occurrences(true)
-                .validator(validate_distribution)
+                .value_parser(validate_distribution)
                 .help("The names of the distributions to publish. Can be supplied multiple times."),
         )
         .arg(

--- a/src/commands/react_native/appcenter.rs
+++ b/src/commands/react_native/appcenter.rs
@@ -141,7 +141,7 @@ pub fn execute(matches: &ArgMatches) -> Result<()> {
 
     let mut processor = SourceMapProcessor::new();
 
-    for path in matches.values_of("paths").unwrap() {
+    for path in matches.get_many::<String>("paths").unwrap() {
         let entries = fs::read_dir(path)
             .map_err(|e| anyhow!(e).context(format!("Failed processing path: \"{}\"", &path)))?;
 
@@ -172,7 +172,7 @@ pub fn execute(matches: &ArgMatches) -> Result<()> {
         },
     )?;
 
-    match matches.values_of("dist") {
+    match matches.get_many::<String>("dist") {
         None => {
             println!(
                 "Uploading sourcemaps for release {} (no distribution value given; use --dist to set distribution value)",

--- a/src/commands/react_native/appcenter.rs
+++ b/src/commands/react_native/appcenter.rs
@@ -103,7 +103,7 @@ pub fn execute(matches: &ArgMatches) -> Result<()> {
         .map(String::as_str)
         .unwrap_or("Staging");
     let api = Api::current();
-    let print_release_name = matches.is_present("print_release_name");
+    let print_release_name = matches.contains_id("print_release_name");
 
     info!(
         "Issuing a command for Organization: {} Project: {}",
@@ -184,7 +184,7 @@ pub fn execute(matches: &ArgMatches) -> Result<()> {
                 project: Some(&project),
                 release: &release.version,
                 dist: None,
-                wait: matches.is_present("wait"),
+                wait: matches.contains_id("wait"),
                 ..Default::default()
             })?;
         }
@@ -200,7 +200,7 @@ pub fn execute(matches: &ArgMatches) -> Result<()> {
                     project: Some(&project),
                     release: &release.version,
                     dist: Some(dist),
-                    wait: matches.is_present("wait"),
+                    wait: matches.contains_id("wait"),
                     ..Default::default()
                 })?;
             }

--- a/src/commands/react_native/appcenter.rs
+++ b/src/commands/react_native/appcenter.rs
@@ -49,7 +49,6 @@ pub fn make_command(command: Command) -> Command {
             Arg::new("dist")
                 .long("dist")
                 .value_name("DISTRIBUTION")
-                .multiple_values(true)
                 .action(ArgAction::Append)
                 .value_parser(validate_distribution)
                 .help("The names of the distributions to publish. Can be supplied multiple times."),

--- a/src/commands/react_native/appcenter.rs
+++ b/src/commands/react_native/appcenter.rs
@@ -96,9 +96,12 @@ pub fn execute(matches: &ArgMatches) -> Result<()> {
     let here = env::current_dir()?;
     let here_str: &str = &here.to_string_lossy();
     let (org, project) = config.get_org_and_project(matches)?;
-    let app = matches.value_of("app_name").unwrap();
-    let platform = matches.value_of("platform").unwrap();
-    let deployment = matches.value_of("deployment").unwrap_or("Staging");
+    let app = matches.get_one::<String>("app_name").unwrap();
+    let platform = matches.get_one::<String>("platform").unwrap();
+    let deployment = matches
+        .get_one::<String>("deployment")
+        .map(String::as_str)
+        .unwrap_or("Staging");
     let api = Api::current();
     let print_release_name = matches.is_present("print_release_name");
 
@@ -118,9 +121,13 @@ pub fn execute(matches: &ArgMatches) -> Result<()> {
     let release = get_react_native_appcenter_release(
         &package,
         platform,
-        matches.value_of("bundle_id"),
-        matches.value_of("version_name"),
-        matches.value_of("release_name"),
+        matches.get_one::<String>("bundle_id").map(String::as_str),
+        matches
+            .get_one::<String>("version_name")
+            .map(String::as_str),
+        matches
+            .get_one::<String>("release_name")
+            .map(String::as_str),
     )?;
     if print_release_name {
         println!("{release}");

--- a/src/commands/react_native/appcenter.rs
+++ b/src/commands/react_native/appcenter.rs
@@ -3,7 +3,7 @@ use std::ffi::OsStr;
 use std::fs;
 
 use anyhow::{anyhow, Result};
-use clap::{Arg, ArgMatches, Command};
+use clap::{Arg, ArgMatches, Command, ArgAction};
 use console::style;
 use if_chain::if_chain;
 use log::info;
@@ -49,7 +49,8 @@ pub fn make_command(command: Command) -> Command {
             Arg::new("dist")
                 .long("dist")
                 .value_name("DISTRIBUTION")
-                .multiple_occurrences(true)
+                .multiple_values(true)
+                .action(ArgAction::Append)
                 .value_parser(validate_distribution)
                 .help("The names of the distributions to publish. Can be supplied multiple times."),
         )
@@ -81,7 +82,8 @@ pub fn make_command(command: Command) -> Command {
             Arg::new("paths")
                 .value_name("PATH")
                 .required(true)
-                .multiple_occurrences(true)
+                .multiple_values(true)
+                .action(ArgAction::Append)
                 .help("A list of folders with assets that should be processed."),
         )
         .arg(

--- a/src/commands/react_native/gradle.rs
+++ b/src/commands/react_native/gradle.rs
@@ -61,8 +61,8 @@ pub fn execute(matches: &ArgMatches) -> Result<()> {
     let api = Api::current();
     let base = env::current_dir()?;
 
-    let sourcemap_path = PathBuf::from(matches.value_of("sourcemap").unwrap());
-    let bundle_path = PathBuf::from(matches.value_of("bundle").unwrap());
+    let sourcemap_path = PathBuf::from(matches.get_one::<String>("sourcemap").unwrap());
+    let bundle_path = PathBuf::from(matches.get_one::<String>("bundle").unwrap());
     let sourcemap_url = format!(
         "~/{}",
         sourcemap_path.file_name().unwrap().to_string_lossy()
@@ -101,7 +101,7 @@ pub fn execute(matches: &ArgMatches) -> Result<()> {
     let release = api.new_release(
         &org,
         &NewRelease {
-            version: matches.value_of("release").unwrap().to_string(),
+            version: matches.get_one::<String>("release").unwrap().to_string(),
             projects: vec![project.to_string()],
             ..Default::default()
         },

--- a/src/commands/react_native/gradle.rs
+++ b/src/commands/react_native/gradle.rs
@@ -44,7 +44,6 @@ pub fn make_command(command: Command) -> Command {
                 .long("dist")
                 .value_name("DISTRIBUTION")
                 .required(true)
-                .multiple_values(true)
                 .action(ArgAction::Append)
                 .value_parser(validate_distribution)
                 .help("The names of the distributions to publish. Can be supplied multiple times."),

--- a/src/commands/react_native/gradle.rs
+++ b/src/commands/react_native/gradle.rs
@@ -2,7 +2,7 @@ use std::env;
 use std::path::PathBuf;
 
 use anyhow::Result;
-use clap::{Arg, ArgMatches, Command};
+use clap::{Arg, ArgMatches, Command, ArgAction};
 use log::{debug, info};
 use sourcemap::ram_bundle::RamBundle;
 
@@ -44,7 +44,8 @@ pub fn make_command(command: Command) -> Command {
                 .long("dist")
                 .value_name("DISTRIBUTION")
                 .required(true)
-                .multiple_occurrences(true)
+                .multiple_values(true)
+                .action(ArgAction::Append)
                 .value_parser(validate_distribution)
                 .help("The names of the distributions to publish. Can be supplied multiple times."),
         )

--- a/src/commands/react_native/gradle.rs
+++ b/src/commands/react_native/gradle.rs
@@ -118,7 +118,7 @@ pub fn execute(matches: &ArgMatches) -> Result<()> {
             project: Some(&project),
             release: &release.version,
             dist: Some(dist),
-            wait: matches.is_present("wait"),
+            wait: matches.contains_id("wait"),
             ..Default::default()
         })?;
     }

--- a/src/commands/react_native/gradle.rs
+++ b/src/commands/react_native/gradle.rs
@@ -107,7 +107,7 @@ pub fn execute(matches: &ArgMatches) -> Result<()> {
         },
     )?;
 
-    for dist in matches.values_of("dist").unwrap() {
+    for dist in matches.get_many::<String>("dist").unwrap() {
         println!(
             "Uploading sourcemaps for release {} distribution {}",
             &release.version, dist

--- a/src/commands/react_native/gradle.rs
+++ b/src/commands/react_native/gradle.rs
@@ -45,7 +45,7 @@ pub fn make_command(command: Command) -> Command {
                 .value_name("DISTRIBUTION")
                 .required(true)
                 .multiple_occurrences(true)
-                .validator(validate_distribution)
+                .value_parser(validate_distribution)
                 .help("The names of the distributions to publish. Can be supplied multiple times."),
         )
         .arg(

--- a/src/commands/react_native/xcode.rs
+++ b/src/commands/react_native/xcode.rs
@@ -105,7 +105,7 @@ pub fn execute(matches: &ArgMatches) -> Result<()> {
             Err(_) => bail!("Need to run this from Xcode"),
         };
     let base = env::current_dir()?;
-    let script = if let Some(path) = matches.value_of("build_script") {
+    let script = if let Some(path) = matches.get_one::<String>("build_script") {
         base.join(path)
     } else {
         base.join("../node_modules/react-native/scripts/react-native-xcode.sh")
@@ -125,7 +125,7 @@ pub fn execute(matches: &ArgMatches) -> Result<()> {
         if let Ok(val) = env::var("PLATFORM_NAME");
         if val.ends_with("simulator");
         then {
-            let url = matches.value_of("fetch_from").unwrap_or("http://127.0.0.1:8081/");
+            let url = matches.get_one::<String>("fetch_from").unwrap_or("http://127.0.0.1:8081/");
             info!("Fetching sourcemaps from {}", url);
             fetch_url = Some(url);
         } else {

--- a/src/commands/react_native/xcode.rs
+++ b/src/commands/react_native/xcode.rs
@@ -5,7 +5,7 @@ use std::process;
 
 use anyhow::{bail, Result};
 use chrono::Duration;
-use clap::{Arg, ArgMatches, Command};
+use clap::{Arg, ArgAction, ArgMatches, Command};
 use if_chain::if_chain;
 use log::info;
 use serde::{Deserialize, Serialize};
@@ -68,7 +68,6 @@ pub fn make_command(command: Command) -> Command {
             Arg::new("dist")
                 .long("dist")
                 .value_name("DISTRIBUTION")
-                .multiple_values(true)
                 .action(ArgAction::Append)
                 .value_parser(validate_distribution)
                 .help("The names of the distributions to publish. Can be supplied multiple times."),

--- a/src/commands/react_native/xcode.rs
+++ b/src/commands/react_native/xcode.rs
@@ -69,7 +69,7 @@ pub fn make_command(command: Command) -> Command {
                 .long("dist")
                 .value_name("DISTRIBUTION")
                 .multiple_occurrences(true)
-                .validator(validate_distribution)
+                .value_parser(validate_distribution)
                 .help("The names of the distributions to publish. Can be supplied multiple times."),
         )
         .arg(

--- a/src/commands/react_native/xcode.rs
+++ b/src/commands/react_native/xcode.rs
@@ -125,7 +125,7 @@ pub fn execute(matches: &ArgMatches) -> Result<()> {
         if let Ok(val) = env::var("PLATFORM_NAME");
         if val.ends_with("simulator");
         then {
-            let url = matches.get_one::<String>("fetch_from").unwrap_or("http://127.0.0.1:8081/");
+            let url = matches.get_one::<String>("fetch_from").map(String::as_str).unwrap_or("http://127.0.0.1:8081/");
             info!("Fetching sourcemaps from {}", url);
             fetch_url = Some(url);
         } else {

--- a/src/commands/react_native/xcode.rs
+++ b/src/commands/react_native/xcode.rs
@@ -68,7 +68,8 @@ pub fn make_command(command: Command) -> Command {
             Arg::new("dist")
                 .long("dist")
                 .value_name("DISTRIBUTION")
-                .multiple_occurrences(true)
+                .multiple_values(true)
+                .action(ArgAction::Append)
                 .value_parser(validate_distribution)
                 .help("The names of the distributions to publish. Can be supplied multiple times."),
         )

--- a/src/commands/react_native/xcode.rs
+++ b/src/commands/react_native/xcode.rs
@@ -278,7 +278,7 @@ pub fn execute(matches: &ArgMatches) -> Result<()> {
             },
         )?;
 
-        match matches.values_of("dist") {
+        match matches.get_many::<String>("dist") {
             None => {
                 processor.upload(&UploadContext {
                     org: &org,

--- a/src/commands/react_native/xcode.rs
+++ b/src/commands/react_native/xcode.rs
@@ -99,7 +99,7 @@ fn find_node() -> String {
 pub fn execute(matches: &ArgMatches) -> Result<()> {
     let config = Config::current();
     let (org, project) = config.get_org_and_project(matches)?;
-    let should_wrap = matches.is_present("force")
+    let should_wrap = matches.contains_id("force")
         || match env::var("CONFIGURATION") {
             Ok(config) => !&config.contains("Debug"),
             Err(_) => bail!("Need to run this from Xcode"),
@@ -121,7 +121,7 @@ pub fn execute(matches: &ArgMatches) -> Result<()> {
     // to simulator mode.
     let fetch_url;
     if_chain! {
-        if matches.is_present("allow_fetch");
+        if matches.contains_id("allow_fetch");
         if let Ok(val) = env::var("PLATFORM_NAME");
         if val.ends_with("simulator");
         then {
@@ -165,7 +165,7 @@ pub fn execute(matches: &ArgMatches) -> Result<()> {
         // case we do indeed fetch it right from the running packager and then
         // store it in temporary files for later consumption.
         if let Some(url) = fetch_url {
-            if !matches.is_present("force_foreground") {
+            if !matches.contains_id("force_foreground") {
                 md.may_detach()?;
             }
             let api = Api::current();
@@ -220,7 +220,7 @@ pub fn execute(matches: &ArgMatches) -> Result<()> {
                 .wait()?;
             propagate_exit_status(rv);
 
-            if !matches.is_present("force_foreground") {
+            if !matches.contains_id("force_foreground") {
                 md.may_detach()?;
             }
             let mut f = fs::File::open(report_file.path())?;
@@ -285,7 +285,7 @@ pub fn execute(matches: &ArgMatches) -> Result<()> {
                     project: Some(&project),
                     release: &release.version,
                     dist: Some(&dist),
-                    wait: matches.is_present("wait"),
+                    wait: matches.contains_id("wait"),
                     ..Default::default()
                 })?;
             }
@@ -296,7 +296,7 @@ pub fn execute(matches: &ArgMatches) -> Result<()> {
                         project: Some(&project),
                         release: &release.version,
                         dist: Some(dist),
-                        wait: matches.is_present("wait"),
+                        wait: matches.contains_id("wait"),
                         ..Default::default()
                     })?;
                 }

--- a/src/commands/releases/archive.rs
+++ b/src/commands/releases/archive.rs
@@ -15,7 +15,7 @@ pub fn make_command(command: Command) -> Command {
 pub fn execute(matches: &ArgMatches) -> Result<()> {
     let config = Config::current();
     let api = Api::current();
-    let version = matches.value_of("version").unwrap();
+    let version = matches.get_one::<String>("version").unwrap();
 
     let info_rv = api.update_release(
         &config.get_org(matches)?,

--- a/src/commands/releases/delete.rs
+++ b/src/commands/releases/delete.rs
@@ -15,15 +15,13 @@ pub fn make_command(command: Command) -> Command {
 pub fn execute(matches: &ArgMatches) -> Result<()> {
     let config = Config::current();
     let api = Api::current();
-    let version = matches.value_of("version").unwrap();
+    let version = matches.get_one::<String>("version").unwrap();
     let project = config.get_project(matches).ok();
 
     if api.delete_release(&config.get_org(matches)?, project.as_deref(), version)? {
         println!("Deleted release {version}!");
     } else {
-        println!(
-            "Did nothing. Release with this version ({version}) does not exist."
-        );
+        println!("Did nothing. Release with this version ({version}) does not exist.");
     }
 
     Ok(())

--- a/src/commands/releases/finalize.rs
+++ b/src/commands/releases/finalize.rs
@@ -43,16 +43,22 @@ pub fn execute(matches: &ArgMatches) -> Result<()> {
 
     let config = Config::current();
     let api = Api::current();
-    let version = matches.value_of("version").unwrap();
+    let version = matches.get_one::<String>("version").unwrap();
 
     api.update_release(
         &config.get_org(matches)?,
         version,
         &UpdatedRelease {
             projects: config.get_projects(matches).ok(),
-            url: matches.value_of("url").map(str::to_owned),
-            date_started: get_date(matches.value_of("started"), false)?,
-            date_released: get_date(matches.value_of("released"), true)?,
+            url: matches.get_one::<String>("url").map(String::clone),
+            date_started: get_date(
+                matches.get_one::<String>("started").map(String::as_str),
+                false,
+            )?,
+            date_released: get_date(
+                matches.get_one::<String>("released").map(String::as_str),
+                true,
+            )?,
             ..Default::default()
         },
     )?;

--- a/src/commands/releases/finalize.rs
+++ b/src/commands/releases/finalize.rs
@@ -43,13 +43,12 @@ pub fn execute(matches: &ArgMatches) -> Result<()> {
         version,
         &UpdatedRelease {
             projects: config.get_projects(matches).ok(),
-            url: matches.get_one::<String>("url").map(String::clone),
+            url: matches.get_one::<String>("url").cloned(),
             date_started: matches.get_one::<DateTime<Utc>>("started").copied(),
             date_released: Some(
                 matches
                     .get_one::<DateTime<Utc>>("released")
-                    .copied()
-                    .unwrap_or(Utc::now()),
+                    .map_or_else(Utc::now, |v| *v),
             ),
             ..Default::default()
         },

--- a/src/commands/releases/info.rs
+++ b/src/commands/releases/info.rs
@@ -29,7 +29,7 @@ pub fn make_command(command: Command) -> Command {
 
 pub fn execute(matches: &ArgMatches) -> Result<()> {
     let api = Api::current();
-    let version = matches.value_of("version").unwrap();
+    let version = matches.get_one::<String>("version").unwrap();
     let config = Config::current();
     let org = config.get_org(matches)?;
     let project = config.get_project(matches).ok();

--- a/src/commands/releases/info.rs
+++ b/src/commands/releases/info.rs
@@ -50,11 +50,11 @@ pub fn execute(matches: &ArgMatches) -> Result<()> {
             title_row.add("Last event");
         }
 
-        if matches.is_present("show_projects") {
+        if matches.contains_id("show_projects") {
             title_row.add("Projects");
         }
 
-        if matches.is_present("show_commits") {
+        if matches.contains_id("show_commits") {
             title_row.add("Commits");
         }
 
@@ -67,7 +67,7 @@ pub fn execute(matches: &ArgMatches) -> Result<()> {
             data_row.add(last_event);
         }
 
-        if matches.is_present("show_projects") {
+        if matches.contains_id("show_projects") {
             let project_slugs = release
                 .projects
                 .into_iter()
@@ -80,7 +80,7 @@ pub fn execute(matches: &ArgMatches) -> Result<()> {
             }
         }
 
-        if matches.is_present("show_commits") {
+        if matches.contains_id("show_commits") {
             if let Ok(Some(commits)) = api.get_release_commits(&org, project.as_deref(), version) {
                 if !commits.is_empty() {
                     data_row.add(

--- a/src/commands/releases/list.rs
+++ b/src/commands/releases/list.rs
@@ -39,12 +39,17 @@ pub fn execute(matches: &ArgMatches) -> Result<()> {
     let project = config.get_project(matches).ok();
     let releases = api.list_releases(&config.get_org(matches)?, project.as_deref())?;
 
-    if matches.is_present("raw") {
+    if matches.contains_id("raw") {
         let versions = releases
             .iter()
             .map(|release_info| release_info.version.clone())
             .collect::<Vec<_>>()
-            .join(matches.get_one::<String>("delimiter").map(String::as_str).unwrap_or("\n"));
+            .join(
+                matches
+                    .get_one::<String>("delimiter")
+                    .map(String::as_str)
+                    .unwrap_or("\n"),
+            );
 
         println!("{versions}");
         return Ok(());
@@ -53,7 +58,7 @@ pub fn execute(matches: &ArgMatches) -> Result<()> {
     let mut table = Table::new();
     let title_row = table.title_row();
     title_row.add("Released").add("Version");
-    if matches.is_present("show_projects") {
+    if matches.contains_id("show_projects") {
         title_row.add("Projects");
     }
     title_row.add("New Events").add("Last Event");
@@ -68,7 +73,7 @@ pub fn execute(matches: &ArgMatches) -> Result<()> {
             row.add("(unreleased)");
         }
         row.add(&release_info.version);
-        if matches.is_present("show_projects") {
+        if matches.contains_id("show_projects") {
             let project_slugs = release_info
                 .projects
                 .into_iter()

--- a/src/commands/releases/list.rs
+++ b/src/commands/releases/list.rs
@@ -44,7 +44,7 @@ pub fn execute(matches: &ArgMatches) -> Result<()> {
             .iter()
             .map(|release_info| release_info.version.clone())
             .collect::<Vec<_>>()
-            .join(matches.value_of("delimiter").unwrap_or("\n"));
+            .join(matches.get_one::<String>("delimiter").map(String::as_str).unwrap_or("\n"));
 
         println!("{versions}");
         return Ok(());

--- a/src/commands/releases/new.rs
+++ b/src/commands/releases/new.rs
@@ -38,7 +38,7 @@ pub fn execute(matches: &ArgMatches) -> Result<()> {
             projects: config.get_projects(matches)?,
             url: matches.get_one::<String>("url").map(String::clone),
             date_started: Some(Utc::now()),
-            date_released: if matches.is_present("finalize") {
+            date_released: if matches.contains_id("finalize") {
                 Some(Utc::now())
             } else {
                 None

--- a/src/commands/releases/new.rs
+++ b/src/commands/releases/new.rs
@@ -29,14 +29,14 @@ pub fn make_command(command: Command) -> Command {
 pub fn execute(matches: &ArgMatches) -> Result<()> {
     let config = Config::current();
     let api = Api::current();
-    let version = matches.value_of("version").unwrap();
+    let version = matches.get_one::<String>("version").unwrap();
 
     api.new_release(
         &config.get_org(matches)?,
         &NewRelease {
             version: version.to_owned(),
             projects: config.get_projects(matches)?,
-            url: matches.value_of("url").map(str::to_owned),
+            url: matches.get_one::<String>("url").map(String::clone),
             date_started: Some(Utc::now()),
             date_released: if matches.is_present("finalize") {
                 Some(Utc::now())

--- a/src/commands/releases/new.rs
+++ b/src/commands/releases/new.rs
@@ -36,7 +36,7 @@ pub fn execute(matches: &ArgMatches) -> Result<()> {
         &NewRelease {
             version: version.to_owned(),
             projects: config.get_projects(matches)?,
-            url: matches.get_one::<String>("url").map(String::clone),
+            url: matches.get_one::<String>("url").cloned(),
             date_started: Some(Utc::now()),
             date_released: if matches.contains_id("finalize") {
                 Some(Utc::now())

--- a/src/commands/releases/restore.rs
+++ b/src/commands/releases/restore.rs
@@ -15,7 +15,7 @@ pub fn make_command(command: Command) -> Command {
 pub fn execute(matches: &ArgMatches) -> Result<()> {
     let config = Config::current();
     let api = Api::current();
-    let version = matches.value_of("version").unwrap();
+    let version = matches.get_one::<String>("version").unwrap();
 
     let info_rv = api.update_release(
         &config.get_org(matches)?,

--- a/src/commands/releases/set_commits.rs
+++ b/src/commands/releases/set_commits.rs
@@ -98,7 +98,7 @@ pub fn execute(matches: &ArgMatches) -> Result<()> {
     } else if matches.contains_id("local") {
         None
     } else {
-        if let Some(commits) = matches.values_of("commits") {
+        if let Some(commits) = matches.get_many::<String>("commits") {
             for spec in commits {
                 let commit_spec = CommitSpec::parse(spec)?;
                 if repos.iter().any(|r| r.name == commit_spec.repo) {

--- a/src/commands/releases/set_commits.rs
+++ b/src/commands/releases/set_commits.rs
@@ -5,7 +5,7 @@ use regex::Regex;
 
 use crate::api::{Api, NewRelease, NoneReleaseInfo, OptionalReleaseInfo, UpdatedRelease};
 use crate::config::Config;
-use crate::utils::args::{validate_int, ArgExt};
+use crate::utils::args::ArgExt;
 use crate::utils::formatting::Table;
 use crate::utils::vcs::{
     find_heads, generate_patch_set, get_commits_from_git, get_repo_from_remote, CommitSpec,
@@ -41,7 +41,7 @@ pub fn make_command(command: Command) -> Command {
             .conflicts_with("auto")
             .long("initial-depth")
             .value_name("INITIAL DEPTH")
-            .validator(validate_int)
+            .value_parser(clap::value_parser!(usize))
             .help("Set the number of commits of the initial release. The default is 20."))
         .arg(Arg::new("commits")
             .long("commit")
@@ -156,10 +156,9 @@ pub fn execute(matches: &ArgMatches) -> Result<()> {
         api.set_release_refs(&org, version, heads)?;
     } else {
         let default_count = matches
-            .get_one::<String>("initial-depth")
-            .map(String::as_str)
-            .unwrap_or("20")
-            .parse::<usize>()?;
+            .get_one::<usize>("initial-depth")
+            .copied()
+            .unwrap_or(20);
 
         if matches.contains_id("auto") {
             println!("Could not determine any commits to be associated with a repo-based integration. Proceeding to find commits from local git tree.");

--- a/src/commands/releases/set_commits.rs
+++ b/src/commands/releases/set_commits.rs
@@ -79,7 +79,7 @@ fn strip_sha(sha: &str) -> &str {
 pub fn execute(matches: &ArgMatches) -> Result<()> {
     let config = Config::current();
     let api = Api::current();
-    let version = matches.value_of("version").unwrap();
+    let version = matches.get_one::<String>("version").unwrap();
     let org = config.get_org(matches)?;
     let repos = api.list_organization_repos(&org)?;
     let mut commit_specs = vec![];
@@ -156,7 +156,8 @@ pub fn execute(matches: &ArgMatches) -> Result<()> {
         api.set_release_refs(&org, version, heads)?;
     } else {
         let default_count = matches
-            .value_of("initial-depth")
+            .get_one::<String>("initial-depth")
+            .map(String::as_str)
             .unwrap_or("20")
             .parse::<usize>()?;
 

--- a/src/commands/releases/set_commits.rs
+++ b/src/commands/releases/set_commits.rs
@@ -1,5 +1,5 @@
 use anyhow::{bail, Result};
-use clap::{Arg, ArgMatches, Command};
+use clap::{Arg, ArgAction, ArgMatches, Command};
 use lazy_static::lazy_static;
 use regex::Regex;
 
@@ -47,7 +47,8 @@ pub fn make_command(command: Command) -> Command {
             .long("commit")
             .short('c')
             .value_name("SPEC")
-            .multiple_occurrences(true)
+            .multiple_values(true)
+            .action(ArgAction::Append)
             .help("Defines a single commit for a repo as \
                     identified by the repo name in the remote Sentry config. \
                     If no commit has been specified sentry-cli will attempt \

--- a/src/commands/releases/set_commits.rs
+++ b/src/commands/releases/set_commits.rs
@@ -86,16 +86,16 @@ pub fn execute(matches: &ArgMatches) -> Result<()> {
 
     let heads = if repos.is_empty() {
         None
-    } else if matches.is_present("auto") {
+    } else if matches.contains_id("auto") {
         let commits = find_heads(None, &repos, Some(config.get_cached_vcs_remote()))?;
         if commits.is_empty() {
             None
         } else {
             Some(commits)
         }
-    } else if matches.is_present("clear") {
+    } else if matches.contains_id("clear") {
         Some(vec![])
-    } else if matches.is_present("local") {
+    } else if matches.contains_id("local") {
         None
     } else {
         if let Some(commits) = matches.values_of("commits") {
@@ -161,7 +161,7 @@ pub fn execute(matches: &ArgMatches) -> Result<()> {
             .unwrap_or("20")
             .parse::<usize>()?;
 
-        if matches.is_present("auto") {
+        if matches.contains_id("auto") {
             println!("Could not determine any commits to be associated with a repo-based integration. Proceeding to find commits from local git tree.");
         }
         // Get the commit of the most recent release.
@@ -176,7 +176,7 @@ pub fn execute(matches: &ArgMatches) -> Result<()> {
         // Parse the git url.
         let remote = config.get_cached_vcs_remote();
         let parsed = get_repo_from_remote(&remote);
-        let ignore_missing = matches.is_present("ignore-missing");
+        let ignore_missing = matches.contains_id("ignore-missing");
         // Fetch all the commits upto the `prev_commit` or return the default (20).
         // Will return a tuple of Vec<GitCommits> and the `prev_commit` if it exists in the git tree.
         let (commit_log, prev_commit) =

--- a/src/commands/releases/set_commits.rs
+++ b/src/commands/releases/set_commits.rs
@@ -47,7 +47,6 @@ pub fn make_command(command: Command) -> Command {
             .long("commit")
             .short('c')
             .value_name("SPEC")
-            .multiple_values(true)
             .action(ArgAction::Append)
             .help("Defines a single commit for a repo as \
                     identified by the repo name in the remote Sentry config. \

--- a/src/commands/send_envelope.rs
+++ b/src/commands/send_envelope.rs
@@ -41,7 +41,7 @@ fn send_raw_envelope(envelope: Envelope, dsn: Dsn) {
 pub fn execute(matches: &ArgMatches) -> Result<()> {
     let config = Config::current();
     let dsn = config.get_dsn()?;
-    let raw = matches.is_present("raw");
+    let raw = matches.contains_id("raw");
 
     let path = matches.get_one::<String>("path").unwrap();
 

--- a/src/commands/send_envelope.rs
+++ b/src/commands/send_envelope.rs
@@ -43,7 +43,7 @@ pub fn execute(matches: &ArgMatches) -> Result<()> {
     let dsn = config.get_dsn()?;
     let raw = matches.is_present("raw");
 
-    let path = matches.value_of("path").unwrap();
+    let path = matches.get_one::<String>("path").unwrap();
 
     let collected_paths: Vec<PathBuf> = glob_with(path, MatchOptions::new())
         .unwrap()

--- a/src/commands/send_event.rs
+++ b/src/commands/send_event.rs
@@ -6,7 +6,7 @@ use std::path::PathBuf;
 
 use anyhow::{format_err, Result};
 use chrono::{DateTime, Utc};
-use clap::{Arg, ArgMatches, Command};
+use clap::{Arg, ArgAction, ArgMatches, Command};
 use glob::{glob_with, MatchOptions};
 use itertools::Itertools;
 use log::{debug, warn};
@@ -79,7 +79,7 @@ pub fn make_command(command: Command) -> Command {
                 .value_name("MESSAGE")
                 .long("message")
                 .short('m')
-                .multiple_occurrences(true)
+                .action(ArgAction::Append)
                 .help("The event message."),
         )
         .arg(
@@ -87,7 +87,7 @@ pub fn make_command(command: Command) -> Command {
                 .value_name("MESSAGE_ARG")
                 .long("message-arg")
                 .short('a')
-                .multiple_occurrences(true)
+                .action(ArgAction::Append)
                 .help("Arguments for the event message."),
         )
         .arg(
@@ -102,7 +102,7 @@ pub fn make_command(command: Command) -> Command {
                 .value_name("KEY:VALUE")
                 .long("tag")
                 .short('t')
-                .multiple_occurrences(true)
+                .action(ArgAction::Append)
                 .help("Add a tag (key:value) to the event."),
         )
         .arg(
@@ -110,7 +110,7 @@ pub fn make_command(command: Command) -> Command {
                 .value_name("KEY:VALUE")
                 .long("extra")
                 .short('e')
-                .multiple_occurrences(true)
+                .action(ArgAction::Append)
                 .help("Add extra information (key:value) to the event."),
         )
         .arg(
@@ -118,7 +118,7 @@ pub fn make_command(command: Command) -> Command {
                 .value_name("KEY:VALUE")
                 .long("user")
                 .short('u')
-                .multiple_occurrences(true)
+                .action(ArgAction::Append)
                 .help(
                     "Add user information (key:value) to the event. \
                      [eg: id:42, username:foo]",
@@ -129,7 +129,7 @@ pub fn make_command(command: Command) -> Command {
                 .value_name("FINGERPRINT")
                 .long("fingerprint")
                 .short('f')
-                .multiple_occurrences(true)
+                .action(ArgAction::Append)
                 .help("Change the fingerprint of the event."),
         )
         .arg(

--- a/src/commands/send_event.rs
+++ b/src/commands/send_event.rs
@@ -201,13 +201,15 @@ pub fn execute(matches: &ArgMatches) -> Result<()> {
         environment: matches
             .get_one::<String>("environment")
             .map(|s| Cow::Owned(s.clone())),
-        logentry: matches.values_of("message").map(|mut lines| LogEntry {
-            message: lines.join("\n"),
-            params: matches
-                .values_of("message_args")
-                .map(|args| args.map(|x| x.into()).collect())
-                .unwrap_or_default(),
-        }),
+        logentry: matches
+            .get_many::<String>("message")
+            .map(|mut lines| LogEntry {
+                message: lines.join("\n"),
+                params: matches
+                    .get_many::<String>("message_args")
+                    .map(|args| args.map(|x| x.as_str().into()).collect())
+                    .unwrap_or_default(),
+            }),
         ..Event::default()
     };
 
@@ -215,7 +217,7 @@ pub fn execute(matches: &ArgMatches) -> Result<()> {
         event.timestamp = get_timestamp(timestamp).map(|t| t.into())?;
     }
 
-    for tag in matches.values_of("tags").unwrap_or_default() {
+    for tag in matches.get_many::<String>("tags").unwrap_or_default() {
         let mut split = tag.splitn(2, ':');
         let key = split.next().ok_or_else(|| format_err!("missing tag key"))?;
         let value = split
@@ -231,7 +233,7 @@ pub fn execute(matches: &ArgMatches) -> Result<()> {
         );
     }
 
-    for pair in matches.values_of("extra").unwrap_or_default() {
+    for pair in matches.get_many::<String>("extra").unwrap_or_default() {
         let mut split = pair.splitn(2, ':');
         let key = split
             .next()
@@ -242,7 +244,7 @@ pub fn execute(matches: &ArgMatches) -> Result<()> {
         event.extra.insert(key.into(), Value::String(value.into()));
     }
 
-    if let Some(user_data) = matches.values_of("user_data") {
+    if let Some(user_data) = matches.get_many::<String>("user_data") {
         let mut user = User::default();
         for pair in user_data {
             let mut split = pair.splitn(2, ':');
@@ -274,7 +276,7 @@ pub fn execute(matches: &ArgMatches) -> Result<()> {
         });
     }
 
-    if let Some(fingerprint) = matches.values_of("fingerprint") {
+    if let Some(fingerprint) = matches.get_many::<String>("fingerprint") {
         event.fingerprint = fingerprint
             .map(|x| x.to_string().into())
             .collect::<Vec<_>>()

--- a/src/commands/send_event.rs
+++ b/src/commands/send_event.rs
@@ -158,7 +158,7 @@ pub fn execute(matches: &ArgMatches) -> Result<()> {
     let config = Config::current();
     let dsn = config.get_dsn()?;
 
-    if let Some(path) = matches.value_of("path") {
+    if let Some(path) = matches.get_one::<String>("path") {
         let collected_paths: Vec<PathBuf> = glob_with(path, MatchOptions::new())
             .unwrap()
             .flatten()
@@ -184,23 +184,23 @@ pub fn execute(matches: &ArgMatches) -> Result<()> {
     let mut event = Event {
         sdk: Some(get_sdk_info()),
         level: matches
-            .value_of("level")
+            .get_one::<String>("level")
             .and_then(|l| l.parse().ok())
             .unwrap_or(Level::Error),
         release: matches
-            .value_of("release")
-            .map(str::to_owned)
-            .or_else(|| detect_release_name().ok())
-            .map(Cow::from),
-        dist: matches.value_of("dist").map(|x| x.to_string().into()),
+            .get_one::<String>("release")
+            .map(|s| Cow::Owned(s.clone()))
+            .or_else(|| detect_release_name().ok().map(Cow::from)),
+        dist: matches
+            .get_one::<String>("dist")
+            .map(|s| Cow::Owned(s.clone())),
         platform: matches
-            .value_of("platform")
-            .unwrap_or("other")
-            .to_string()
-            .into(),
+            .get_one::<String>("platform")
+            .map(|s| Cow::Owned(s.clone()))
+            .unwrap_or(Cow::from("other")),
         environment: matches
-            .value_of("environment")
-            .map(|x| x.to_string().into()),
+            .get_one::<String>("environment")
+            .map(|s| Cow::Owned(s.clone())),
         logentry: matches.values_of("message").map(|mut lines| LogEntry {
             message: lines.join("\n"),
             params: matches
@@ -211,7 +211,7 @@ pub fn execute(matches: &ArgMatches) -> Result<()> {
         ..Event::default()
     };
 
-    if let Some(timestamp) = matches.value_of("timestamp") {
+    if let Some(timestamp) = matches.get_one::<String>("timestamp") {
         event.timestamp = get_timestamp(timestamp).map(|t| t.into())?;
     }
 
@@ -281,7 +281,7 @@ pub fn execute(matches: &ArgMatches) -> Result<()> {
             .into();
     }
 
-    if let Some(logfile) = matches.value_of("logfile") {
+    if let Some(logfile) = matches.get_one::<String>("logfile") {
         attach_logfile(&mut event, logfile, matches.is_present("with_categories"))?;
     }
 

--- a/src/commands/send_event.rs
+++ b/src/commands/send_event.rs
@@ -3,6 +3,7 @@ use std::env;
 use std::fs::File;
 use std::io::BufReader;
 use std::path::PathBuf;
+use std::time::SystemTime;
 
 use anyhow::{format_err, Result};
 use chrono::{DateTime, Utc};
@@ -215,7 +216,7 @@ pub fn execute(matches: &ArgMatches) -> Result<()> {
     };
 
     if let Some(timestamp) = matches.get_one::<DateTime<Utc>>("timestamp") {
-        event.timestamp = (*timestamp).into();
+        event.timestamp = SystemTime::from(*timestamp);
     }
 
     for tag in matches.get_many::<String>("tags").unwrap_or_default() {

--- a/src/commands/send_event.rs
+++ b/src/commands/send_event.rs
@@ -224,7 +224,7 @@ pub fn execute(matches: &ArgMatches) -> Result<()> {
         event.tags.insert(key.into(), value.into());
     }
 
-    if !matches.is_present("no_environ") {
+    if !matches.contains_id("no_environ") {
         event.extra.insert(
             "environ".into(),
             Value::Object(env::vars().map(|(k, v)| (k, Value::String(v))).collect()),
@@ -282,7 +282,7 @@ pub fn execute(matches: &ArgMatches) -> Result<()> {
     }
 
     if let Some(logfile) = matches.get_one::<String>("logfile") {
-        attach_logfile(&mut event, logfile, matches.is_present("with_categories"))?;
+        attach_logfile(&mut event, logfile, matches.contains_id("with_categories"))?;
     }
 
     let id = send_raw_event(event, dsn);

--- a/src/commands/sourcemaps/explain.rs
+++ b/src/commands/sourcemaps/explain.rs
@@ -362,7 +362,7 @@ fn unify_artifact_url(abs_path: &str) -> Result<String> {
 pub fn execute(matches: &ArgMatches) -> Result<()> {
     let config = Config::current();
     let (org, project) = config.get_org_and_project(matches)?;
-    let event_id = matches.value_of("event").unwrap();
+    let event_id = matches.get_one::<String>("event").unwrap();
 
     let event = fetch_event(&org, &project, event_id)?;
     let release = extract_release(&event)?;

--- a/src/commands/sourcemaps/explain.rs
+++ b/src/commands/sourcemaps/explain.rs
@@ -387,7 +387,7 @@ pub fn execute(matches: &ArgMatches) -> Result<()> {
         })?;
 
     if exception.raw_stacktrace.is_some() {
-        if matches.is_present("force") {
+        if matches.contains_id("force") {
             warning(
                 "Exception is already source mapped, however 'force' flag was used. Moving along.",
             );

--- a/src/commands/sourcemaps/resolve.rs
+++ b/src/commands/sourcemaps/resolve.rs
@@ -5,8 +5,6 @@ use anyhow::{format_err, Result};
 use clap::{Arg, ArgMatches, Command};
 use sourcemap::{DecodedMap, SourceView, Token};
 
-use crate::utils::args::validate_int;
-
 pub fn make_command(command: Command) -> Command {
     command
         .about("Resolve sourcemap for a given line/column position.")
@@ -20,7 +18,7 @@ pub fn make_command(command: Command) -> Command {
                 .long("line")
                 .short('l')
                 .value_name("LINE")
-                .validator(validate_int)
+                .value_parser(clap::value_parser!(u32))
                 .help("Line number for minified source."),
         )
         .arg(
@@ -28,7 +26,7 @@ pub fn make_command(command: Command) -> Command {
                 .long("column")
                 .short('c')
                 .value_name("COLUMN")
-                .validator(validate_int)
+                .value_parser(clap::value_parser!(u32))
                 .help("Column number for minified source."),
         )
 }
@@ -36,12 +34,8 @@ pub fn make_command(command: Command) -> Command {
 /// Returns the zero indexed position from matches
 fn lookup_pos(matches: &ArgMatches) -> Option<(u32, u32)> {
     Some((
-        matches
-            .get_one::<String>("line")
-            .map_or(0, |x| x.parse::<u32>().unwrap() - 1),
-        matches
-            .get_one::<String>("column")
-            .map_or(0, |x| x.parse::<u32>().unwrap() - 1),
+        matches.get_one::<u32>("line").map_or(0, |x| x - 1),
+        matches.get_one::<u32>("column").map_or(0, |x| x - 1),
     ))
 }
 

--- a/src/commands/sourcemaps/resolve.rs
+++ b/src/commands/sourcemaps/resolve.rs
@@ -37,10 +37,10 @@ pub fn make_command(command: Command) -> Command {
 fn lookup_pos(matches: &ArgMatches) -> Option<(u32, u32)> {
     Some((
         matches
-            .value_of("line")
+            .get_one::<String>("line")
             .map_or(0, |x| x.parse::<u32>().unwrap() - 1),
         matches
-            .value_of("column")
+            .get_one::<String>("column")
             .map_or(0, |x| x.parse::<u32>().unwrap() - 1),
     ))
 }
@@ -106,7 +106,7 @@ fn print_token(token: &Token<'_>) {
 
 pub fn execute(matches: &ArgMatches) -> Result<()> {
     let sourcemap_path = matches
-        .value_of("path")
+        .get_one::<String>("path")
         .ok_or_else(|| format_err!("Sourcemap not provided"))?;
 
     let sm = sourcemap::decode_slice(&fs::read(PathBuf::from(sourcemap_path))?)?;

--- a/src/commands/sourcemaps/upload.rs
+++ b/src/commands/sourcemaps/upload.rs
@@ -43,7 +43,7 @@ pub fn make_command(command: Command) -> Command {
                 .long("dist")
                 .short('d')
                 .value_name("DISTRIBUTION")
-                .validator(validate_distribution)
+                .value_parser(validate_distribution)
                 .help("Optional distribution identifier for the sourcemaps."),
         )
         .arg(

--- a/src/commands/sourcemaps/upload.rs
+++ b/src/commands/sourcemaps/upload.rs
@@ -178,14 +178,20 @@ fn process_sources_from_bundle(
     matches: &ArgMatches,
     processor: &mut SourceMapProcessor,
 ) -> Result<()> {
-    let url_suffix = matches.value_of("url_suffix").unwrap_or("");
-    let mut url_prefix = matches.value_of("url_prefix").unwrap_or("~");
+    let url_suffix = matches
+        .get_one::<String>("url_suffix")
+        .map(String::as_str)
+        .unwrap_or_default();
+    let mut url_prefix = matches
+        .get_one::<String>("url_prefix")
+        .map(String::as_str)
+        .unwrap_or("~");
     // remove a single slash from the end.  so ~/ becomes ~ and app:/// becomes app://
     if url_prefix.ends_with('/') {
         url_prefix = &url_prefix[..url_prefix.len() - 1];
     }
 
-    let bundle_path = PathBuf::from(matches.value_of("bundle").unwrap());
+    let bundle_path = PathBuf::from(matches.get_one::<String>("bundle").unwrap());
     let bundle_url = format!(
         "{}/{}{}",
         url_prefix,
@@ -193,7 +199,7 @@ fn process_sources_from_bundle(
         url_suffix
     );
 
-    let sourcemap_path = PathBuf::from(matches.value_of("bundle_sourcemap").unwrap());
+    let sourcemap_path = PathBuf::from(matches.get_one::<String>("bundle_sourcemap").unwrap());
     let sourcemap_url = format!(
         "{}/{}{}",
         url_prefix,
@@ -242,7 +248,10 @@ fn process_sources_from_paths(
     processor: &mut SourceMapProcessor,
 ) -> Result<()> {
     let paths = matches.values_of("paths").unwrap();
-    let ignore_file = matches.value_of("ignore_file").unwrap_or("");
+    let ignore_file = matches
+        .get_one::<String>("ignore_file")
+        .map(String::as_str)
+        .unwrap_or_default();
     let extensions = matches
         .values_of("extensions")
         .map(|extensions| extensions.map(|ext| ext.trim_start_matches('.')).collect())
@@ -279,8 +288,14 @@ fn process_sources_from_paths(
 
         let sources = search.collect_files()?;
 
-        let url_suffix = matches.value_of("url_suffix").unwrap_or("");
-        let mut url_prefix = matches.value_of("url_prefix").unwrap_or("~");
+        let url_suffix = matches
+            .get_one::<String>("url_suffix")
+            .map(String::as_str)
+            .unwrap_or_default();
+        let mut url_prefix = matches
+            .get_one::<String>("url_prefix")
+            .map(String::as_str)
+            .unwrap_or("~");
         // remove a single slash from the end.  so ~/ becomes ~ and app:/// becomes app://
         if url_prefix.ends_with('/') {
             url_prefix = &url_prefix[..url_prefix.len() - 1];
@@ -336,7 +351,7 @@ pub fn execute(matches: &ArgMatches) -> Result<()> {
         org: &org,
         project: Some(&project),
         release: &release.version,
-        dist: matches.value_of("dist"),
+        dist: matches.get_one::<String>("dist").map(String::as_str),
         wait: matches.is_present("wait"),
         dedupe: !matches.is_present("no_dedupe"),
     })?;

--- a/src/commands/sourcemaps/upload.rs
+++ b/src/commands/sourcemaps/upload.rs
@@ -168,7 +168,7 @@ fn get_prefixes_from_args(matches: &ArgMatches) -> Vec<&str> {
         Some(paths) => paths.collect(),
         None => vec![],
     };
-    if matches.is_present("strip_common_prefix") {
+    if matches.contains_id("strip_common_prefix") {
         prefixes.push("~");
     }
     prefixes
@@ -277,7 +277,7 @@ fn process_sources_from_paths(
         };
 
         let mut search = ReleaseFileSearch::new(path.to_path_buf());
-        search.decompress(matches.is_present("decompress"));
+        search.decompress(matches.contains_id("decompress"));
 
         if check_ignore {
             search
@@ -308,16 +308,16 @@ fn process_sources_from_paths(
         }
     }
 
-    if !matches.is_present("no_rewrite") {
+    if !matches.contains_id("no_rewrite") {
         let prefixes = get_prefixes_from_args(matches);
         processor.rewrite(&prefixes)?;
     }
 
-    if !matches.is_present("no_sourcemap_reference") {
+    if !matches.contains_id("no_sourcemap_reference") {
         processor.add_sourcemap_references()?;
     }
 
-    if matches.is_present("validate") {
+    if matches.contains_id("validate") {
         processor.validate_all()?;
     }
 
@@ -331,7 +331,7 @@ pub fn execute(matches: &ArgMatches) -> Result<()> {
     let api = Api::current();
     let mut processor = SourceMapProcessor::new();
 
-    if matches.is_present("bundle") && matches.is_present("bundle_sourcemap") {
+    if matches.contains_id("bundle") && matches.contains_id("bundle_sourcemap") {
         process_sources_from_bundle(matches, &mut processor)?;
     } else {
         process_sources_from_paths(matches, &mut processor)?;
@@ -352,8 +352,8 @@ pub fn execute(matches: &ArgMatches) -> Result<()> {
         project: Some(&project),
         release: &release.version,
         dist: matches.get_one::<String>("dist").map(String::as_str),
-        wait: matches.is_present("wait"),
-        dedupe: !matches.is_present("no_dedupe"),
+        wait: matches.contains_id("wait"),
+        dedupe: !matches.contains_id("no_dedupe"),
     })?;
 
     Ok(())

--- a/src/commands/sourcemaps/upload.rs
+++ b/src/commands/sourcemaps/upload.rs
@@ -164,8 +164,8 @@ pub fn make_command(command: Command) -> Command {
 }
 
 fn get_prefixes_from_args(matches: &ArgMatches) -> Vec<&str> {
-    let mut prefixes: Vec<&str> = match matches.values_of("strip_prefix") {
-        Some(paths) => paths.collect(),
+    let mut prefixes: Vec<&str> = match matches.get_many::<String>("strip_prefix") {
+        Some(paths) => paths.map(String::as_str).collect(),
         None => vec![],
     };
     if matches.contains_id("strip_common_prefix") {
@@ -247,17 +247,17 @@ fn process_sources_from_paths(
     matches: &ArgMatches,
     processor: &mut SourceMapProcessor,
 ) -> Result<()> {
-    let paths = matches.values_of("paths").unwrap();
+    let paths = matches.get_many::<String>("paths").unwrap();
     let ignore_file = matches
         .get_one::<String>("ignore_file")
         .map(String::as_str)
         .unwrap_or_default();
     let extensions = matches
-        .values_of("extensions")
+        .get_many::<String>("extensions")
         .map(|extensions| extensions.map(|ext| ext.trim_start_matches('.')).collect())
         .unwrap_or_else(|| vec!["js", "map", "jsbundle", "bundle"]);
     let ignores = matches
-        .values_of("ignore")
+        .get_many::<String>("ignore")
         .map(|ignores| ignores.map(|i| format!("!{i}")).collect())
         .unwrap_or_else(Vec::new);
 

--- a/src/commands/sourcemaps/upload.rs
+++ b/src/commands/sourcemaps/upload.rs
@@ -1,7 +1,7 @@
 use std::path::PathBuf;
 
 use anyhow::Result;
-use clap::{Arg, ArgMatches, Command};
+use clap::{Arg, ArgAction, ArgMatches, Command};
 use glob::{glob_with, MatchOptions};
 use log::{debug, warn};
 
@@ -22,7 +22,8 @@ pub fn make_command(command: Command) -> Command {
             Arg::new("paths")
                 .value_name("PATHS")
                 .required_unless_present_any(["bundle", "bundle_sourcemap"])
-                .multiple_occurrences(true)
+                .multiple_values(true)
+                .action(ArgAction::Append)
                 .help("The files to upload."),
         )
         .arg(
@@ -85,7 +86,7 @@ pub fn make_command(command: Command) -> Command {
             Arg::new("strip_prefix")
                 .long("strip-prefix")
                 .value_name("PREFIX")
-                .multiple_occurrences(true)
+                .action(ArgAction::Append)
                 .help(
                     "Strips the given prefix from all sources references inside the upload \
                     sourcemaps (paths used within the sourcemap content, to map minified code \
@@ -110,7 +111,7 @@ pub fn make_command(command: Command) -> Command {
                 .long("ignore")
                 .short('i')
                 .value_name("IGNORE")
-                .multiple_occurrences(true)
+                .action(ArgAction::Append)
                 .help("Ignores all files and folders matching the given glob"),
         )
         .arg(
@@ -149,7 +150,7 @@ pub fn make_command(command: Command) -> Command {
                 .long("ext")
                 .short('x')
                 .value_name("EXT")
-                .multiple_occurrences(true)
+                .action(ArgAction::Append)
                 .help(
                     "Set the file extensions that are considered for upload. \
                     This overrides the default extensions. To add an extension, all default \

--- a/src/commands/uninstall.rs
+++ b/src/commands/uninstall.rs
@@ -58,7 +58,7 @@ pub fn execute(matches: &ArgMatches) -> Result<()> {
         return Ok(());
     }
 
-    if !matches.is_present("confirm")
+    if !matches.contains_id("confirm")
         && !prompt_to_continue("Do you really want to uninstall sentry-cli?")?
     {
         println!("Aborted!");

--- a/src/commands/update.rs
+++ b/src/commands/update.rs
@@ -43,7 +43,7 @@ pub fn execute(matches: &ArgMatches) -> Result<()> {
     }
 
     if update.is_latest_version() {
-        if matches.is_present("force") {
+        if matches.contains_id("force") {
             println!("Forcing update");
         } else {
             println!("Already up to date!");

--- a/src/commands/upload_proguard.rs
+++ b/src/commands/upload_proguard.rs
@@ -199,7 +199,7 @@ pub fn execute(matches: &ArgMatches) -> Result<()> {
         }
     }
 
-    if mappings.is_empty() && matches.is_present("require_one") {
+    if mappings.is_empty() && matches.contains_id("require_one") {
         println!();
         eprintln!("{}", style("error: found no mapping files to upload").red());
         return Err(QuietExit(1).into());
@@ -227,7 +227,7 @@ pub fn execute(matches: &ArgMatches) -> Result<()> {
         dump_proguard_uuids_as_properties(p, &uuids)?;
     }
 
-    if matches.is_present("no_upload") {
+    if matches.contains_id("no_upload") {
         println!("{} skipping upload.", style(">").dim());
         return Ok(());
     }
@@ -279,7 +279,7 @@ pub fn execute(matches: &ArgMatches) -> Result<()> {
     }
 
     // If wanted trigger reprocessing
-    if !matches.is_present("no_reprocessing") && !matches.is_present("no_upload") {
+    if !matches.contains_id("no_reprocessing") && !matches.contains_id("no_upload") {
         if !api.trigger_reprocessing(&org, &project)? {
             println!(
                 "{} Server does not support reprocessing. Not triggering.",

--- a/src/commands/upload_proguard.rs
+++ b/src/commands/upload_proguard.rs
@@ -273,7 +273,7 @@ pub fn execute(matches: &ArgMatches) -> Result<()> {
                 name: app_id.to_string(),
                 app_id: app_id.to_string(),
                 version: matches.get_one::<String>("version").unwrap().to_owned(),
-                build: matches.get_one::<String>("version_code").map(String::clone),
+                build: matches.get_one::<String>("version_code").cloned(),
             },
         )?;
     }

--- a/src/commands/upload_proguard.rs
+++ b/src/commands/upload_proguard.rs
@@ -133,7 +133,7 @@ pub fn make_command(command: Command) -> Command {
 pub fn execute(matches: &ArgMatches) -> Result<()> {
     let api = Api::current();
 
-    let paths: Vec<_> = match matches.values_of("paths") {
+    let paths: Vec<_> = match matches.get_many::<String>("paths") {
         Some(paths) => paths.collect(),
         None => {
             return Ok(());

--- a/src/commands/upload_proguard.rs
+++ b/src/commands/upload_proguard.rs
@@ -3,6 +3,7 @@ use std::io;
 use std::path::PathBuf;
 
 use anyhow::{bail, Error, Result};
+use clap::ArgAction;
 use clap::{Arg, ArgMatches, Command};
 use console::style;
 use log::{debug, info};
@@ -34,7 +35,8 @@ pub fn make_command(command: Command) -> Command {
             Arg::new("paths")
                 .value_name("PATH")
                 .help("The path to the mapping files.")
-                .multiple_occurrences(true),
+                .multiple_values(true)
+                .action(ArgAction::Append),
         )
         .arg(
             Arg::new("version")

--- a/src/config.rs
+++ b/src/config.rs
@@ -274,8 +274,8 @@ impl Config {
     /// Given a match object from clap, this returns the org from it.
     pub fn get_org(&self, matches: &ArgMatches) -> Result<String> {
         matches
-            .value_of("org")
-            .map(str::to_owned)
+            .get_one::<String>("org")
+            .map(String::clone)
             .or_else(|| env::var("SENTRY_ORG").ok())
             .or_else(|| {
                 self.ini
@@ -288,15 +288,15 @@ impl Config {
     /// Given a match object from clap, this returns the release from it.
     pub fn get_release(&self, matches: &ArgMatches) -> Result<String> {
         matches
-            .value_of("release")
-            .map(str::to_owned)
+            .get_one::<String>("release")
+            .map(String::clone)
             .or_else(|| env::var("SENTRY_RELEASE").ok())
             .ok_or_else(|| format_err!("A release slug is required (provide with --release)"))
     }
 
     // Backward compatibility with `releases files <VERSION>` commands.
     pub fn get_release_with_legacy_fallback(&self, matches: &ArgMatches) -> Result<String> {
-        if let Some(version) = matches.value_of("version") {
+        if let Some(version) = matches.get_one::<String>("version") {
             Ok(version.to_string())
         } else {
             self.get_release(matches)

--- a/src/config.rs
+++ b/src/config.rs
@@ -275,7 +275,7 @@ impl Config {
     pub fn get_org(&self, matches: &ArgMatches) -> Result<String> {
         matches
             .get_one::<String>("org")
-            .map(String::clone)
+            .cloned()
             .or_else(|| env::var("SENTRY_ORG").ok())
             .or_else(|| {
                 self.ini
@@ -289,7 +289,7 @@ impl Config {
     pub fn get_release(&self, matches: &ArgMatches) -> Result<String> {
         matches
             .get_one::<String>("release")
-            .map(String::clone)
+            .cloned()
             .or_else(|| env::var("SENTRY_RELEASE").ok())
             .ok_or_else(|| format_err!("A release slug is required (provide with --release)"))
     }
@@ -311,7 +311,7 @@ impl Config {
     /// Given a match object from clap, this returns the projects from it.
     pub fn get_projects(&self, matches: &ArgMatches) -> Result<Vec<String>> {
         if let Some(projects) = matches.get_many::<String>("project") {
-            Ok(projects.map(String::clone).collect())
+            Ok(projects.cloned().collect())
         } else {
             Ok(vec![self.get_project_default()?])
         }

--- a/src/config.rs
+++ b/src/config.rs
@@ -443,7 +443,7 @@ impl Config {
     }
 
     pub fn get_allow_failure(&self, matches: &ArgMatches) -> bool {
-        matches.is_present("allow_failure")
+        matches.contains_id("allow_failure")
             || if let Ok(var) = env::var("SENTRY_ALLOW_FAILURE") {
                 &var == "1" || &var == "true"
             } else {

--- a/src/config.rs
+++ b/src/config.rs
@@ -310,8 +310,8 @@ impl Config {
 
     /// Given a match object from clap, this returns the projects from it.
     pub fn get_projects(&self, matches: &ArgMatches) -> Result<Vec<String>> {
-        if let Some(projects) = matches.values_of("project") {
-            Ok(projects.map(str::to_owned).collect())
+        if let Some(projects) = matches.get_many::<String>("project") {
+            Ok(projects.map(String::clone).collect())
         } else {
             Ok(vec![self.get_project_default()?])
         }

--- a/src/utils/args.rs
+++ b/src/utils/args.rs
@@ -1,20 +1,16 @@
-use std::str::FromStr;
-
 use anyhow::{bail, Result};
 use chrono::{DateTime, TimeZone, Utc};
 use clap::{Arg, Command};
-use symbolic::common::DebugId;
-use uuid::Uuid;
 
-fn validate_org(v: &str) -> Result<(), String> {
+fn validate_org(v: &str) -> Result<String, String> {
     if v.contains('/') || v == "." || v == ".." || v.contains(' ') {
         Err("Invalid value for organization. Use the URL slug and not the name!".to_string())
     } else {
-        Ok(())
+        Ok(v.to_owned())
     }
 }
 
-pub fn validate_project(v: &str) -> Result<(), String> {
+pub fn validate_project(v: &str) -> Result<String, String> {
     if v.contains('/')
         || v == "."
         || v == ".."
@@ -25,11 +21,11 @@ pub fn validate_project(v: &str) -> Result<(), String> {
     {
         Err("Invalid value for project. Use the URL slug and not the name!".to_string())
     } else {
-        Ok(())
+        Ok(v.to_owned())
     }
 }
 
-fn validate_release(v: &str) -> Result<(), String> {
+fn validate_release(v: &str) -> Result<String, String> {
     if v.trim() != v {
         Err(
             "Invalid release version. Releases must not contain leading or trailing spaces."
@@ -46,11 +42,11 @@ fn validate_release(v: &str) -> Result<(), String> {
                 .to_string(),
         )
     } else {
-        Ok(())
+        Ok(v.to_owned())
     }
 }
 
-pub fn validate_distribution(v: &str) -> Result<(), String> {
+pub fn validate_distribution(v: &str) -> Result<String, String> {
     if v.trim() != v {
         Err(
             "Invalid distribution name. Distribution must not contain leading or trailing spaces."
@@ -62,39 +58,7 @@ pub fn validate_distribution(v: &str) -> Result<(), String> {
                 .to_string(),
         )
     } else {
-        Ok(())
-    }
-}
-
-pub fn validate_int(v: &str) -> Result<(), String> {
-    if v.parse::<i64>().is_ok() {
-        Ok(())
-    } else {
-        Err("Invalid number, integer required.".to_string())
-    }
-}
-
-pub fn validate_timestamp(v: &str) -> Result<(), String> {
-    if let Err(err) = get_timestamp(v) {
-        Err(err.to_string())
-    } else {
-        Ok(())
-    }
-}
-
-pub fn validate_uuid(s: &str) -> Result<(), String> {
-    if Uuid::parse_str(s).is_err() {
-        Err("Invalid UUID.".to_string())
-    } else {
-        Ok(())
-    }
-}
-
-pub fn validate_id(s: &str) -> Result<(), String> {
-    if DebugId::from_str(s).is_err() {
-        Err("Invalid ID.".to_string())
-    } else {
-        Ok(())
+        Ok(v.to_owned())
     }
 }
 
@@ -124,7 +88,7 @@ impl<'a: 'b, 'b> ArgExt for Command<'a> {
                 .value_name("ORG")
                 .long("org")
                 .short('o')
-                .validator(validate_org)
+                .value_parser(validate_org)
                 .global(true)
                 .help("The organization slug"),
         )
@@ -136,7 +100,7 @@ impl<'a: 'b, 'b> ArgExt for Command<'a> {
                 .value_name("PROJECT")
                 .long("project")
                 .short('p')
-                .validator(validate_project)
+                .value_parser(validate_project)
                 .global(true)
                 .multiple_occurrences(multiple)
                 .help("The project slug."),
@@ -151,7 +115,7 @@ impl<'a: 'b, 'b> ArgExt for Command<'a> {
                 .short('r')
                 .global(true)
                 .allow_hyphen_values(true)
-                .validator(validate_release)
+                .value_parser(validate_release)
                 .help("The release slug."),
         )
     }
@@ -161,7 +125,7 @@ impl<'a: 'b, 'b> ArgExt for Command<'a> {
             Arg::new("version")
                 .value_name("VERSION")
                 .required(true)
-                .validator(validate_release)
+                .value_parser(validate_release)
                 .help("The version of the release"),
         )
     }

--- a/src/utils/args.rs
+++ b/src/utils/args.rs
@@ -1,6 +1,6 @@
 use anyhow::{bail, Result};
 use chrono::{DateTime, TimeZone, Utc};
-use clap::{Arg, Command};
+use clap::{Arg, ArgAction, Command};
 
 fn validate_org(v: &str) -> Result<String, String> {
     if v.contains('/') || v == "." || v == ".." || v.contains(' ') {
@@ -102,7 +102,11 @@ impl<'a: 'b, 'b> ArgExt for Command<'a> {
                 .short('p')
                 .value_parser(validate_project)
                 .global(true)
-                .multiple_occurrences(multiple)
+                .action(if multiple {
+                    ArgAction::Append
+                } else {
+                    ArgAction::Set
+                })
                 .help("The project slug."),
         )
     }

--- a/tests/integration/_cases/monitors/monitors-run-invalid-uuid.trycmd
+++ b/tests/integration/_cases/monitors/monitors-run-invalid-uuid.trycmd
@@ -1,7 +1,7 @@
 ```
 $ sentry-cli monitors run xyz -- echo 123
 ? failed
-error: Invalid value "xyz" for '<monitor>': Invalid UUID.
+error: Invalid value "xyz" for '<monitor>': invalid character: expected an optional prefix of `urn:uuid:` followed by [0-9a-fA-F-], found `x` at 1
 
 For more information try --help
 


### PR DESCRIPTION
This fixes the 246 warnings produced by `cargo check --features clap/deprecated` in order to be able to update to `clap` v4.

- value_of() with get_one()
- is_present() with contains_id()
- values_of() with get_many()
- validator() with value_parser()
- multiple_occurrences() with action(ArgAction::Append)
- possible_values() with PossibleValueParser
- Arg::with_name with Arg::new
