### PR TITLE
chore: reapply clap update to v4 & fix releases subcommands

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -330,23 +330,21 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "3.2.23"
+version = "4.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71655c45cb9845d3270c9d6df84ebe72b4dad3c2ba3f7023ad47c144e4e473a5"
+checksum = "ec0b0588d44d4d63a87dbd75c136c166bbfd9a86a31cb89e09906521c7d3f5e3"
 dependencies = [
  "bitflags",
  "clap_lex",
- "indexmap",
  "strsim",
  "terminal_size",
- "textwrap",
 ]
 
 [[package]]
 name = "clap_lex"
-version = "0.2.4"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2850f2f5a82cbf437dd5af4d49848fbdfc27c157c3d010345776f952765261c5"
+checksum = "783fe232adfca04f90f56201b26d79682d4cd2625e0bc7290b95123afe558ade"
 dependencies = [
  "os_str_bytes",
 ]
@@ -2674,15 +2672,6 @@ checksum = "cb20089a8ba2b69debd491f8d2d023761cbf196e999218c591fa1e7e15a21907"
 dependencies = [
  "rustix",
  "windows-sys",
-]
-
-[[package]]
-name = "textwrap"
-version = "0.16.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "222a222a5bfe1bba4a77b45ec488a741b3cb8872e5e499451fd7d0129c9c7c3d"
-dependencies = [
- "terminal_size",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,10 +15,14 @@ brotli2 = "0.3.2"
 bytecount = "0.6.3"
 chardet = "0.2.4"
 chrono = { version = "0.4.23", features = ["serde"] }
-clap = { version = "3.2.23", default-features = false, features = [
+clap = { version = "4.1.6", default-features = false, features = [
   "std",
   "suggestions",
   "wrap_help",
+  "string",
+  "help",
+  "usage",
+  "error-context"
 ] }
 console = "0.15.5"
 curl = { version = "0.4.44", features = ["static-curl", "static-ssl"] }

--- a/src/api.rs
+++ b/src/api.rs
@@ -2326,7 +2326,7 @@ impl IssueFilter {
     }
 
     pub fn get_filter_from_matches(matches: &ArgMatches) -> Result<IssueFilter> {
-        if matches.contains_id("all") {
+        if matches.get_flag("all") {
             return Ok(IssueFilter::All);
         }
         if let Some(status) = matches.get_one::<String>("status") {

--- a/src/commands/bash_hook.rs
+++ b/src/commands/bash_hook.rs
@@ -6,8 +6,7 @@ use std::io::{BufRead, BufReader};
 use std::path::Path;
 
 use anyhow::Result;
-use clap::Command;
-use clap::{Arg, ArgMatches};
+use clap::{builder::ArgPredicate, Arg, ArgAction, ArgMatches, Command};
 use lazy_static::lazy_static;
 use regex::Regex;
 use sentry::protocol::{Event, Exception, Frame, Stacktrace, User, Value};
@@ -31,11 +30,13 @@ pub fn make_command(command: Command) -> Command {
         .arg(
             Arg::new("no_exit")
                 .long("no-exit")
+                .action(ArgAction::SetTrue)
                 .help("Do not turn on -e (exit immediately) flag automatically"),
         )
         .arg(
             Arg::new("no_environ")
                 .long("no-environ")
+                .action(ArgAction::SetTrue)
                 .help("Do not send environment variables along"),
         )
         .arg(
@@ -47,7 +48,11 @@ pub fn make_command(command: Command) -> Command {
         .arg(
             Arg::new("send_event")
                 .long("send-event")
-                .requires_all(&["traceback", "log"])
+                .action(ArgAction::SetTrue)
+                .requires_ifs([
+                    (ArgPredicate::IsPresent, "traceback"),
+                    (ArgPredicate::IsPresent, "log"),
+                ])
                 .hide(true),
         )
         .arg(
@@ -171,11 +176,11 @@ fn send_event(traceback: &str, logfile: &str, environ: bool) -> Result<()> {
 }
 
 pub fn execute(matches: &ArgMatches) -> Result<()> {
-    if matches.contains_id("send_event") {
+    if matches.get_flag("send_event") {
         return send_event(
             matches.get_one::<String>("traceback").unwrap(),
             matches.get_one::<String>("log").unwrap(),
-            !matches.contains_id("no_environ"),
+            !matches.get_flag("no_environ"),
         );
     }
 
@@ -203,13 +208,13 @@ pub fn execute(matches: &ArgMatches) -> Result<()> {
             .as_str(),
     );
 
-    if matches.contains_id("no_environ") {
+    if matches.get_flag("no_environ") {
         script = script.replace("___SENTRY_NO_ENVIRON___", "--no-environ");
     } else {
         script = script.replace("___SENTRY_NO_ENVIRON___", "");
     }
 
-    if !matches.contains_id("no_exit") {
+    if !matches.get_flag("no_exit") {
         script.insert_str(0, "set -e\n\n");
     }
     println!("{script}");

--- a/src/commands/debug_files/bundle_sources.rs
+++ b/src/commands/debug_files/bundle_sources.rs
@@ -15,7 +15,7 @@ pub fn make_command(command: Command) -> Command {
         .arg(
             Arg::new("paths")
                 .required(true)
-                .multiple_values(true)
+                .num_args(1..)
                 .action(ArgAction::Append)
                 .help("The path to the input debug info files."),
         )

--- a/src/commands/debug_files/check.rs
+++ b/src/commands/debug_files/check.rs
@@ -2,7 +2,7 @@ use std::io;
 use std::path::Path;
 
 use anyhow::Result;
-use clap::{builder::PossibleValuesParser, Arg, ArgMatches, Command};
+use clap::{builder::PossibleValuesParser, Arg, ArgAction, ArgMatches, Command};
 use console::style;
 
 use crate::utils::dif::{DifFile, DifType};
@@ -35,6 +35,7 @@ pub fn make_command(command: Command) -> Command {
         .arg(
             Arg::new("json")
                 .long("json")
+                .action(ArgAction::SetTrue)
                 .help("Format outputs as JSON."),
         )
 }
@@ -48,12 +49,12 @@ pub fn execute(matches: &ArgMatches) -> Result<()> {
         .map(|t| t.parse().unwrap());
     let dif = DifFile::open_path(path, ty)?;
 
-    if matches.contains_id("json") {
+    if matches.get_flag("json") {
         serde_json::to_writer_pretty(&mut io::stdout(), &dif)?;
         println!();
     }
 
-    if matches.contains_id("json") || is_quiet_mode() {
+    if matches.get_flag("json") || is_quiet_mode() {
         return if dif.is_usable() {
             Ok(())
         } else {

--- a/src/commands/debug_files/find.rs
+++ b/src/commands/debug_files/find.rs
@@ -40,7 +40,7 @@ pub fn make_command(command: Command) -> Command {
                 .value_name("ID")
                 .help("The debug identifiers of the files to search for.")
                 .value_parser(DebugId::from_str)
-                .multiple_values(true)
+                .num_args(1..)
                 .action(ArgAction::Append),
         )
         .arg(
@@ -58,11 +58,13 @@ pub fn make_command(command: Command) -> Command {
         .arg(
             Arg::new("no_well_known")
                 .long("no-well-known")
+                .action(ArgAction::SetTrue)
                 .help("Do not look for debug symbols in well known locations."),
         )
         .arg(
             Arg::new("no_cwd")
                 .long("no-cwd")
+                .action(ArgAction::SetTrue)
                 .help("Do not look for debug symbols in the current working directory."),
         )
         .arg(
@@ -76,6 +78,7 @@ pub fn make_command(command: Command) -> Command {
         .arg(
             Arg::new("json")
                 .long("json")
+                .action(ArgAction::SetTrue)
                 .help("Format outputs as JSON."),
         )
 }
@@ -339,8 +342,8 @@ pub fn execute(matches: &ArgMatches) -> Result<()> {
         types.extend(DifType::all());
     }
 
-    let with_well_known = !matches.contains_id("no_well_known");
-    let with_cwd = !matches.contains_id("no_cwd");
+    let with_well_known = !matches.get_flag("no_well_known");
+    let with_cwd = !matches.get_flag("no_cwd");
 
     // start adding well known locations
     if_chain! {
@@ -378,7 +381,7 @@ pub fn execute(matches: &ArgMatches) -> Result<()> {
         return Ok(());
     }
 
-    if !find_ids(&paths, &types, &ids, matches.contains_id("json"))? {
+    if !find_ids(&paths, &types, &ids, matches.get_flag("json"))? {
         return Err(QuietExit(1).into());
     }
 

--- a/src/commands/debug_files/upload.rs
+++ b/src/commands/debug_files/upload.rs
@@ -31,7 +31,7 @@ pub fn make_command(command: Command) -> Command {
             Arg::new("paths")
                 .value_name("PATH")
                 .help("A path to search recursively for symbol files.")
-                .multiple_values(true)
+                .num_args(1..)
                 .action(ArgAction::Append),
         )
         .arg(
@@ -50,6 +50,7 @@ pub fn make_command(command: Command) -> Command {
             Arg::new("no_unwind")
                 .long("no-unwind")
                 .alias("no-bin")
+                .action(ArgAction::SetTrue)
                 .help(
                     "Do not scan for stack unwinding information. Specify \
                     this flag for builds with disabled FPO, or when \
@@ -62,6 +63,7 @@ pub fn make_command(command: Command) -> Command {
         .arg(
             Arg::new("no_debug")
                 .long("no-debug")
+                .action(ArgAction::SetTrue)
                 .help(
                     "Do not scan for debugging information. This will \
                     usually exclude debug companion files. They might \
@@ -70,12 +72,17 @@ pub fn make_command(command: Command) -> Command {
                 )
                 .conflicts_with("no_unwind"),
         )
-        .arg(Arg::new("no_sources").long("no-sources").help(
-            "Do not scan for source information. This will \
-            usually exclude source bundle files. They might \
-            still be uploaded, if they contain additional \
-            processable information (see other flags).",
-        ))
+        .arg(
+            Arg::new("no_sources")
+                .long("no-sources")
+                .action(ArgAction::SetTrue)
+                .help(
+                    "Do not scan for source information. This will \
+                    usually exclude source bundle files. They might \
+                    still be uploaded, if they contain additional \
+                    processable information (see other flags).",
+                ),
+        )
         .arg(
             Arg::new("ids")
                 .value_name("ID")
@@ -87,6 +94,7 @@ pub fn make_command(command: Command) -> Command {
         .arg(
             Arg::new("require_all")
                 .long("require-all")
+                .action(ArgAction::SetTrue)
                 .help("Errors if not all identifiers specified with --id could be found."),
         )
         .arg(
@@ -106,11 +114,13 @@ pub fn make_command(command: Command) -> Command {
         .arg(
             Arg::new("derived_data")
                 .long("derived-data")
+                .action(ArgAction::SetTrue)
                 .help("Search for debug symbols in Xcode's derived data."),
         )
         .arg(
             Arg::new("no_zips")
                 .long("no-zips")
+                .action(ArgAction::SetTrue)
                 .help("Do not search in ZIP files."),
         )
         .arg(
@@ -128,41 +138,64 @@ pub fn make_command(command: Command) -> Command {
         .arg(
             Arg::new("no_reprocessing")
                 .long("no-reprocessing")
+                .action(ArgAction::SetTrue)
                 .help("Do not trigger reprocessing after uploading."),
         )
-        .arg(Arg::new("no_upload").long("no-upload").help(
-            "Disable the actual upload.{n}This runs all steps for the \
-            processing but does not trigger the upload (this also \
-            automatically disables reprocessing).  This is useful if you \
-            just want to verify the setup or skip the upload in tests.",
-        ))
-        .arg(Arg::new("force_foreground").long("force-foreground").help(
-            "Wait for the process to finish.{n}\
-            By default, the upload process will detach and continue in the \
-            background when triggered from Xcode.  When an error happens, \
-            a dialog is shown.  If this parameter is passed Xcode will wait \
-            for the process to finish before the build finishes and output \
-            will be shown in the Xcode build output.",
-        ))
-        .arg(Arg::new("include_sources").long("include-sources").help(
-            "Include sources from the local file system and upload \
-            them as source bundles.",
-        ))
-        .arg(Arg::new("wait").long("wait").help(
-            "Wait for the server to fully process uploaded files. Errors \
-            can only be displayed if --wait is specified, but this will \
-            significantly slow down the upload process.",
-        ))
+        .arg(
+            Arg::new("no_upload")
+                .long("no-upload")
+                .action(ArgAction::SetTrue)
+                .help(
+                    "Disable the actual upload.{n}This runs all steps for the \
+                    processing but does not trigger the upload (this also \
+                    automatically disables reprocessing).  This is useful if you \
+                    just want to verify the setup or skip the upload in tests.",
+                ),
+        )
+        .arg(
+            Arg::new("force_foreground")
+                .long("force-foreground")
+                .action(ArgAction::SetTrue)
+                .help(
+                    "Wait for the process to finish.{n}\
+                    By default, the upload process will detach and continue in the \
+                    background when triggered from Xcode.  When an error happens, \
+                    a dialog is shown.  If this parameter is passed Xcode will wait \
+                    for the process to finish before the build finishes and output \
+                    will be shown in the Xcode build output.",
+                ),
+        )
+        .arg(
+            Arg::new("include_sources")
+                .long("include-sources")
+                .action(ArgAction::SetTrue)
+                .help(
+                    "Include sources from the local file system and upload them as source bundles.",
+                ),
+        )
+        .arg(
+            Arg::new("wait")
+                .long("wait")
+                .action(ArgAction::SetTrue)
+                .help(
+                    "Wait for the server to fully process uploaded files. Errors \
+                    can only be displayed if --wait is specified, but this will \
+                    significantly slow down the upload process.",
+                ),
+        )
         // Legacy flag that has no effect, left hidden for backward compatibility
         .arg(
             Arg::new("upload_symbol_maps")
                 .long("upload-symbol-maps")
+                .action(ArgAction::SetTrue)
                 .hide(true),
         )
-        .arg(Arg::new("il2cpp_mapping").long("il2cpp-mapping").help(
-            "Compute il2cpp line mappings and upload \
-            them along with sources.",
-        ))
+        .arg(
+            Arg::new("il2cpp_mapping")
+                .long("il2cpp-mapping")
+                .action(ArgAction::SetTrue)
+                .help("Compute il2cpp line mappings and upload them along with sources."),
+        )
 }
 
 pub fn execute(matches: &ArgMatches) -> Result<()> {
@@ -182,9 +215,9 @@ pub fn execute(matches: &ArgMatches) -> Result<()> {
     // Build generic upload parameters
     let mut upload = DifUpload::new(org.clone(), project.clone());
     upload
-        .wait(matches.contains_id("wait"))
+        .wait(matches.get_flag("wait"))
         .search_paths(matches.get_many::<String>("paths").unwrap_or_default())
-        .allow_zips(!matches.contains_id("no_zips"))
+        .allow_zips(!matches.get_flag("no_zips"))
         .filter_ids(ids);
 
     // Restrict symbol types, if specified by the user
@@ -213,17 +246,17 @@ pub fn execute(matches: &ArgMatches) -> Result<()> {
         // Allow stripped debug symbols. These are dSYMs, ELF binaries generated
         // with `objcopy --only-keep-debug` or Breakpad symbols. As a fallback,
         // we also upload all files with a public symbol table.
-        debug: !matches.contains_id("no_debug"),
-        symtab: !matches.contains_id("no_debug"),
+        debug: !matches.get_flag("no_debug"),
+        symtab: !matches.get_flag("no_debug"),
         // Allow executables and dynamic/shared libraries, but not object files.
         // They are guaranteed to contain unwind info, for instance `eh_frame`,
         // and may optionally contain debugging information such as DWARF.
-        unwind: !matches.contains_id("no_unwind"),
-        sources: !matches.contains_id("no_sources"),
+        unwind: !matches.get_flag("no_unwind"),
+        sources: !matches.get_flag("no_sources"),
     });
 
-    upload.include_sources(matches.contains_id("include_sources"));
-    upload.il2cpp_mapping(matches.contains_id("il2cpp_mapping"));
+    upload.include_sources(matches.get_flag("include_sources"));
+    upload.il2cpp_mapping(matches.get_flag("il2cpp_mapping"));
 
     // Configure BCSymbolMap resolution, if possible
     if let Some(symbol_map) = matches.get_one::<String>("symbol_maps") {
@@ -233,7 +266,7 @@ pub fn execute(matches: &ArgMatches) -> Result<()> {
     }
 
     // Add a path to XCode's DerivedData, if configured
-    if matches.contains_id("derived_data") {
+    if matches.get_flag("derived_data") {
         let derived_data = dirs::home_dir().map(|x| x.join(DERIVED_DATA_FOLDER));
         if let Some(path) = derived_data {
             if path.is_dir() {
@@ -248,14 +281,14 @@ pub fn execute(matches: &ArgMatches) -> Result<()> {
         None => InfoPlist::discover_from_env()?,
     };
 
-    if matches.contains_id("no_upload") {
+    if matches.get_flag("no_upload") {
         println!("{} skipping upload.", style(">").dim());
         return Ok(());
     }
 
     MayDetach::wrap("Debug symbol upload", |handle| {
         // Optionally detach if run from Xcode
-        if !matches.contains_id("force_foreground") {
+        if !matches.get_flag("force_foreground") {
             handle.may_detach()?;
         }
 
@@ -293,14 +326,14 @@ pub fn execute(matches: &ArgMatches) -> Result<()> {
         }
 
         // Trigger reprocessing only if requested by user
-        if matches.contains_id("no_reprocessing") {
+        if matches.get_flag("no_reprocessing") {
             println!("{} skipped reprocessing", style(">").dim());
         } else if !api.trigger_reprocessing(&org, &project)? {
             println!("{} Server does not support reprocessing.", style(">").dim());
         }
 
         // Did we miss explicitly requested symbols?
-        if matches.contains_id("require_all") {
+        if matches.get_flag("require_all") {
             let required_ids: BTreeSet<DebugId> = matches
                 .get_many::<DebugId>("ids")
                 .unwrap_or_default()

--- a/src/commands/events/list.rs
+++ b/src/commands/events/list.rs
@@ -1,5 +1,5 @@
 use anyhow::Result;
-use clap::{Arg, ArgMatches, Command};
+use clap::{Arg, ArgAction, ArgMatches, Command};
 
 use crate::api::Api;
 use crate::config::Config;
@@ -12,12 +12,14 @@ pub fn make_command(command: Command) -> Command {
             Arg::new("show_user")
                 .long("show-user")
                 .short('U')
+                .action(ArgAction::SetTrue)
                 .help("Display the Users column."),
         )
         .arg(
             Arg::new("show_tags")
                 .long("show-tags")
                 .short('T')
+                .action(ArgAction::SetTrue)
                 .help("Display the Tags column."),
         )
         .arg(
@@ -49,11 +51,11 @@ pub fn execute(matches: &ArgMatches) -> Result<()> {
     let mut table = Table::new();
     let title_row = table.title_row().add("Event ID").add("Date").add("Title");
 
-    if matches.contains_id("show_user") {
+    if matches.get_flag("show_user") {
         title_row.add("User");
     }
 
-    if matches.contains_id("show_tags") {
+    if matches.get_flag("show_tags") {
         title_row.add("Tags");
     }
 
@@ -69,7 +71,7 @@ pub fn execute(matches: &ArgMatches) -> Result<()> {
                 .add(&event.date_created)
                 .add(&event.title);
 
-            if matches.contains_id("show_user") {
+            if matches.get_flag("show_user") {
                 if let Some(user) = &event.user {
                     row.add(user);
                 } else {
@@ -77,7 +79,7 @@ pub fn execute(matches: &ArgMatches) -> Result<()> {
                 }
             }
 
-            if matches.contains_id("show_tags") {
+            if matches.get_flag("show_tags") {
                 if let Some(tags) = &event.tags {
                     row.add(
                         tags.iter()

--- a/src/commands/files/delete.rs
+++ b/src/commands/files/delete.rs
@@ -1,7 +1,7 @@
 use std::collections::HashSet;
 
 use anyhow::Result;
-use clap::{Arg, ArgMatches, Command, ArgAction};
+use clap::{Arg, ArgAction, ArgMatches, Command};
 
 use crate::api::Api;
 use crate::config::Config;
@@ -14,7 +14,7 @@ pub fn make_command(command: Command) -> Command {
         .arg(
             Arg::new("names")
                 .value_name("NAMES")
-                .multiple_values(true)
+                .num_args(1..)
                 .action(ArgAction::Append)
                 .help("Filenames to delete."),
         )
@@ -22,6 +22,7 @@ pub fn make_command(command: Command) -> Command {
             Arg::new("all")
                 .short('A')
                 .long("all")
+                .action(ArgAction::SetTrue)
                 .help("Delete all files."),
         )
 }
@@ -33,7 +34,7 @@ pub fn execute(matches: &ArgMatches) -> Result<()> {
     let project = config.get_project(matches).ok();
     let api = Api::current();
 
-    if matches.contains_id("all") {
+    if matches.get_flag("all") {
         if api.delete_release_files(&org, project.as_deref(), &release)? {
             println!("All files deleted.");
         }

--- a/src/commands/files/upload.rs
+++ b/src/commands/files/upload.rs
@@ -4,7 +4,7 @@ use std::io::Read;
 use std::path::Path;
 
 use anyhow::{bail, format_err, Result};
-use clap::{Arg, ArgMatches, Command, ArgAction};
+use clap::{Arg, ArgAction, ArgMatches, Command};
 use log::warn;
 use symbolic::debuginfo::sourcebundle::SourceFileType;
 
@@ -42,11 +42,13 @@ pub fn make_command(command: Command) -> Command {
         .arg(
             Arg::new("decompress")
                 .long("decompress")
+                .action(ArgAction::SetTrue)
                 .help("Enable files gzip decompression prior to upload."),
         )
         .arg(
             Arg::new("wait")
                 .long("wait")
+                .action(ArgAction::SetTrue)
                 .help("Wait for the server to fully process uploaded files."),
         )
         .arg(
@@ -126,7 +128,7 @@ pub fn execute(matches: &ArgMatches) -> Result<()> {
         project: project.as_deref(),
         release: &release,
         dist,
-        wait: matches.contains_id("wait"),
+        wait: matches.get_flag("wait"),
         ..Default::default()
     };
 
@@ -150,7 +152,7 @@ pub fn execute(matches: &ArgMatches) -> Result<()> {
             .ignore_file(ignore_file)
             .ignores(ignores)
             .extensions(extensions)
-            .decompress(matches.contains_id("decompress"))
+            .decompress(matches.get_flag("decompress"))
             .collect_files()?;
 
         let url_suffix = matches
@@ -202,7 +204,7 @@ pub fn execute(matches: &ArgMatches) -> Result<()> {
         let mut contents = Vec::new();
         f.read_to_end(&mut contents)?;
 
-        if matches.contains_id("decompress") && is_gzip_compressed(&contents) {
+        if matches.get_flag("decompress") && is_gzip_compressed(&contents) {
             contents = decompress_gzip_content(&contents).unwrap_or_else(|_| {
                 warn!("Could not decompress: {}", name);
                 contents

--- a/src/commands/info.rs
+++ b/src/commands/info.rs
@@ -1,7 +1,7 @@
 use std::io;
 
 use anyhow::Result;
-use clap::{Arg, ArgMatches, Command};
+use clap::{Arg, ArgAction, ArgMatches, Command};
 use serde::Serialize;
 
 use crate::api::Api;
@@ -36,17 +36,23 @@ pub fn make_command(command: Command) -> Command {
         .arg(
             Arg::new("config_status_json")
                 .long("config-status-json")
+                .action(ArgAction::SetTrue)
                 .help(
                     "Return the status of the config that sentry-cli loads \
                      as JSON dump. This can be used by external tools to aid \
                      the user towards configuration.",
                 ),
         )
-        .arg(Arg::new("no_defaults").long("no-defaults").help(
-            "Skip default organization and project checks. \
-             This allows you to verify your authentication method, \
-             without the need for setting other defaults.",
-        ))
+        .arg(
+            Arg::new("no_defaults")
+                .long("no-defaults")
+                .action(ArgAction::SetTrue)
+                .help(
+                    "Skip default organization and project checks. \
+                    This allows you to verify your authentication method, \
+                    without the need for setting other defaults.",
+                ),
+        )
 }
 
 fn describe_auth(auth: Option<&Auth>) -> &str {
@@ -79,7 +85,7 @@ fn get_config_status_json() -> Result<()> {
 }
 
 pub fn execute(matches: &ArgMatches) -> Result<()> {
-    if matches.contains_id("config_status_json") {
+    if matches.get_flag("config_status_json") {
         return get_config_status_json();
     }
 
@@ -91,7 +97,7 @@ pub fn execute(matches: &ArgMatches) -> Result<()> {
     let mut errors = config.get_auth().is_none() || info_rv.is_err();
 
     // If `no-defaults` is present, only authentication should be verified.
-    if !matches.contains_id("no_defaults") {
+    if !matches.get_flag("no_defaults") {
         errors = errors || project.is_none() || org.is_none();
     }
 
@@ -105,7 +111,7 @@ pub fn execute(matches: &ArgMatches) -> Result<()> {
 
     println!("Sentry Server: {}", config.get_base_url().unwrap_or("-"));
 
-    if !matches.contains_id("no_defaults") {
+    if !matches.get_flag("no_defaults") {
         println!(
             "Default Organization: {}",
             org.unwrap_or_else(|| "-".into())

--- a/src/commands/issues/mod.rs
+++ b/src/commands/issues/mod.rs
@@ -43,6 +43,7 @@ pub fn make_command(mut command: Command) -> Command {
             Arg::new("all")
                 .long("all")
                 .short('a')
+                .action(ArgAction::SetTrue)
                 .global(true)
                 .help("Select all issues (this might be limited)."),
         )

--- a/src/commands/issues/resolve.rs
+++ b/src/commands/issues/resolve.rs
@@ -1,5 +1,5 @@
 use anyhow::Result;
-use clap::{Arg, ArgMatches, Command};
+use clap::{Arg, ArgAction, ArgMatches, Command};
 use log::info;
 
 use crate::api::{Api, IssueChanges, IssueFilter};
@@ -10,6 +10,7 @@ pub fn make_command(command: Command) -> Command {
         Arg::new("next_release")
             .long("next-release")
             .short('n')
+            .action(ArgAction::SetTrue)
             .help("Only select issues in the next release."),
     )
 }
@@ -25,7 +26,7 @@ pub fn execute(matches: &ArgMatches) -> Result<()> {
         org, project
     );
 
-    if matches.contains_id("next_release") {
+    if matches.get_flag("next_release") {
         changes.new_status = Some("resolvedInNextRelease".into());
     } else {
         changes.new_status = Some("resolved".into());

--- a/src/commands/login.rs
+++ b/src/commands/login.rs
@@ -1,7 +1,7 @@
 use std::env;
 
 use anyhow::{bail, Result};
-use clap::{Arg, ArgMatches, Command};
+use clap::{Arg, ArgAction, ArgMatches, Command};
 use url::Url;
 
 use crate::api::Api;
@@ -13,6 +13,7 @@ pub fn make_command(command: Command) -> Command {
         Arg::new("global")
             .short('g')
             .long("global")
+            .action(ArgAction::SetTrue)
             .help("Store authentication token globally rather than locally."),
     )
 }
@@ -85,7 +86,7 @@ pub fn execute(matches: &ArgMatches) -> Result<()> {
         }
     }
 
-    let config_to_update = if matches.contains_id("global") {
+    let config_to_update = if matches.get_flag("global") {
         Config::global()?
     } else {
         Config::from_cli_config()?

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -4,8 +4,7 @@ use std::env;
 use std::process;
 
 use anyhow::{bail, Result};
-use clap::ArgAction;
-use clap::{Arg, ArgMatches, Command};
+use clap::{Arg, ArgAction, ArgMatches, Command};
 use log::{debug, info, set_logger, set_max_level, LevelFilter};
 
 use crate::api::Api;
@@ -129,7 +128,7 @@ fn configure_args(config: &mut Config, matches: &ArgMatches) -> Result<()> {
     Ok(())
 }
 
-fn app() -> Command<'static> {
+fn app() -> Command {
     Command::new("sentry-cli")
         .version(VERSION)
         .about(ABOUT)
@@ -176,12 +175,14 @@ fn app() -> Command<'static> {
             Arg::new("quiet")
                 .long("quiet")
                 .visible_alias("silent")
+                .action(ArgAction::SetTrue)
                 .global(true)
                 .help("Do not print any output while preserving correct exit code. This flag is currently implemented only for selected subcommands."),
         )
         .arg(
           Arg::new("allow_failure")
               .long("allow-failure")
+              .action(ArgAction::SetTrue)
               .global(true)
               .hide(true)
               .help("Always return 0 exit code."),
@@ -191,8 +192,7 @@ fn app() -> Command<'static> {
 fn add_commands(mut app: Command) -> Command {
     macro_rules! add_subcommand {
         ($name:ident) => {{
-            let cmd =
-                $name::make_command(Command::new(stringify!($name).replace("_", "-").as_str()));
+            let cmd = $name::make_command(Command::new(stringify!($name).replace("_", "-")));
             app = app.subcommand(cmd);
         }};
     }
@@ -231,7 +231,7 @@ pub fn execute() -> Result<()> {
     app = add_commands(app);
     let matches = app.get_matches();
     configure_args(&mut config, &matches)?;
-    set_quiet_mode(matches.contains_id("quiet"));
+    set_quiet_mode(matches.get_flag("quiet"));
 
     // bind the config to the process and fetch an immutable reference to it
     config.bind_to_process();

--- a/src/commands/monitors/run.rs
+++ b/src/commands/monitors/run.rs
@@ -2,7 +2,7 @@ use std::process;
 use std::time::Instant;
 
 use anyhow::Result;
-use clap::{Arg, ArgMatches, Command};
+use clap::{Arg, ArgAction, ArgMatches, Command};
 use console::style;
 use uuid::Uuid;
 
@@ -22,14 +22,14 @@ pub fn make_command(command: Command) -> Command {
             Arg::new("allow_failure")
                 .short('f')
                 .long("allow-failure")
+                .action(ArgAction::SetTrue)
                 .help("Run provided command even when Sentry reports an error."),
         )
         .arg(
             Arg::new("args")
                 .value_name("ARGS")
                 .required(true)
-                .takes_value(true)
-                .multiple_values(true)
+                .num_args(1..)
                 .last(true),
         )
 }
@@ -39,7 +39,7 @@ pub fn execute(matches: &ArgMatches) -> Result<()> {
 
     let monitor = matches.get_one::<Uuid>("monitor").unwrap();
 
-    let allow_failure = matches.contains_id("allow_failure");
+    let allow_failure = matches.get_flag("allow_failure");
     let args: Vec<_> = matches.get_many::<String>("args").unwrap().collect();
 
     let monitor_checkin = api.create_monitor_checkin(

--- a/src/commands/react_native/appcenter.rs
+++ b/src/commands/react_native/appcenter.rs
@@ -3,7 +3,7 @@ use std::ffi::OsStr;
 use std::fs;
 
 use anyhow::{anyhow, Result};
-use clap::{Arg, ArgMatches, Command, ArgAction};
+use clap::{Arg, ArgAction, ArgMatches, Command};
 use console::style;
 use if_chain::if_chain;
 use log::info;
@@ -56,13 +56,14 @@ pub fn make_command(command: Command) -> Command {
         .arg(
             Arg::new("print_release_name")
                 .long("print-release-name")
+                .action(ArgAction::SetTrue)
                 .help("Print the release name instead."),
         )
         .arg(
             Arg::new("release_name")
                 .value_name("RELEASE_NAME")
                 .long("release-name")
-                .conflicts_with_all(&["bundle_id", "version_name"])
+                .conflicts_with_all(["bundle_id", "version_name"])
                 .help("Override the entire release-name"),
         )
         .arg(
@@ -81,13 +82,14 @@ pub fn make_command(command: Command) -> Command {
             Arg::new("paths")
                 .value_name("PATH")
                 .required(true)
-                .multiple_values(true)
+                .num_args(1..)
                 .action(ArgAction::Append)
                 .help("A list of folders with assets that should be processed."),
         )
         .arg(
             Arg::new("wait")
                 .long("wait")
+                .action(ArgAction::SetTrue)
                 .help("Wait for the server to fully process uploaded files."),
         )
 }
@@ -104,7 +106,7 @@ pub fn execute(matches: &ArgMatches) -> Result<()> {
         .map(String::as_str)
         .unwrap_or("Staging");
     let api = Api::current();
-    let print_release_name = matches.contains_id("print_release_name");
+    let print_release_name = matches.get_flag("print_release_name");
 
     info!(
         "Issuing a command for Organization: {} Project: {}",
@@ -185,7 +187,7 @@ pub fn execute(matches: &ArgMatches) -> Result<()> {
                 project: Some(&project),
                 release: &release.version,
                 dist: None,
-                wait: matches.contains_id("wait"),
+                wait: matches.get_flag("wait"),
                 ..Default::default()
             })?;
         }
@@ -201,7 +203,7 @@ pub fn execute(matches: &ArgMatches) -> Result<()> {
                     project: Some(&project),
                     release: &release.version,
                     dist: Some(dist),
-                    wait: matches.contains_id("wait"),
+                    wait: matches.get_flag("wait"),
                     ..Default::default()
                 })?;
             }

--- a/src/commands/react_native/gradle.rs
+++ b/src/commands/react_native/gradle.rs
@@ -2,7 +2,7 @@ use std::env;
 use std::path::PathBuf;
 
 use anyhow::Result;
-use clap::{Arg, ArgMatches, Command, ArgAction};
+use clap::{Arg, ArgAction, ArgMatches, Command};
 use log::{debug, info};
 use sourcemap::ram_bundle::RamBundle;
 
@@ -51,6 +51,7 @@ pub fn make_command(command: Command) -> Command {
         .arg(
             Arg::new("wait")
                 .long("wait")
+                .action(ArgAction::SetTrue)
                 .help("Wait for the server to fully process uploaded files."),
         )
 }
@@ -118,7 +119,7 @@ pub fn execute(matches: &ArgMatches) -> Result<()> {
             project: Some(&project),
             release: &release.version,
             dist: Some(dist),
-            wait: matches.contains_id("wait"),
+            wait: matches.get_flag("wait"),
             ..Default::default()
         })?;
     }

--- a/src/commands/react_native/xcode.rs
+++ b/src/commands/react_native/xcode.rs
@@ -31,16 +31,27 @@ pub fn make_command(command: Command) -> Command {
         .about("Upload react-native projects in a Xcode build step.")
         .org_arg()
         .project_arg(false)
-        .arg(Arg::new("force").long("force").short('f').help(
-            "Force the script to run, even in debug configuration.{n}This rarely \
-             does what you want because the default build script does not actually \
-             produce any information that the sentry build tool could pick up on.",
-        ))
-        .arg(Arg::new("allow_fetch").long("allow-fetch").help(
-            "Enable sourcemap fetching from the packager.{n}If this is enabled \
-             the react native packager needs to run and sourcemaps are downloade \
-             from it if the simulator platform is detected.",
-        ))
+        .arg(
+            Arg::new("force")
+                .long("force")
+                .short('f')
+                .action(ArgAction::SetTrue)
+                .help(
+                    "Force the script to run, even in debug configuration.{n}This rarely \
+                    does what you want because the default build script does not actually \
+                    produce any information that the sentry build tool could pick up on.",
+                ),
+        )
+        .arg(
+            Arg::new("allow_fetch")
+                .long("allow-fetch")
+                .action(ArgAction::SetTrue)
+                .help(
+                    "Enable sourcemap fetching from the packager.{n}If this is enabled \
+                    the react native packager needs to run and sourcemaps are downloade \
+                    from it if the simulator platform is detected.",
+                ),
+        )
         .arg(
             Arg::new("fetch_from")
                 .long("fetch-from")
@@ -51,14 +62,19 @@ pub fn make_command(command: Command) -> Command {
                      packager runs by default.",
                 ),
         )
-        .arg(Arg::new("force_foreground").long("force-foreground").help(
-            "Wait for the process to finish.{n}\
+        .arg(
+            Arg::new("force_foreground")
+                .long("force-foreground")
+                .action(ArgAction::SetTrue)
+                .help(
+                    "Wait for the process to finish.{n}\
                      By default part of the build process will when triggered from Xcode \
                      detach and continue in the background.  When an error happens, \
                      a dialog is shown.  If this parameter is passed, Xcode will wait \
                      for the process to finish before the build finishes and output \
                      will be shown in the Xcode build output.",
-        ))
+                ),
+        )
         .arg(Arg::new("build_script").value_name("BUILD_SCRIPT").help(
             "Optional path to the build script.{n}\
                      This is the path to the `react-native-xcode.sh` script you want \
@@ -75,14 +91,14 @@ pub fn make_command(command: Command) -> Command {
         .arg(
             Arg::new("args")
                 .value_name("ARGS")
-                .takes_value(true)
-                .multiple_values(true)
+                .num_args(1..)
                 .last(true)
                 .help("Optional arguments to pass to the build script."),
         )
         .arg(
             Arg::new("wait")
                 .long("wait")
+                .action(ArgAction::SetTrue)
                 .help("Wait for the server to fully process uploaded files."),
         )
 }
@@ -99,7 +115,7 @@ fn find_node() -> String {
 pub fn execute(matches: &ArgMatches) -> Result<()> {
     let config = Config::current();
     let (org, project) = config.get_org_and_project(matches)?;
-    let should_wrap = matches.contains_id("force")
+    let should_wrap = matches.get_flag("force")
         || match env::var("CONFIGURATION") {
             Ok(config) => !&config.contains("Debug"),
             Err(_) => bail!("Need to run this from Xcode"),
@@ -121,7 +137,7 @@ pub fn execute(matches: &ArgMatches) -> Result<()> {
     // to simulator mode.
     let fetch_url;
     if_chain! {
-        if matches.contains_id("allow_fetch");
+        if matches.get_flag("allow_fetch");
         if let Ok(val) = env::var("PLATFORM_NAME");
         if val.ends_with("simulator");
         then {
@@ -165,7 +181,7 @@ pub fn execute(matches: &ArgMatches) -> Result<()> {
         // case we do indeed fetch it right from the running packager and then
         // store it in temporary files for later consumption.
         if let Some(url) = fetch_url {
-            if !matches.contains_id("force_foreground") {
+            if !matches.get_flag("force_foreground") {
                 md.may_detach()?;
             }
             let api = Api::current();
@@ -220,7 +236,7 @@ pub fn execute(matches: &ArgMatches) -> Result<()> {
                 .wait()?;
             propagate_exit_status(rv);
 
-            if !matches.contains_id("force_foreground") {
+            if !matches.get_flag("force_foreground") {
                 md.may_detach()?;
             }
             let mut f = fs::File::open(report_file.path())?;
@@ -285,7 +301,7 @@ pub fn execute(matches: &ArgMatches) -> Result<()> {
                     project: Some(&project),
                     release: &release.version,
                     dist: Some(&dist),
-                    wait: matches.contains_id("wait"),
+                    wait: matches.get_flag("wait"),
                     ..Default::default()
                 })?;
             }
@@ -296,7 +312,7 @@ pub fn execute(matches: &ArgMatches) -> Result<()> {
                         project: Some(&project),
                         release: &release.version,
                         dist: Some(dist),
-                        wait: matches.contains_id("wait"),
+                        wait: matches.get_flag("wait"),
                         ..Default::default()
                     })?;
                 }

--- a/src/commands/releases/archive.rs
+++ b/src/commands/releases/archive.rs
@@ -9,7 +9,7 @@ pub fn make_command(command: Command) -> Command {
     command
         .about("Archive a release.")
         .allow_hyphen_values(true)
-        .version_arg()
+        .version_arg(false)
 }
 
 pub fn execute(matches: &ArgMatches) -> Result<()> {

--- a/src/commands/releases/delete.rs
+++ b/src/commands/releases/delete.rs
@@ -9,7 +9,7 @@ pub fn make_command(command: Command) -> Command {
     command
         .about("Delete a release.")
         .allow_hyphen_values(true)
-        .version_arg()
+        .version_arg(false)
 }
 
 pub fn execute(matches: &ArgMatches) -> Result<()> {

--- a/src/commands/releases/finalize.rs
+++ b/src/commands/releases/finalize.rs
@@ -10,7 +10,7 @@ pub fn make_command(command: Command) -> Command {
     command
         .about("Mark a release as finalized and released.")
         .allow_hyphen_values(true)
-        .version_arg()
+        .version_arg(false)
         .arg(
             Arg::new("url")
                 .long("url")

--- a/src/commands/releases/info.rs
+++ b/src/commands/releases/info.rs
@@ -12,7 +12,7 @@ pub fn make_command(command: Command) -> Command {
     command
         .about("Print information about a release.")
         .allow_hyphen_values(true)
-        .version_arg()
+        .version_arg(false)
         .arg(
             Arg::new("show_projects")
                 .short('P')

--- a/src/commands/releases/info.rs
+++ b/src/commands/releases/info.rs
@@ -1,5 +1,5 @@
 use anyhow::Result;
-use clap::{Arg, ArgMatches, Command};
+use clap::{Arg, ArgAction, ArgMatches, Command};
 
 use crate::api::Api;
 use crate::config::Config;
@@ -17,12 +17,14 @@ pub fn make_command(command: Command) -> Command {
             Arg::new("show_projects")
                 .short('P')
                 .long("show-projects")
+                .action(ArgAction::SetTrue)
                 .help("Display the Projects column"),
         )
         .arg(
             Arg::new("show_commits")
                 .short('C')
                 .long("show-commits")
+                .action(ArgAction::SetTrue)
                 .help("Display the Commits column"),
         )
 }
@@ -50,11 +52,11 @@ pub fn execute(matches: &ArgMatches) -> Result<()> {
             title_row.add("Last event");
         }
 
-        if matches.contains_id("show_projects") {
+        if matches.get_flag("show_projects") {
             title_row.add("Projects");
         }
 
-        if matches.contains_id("show_commits") {
+        if matches.get_flag("show_commits") {
             title_row.add("Commits");
         }
 
@@ -67,7 +69,7 @@ pub fn execute(matches: &ArgMatches) -> Result<()> {
             data_row.add(last_event);
         }
 
-        if matches.contains_id("show_projects") {
+        if matches.get_flag("show_projects") {
             let project_slugs = release
                 .projects
                 .into_iter()
@@ -80,7 +82,7 @@ pub fn execute(matches: &ArgMatches) -> Result<()> {
             }
         }
 
-        if matches.contains_id("show_commits") {
+        if matches.get_flag("show_commits") {
             if let Ok(Some(commits)) = api.get_release_commits(&org, project.as_deref(), version) {
                 if !commits.is_empty() {
                     data_row.add(

--- a/src/commands/releases/list.rs
+++ b/src/commands/releases/list.rs
@@ -1,6 +1,6 @@
 use anyhow::Result;
 use chrono::Utc;
-use clap::{Arg, ArgMatches, Command};
+use clap::{Arg, ArgAction, ArgMatches, Command};
 
 use crate::api::Api;
 use crate::config::Config;
@@ -13,24 +13,31 @@ pub fn make_command(command: Command) -> Command {
             Arg::new("show_projects")
                 .short('P')
                 .long("show-projects")
+                .action(ArgAction::SetTrue)
                 .help("Display the Projects column"),
         )
         .arg(
             Arg::new("raw")
                 .short('R')
                 .long("raw")
+                .action(ArgAction::SetTrue)
                 .help("Print raw, delimiter separated list of releases. [defaults to new line]"),
         )
         .arg(
             Arg::new("delimiter")
                 .short('D')
                 .long("delimiter")
-                .takes_value(true)
+                .num_args(1)
                 .requires("raw")
                 .help("Delimiter for the --raw flag"),
         )
         // Legacy flag that has no effect, left hidden for backward compatibility
-        .arg(Arg::new("no_abbrev").long("no-abbrev").hide(true))
+        .arg(
+            Arg::new("no_abbrev")
+                .long("no-abbrev")
+                .action(ArgAction::SetTrue)
+                .hide(true),
+        )
 }
 
 pub fn execute(matches: &ArgMatches) -> Result<()> {
@@ -39,7 +46,7 @@ pub fn execute(matches: &ArgMatches) -> Result<()> {
     let project = config.get_project(matches).ok();
     let releases = api.list_releases(&config.get_org(matches)?, project.as_deref())?;
 
-    if matches.contains_id("raw") {
+    if matches.get_flag("raw") {
         let versions = releases
             .iter()
             .map(|release_info| release_info.version.clone())
@@ -58,7 +65,7 @@ pub fn execute(matches: &ArgMatches) -> Result<()> {
     let mut table = Table::new();
     let title_row = table.title_row();
     title_row.add("Released").add("Version");
-    if matches.contains_id("show_projects") {
+    if matches.get_flag("show_projects") {
         title_row.add("Projects");
     }
     title_row.add("New Events").add("Last Event");
@@ -73,7 +80,7 @@ pub fn execute(matches: &ArgMatches) -> Result<()> {
             row.add("(unreleased)");
         }
         row.add(&release_info.version);
-        if matches.contains_id("show_projects") {
+        if matches.get_flag("show_projects") {
             let project_slugs = release_info
                 .projects
                 .into_iter()

--- a/src/commands/releases/mod.rs
+++ b/src/commands/releases/mod.rs
@@ -46,14 +46,14 @@ pub fn make_command(mut command: Command) -> Command {
         .subcommand(
             crate::commands::files::make_command(Command::new("files"))
                 .allow_hyphen_values(true)
-                .version_arg()
+                .version_arg(true)
                 .hide(true),
         )
         // Backward compatibility with `releases deploys <VERSION>` commands.
         .subcommand(
             crate::commands::deploys::make_command(Command::new("deploys"))
                 .allow_hyphen_values(true)
-                .version_arg()
+                .version_arg(true)
                 .hide(true),
         );
 

--- a/src/commands/releases/new.rs
+++ b/src/commands/releases/new.rs
@@ -1,6 +1,6 @@
 use anyhow::Result;
 use chrono::Utc;
-use clap::{Arg, ArgMatches, Command};
+use clap::{Arg, ArgAction, ArgMatches, Command};
 
 use crate::api::{Api, NewRelease};
 use crate::config::Config;
@@ -20,6 +20,7 @@ pub fn make_command(command: Command) -> Command {
         .arg(
             Arg::new("finalize")
                 .long("finalize")
+                .action(ArgAction::SetTrue)
                 .help("Immediately finalize the release. (sets it to released)"),
         )
         // Legacy flag that has no effect, left hidden for backward compatibility
@@ -38,7 +39,7 @@ pub fn execute(matches: &ArgMatches) -> Result<()> {
             projects: config.get_projects(matches)?,
             url: matches.get_one::<String>("url").cloned(),
             date_started: Some(Utc::now()),
-            date_released: if matches.contains_id("finalize") {
+            date_released: if matches.get_flag("finalize") {
                 Some(Utc::now())
             } else {
                 None

--- a/src/commands/releases/new.rs
+++ b/src/commands/releases/new.rs
@@ -10,7 +10,7 @@ pub fn make_command(command: Command) -> Command {
     command
         .about("Create a new release.")
         .allow_hyphen_values(true)
-        .version_arg()
+        .version_arg(false)
         .arg(
             Arg::new("url")
                 .long("url")

--- a/src/commands/releases/restore.rs
+++ b/src/commands/releases/restore.rs
@@ -9,7 +9,7 @@ pub fn make_command(command: Command) -> Command {
     command
         .about("Restore a release.")
         .allow_hyphen_values(true)
-        .version_arg()
+        .version_arg(false)
 }
 
 pub fn execute(matches: &ArgMatches) -> Result<()> {

--- a/src/commands/releases/set_commits.rs
+++ b/src/commands/releases/set_commits.rs
@@ -15,7 +15,7 @@ pub fn make_command(command: Command) -> Command {
     command
         .about("Set commits of a release.")
         .allow_hyphen_values(true)
-        .version_arg()
+        .version_arg(false)
         .arg(Arg::new("clear")
             .long("clear")
             .action(ArgAction::SetTrue)

--- a/src/commands/releases/set_commits.rs
+++ b/src/commands/releases/set_commits.rs
@@ -18,21 +18,25 @@ pub fn make_command(command: Command) -> Command {
         .version_arg()
         .arg(Arg::new("clear")
             .long("clear")
+            .action(ArgAction::SetTrue)
             .help("Clear all current commits from the release."))
         .arg(Arg::new("auto")
             .long("auto")
+            .action(ArgAction::SetTrue)
             .help("Enable completely automated commit management.{n}\
                     This requires that the command is run from within a git repository.  \
                     sentry-cli will then automatically find remotely configured \
                     repositories and discover commits."))
         .arg(Arg::new("ignore-missing")
             .long("ignore-missing")
+            .action(ArgAction::SetTrue)
             .help("When the flag is set and the previous release commit was not found in the repository, \
                     will create a release with the default commits count (or the one specified with `--initial-depth`) \
                     instead of failing the command."))
         .arg(Arg::new("local")
-            .conflicts_with_all(&["auto", "clear", "commits", ])
+            .conflicts_with_all(["auto", "clear", "commits", ])
             .long("local")
+            .action(ArgAction::SetTrue)
             .help("Set commits of a release from local git.{n}\
                     This requires that the command is run from within a git repository.  \
                     sentry-cli will then automatically find remotely configured \
@@ -63,7 +67,9 @@ pub fn make_command(command: Command) -> Command {
                     which will force the revision to a certain value."))
         // Legacy flag that has no effect, left hidden for backward compatibility
         .arg(Arg::new("ignore-empty")
-            .long("ignore-empty").hide(true))
+            .long("ignore-empty")
+            .action(ArgAction::SetTrue)
+            .hide(true))
 }
 
 fn strip_sha(sha: &str) -> &str {
@@ -86,16 +92,16 @@ pub fn execute(matches: &ArgMatches) -> Result<()> {
 
     let heads = if repos.is_empty() {
         None
-    } else if matches.contains_id("auto") {
+    } else if matches.get_flag("auto") {
         let commits = find_heads(None, &repos, Some(config.get_cached_vcs_remote()))?;
         if commits.is_empty() {
             None
         } else {
             Some(commits)
         }
-    } else if matches.contains_id("clear") {
+    } else if matches.get_flag("clear") {
         Some(vec![])
-    } else if matches.contains_id("local") {
+    } else if matches.get_flag("local") {
         None
     } else {
         if let Some(commits) = matches.get_many::<String>("commits") {
@@ -160,7 +166,7 @@ pub fn execute(matches: &ArgMatches) -> Result<()> {
             .copied()
             .unwrap_or(20);
 
-        if matches.contains_id("auto") {
+        if matches.get_flag("auto") {
             println!("Could not determine any commits to be associated with a repo-based integration. Proceeding to find commits from local git tree.");
         }
         // Get the commit of the most recent release.
@@ -175,7 +181,7 @@ pub fn execute(matches: &ArgMatches) -> Result<()> {
         // Parse the git url.
         let remote = config.get_cached_vcs_remote();
         let parsed = get_repo_from_remote(&remote);
-        let ignore_missing = matches.contains_id("ignore-missing");
+        let ignore_missing = matches.get_flag("ignore-missing");
         // Fetch all the commits upto the `prev_commit` or return the default (20).
         // Will return a tuple of Vec<GitCommits> and the `prev_commit` if it exists in the git tree.
         let (commit_log, prev_commit) =

--- a/src/commands/send_envelope.rs
+++ b/src/commands/send_envelope.rs
@@ -1,7 +1,7 @@
 use std::path::PathBuf;
 
 use anyhow::Result;
-use clap::{Arg, ArgMatches, Command};
+use clap::{Arg, ArgAction, ArgMatches, Command};
 use glob::{glob_with, MatchOptions};
 use log::{debug, warn};
 use sentry::types::Dsn;
@@ -29,6 +29,7 @@ pub fn make_command(command: Command) -> Command {
         .arg(
             Arg::new("raw")
                 .long("raw")
+                .action(ArgAction::SetTrue)
                 .help("Send envelopes without attempting to parse their contents."),
         )
 }
@@ -41,7 +42,7 @@ fn send_raw_envelope(envelope: Envelope, dsn: Dsn) {
 pub fn execute(matches: &ArgMatches) -> Result<()> {
     let config = Config::current();
     let dsn = config.get_dsn()?;
-    let raw = matches.contains_id("raw");
+    let raw = matches.get_flag("raw");
 
     let path = matches.get_one::<String>("path").unwrap();
 

--- a/src/commands/send_event.rs
+++ b/src/commands/send_event.rs
@@ -73,6 +73,7 @@ pub fn make_command(command: Command) -> Command {
         .arg(
             Arg::new("no_environ")
                 .long("no-environ")
+                .action(ArgAction::SetTrue)
                 .help("Do not send environment variables along"),
         )
         .arg(
@@ -142,6 +143,7 @@ pub fn make_command(command: Command) -> Command {
         .arg(
             Arg::new("with_categories")
                 .long("with-categories")
+                .action(ArgAction::SetTrue)
                 .help("Parses off a leading category for breadcrumbs from the logfile")
                 .long_help(
                     "When logfile is provided, this flag will try to assign correct level \
@@ -228,7 +230,7 @@ pub fn execute(matches: &ArgMatches) -> Result<()> {
         event.tags.insert(key.into(), value.into());
     }
 
-    if !matches.contains_id("no_environ") {
+    if !matches.get_flag("no_environ") {
         event.extra.insert(
             "environ".into(),
             Value::Object(env::vars().map(|(k, v)| (k, Value::String(v))).collect()),
@@ -286,7 +288,7 @@ pub fn execute(matches: &ArgMatches) -> Result<()> {
     }
 
     if let Some(logfile) = matches.get_one::<String>("logfile") {
-        attach_logfile(&mut event, logfile, matches.contains_id("with_categories"))?;
+        attach_logfile(&mut event, logfile, matches.get_flag("with_categories"))?;
     }
 
     let id = send_raw_event(event, dsn);

--- a/src/commands/sourcemaps/explain.rs
+++ b/src/commands/sourcemaps/explain.rs
@@ -2,7 +2,7 @@ use std::io::Read;
 use std::path::Path;
 
 use anyhow::{bail, format_err, Result};
-use clap::{Arg, ArgMatches, Command};
+use clap::{Arg, ArgAction, ArgMatches, Command};
 use console::style;
 use sentry::protocol::{Frame, Stacktrace};
 use url::Url;
@@ -35,6 +35,7 @@ pub fn make_command(command: Command) -> Command {
             Arg::new("force")
                 .long("force")
                 .short('f')
+                .action(ArgAction::SetTrue)
                 .help("Force full validation flow, even when event is already source mapped."),
         )
 }
@@ -387,7 +388,7 @@ pub fn execute(matches: &ArgMatches) -> Result<()> {
         })?;
 
     if exception.raw_stacktrace.is_some() {
-        if matches.contains_id("force") {
+        if matches.get_flag("force") {
             warning(
                 "Exception is already source mapped, however 'force' flag was used. Moving along.",
             );

--- a/src/commands/sourcemaps/upload.rs
+++ b/src/commands/sourcemaps/upload.rs
@@ -22,7 +22,7 @@ pub fn make_command(command: Command) -> Command {
             Arg::new("paths")
                 .value_name("PATHS")
                 .required_unless_present_any(["bundle", "bundle_sourcemap"])
-                .multiple_values(true)
+                .num_args(1..)
                 .action(ArgAction::Append)
                 .help("The files to upload."),
         )
@@ -50,21 +50,25 @@ pub fn make_command(command: Command) -> Command {
         .arg(
             Arg::new("validate")
                 .long("validate")
+                .action(ArgAction::SetTrue)
                 .help("Enable basic sourcemap validation."),
         )
         .arg(
             Arg::new("decompress")
                 .long("decompress")
+                .action(ArgAction::SetTrue)
                 .help("Enable files gzip decompression prior to upload."),
         )
         .arg(
             Arg::new("wait")
                 .long("wait")
+                .action(ArgAction::SetTrue)
                 .help("Wait for the server to fully process uploaded files."),
         )
         .arg(
             Arg::new("no_sourcemap_reference")
                 .long("no-sourcemap-reference")
+                .action(ArgAction::SetTrue)
                 .help(
                     "Disable emitting of automatic sourcemap references.{n}\
                     By default the tool will store a 'Sourcemap' header with \
@@ -73,15 +77,20 @@ pub fn make_command(command: Command) -> Command {
                     be disabled.",
                 ),
         )
-        .arg(Arg::new("no_rewrite").long("no-rewrite").help(
-            "Disables rewriting of matching sourcemaps. By default the tool \
-                will rewrite sources, so that indexed maps are flattened and missing \
-                sources are inlined if possible.{n}This fundamentally \
-                changes the upload process to be based on sourcemaps \
-                and minified files exclusively and comes in handy for \
-                setups like react-native that generate sourcemaps that \
-                would otherwise not work for sentry.",
-        ))
+        .arg(
+            Arg::new("no_rewrite")
+                .long("no-rewrite")
+                .action(ArgAction::SetTrue)
+                .help(
+                    "Disables rewriting of matching sourcemaps. By default the tool \
+                    will rewrite sources, so that indexed maps are flattened and missing \
+                    sources are inlined if possible.{n}This fundamentally \
+                    changes the upload process to be based on sourcemaps \
+                    and minified files exclusively and comes in handy for \
+                    setups like react-native that generate sourcemaps that \
+                    would otherwise not work for sentry.",
+                ),
+        )
         .arg(
             Arg::new("strip_prefix")
                 .long("strip-prefix")
@@ -100,6 +109,7 @@ pub fn make_command(command: Command) -> Command {
         .arg(
             Arg::new("strip_common_prefix")
                 .long("strip-common-prefix")
+                .action(ArgAction::SetTrue)
                 .help(
                     "Similar to --strip-prefix but strips the most common \
                     prefix on all sources references.",
@@ -129,7 +139,7 @@ pub fn make_command(command: Command) -> Command {
                 .long("bundle")
                 .value_name("BUNDLE")
                 .conflicts_with("paths")
-                .requires_all(&["bundle_sourcemap"])
+                .requires("bundle_sourcemap")
                 .help("Path to the application bundle (indexed, file, or regular)"),
         )
         .arg(
@@ -137,14 +147,19 @@ pub fn make_command(command: Command) -> Command {
                 .long("bundle-sourcemap")
                 .value_name("BUNDLE_SOURCEMAP")
                 .conflicts_with("paths")
-                .requires_all(&["bundle"])
+                .requires("bundle")
                 .help("Path to the bundle sourcemap"),
         )
-        .arg(Arg::new("no_dedupe").long("no-dedupe").help(
-            "Skip artifacts deduplication prior to uploading. \
-                This will force all artifacts to be uploaded, \
-                no matter whether they are already present on the server.",
-        ))
+        .arg(
+            Arg::new("no_dedupe")
+                .long("no-dedupe")
+                .action(ArgAction::SetTrue)
+                .help(
+                    "Skip artifacts deduplication prior to uploading. \
+                    This will force all artifacts to be uploaded, \
+                    no matter whether they are already present on the server.",
+                ),
+        )
         .arg(
             Arg::new("extensions")
                 .long("ext")
@@ -159,9 +174,20 @@ pub fn make_command(command: Command) -> Command {
                 ),
         )
         // Legacy flag that has no effect, left hidden for backward compatibility
-        .arg(Arg::new("rewrite").long("rewrite").hide(true))
+        .arg(
+            Arg::new("rewrite")
+                .long("rewrite")
+                .action(ArgAction::SetTrue)
+                .hide(true),
+        )
         // Legacy flag that has no effect, left hidden for backward compatibility
-        .arg(Arg::new("verbose").long("verbose").short('v').hide(true))
+        .arg(
+            Arg::new("verbose")
+                .long("verbose")
+                .action(ArgAction::SetTrue)
+                .short('v')
+                .hide(true),
+        )
 }
 
 fn get_prefixes_from_args(matches: &ArgMatches) -> Vec<&str> {
@@ -169,7 +195,7 @@ fn get_prefixes_from_args(matches: &ArgMatches) -> Vec<&str> {
         Some(paths) => paths.map(String::as_str).collect(),
         None => vec![],
     };
-    if matches.contains_id("strip_common_prefix") {
+    if matches.get_flag("strip_common_prefix") {
         prefixes.push("~");
     }
     prefixes
@@ -278,7 +304,7 @@ fn process_sources_from_paths(
         };
 
         let mut search = ReleaseFileSearch::new(path.to_path_buf());
-        search.decompress(matches.contains_id("decompress"));
+        search.decompress(matches.get_flag("decompress"));
 
         if check_ignore {
             search
@@ -309,16 +335,16 @@ fn process_sources_from_paths(
         }
     }
 
-    if !matches.contains_id("no_rewrite") {
+    if !matches.get_flag("no_rewrite") {
         let prefixes = get_prefixes_from_args(matches);
         processor.rewrite(&prefixes)?;
     }
 
-    if !matches.contains_id("no_sourcemap_reference") {
+    if !matches.get_flag("no_sourcemap_reference") {
         processor.add_sourcemap_references()?;
     }
 
-    if matches.contains_id("validate") {
+    if matches.get_flag("validate") {
         processor.validate_all()?;
     }
 
@@ -353,8 +379,8 @@ pub fn execute(matches: &ArgMatches) -> Result<()> {
         project: Some(&project),
         release: &release.version,
         dist: matches.get_one::<String>("dist").map(String::as_str),
-        wait: matches.contains_id("wait"),
-        dedupe: !matches.contains_id("no_dedupe"),
+        wait: matches.get_flag("wait"),
+        dedupe: !matches.get_flag("no_dedupe"),
     })?;
 
     Ok(())

--- a/src/commands/uninstall.rs
+++ b/src/commands/uninstall.rs
@@ -2,7 +2,7 @@ use std::env;
 use std::fs;
 
 use anyhow::Result;
-use clap::{Arg, ArgMatches, Command};
+use clap::{Arg, ArgAction, ArgMatches, Command};
 use console::style;
 
 use crate::utils::fs::is_writable;
@@ -13,6 +13,7 @@ pub fn make_command(command: Command) -> Command {
     let command = command.about("Uninstall the sentry-cli executable.").arg(
         Arg::new("confirm")
             .long("confirm")
+            .action(ArgAction::SetTrue)
             .help("Skip uninstall confirmation prompt."),
     );
 
@@ -58,7 +59,7 @@ pub fn execute(matches: &ArgMatches) -> Result<()> {
         return Ok(());
     }
 
-    if !matches.contains_id("confirm")
+    if !matches.get_flag("confirm")
         && !prompt_to_continue("Do you really want to uninstall sentry-cli?")?
     {
         println!("Aborted!");

--- a/src/commands/update.rs
+++ b/src/commands/update.rs
@@ -1,7 +1,7 @@
 use std::env;
 
 use anyhow::{bail, Result};
-use clap::{Arg, ArgMatches, Command};
+use clap::{Arg, ArgAction, ArgMatches, Command};
 
 use crate::utils::update::{assert_updatable, can_update_sentrycli, get_latest_sentrycli_release};
 
@@ -10,6 +10,7 @@ pub fn make_command(command: Command) -> Command {
         Arg::new("force")
             .long("force")
             .short('f')
+            .action(ArgAction::SetTrue)
             .help("Force the update even if the latest version is already installed."),
     );
 
@@ -43,7 +44,7 @@ pub fn execute(matches: &ArgMatches) -> Result<()> {
     }
 
     if update.is_latest_version() {
-        if matches.contains_id("force") {
+        if matches.get_flag("force") {
             println!("Forcing update");
         } else {
             println!("Already up to date!");

--- a/src/commands/upload_proguard.rs
+++ b/src/commands/upload_proguard.rs
@@ -35,7 +35,7 @@ pub fn make_command(command: Command) -> Command {
             Arg::new("paths")
                 .value_name("PATH")
                 .help("The path to the mapping files.")
-                .multiple_values(true)
+                .num_args(1..)
                 .action(ArgAction::Append),
         )
         .arg(
@@ -85,15 +85,21 @@ pub fn make_command(command: Command) -> Command {
         .arg(
             Arg::new("no_reprocessing")
                 .long("no-reprocessing")
+                .action(ArgAction::SetTrue)
                 .help("Do not trigger reprocessing after upload."),
         )
-        .arg(Arg::new("no_upload").long("no-upload").help(
-            "Disable the actual upload.{n}This runs all steps for the \
-             processing but does not trigger the upload (this also \
-             automatically disables reprocessing).  This is useful if you \
-             just want to verify the mapping files and write the \
-             proguard UUIDs into a properties file.",
-        ))
+        .arg(
+            Arg::new("no_upload")
+                .long("no-upload")
+                .action(ArgAction::SetTrue)
+                .help(
+                    "Disable the actual upload.{n}This runs all steps for the \
+                    processing but does not trigger the upload (this also \
+                    automatically disables reprocessing).  This is useful if you \
+                    just want to verify the mapping files and write the \
+                    proguard UUIDs into a properties file.",
+                ),
+        )
         .arg(
             Arg::new("android_manifest")
                 .long("android-manifest")
@@ -113,6 +119,7 @@ pub fn make_command(command: Command) -> Command {
         .arg(
             Arg::new("require_one")
                 .long("require-one")
+                .action(ArgAction::SetTrue)
                 .help("Requires at least one file to upload or the command will error."),
         )
         .arg(
@@ -199,7 +206,7 @@ pub fn execute(matches: &ArgMatches) -> Result<()> {
         }
     }
 
-    if mappings.is_empty() && matches.contains_id("require_one") {
+    if mappings.is_empty() && matches.get_flag("require_one") {
         println!();
         eprintln!("{}", style("error: found no mapping files to upload").red());
         return Err(QuietExit(1).into());
@@ -227,7 +234,7 @@ pub fn execute(matches: &ArgMatches) -> Result<()> {
         dump_proguard_uuids_as_properties(p, &uuids)?;
     }
 
-    if matches.contains_id("no_upload") {
+    if matches.get_flag("no_upload") {
         println!("{} skipping upload.", style(">").dim());
         return Ok(());
     }
@@ -279,7 +286,7 @@ pub fn execute(matches: &ArgMatches) -> Result<()> {
     }
 
     // If wanted trigger reprocessing
-    if !matches.contains_id("no_reprocessing") && !matches.contains_id("no_upload") {
+    if !matches.get_flag("no_reprocessing") && !matches.get_flag("no_upload") {
         if !api.trigger_reprocessing(&org, &project)? {
             println!(
                 "{} Server does not support reprocessing. Not triggering.",

--- a/src/config.rs
+++ b/src/config.rs
@@ -443,7 +443,7 @@ impl Config {
     }
 
     pub fn get_allow_failure(&self, matches: &ArgMatches) -> bool {
-        matches.contains_id("allow_failure")
+        matches.get_flag("allow_failure")
             || if let Ok(var) = env::var("SENTRY_ALLOW_FAILURE") {
                 &var == "1" || &var == "true"
             } else {

--- a/src/utils/args.rs
+++ b/src/utils/args.rs
@@ -78,7 +78,7 @@ pub trait ArgExt: Sized {
     fn org_arg(self) -> Self;
     fn project_arg(self, multiple: bool) -> Self;
     fn release_arg(self) -> Self;
-    fn version_arg(self) -> Self;
+    fn version_arg(self, global: bool) -> Self;
 }
 
 impl<'a: 'b, 'b> ArgExt for Command {
@@ -124,11 +124,13 @@ impl<'a: 'b, 'b> ArgExt for Command {
         )
     }
 
-    fn version_arg(self) -> Command {
+    fn version_arg(self, global: bool) -> Command {
         self.arg(
             Arg::new("version")
                 .value_name("VERSION")
-                .required(true)
+                // either specified for subcommands (global=true) or for this command (required=true)
+                .required(!global)
+                .global(global)
                 .value_parser(validate_release)
                 .help("The version of the release"),
         )

--- a/src/utils/args.rs
+++ b/src/utils/args.rs
@@ -81,8 +81,8 @@ pub trait ArgExt: Sized {
     fn version_arg(self) -> Self;
 }
 
-impl<'a: 'b, 'b> ArgExt for Command<'a> {
-    fn org_arg(self) -> Command<'a> {
+impl<'a: 'b, 'b> ArgExt for Command {
+    fn org_arg(self) -> Command {
         self.arg(
             Arg::new("org")
                 .value_name("ORG")
@@ -94,7 +94,7 @@ impl<'a: 'b, 'b> ArgExt for Command<'a> {
         )
     }
 
-    fn project_arg(self, multiple: bool) -> Command<'a> {
+    fn project_arg(self, multiple: bool) -> Command {
         self.arg(
             Arg::new("project")
                 .value_name("PROJECT")
@@ -111,7 +111,7 @@ impl<'a: 'b, 'b> ArgExt for Command<'a> {
         )
     }
 
-    fn release_arg(self) -> Command<'a> {
+    fn release_arg(self) -> Command {
         self.arg(
             Arg::new("release")
                 .value_name("RELEASE")
@@ -124,7 +124,7 @@ impl<'a: 'b, 'b> ArgExt for Command<'a> {
         )
     }
 
-    fn version_arg(self) -> Command<'a> {
+    fn version_arg(self) -> Command {
         self.arg(
             Arg::new("version")
                 .value_name("VERSION")

--- a/tests/integration/_cases/bash_hook/bash_hook-help.trycmd
+++ b/tests/integration/_cases/bash_hook/bash_hook-help.trycmd
@@ -1,24 +1,22 @@
 ```
 $ sentry-cli bash-hook --help
 ? success
-sentry-cli[EXE]-bash-hook 
 Prints out a bash script that does error handling.
 
-USAGE:
-    sentry-cli[EXE] bash-hook [OPTIONS]
+Usage: sentry-cli[EXE] bash-hook [OPTIONS]
 
-OPTIONS:
-        --auth-token <AUTH_TOKEN>    Use the given Sentry auth token.
-        --cli <CMD>                  Explicitly set/override the sentry-cli command
-    -h, --help                       Print help information
-        --header <KEY:VALUE>         Custom headers that should be attached to all requests
-                                     in key:value format.
-        --log-level <LOG_LEVEL>      Set the log output verbosity. [possible values: trace, debug,
-                                     info, warn, error]
-        --no-environ                 Do not send environment variables along
-        --no-exit                    Do not turn on -e (exit immediately) flag automatically
-        --quiet                      Do not print any output while preserving correct exit code.
-                                     This flag is currently implemented only for selected
-                                     subcommands. [aliases: silent]
+Options:
+      --no-exit                  Do not turn on -e (exit immediately) flag automatically
+      --header <KEY:VALUE>       Custom headers that should be attached to all requests
+                                 in key:value format.
+      --no-environ               Do not send environment variables along
+      --auth-token <AUTH_TOKEN>  Use the given Sentry auth token.
+      --cli <CMD>                Explicitly set/override the sentry-cli command
+      --log-level <LOG_LEVEL>    Set the log output verbosity. [possible values: trace, debug, info,
+                                 warn, error]
+      --quiet                    Do not print any output while preserving correct exit code. This
+                                 flag is currently implemented only for selected subcommands.
+                                 [aliases: silent]
+  -h, --help                     Print help
 
 ```

--- a/tests/integration/_cases/debug_files/debug_files-help.trycmd
+++ b/tests/integration/_cases/debug_files/debug_files-help.trycmd
@@ -1,29 +1,27 @@
 ```
 $ sentry-cli debug-files --help
 ? success
-sentry-cli[EXE]-debug-files 
 Locate, analyze or upload debug information files.
 
-USAGE:
-    sentry-cli[EXE] debug-files [OPTIONS] <SUBCOMMAND>
+Usage: sentry-cli[EXE] debug-files [OPTIONS] <COMMAND>
 
-OPTIONS:
-        --auth-token <AUTH_TOKEN>    Use the given Sentry auth token.
-    -h, --help                       Print help information
-        --header <KEY:VALUE>         Custom headers that should be attached to all requests
-                                     in key:value format.
-        --log-level <LOG_LEVEL>      Set the log output verbosity. [possible values: trace, debug,
-                                     info, warn, error]
-        --quiet                      Do not print any output while preserving correct exit code.
-                                     This flag is currently implemented only for selected
-                                     subcommands. [aliases: silent]
+Commands:
+  bundle-sources  Create a source bundle for a given debug information file
+  check           Check the debug info file at a given path.
+  find            Locate debug information files for given debug identifiers.
+  print-sources   Print source files linked by the given debug info file.
+  upload          Upload debugging information files.
+  help            Print this message or the help of the given subcommand(s)
 
-SUBCOMMANDS:
-    bundle-sources    Create a source bundle for a given debug information file
-    check             Check the debug info file at a given path.
-    find              Locate debug information files for given debug identifiers.
-    help              Print this message or the help of the given subcommand(s)
-    print-sources     Print source files linked by the given debug info file.
-    upload            Upload debugging information files.
+Options:
+      --header <KEY:VALUE>       Custom headers that should be attached to all requests
+                                 in key:value format.
+      --auth-token <AUTH_TOKEN>  Use the given Sentry auth token.
+      --log-level <LOG_LEVEL>    Set the log output verbosity. [possible values: trace, debug, info,
+                                 warn, error]
+      --quiet                    Do not print any output while preserving correct exit code. This
+                                 flag is currently implemented only for selected subcommands.
+                                 [aliases: silent]
+  -h, --help                     Print help
 
 ```

--- a/tests/integration/_cases/debug_files/debug_files-no-subcommand.trycmd
+++ b/tests/integration/_cases/debug_files/debug_files-no-subcommand.trycmd
@@ -1,29 +1,27 @@
 ```
 $ sentry-cli debug-files
 ? failed
-sentry-cli[EXE]-debug-files 
 Locate, analyze or upload debug information files.
 
-USAGE:
-    sentry-cli[EXE] debug-files [OPTIONS] <SUBCOMMAND>
+Usage: sentry-cli[EXE] debug-files [OPTIONS] <COMMAND>
 
-OPTIONS:
-        --auth-token <AUTH_TOKEN>    Use the given Sentry auth token.
-    -h, --help                       Print help information
-        --header <KEY:VALUE>         Custom headers that should be attached to all requests
-                                     in key:value format.
-        --log-level <LOG_LEVEL>      Set the log output verbosity. [possible values: trace, debug,
-                                     info, warn, error]
-        --quiet                      Do not print any output while preserving correct exit code.
-                                     This flag is currently implemented only for selected
-                                     subcommands. [aliases: silent]
+Commands:
+  bundle-sources  Create a source bundle for a given debug information file
+  check           Check the debug info file at a given path.
+  find            Locate debug information files for given debug identifiers.
+  print-sources   Print source files linked by the given debug info file.
+  upload          Upload debugging information files.
+  help            Print this message or the help of the given subcommand(s)
 
-SUBCOMMANDS:
-    bundle-sources    Create a source bundle for a given debug information file
-    check             Check the debug info file at a given path.
-    find              Locate debug information files for given debug identifiers.
-    help              Print this message or the help of the given subcommand(s)
-    print-sources     Print source files linked by the given debug info file.
-    upload            Upload debugging information files.
+Options:
+      --header <KEY:VALUE>       Custom headers that should be attached to all requests
+                                 in key:value format.
+      --auth-token <AUTH_TOKEN>  Use the given Sentry auth token.
+      --log-level <LOG_LEVEL>    Set the log output verbosity. [possible values: trace, debug, info,
+                                 warn, error]
+      --quiet                    Do not print any output while preserving correct exit code. This
+                                 flag is currently implemented only for selected subcommands.
+                                 [aliases: silent]
+  -h, --help                     Print help
 
 ```

--- a/tests/integration/_cases/debug_files/debug_files-upload-help.trycmd
+++ b/tests/integration/_cases/debug_files/debug_files-upload-help.trycmd
@@ -1,79 +1,72 @@
 ```
 $ sentry-cli debug-files upload --help
 ? success
-sentry-cli[EXE]-debug-files-upload 
 Upload debugging information files.
 
-USAGE:
-    sentry-cli[EXE] debug-files upload [OPTIONS] [PATH]...
+Usage: sentry-cli[EXE] debug-files upload [OPTIONS] [PATH]...
 
-ARGS:
-    <PATH>...    A path to search recursively for symbol files.
+Arguments:
+  [PATH]...  A path to search recursively for symbol files.
 
-OPTIONS:
-        --auth-token <AUTH_TOKEN>    Use the given Sentry auth token.
-        --derived-data               Search for debug symbols in Xcode's derived data.
-        --force-foreground           Wait for the process to finish.
-                                     By default, the upload process will detach and continue in the
-                                     background when triggered from Xcode.  When an error happens, a
-                                     dialog is shown.  If this parameter is passed Xcode will wait
-                                     for the process to finish before the build finishes and output
-                                     will be shown in the Xcode build output.
-    -h, --help                       Print help information
-        --header <KEY:VALUE>         Custom headers that should be attached to all requests
-                                     in key:value format.
-        --id <ID>                    Search for specific debug identifiers.
-        --il2cpp-mapping             Compute il2cpp line mappings and upload them along with
-                                     sources.
-        --include-sources            Include sources from the local file system and upload them as
-                                     source bundles.
-        --info-plist <PATH>          Optional path to the Info.plist.
-                                     We will try to find this automatically if run from Xcode.
-                                     Providing this information will associate the debug symbols
-                                     with a specific ITC application and build in Sentry.  Note that
-                                     if you provide the plist explicitly it must already be
-                                     processed.
-        --log-level <LOG_LEVEL>      Set the log output verbosity. [possible values: trace, debug,
-                                     info, warn, error]
-        --no-debug                   Do not scan for debugging information. This will usually
-                                     exclude debug companion files. They might still be uploaded, if
-                                     they contain additional processable information (see other
-                                     flags).
-        --no-reprocessing            Do not trigger reprocessing after uploading.
-        --no-sources                 Do not scan for source information. This will usually exclude
-                                     source bundle files. They might still be uploaded, if they
-                                     contain additional processable information (see other flags).
-        --no-unwind                  Do not scan for stack unwinding information. Specify this flag
-                                     for builds with disabled FPO, or when stackwalking occurs on
-                                     the device. This usually excludes executables and dynamic
-                                     libraries. They might still be uploaded, if they contain
-                                     additional processable information (see other flags).
-        --no-upload                  Disable the actual upload.
-                                     This runs all steps for the processing but does not trigger the
-                                     upload (this also automatically disables reprocessing).  This
-                                     is useful if you just want to verify the setup or skip the
-                                     upload in tests.
-        --no-zips                    Do not search in ZIP files.
-    -o, --org <ORG>                  The organization slug
-    -p, --project <PROJECT>          The project slug.
-        --quiet                      Do not print any output while preserving correct exit code.
-                                     This flag is currently implemented only for selected
-                                     subcommands. [aliases: silent]
-        --require-all                Errors if not all identifiers specified with --id could be
-                                     found.
-        --symbol-maps <PATH>         Optional path to BCSymbolMap files which are used to resolve
-                                     hidden symbols in dSYM files downloaded from iTunes Connect.
-                                     This requires the dsymutil tool to be available.  This should
-                                     not be used when using the App Store Connect integration, the
-                                     .bcsymbolmap files needed for the integration are uploaded
-                                     without this option if they are found in the PATH searched for
-                                     symbol files.
-    -t, --type <TYPE>                Only consider debug information files of the given type.  By
-                                     default, all types are considered. [possible values:
-                                     bcsymbolmap, dsym, elf, pe, pdb, portablepdb, sourcebundle,
-                                     breakpad, proguard, wasm]
-        --wait                       Wait for the server to fully process uploaded files. Errors can
-                                     only be displayed if --wait is specified, but this will
-                                     significantly slow down the upload process.
+Options:
+  -o, --org <ORG>                The organization slug
+      --header <KEY:VALUE>       Custom headers that should be attached to all requests
+                                 in key:value format.
+  -p, --project <PROJECT>        The project slug.
+      --auth-token <AUTH_TOKEN>  Use the given Sentry auth token.
+  -t, --type <TYPE>              Only consider debug information files of the given type.  By
+                                 default, all types are considered. [possible values: bcsymbolmap,
+                                 dsym, elf, pe, pdb, portablepdb, sourcebundle, breakpad, proguard,
+                                 wasm]
+      --no-unwind                Do not scan for stack unwinding information. Specify this flag for
+                                 builds with disabled FPO, or when stackwalking occurs on the
+                                 device. This usually excludes executables and dynamic libraries.
+                                 They might still be uploaded, if they contain additional
+                                 processable information (see other flags).
+      --log-level <LOG_LEVEL>    Set the log output verbosity. [possible values: trace, debug, info,
+                                 warn, error]
+      --no-debug                 Do not scan for debugging information. This will usually exclude
+                                 debug companion files. They might still be uploaded, if they
+                                 contain additional processable information (see other flags).
+      --no-sources               Do not scan for source information. This will usually exclude
+                                 source bundle files. They might still be uploaded, if they contain
+                                 additional processable information (see other flags).
+      --quiet                    Do not print any output while preserving correct exit code. This
+                                 flag is currently implemented only for selected subcommands.
+                                 [aliases: silent]
+      --id <ID>                  Search for specific debug identifiers.
+      --require-all              Errors if not all identifiers specified with --id could be found.
+      --symbol-maps <PATH>       Optional path to BCSymbolMap files which are used to resolve hidden
+                                 symbols in dSYM files downloaded from iTunes Connect.  This
+                                 requires the dsymutil tool to be available.  This should not be
+                                 used when using the App Store Connect integration, the .bcsymbolmap
+                                 files needed for the integration are uploaded without this option
+                                 if they are found in the PATH searched for symbol files.
+      --derived-data             Search for debug symbols in Xcode's derived data.
+      --no-zips                  Do not search in ZIP files.
+      --info-plist <PATH>        Optional path to the Info.plist.
+                                 We will try to find this automatically if run from Xcode.
+                                 Providing this information will associate the debug symbols with a
+                                 specific ITC application and build in Sentry.  Note that if you
+                                 provide the plist explicitly it must already be processed.
+      --no-reprocessing          Do not trigger reprocessing after uploading.
+      --no-upload                Disable the actual upload.
+                                 This runs all steps for the processing but does not trigger the
+                                 upload (this also automatically disables reprocessing).  This is
+                                 useful if you just want to verify the setup or skip the upload in
+                                 tests.
+      --force-foreground         Wait for the process to finish.
+                                 By default, the upload process will detach and continue in the
+                                 background when triggered from Xcode.  When an error happens, a
+                                 dialog is shown.  If this parameter is passed Xcode will wait for
+                                 the process to finish before the build finishes and output will be
+                                 shown in the Xcode build output.
+      --include-sources          Include sources from the local file system and upload them as
+                                 source bundles.
+      --wait                     Wait for the server to fully process uploaded files. Errors can
+                                 only be displayed if --wait is specified, but this will
+                                 significantly slow down the upload process.
+      --il2cpp-mapping           Compute il2cpp line mappings and upload them along with sources.
+  -h, --help                     Print help
 
 ```

--- a/tests/integration/_cases/deploys/deploys-help.trycmd
+++ b/tests/integration/_cases/deploys/deploys-help.trycmd
@@ -1,29 +1,27 @@
 ```
 $ sentry-cli deploys --help
 ? success
-sentry-cli[EXE]-deploys 
 Manage deployments for Sentry releases.
 
-USAGE:
-    sentry-cli[EXE] deploys [OPTIONS] <SUBCOMMAND>
+Usage: sentry-cli[EXE] deploys [OPTIONS] <COMMAND>
 
-OPTIONS:
-        --auth-token <AUTH_TOKEN>    Use the given Sentry auth token.
-    -h, --help                       Print help information
-        --header <KEY:VALUE>         Custom headers that should be attached to all requests
-                                     in key:value format.
-        --log-level <LOG_LEVEL>      Set the log output verbosity. [possible values: trace, debug,
-                                     info, warn, error]
-    -o, --org <ORG>                  The organization slug
-    -p, --project <PROJECT>          The project slug.
-        --quiet                      Do not print any output while preserving correct exit code.
-                                     This flag is currently implemented only for selected
-                                     subcommands. [aliases: silent]
-    -r, --release <RELEASE>          The release slug.
+Commands:
+  list  List all deployments of a release.
+  new   Creates a new release deployment.
+  help  Print this message or the help of the given subcommand(s)
 
-SUBCOMMANDS:
-    help    Print this message or the help of the given subcommand(s)
-    list    List all deployments of a release.
-    new     Creates a new release deployment.
+Options:
+  -o, --org <ORG>                The organization slug
+      --header <KEY:VALUE>       Custom headers that should be attached to all requests
+                                 in key:value format.
+  -p, --project <PROJECT>        The project slug.
+      --auth-token <AUTH_TOKEN>  Use the given Sentry auth token.
+  -r, --release <RELEASE>        The release slug.
+      --log-level <LOG_LEVEL>    Set the log output verbosity. [possible values: trace, debug, info,
+                                 warn, error]
+      --quiet                    Do not print any output while preserving correct exit code. This
+                                 flag is currently implemented only for selected subcommands.
+                                 [aliases: silent]
+  -h, --help                     Print help
 
 ```

--- a/tests/integration/_cases/deploys/deploys-no-subcommand.trycmd
+++ b/tests/integration/_cases/deploys/deploys-no-subcommand.trycmd
@@ -1,29 +1,27 @@
 ```
 $ sentry-cli deploys
 ? failed
-sentry-cli[EXE]-deploys 
 Manage deployments for Sentry releases.
 
-USAGE:
-    sentry-cli[EXE] deploys [OPTIONS] <SUBCOMMAND>
+Usage: sentry-cli[EXE] deploys [OPTIONS] <COMMAND>
 
-OPTIONS:
-        --auth-token <AUTH_TOKEN>    Use the given Sentry auth token.
-    -h, --help                       Print help information
-        --header <KEY:VALUE>         Custom headers that should be attached to all requests
-                                     in key:value format.
-        --log-level <LOG_LEVEL>      Set the log output verbosity. [possible values: trace, debug,
-                                     info, warn, error]
-    -o, --org <ORG>                  The organization slug
-    -p, --project <PROJECT>          The project slug.
-        --quiet                      Do not print any output while preserving correct exit code.
-                                     This flag is currently implemented only for selected
-                                     subcommands. [aliases: silent]
-    -r, --release <RELEASE>          The release slug.
+Commands:
+  list  List all deployments of a release.
+  new   Creates a new release deployment.
+  help  Print this message or the help of the given subcommand(s)
 
-SUBCOMMANDS:
-    help    Print this message or the help of the given subcommand(s)
-    list    List all deployments of a release.
-    new     Creates a new release deployment.
+Options:
+  -o, --org <ORG>                The organization slug
+      --header <KEY:VALUE>       Custom headers that should be attached to all requests
+                                 in key:value format.
+  -p, --project <PROJECT>        The project slug.
+      --auth-token <AUTH_TOKEN>  Use the given Sentry auth token.
+  -r, --release <RELEASE>        The release slug.
+      --log-level <LOG_LEVEL>    Set the log output verbosity. [possible values: trace, debug, info,
+                                 warn, error]
+      --quiet                    Do not print any output while preserving correct exit code. This
+                                 flag is currently implemented only for selected subcommands.
+                                 [aliases: silent]
+  -h, --help                     Print help
 
 ```

--- a/tests/integration/_cases/events/events-help.trycmd
+++ b/tests/integration/_cases/events/events-help.trycmd
@@ -1,27 +1,25 @@
 ```
 $ sentry-cli events --help
 ? success
-sentry-cli[EXE]-events 
 Manage events on Sentry.
 
-USAGE:
-    sentry-cli[EXE] events [OPTIONS] <SUBCOMMAND>
+Usage: sentry-cli[EXE] events [OPTIONS] <COMMAND>
 
-OPTIONS:
-        --auth-token <AUTH_TOKEN>    Use the given Sentry auth token.
-    -h, --help                       Print help information
-        --header <KEY:VALUE>         Custom headers that should be attached to all requests
-                                     in key:value format.
-        --log-level <LOG_LEVEL>      Set the log output verbosity. [possible values: trace, debug,
-                                     info, warn, error]
-    -o, --org <ORG>                  The organization slug
-    -p, --project <PROJECT>          The project slug.
-        --quiet                      Do not print any output while preserving correct exit code.
-                                     This flag is currently implemented only for selected
-                                     subcommands. [aliases: silent]
+Commands:
+  list  List all events in your organization.
+  help  Print this message or the help of the given subcommand(s)
 
-SUBCOMMANDS:
-    help    Print this message or the help of the given subcommand(s)
-    list    List all events in your organization.
+Options:
+  -o, --org <ORG>                The organization slug
+      --header <KEY:VALUE>       Custom headers that should be attached to all requests
+                                 in key:value format.
+  -p, --project <PROJECT>        The project slug.
+      --auth-token <AUTH_TOKEN>  Use the given Sentry auth token.
+      --log-level <LOG_LEVEL>    Set the log output verbosity. [possible values: trace, debug, info,
+                                 warn, error]
+      --quiet                    Do not print any output while preserving correct exit code. This
+                                 flag is currently implemented only for selected subcommands.
+                                 [aliases: silent]
+  -h, --help                     Print help
 
 ```

--- a/tests/integration/_cases/events/events-list-help.trycmd
+++ b/tests/integration/_cases/events/events-list-help.trycmd
@@ -1,28 +1,25 @@
 ```
 $ sentry-cli events list --help
 ? success
-sentry-cli[EXE]-events-list 
 List all events in your organization.
 
-USAGE:
-    sentry-cli[EXE] events list [OPTIONS]
+Usage: sentry-cli[EXE] events list [OPTIONS]
 
-OPTIONS:
-        --auth-token <AUTH_TOKEN>    Use the given Sentry auth token.
-    -h, --help                       Print help information
-        --header <KEY:VALUE>         Custom headers that should be attached to all requests
-                                     in key:value format.
-        --log-level <LOG_LEVEL>      Set the log output verbosity. [possible values: trace, debug,
-                                     info, warn, error]
-        --max-rows <MAX_ROWS>        Maximum number of rows to print.
-    -o, --org <ORG>                  The organization slug
-    -p, --project <PROJECT>          The project slug.
-        --pages <PAGES>              Maximum number of pages to fetch (100 events/page). [default:
-                                     5]
-        --quiet                      Do not print any output while preserving correct exit code.
-                                     This flag is currently implemented only for selected
-                                     subcommands. [aliases: silent]
-    -T, --show-tags                  Display the Tags column.
-    -U, --show-user                  Display the Users column.
+Options:
+  -o, --org <ORG>                The organization slug
+  -U, --show-user                Display the Users column.
+      --header <KEY:VALUE>       Custom headers that should be attached to all requests
+                                 in key:value format.
+  -p, --project <PROJECT>        The project slug.
+  -T, --show-tags                Display the Tags column.
+      --auth-token <AUTH_TOKEN>  Use the given Sentry auth token.
+      --max-rows <MAX_ROWS>      Maximum number of rows to print.
+      --pages <PAGES>            Maximum number of pages to fetch (100 events/page). [default: 5]
+      --log-level <LOG_LEVEL>    Set the log output verbosity. [possible values: trace, debug, info,
+                                 warn, error]
+      --quiet                    Do not print any output while preserving correct exit code. This
+                                 flag is currently implemented only for selected subcommands.
+                                 [aliases: silent]
+  -h, --help                     Print help
 
 ```

--- a/tests/integration/_cases/events/events-no-subcommand.trycmd
+++ b/tests/integration/_cases/events/events-no-subcommand.trycmd
@@ -1,27 +1,25 @@
 ```
 $ sentry-cli events
 ? failed
-sentry-cli[EXE]-events 
 Manage events on Sentry.
 
-USAGE:
-    sentry-cli[EXE] events [OPTIONS] <SUBCOMMAND>
+Usage: sentry-cli[EXE] events [OPTIONS] <COMMAND>
 
-OPTIONS:
-        --auth-token <AUTH_TOKEN>    Use the given Sentry auth token.
-    -h, --help                       Print help information
-        --header <KEY:VALUE>         Custom headers that should be attached to all requests
-                                     in key:value format.
-        --log-level <LOG_LEVEL>      Set the log output verbosity. [possible values: trace, debug,
-                                     info, warn, error]
-    -o, --org <ORG>                  The organization slug
-    -p, --project <PROJECT>          The project slug.
-        --quiet                      Do not print any output while preserving correct exit code.
-                                     This flag is currently implemented only for selected
-                                     subcommands. [aliases: silent]
+Commands:
+  list  List all events in your organization.
+  help  Print this message or the help of the given subcommand(s)
 
-SUBCOMMANDS:
-    help    Print this message or the help of the given subcommand(s)
-    list    List all events in your organization.
+Options:
+  -o, --org <ORG>                The organization slug
+      --header <KEY:VALUE>       Custom headers that should be attached to all requests
+                                 in key:value format.
+  -p, --project <PROJECT>        The project slug.
+      --auth-token <AUTH_TOKEN>  Use the given Sentry auth token.
+      --log-level <LOG_LEVEL>    Set the log output verbosity. [possible values: trace, debug, info,
+                                 warn, error]
+      --quiet                    Do not print any output while preserving correct exit code. This
+                                 flag is currently implemented only for selected subcommands.
+                                 [aliases: silent]
+  -h, --help                     Print help
 
 ```

--- a/tests/integration/_cases/help/help-windows.trycmd
+++ b/tests/integration/_cases/help/help-windows.trycmd
@@ -1,49 +1,46 @@
 ```
 $ sentry-cli help
 ? success
-sentry-cli [VERSION]
-
 Command line utility for Sentry.
 
 This tool helps you manage remote resources on a Sentry server like
 sourcemaps, debug symbols or releases.  Use `--help` on the subcommands
 to learn more about them.
 
-USAGE:
-    sentry-cli[EXE] [OPTIONS] <SUBCOMMAND>
+Usage: sentry-cli[EXE] [OPTIONS] <COMMAND>
 
-OPTIONS:
-        --api-key <API_KEY>          The given Sentry API key.
-        --auth-token <AUTH_TOKEN>    Use the given Sentry auth token.
-    -h, --help                       Print help information
-        --header <KEY:VALUE>         Custom headers that should be attached to all requests
-                                     in key:value format.
-        --log-level <LOG_LEVEL>      Set the log output verbosity. [possible values: trace, debug,
-                                     info, warn, error]
-        --quiet                      Do not print any output while preserving correct exit code.
-                                     This flag is currently implemented only for selected
-                                     subcommands. [aliases: silent]
-        --url <URL>                  Fully qualified URL to the Sentry server.
-                                     [default: https://sentry.io/]
-    -V, --version                    Print version information
+Commands:
+  debug-files      Locate, analyze or upload debug information files. [aliases: dif]
+  deploys          Manage deployments for Sentry releases.
+  events           Manage events on Sentry.
+  files            Manage release artifacts.
+  info             Print information about the configuration and verify authentication.
+  issues           Manage issues in Sentry.
+  login            Authenticate with the Sentry server.
+  organizations    Manage organizations on Sentry.
+  projects         Manage projects on Sentry.
+  react-native     Upload build artifacts for react-native projects.
+  releases         Manage releases on Sentry.
+  repos            Manage repositories on Sentry.
+  send-event       Send a manual event to Sentry.
+  send-envelope    Send a stored envelope to Sentry.
+  sourcemaps       Manage sourcemaps for Sentry releases.
+  upload-proguard  Upload ProGuard mapping files to a project.
+  help             Print this message or the help of the given subcommand(s)
 
-SUBCOMMANDS:
-    debug-files        Locate, analyze or upload debug information files. [aliases: dif]
-    deploys            Manage deployments for Sentry releases.
-    events             Manage events on Sentry.
-    files              Manage release artifacts.
-    help               Print this message or the help of the given subcommand(s)
-    info               Print information about the configuration and verify authentication.
-    issues             Manage issues in Sentry.
-    login              Authenticate with the Sentry server.
-    organizations      Manage organizations on Sentry.
-    projects           Manage projects on Sentry.
-    react-native       Upload build artifacts for react-native projects.
-    releases           Manage releases on Sentry.
-    repos              Manage repositories on Sentry.
-    send-envelope      Send a stored envelope to Sentry.
-    send-event         Send a manual event to Sentry.
-    sourcemaps         Manage sourcemaps for Sentry releases.
-    upload-proguard    Upload ProGuard mapping files to a project.
+Options:
+      --url <URL>                Fully qualified URL to the Sentry server.
+                                 [default: https://sentry.io/]
+      --header <KEY:VALUE>       Custom headers that should be attached to all requests
+                                 in key:value format.
+      --auth-token <AUTH_TOKEN>  Use the given Sentry auth token.
+      --api-key <API_KEY>        The given Sentry API key.
+      --log-level <LOG_LEVEL>    Set the log output verbosity. [possible values: trace, debug, info,
+                                 warn, error]
+      --quiet                    Do not print any output while preserving correct exit code. This
+                                 flag is currently implemented only for selected subcommands.
+                                 [aliases: silent]
+  -h, --help                     Print help
+  -V, --version                  Print version
 
 ```

--- a/tests/integration/_cases/help/help.trycmd
+++ b/tests/integration/_cases/help/help.trycmd
@@ -1,50 +1,47 @@
 ```
 $ sentry-cli help
 ? success
-sentry-cli [VERSION]
-
 Command line utility for Sentry.
 
 This tool helps you manage remote resources on a Sentry server like
 sourcemaps, debug symbols or releases.  Use `--help` on the subcommands
 to learn more about them.
 
-USAGE:
-    sentry-cli [OPTIONS] <SUBCOMMAND>
+Usage: sentry-cli[EXE] [OPTIONS] <COMMAND>
 
-OPTIONS:
-        --api-key <API_KEY>          The given Sentry API key.
-        --auth-token <AUTH_TOKEN>    Use the given Sentry auth token.
-    -h, --help                       Print help information
-        --header <KEY:VALUE>         Custom headers that should be attached to all requests
-                                     in key:value format.
-        --log-level <LOG_LEVEL>      Set the log output verbosity. [possible values: trace, debug,
-                                     info, warn, error]
-        --quiet                      Do not print any output while preserving correct exit code.
-                                     This flag is currently implemented only for selected
-                                     subcommands. [aliases: silent]
-        --url <URL>                  Fully qualified URL to the Sentry server.
-                                     [default: https://sentry.io/]
-    -V, --version                    Print version information
+Commands:
+  debug-files      Locate, analyze or upload debug information files. [aliases: dif]
+  deploys          Manage deployments for Sentry releases.
+  events           Manage events on Sentry.
+  files            Manage release artifacts.
+  info             Print information about the configuration and verify authentication.
+  issues           Manage issues in Sentry.
+  login            Authenticate with the Sentry server.
+  organizations    Manage organizations on Sentry.
+  projects         Manage projects on Sentry.
+  react-native     Upload build artifacts for react-native projects.
+  releases         Manage releases on Sentry.
+  repos            Manage repositories on Sentry.
+  send-event       Send a manual event to Sentry.
+  send-envelope    Send a stored envelope to Sentry.
+  sourcemaps       Manage sourcemaps for Sentry releases.
+  uninstall        Uninstall the sentry-cli executable.
+  upload-proguard  Upload ProGuard mapping files to a project.
+  help             Print this message or the help of the given subcommand(s)
 
-SUBCOMMANDS:
-    debug-files        Locate, analyze or upload debug information files. [aliases: dif]
-    deploys            Manage deployments for Sentry releases.
-    events             Manage events on Sentry.
-    files              Manage release artifacts.
-    help               Print this message or the help of the given subcommand(s)
-    info               Print information about the configuration and verify authentication.
-    issues             Manage issues in Sentry.
-    login              Authenticate with the Sentry server.
-    organizations      Manage organizations on Sentry.
-    projects           Manage projects on Sentry.
-    react-native       Upload build artifacts for react-native projects.
-    releases           Manage releases on Sentry.
-    repos              Manage repositories on Sentry.
-    send-envelope      Send a stored envelope to Sentry.
-    send-event         Send a manual event to Sentry.
-    sourcemaps         Manage sourcemaps for Sentry releases.
-    uninstall          Uninstall the sentry-cli executable.
-    upload-proguard    Upload ProGuard mapping files to a project.
+Options:
+      --url <URL>                Fully qualified URL to the Sentry server.
+                                 [default: https://sentry.io/]
+      --header <KEY:VALUE>       Custom headers that should be attached to all requests
+                                 in key:value format.
+      --auth-token <AUTH_TOKEN>  Use the given Sentry auth token.
+      --api-key <API_KEY>        The given Sentry API key.
+      --log-level <LOG_LEVEL>    Set the log output verbosity. [possible values: trace, debug, info,
+                                 warn, error]
+      --quiet                    Do not print any output while preserving correct exit code. This
+                                 flag is currently implemented only for selected subcommands.
+                                 [aliases: silent]
+  -h, --help                     Print help
+  -V, --version                  Print version
 
 ```

--- a/tests/integration/_cases/info/info-help.trycmd
+++ b/tests/integration/_cases/info/info-help.trycmd
@@ -1,27 +1,25 @@
 ```
 $ sentry-cli info --help
 ? success
-sentry-cli[EXE]-info 
 Print information about the configuration and verify authentication.
 
-USAGE:
-    sentry-cli[EXE] info [OPTIONS]
+Usage: sentry-cli[EXE] info [OPTIONS]
 
-OPTIONS:
-        --auth-token <AUTH_TOKEN>    Use the given Sentry auth token.
-        --config-status-json         Return the status of the config that sentry-cli loads as JSON
-                                     dump. This can be used by external tools to aid the user
-                                     towards configuration.
-    -h, --help                       Print help information
-        --header <KEY:VALUE>         Custom headers that should be attached to all requests
-                                     in key:value format.
-        --log-level <LOG_LEVEL>      Set the log output verbosity. [possible values: trace, debug,
-                                     info, warn, error]
-        --no-defaults                Skip default organization and project checks. This allows you
-                                     to verify your authentication method, without the need for
-                                     setting other defaults.
-        --quiet                      Do not print any output while preserving correct exit code.
-                                     This flag is currently implemented only for selected
-                                     subcommands. [aliases: silent]
+Options:
+      --config-status-json       Return the status of the config that sentry-cli loads as JSON dump.
+                                 This can be used by external tools to aid the user towards
+                                 configuration.
+      --header <KEY:VALUE>       Custom headers that should be attached to all requests
+                                 in key:value format.
+      --no-defaults              Skip default organization and project checks. This allows you to
+                                 verify your authentication method, without the need for setting
+                                 other defaults.
+      --auth-token <AUTH_TOKEN>  Use the given Sentry auth token.
+      --log-level <LOG_LEVEL>    Set the log output verbosity. [possible values: trace, debug, info,
+                                 warn, error]
+      --quiet                    Do not print any output while preserving correct exit code. This
+                                 flag is currently implemented only for selected subcommands.
+                                 [aliases: silent]
+  -h, --help                     Print help
 
 ```

--- a/tests/integration/_cases/login/login-help.trycmd
+++ b/tests/integration/_cases/login/login-help.trycmd
@@ -1,22 +1,20 @@
 ```
 $ sentry-cli login --help
 ? success
-sentry-cli[EXE]-login 
 Authenticate with the Sentry server.
 
-USAGE:
-    sentry-cli[EXE] login [OPTIONS]
+Usage: sentry-cli[EXE] login [OPTIONS]
 
-OPTIONS:
-        --auth-token <AUTH_TOKEN>    Use the given Sentry auth token.
-    -g, --global                     Store authentication token globally rather than locally.
-    -h, --help                       Print help information
-        --header <KEY:VALUE>         Custom headers that should be attached to all requests
-                                     in key:value format.
-        --log-level <LOG_LEVEL>      Set the log output verbosity. [possible values: trace, debug,
-                                     info, warn, error]
-        --quiet                      Do not print any output while preserving correct exit code.
-                                     This flag is currently implemented only for selected
-                                     subcommands. [aliases: silent]
+Options:
+  -g, --global                   Store authentication token globally rather than locally.
+      --header <KEY:VALUE>       Custom headers that should be attached to all requests
+                                 in key:value format.
+      --auth-token <AUTH_TOKEN>  Use the given Sentry auth token.
+      --log-level <LOG_LEVEL>    Set the log output verbosity. [possible values: trace, debug, info,
+                                 warn, error]
+      --quiet                    Do not print any output while preserving correct exit code. This
+                                 flag is currently implemented only for selected subcommands.
+                                 [aliases: silent]
+  -h, --help                     Print help
 
 ```

--- a/tests/integration/_cases/monitors/monitors-help.trycmd
+++ b/tests/integration/_cases/monitors/monitors-help.trycmd
@@ -1,26 +1,24 @@
 ```
 $ sentry-cli monitors --help
 ? success
-sentry-cli[EXE]-monitors 
 Manage monitors on Sentry.
 
-USAGE:
-    sentry-cli[EXE] monitors [OPTIONS] <SUBCOMMAND>
+Usage: sentry-cli[EXE] monitors [OPTIONS] <COMMAND>
 
-OPTIONS:
-        --auth-token <AUTH_TOKEN>    Use the given Sentry auth token.
-    -h, --help                       Print help information
-        --header <KEY:VALUE>         Custom headers that should be attached to all requests
-                                     in key:value format.
-        --log-level <LOG_LEVEL>      Set the log output verbosity. [possible values: trace, debug,
-                                     info, warn, error]
-        --quiet                      Do not print any output while preserving correct exit code.
-                                     This flag is currently implemented only for selected
-                                     subcommands. [aliases: silent]
+Commands:
+  list  List all monitors for an organization.
+  run   Wraps a command
+  help  Print this message or the help of the given subcommand(s)
 
-SUBCOMMANDS:
-    help    Print this message or the help of the given subcommand(s)
-    list    List all monitors for an organization.
-    run     Wraps a command
+Options:
+      --header <KEY:VALUE>       Custom headers that should be attached to all requests
+                                 in key:value format.
+      --auth-token <AUTH_TOKEN>  Use the given Sentry auth token.
+      --log-level <LOG_LEVEL>    Set the log output verbosity. [possible values: trace, debug, info,
+                                 warn, error]
+      --quiet                    Do not print any output while preserving correct exit code. This
+                                 flag is currently implemented only for selected subcommands.
+                                 [aliases: silent]
+  -h, --help                     Print help
 
 ```

--- a/tests/integration/_cases/monitors/monitors-list-help.trycmd
+++ b/tests/integration/_cases/monitors/monitors-list-help.trycmd
@@ -1,22 +1,20 @@
 ```
 $ sentry-cli monitors list --help
 ? success
-sentry-cli[EXE]-monitors-list 
 List all monitors for an organization.
 
-USAGE:
-    sentry-cli[EXE] monitors list [OPTIONS]
+Usage: sentry-cli[EXE] monitors list [OPTIONS]
 
-OPTIONS:
-        --auth-token <AUTH_TOKEN>    Use the given Sentry auth token.
-    -h, --help                       Print help information
-        --header <KEY:VALUE>         Custom headers that should be attached to all requests
-                                     in key:value format.
-        --log-level <LOG_LEVEL>      Set the log output verbosity. [possible values: trace, debug,
-                                     info, warn, error]
-    -o, --org <ORG>                  The organization slug
-        --quiet                      Do not print any output while preserving correct exit code.
-                                     This flag is currently implemented only for selected
-                                     subcommands. [aliases: silent]
+Options:
+  -o, --org <ORG>                The organization slug
+      --header <KEY:VALUE>       Custom headers that should be attached to all requests
+                                 in key:value format.
+      --auth-token <AUTH_TOKEN>  Use the given Sentry auth token.
+      --log-level <LOG_LEVEL>    Set the log output verbosity. [possible values: trace, debug, info,
+                                 warn, error]
+      --quiet                    Do not print any output while preserving correct exit code. This
+                                 flag is currently implemented only for selected subcommands.
+                                 [aliases: silent]
+  -h, --help                     Print help
 
 ```

--- a/tests/integration/_cases/monitors/monitors-no-subcommand.trycmd
+++ b/tests/integration/_cases/monitors/monitors-no-subcommand.trycmd
@@ -1,26 +1,24 @@
 ```
 $ sentry-cli monitors
 ? failed
-sentry-cli[EXE]-monitors 
 Manage monitors on Sentry.
 
-USAGE:
-    sentry-cli[EXE] monitors [OPTIONS] <SUBCOMMAND>
+Usage: sentry-cli[EXE] monitors [OPTIONS] <COMMAND>
 
-OPTIONS:
-        --auth-token <AUTH_TOKEN>    Use the given Sentry auth token.
-    -h, --help                       Print help information
-        --header <KEY:VALUE>         Custom headers that should be attached to all requests
-                                     in key:value format.
-        --log-level <LOG_LEVEL>      Set the log output verbosity. [possible values: trace, debug,
-                                     info, warn, error]
-        --quiet                      Do not print any output while preserving correct exit code.
-                                     This flag is currently implemented only for selected
-                                     subcommands. [aliases: silent]
+Commands:
+  list  List all monitors for an organization.
+  run   Wraps a command
+  help  Print this message or the help of the given subcommand(s)
 
-SUBCOMMANDS:
-    help    Print this message or the help of the given subcommand(s)
-    list    List all monitors for an organization.
-    run     Wraps a command
+Options:
+      --header <KEY:VALUE>       Custom headers that should be attached to all requests
+                                 in key:value format.
+      --auth-token <AUTH_TOKEN>  Use the given Sentry auth token.
+      --log-level <LOG_LEVEL>    Set the log output verbosity. [possible values: trace, debug, info,
+                                 warn, error]
+      --quiet                    Do not print any output while preserving correct exit code. This
+                                 flag is currently implemented only for selected subcommands.
+                                 [aliases: silent]
+  -h, --help                     Print help
 
 ```

--- a/tests/integration/_cases/monitors/monitors-run-help.trycmd
+++ b/tests/integration/_cases/monitors/monitors-run-help.trycmd
@@ -1,26 +1,24 @@
 ```
 $ sentry-cli monitors run --help
 ? success
-sentry-cli[EXE]-monitors-run 
 Wraps a command
 
-USAGE:
-    sentry-cli[EXE] monitors run [OPTIONS] <monitor> [--] <ARGS>...
+Usage: sentry-cli[EXE] monitors run [OPTIONS] <monitor> -- <ARGS>...
 
-ARGS:
-    <monitor>    The monitor ID
-    <ARGS>...    
+Arguments:
+  <monitor>  The monitor ID
+  <ARGS>...  
 
-OPTIONS:
-        --auth-token <AUTH_TOKEN>    Use the given Sentry auth token.
-    -f, --allow-failure              Run provided command even when Sentry reports an error.
-    -h, --help                       Print help information
-        --header <KEY:VALUE>         Custom headers that should be attached to all requests
-                                     in key:value format.
-        --log-level <LOG_LEVEL>      Set the log output verbosity. [possible values: trace, debug,
-                                     info, warn, error]
-        --quiet                      Do not print any output while preserving correct exit code.
-                                     This flag is currently implemented only for selected
-                                     subcommands. [aliases: silent]
+Options:
+  -f, --allow-failure            Run provided command even when Sentry reports an error.
+      --header <KEY:VALUE>       Custom headers that should be attached to all requests
+                                 in key:value format.
+      --auth-token <AUTH_TOKEN>  Use the given Sentry auth token.
+      --log-level <LOG_LEVEL>    Set the log output verbosity. [possible values: trace, debug, info,
+                                 warn, error]
+      --quiet                    Do not print any output while preserving correct exit code. This
+                                 flag is currently implemented only for selected subcommands.
+                                 [aliases: silent]
+  -h, --help                     Print help
 
 ```

--- a/tests/integration/_cases/monitors/monitors-run-invalid-uuid.trycmd
+++ b/tests/integration/_cases/monitors/monitors-run-invalid-uuid.trycmd
@@ -1,8 +1,8 @@
 ```
 $ sentry-cli monitors run xyz -- echo 123
 ? failed
-error: Invalid value "xyz" for '<monitor>': invalid character: expected an optional prefix of `urn:uuid:` followed by [0-9a-fA-F-], found `x` at 1
+error: invalid value 'xyz' for '<monitor>': invalid character: expected an optional prefix of `urn:uuid:` followed by [0-9a-fA-F-], found `x` at 1
 
-For more information try --help
+For more information, try '--help'.
 
 ```

--- a/tests/integration/_cases/organizations/organizations-help.trycmd
+++ b/tests/integration/_cases/organizations/organizations-help.trycmd
@@ -1,25 +1,23 @@
 ```
 $ sentry-cli organizations --help
 ? success
-sentry-cli[EXE]-organizations 
 Manage organizations on Sentry.
 
-USAGE:
-    sentry-cli[EXE] organizations [OPTIONS] <SUBCOMMAND>
+Usage: sentry-cli[EXE] organizations [OPTIONS] <COMMAND>
 
-OPTIONS:
-        --auth-token <AUTH_TOKEN>    Use the given Sentry auth token.
-    -h, --help                       Print help information
-        --header <KEY:VALUE>         Custom headers that should be attached to all requests
-                                     in key:value format.
-        --log-level <LOG_LEVEL>      Set the log output verbosity. [possible values: trace, debug,
-                                     info, warn, error]
-        --quiet                      Do not print any output while preserving correct exit code.
-                                     This flag is currently implemented only for selected
-                                     subcommands. [aliases: silent]
+Commands:
+  list  List all organizations available to the authenticated token.
+  help  Print this message or the help of the given subcommand(s)
 
-SUBCOMMANDS:
-    help    Print this message or the help of the given subcommand(s)
-    list    List all organizations available to the authenticated token.
+Options:
+      --header <KEY:VALUE>       Custom headers that should be attached to all requests
+                                 in key:value format.
+      --auth-token <AUTH_TOKEN>  Use the given Sentry auth token.
+      --log-level <LOG_LEVEL>    Set the log output verbosity. [possible values: trace, debug, info,
+                                 warn, error]
+      --quiet                    Do not print any output while preserving correct exit code. This
+                                 flag is currently implemented only for selected subcommands.
+                                 [aliases: silent]
+  -h, --help                     Print help
 
 ```

--- a/tests/integration/_cases/organizations/organizations-list-help.trycmd
+++ b/tests/integration/_cases/organizations/organizations-list-help.trycmd
@@ -1,21 +1,19 @@
 ```
 $ sentry-cli organizations list --help
 ? success
-sentry-cli[EXE]-organizations-list 
 List all organizations available to the authenticated token.
 
-USAGE:
-    sentry-cli[EXE] organizations list [OPTIONS]
+Usage: sentry-cli[EXE] organizations list [OPTIONS]
 
-OPTIONS:
-        --auth-token <AUTH_TOKEN>    Use the given Sentry auth token.
-    -h, --help                       Print help information
-        --header <KEY:VALUE>         Custom headers that should be attached to all requests
-                                     in key:value format.
-        --log-level <LOG_LEVEL>      Set the log output verbosity. [possible values: trace, debug,
-                                     info, warn, error]
-        --quiet                      Do not print any output while preserving correct exit code.
-                                     This flag is currently implemented only for selected
-                                     subcommands. [aliases: silent]
+Options:
+      --header <KEY:VALUE>       Custom headers that should be attached to all requests
+                                 in key:value format.
+      --auth-token <AUTH_TOKEN>  Use the given Sentry auth token.
+      --log-level <LOG_LEVEL>    Set the log output verbosity. [possible values: trace, debug, info,
+                                 warn, error]
+      --quiet                    Do not print any output while preserving correct exit code. This
+                                 flag is currently implemented only for selected subcommands.
+                                 [aliases: silent]
+  -h, --help                     Print help
 
 ```

--- a/tests/integration/_cases/organizations/organizations-no-subcommand.trycmd
+++ b/tests/integration/_cases/organizations/organizations-no-subcommand.trycmd
@@ -1,25 +1,23 @@
 ```
 $ sentry-cli organizations
 ? failed
-sentry-cli[EXE]-organizations 
 Manage organizations on Sentry.
 
-USAGE:
-    sentry-cli[EXE] organizations [OPTIONS] <SUBCOMMAND>
+Usage: sentry-cli[EXE] organizations [OPTIONS] <COMMAND>
 
-OPTIONS:
-        --auth-token <AUTH_TOKEN>    Use the given Sentry auth token.
-    -h, --help                       Print help information
-        --header <KEY:VALUE>         Custom headers that should be attached to all requests
-                                     in key:value format.
-        --log-level <LOG_LEVEL>      Set the log output verbosity. [possible values: trace, debug,
-                                     info, warn, error]
-        --quiet                      Do not print any output while preserving correct exit code.
-                                     This flag is currently implemented only for selected
-                                     subcommands. [aliases: silent]
+Commands:
+  list  List all organizations available to the authenticated token.
+  help  Print this message or the help of the given subcommand(s)
 
-SUBCOMMANDS:
-    help    Print this message or the help of the given subcommand(s)
-    list    List all organizations available to the authenticated token.
+Options:
+      --header <KEY:VALUE>       Custom headers that should be attached to all requests
+                                 in key:value format.
+      --auth-token <AUTH_TOKEN>  Use the given Sentry auth token.
+      --log-level <LOG_LEVEL>    Set the log output verbosity. [possible values: trace, debug, info,
+                                 warn, error]
+      --quiet                    Do not print any output while preserving correct exit code. This
+                                 flag is currently implemented only for selected subcommands.
+                                 [aliases: silent]
+  -h, --help                     Print help
 
 ```

--- a/tests/integration/_cases/projects/projects-help.trycmd
+++ b/tests/integration/_cases/projects/projects-help.trycmd
@@ -1,26 +1,24 @@
 ```
 $ sentry-cli projects --help
 ? success
-sentry-cli[EXE]-projects 
 Manage projects on Sentry.
 
-USAGE:
-    sentry-cli[EXE] projects [OPTIONS] <SUBCOMMAND>
+Usage: sentry-cli[EXE] projects [OPTIONS] <COMMAND>
 
-OPTIONS:
-        --auth-token <AUTH_TOKEN>    Use the given Sentry auth token.
-    -h, --help                       Print help information
-        --header <KEY:VALUE>         Custom headers that should be attached to all requests
-                                     in key:value format.
-        --log-level <LOG_LEVEL>      Set the log output verbosity. [possible values: trace, debug,
-                                     info, warn, error]
-    -o, --org <ORG>                  The organization slug
-        --quiet                      Do not print any output while preserving correct exit code.
-                                     This flag is currently implemented only for selected
-                                     subcommands. [aliases: silent]
+Commands:
+  list  List all projects for an organization.
+  help  Print this message or the help of the given subcommand(s)
 
-SUBCOMMANDS:
-    help    Print this message or the help of the given subcommand(s)
-    list    List all projects for an organization.
+Options:
+  -o, --org <ORG>                The organization slug
+      --header <KEY:VALUE>       Custom headers that should be attached to all requests
+                                 in key:value format.
+      --auth-token <AUTH_TOKEN>  Use the given Sentry auth token.
+      --log-level <LOG_LEVEL>    Set the log output verbosity. [possible values: trace, debug, info,
+                                 warn, error]
+      --quiet                    Do not print any output while preserving correct exit code. This
+                                 flag is currently implemented only for selected subcommands.
+                                 [aliases: silent]
+  -h, --help                     Print help
 
 ```

--- a/tests/integration/_cases/projects/projects-list-help.trycmd
+++ b/tests/integration/_cases/projects/projects-list-help.trycmd
@@ -1,22 +1,20 @@
 ```
 $ sentry-cli projects list --help
 ? success
-sentry-cli[EXE]-projects-list 
 List all projects for an organization.
 
-USAGE:
-    sentry-cli[EXE] projects list [OPTIONS]
+Usage: sentry-cli[EXE] projects list [OPTIONS]
 
-OPTIONS:
-        --auth-token <AUTH_TOKEN>    Use the given Sentry auth token.
-    -h, --help                       Print help information
-        --header <KEY:VALUE>         Custom headers that should be attached to all requests
-                                     in key:value format.
-        --log-level <LOG_LEVEL>      Set the log output verbosity. [possible values: trace, debug,
-                                     info, warn, error]
-    -o, --org <ORG>                  The organization slug
-        --quiet                      Do not print any output while preserving correct exit code.
-                                     This flag is currently implemented only for selected
-                                     subcommands. [aliases: silent]
+Options:
+  -o, --org <ORG>                The organization slug
+      --header <KEY:VALUE>       Custom headers that should be attached to all requests
+                                 in key:value format.
+      --auth-token <AUTH_TOKEN>  Use the given Sentry auth token.
+      --log-level <LOG_LEVEL>    Set the log output verbosity. [possible values: trace, debug, info,
+                                 warn, error]
+      --quiet                    Do not print any output while preserving correct exit code. This
+                                 flag is currently implemented only for selected subcommands.
+                                 [aliases: silent]
+  -h, --help                     Print help
 
 ```

--- a/tests/integration/_cases/projects/projects-no-subcommand.trycmd
+++ b/tests/integration/_cases/projects/projects-no-subcommand.trycmd
@@ -1,26 +1,24 @@
 ```
 $ sentry-cli projects
 ? failed
-sentry-cli[EXE]-projects 
 Manage projects on Sentry.
 
-USAGE:
-    sentry-cli[EXE] projects [OPTIONS] <SUBCOMMAND>
+Usage: sentry-cli[EXE] projects [OPTIONS] <COMMAND>
 
-OPTIONS:
-        --auth-token <AUTH_TOKEN>    Use the given Sentry auth token.
-    -h, --help                       Print help information
-        --header <KEY:VALUE>         Custom headers that should be attached to all requests
-                                     in key:value format.
-        --log-level <LOG_LEVEL>      Set the log output verbosity. [possible values: trace, debug,
-                                     info, warn, error]
-    -o, --org <ORG>                  The organization slug
-        --quiet                      Do not print any output while preserving correct exit code.
-                                     This flag is currently implemented only for selected
-                                     subcommands. [aliases: silent]
+Commands:
+  list  List all projects for an organization.
+  help  Print this message or the help of the given subcommand(s)
 
-SUBCOMMANDS:
-    help    Print this message or the help of the given subcommand(s)
-    list    List all projects for an organization.
+Options:
+  -o, --org <ORG>                The organization slug
+      --header <KEY:VALUE>       Custom headers that should be attached to all requests
+                                 in key:value format.
+      --auth-token <AUTH_TOKEN>  Use the given Sentry auth token.
+      --log-level <LOG_LEVEL>    Set the log output verbosity. [possible values: trace, debug, info,
+                                 warn, error]
+      --quiet                    Do not print any output while preserving correct exit code. This
+                                 flag is currently implemented only for selected subcommands.
+                                 [aliases: silent]
+  -h, --help                     Print help
 
 ```

--- a/tests/integration/_cases/releases/releases-deploys-new.trycmd
+++ b/tests/integration/_cases/releases/releases-deploys-new.trycmd
@@ -1,0 +1,6 @@
+```
+$ sentry-cli releases deploys wat-release new -n custom-deploy -e production
+? success
+Created new deploy custom-deploy for 'production'
+
+```

--- a/tests/integration/_cases/releases/releases-help.trycmd
+++ b/tests/integration/_cases/releases/releases-help.trycmd
@@ -1,35 +1,33 @@
 ```
 $ sentry-cli releases --help
 ? success
-sentry-cli[EXE]-releases 
 Manage releases on Sentry.
 
-USAGE:
-    sentry-cli[EXE] releases [OPTIONS] <SUBCOMMAND>
+Usage: sentry-cli[EXE] releases [OPTIONS] <COMMAND>
 
-OPTIONS:
-        --auth-token <AUTH_TOKEN>    Use the given Sentry auth token.
-    -h, --help                       Print help information
-        --header <KEY:VALUE>         Custom headers that should be attached to all requests
-                                     in key:value format.
-        --log-level <LOG_LEVEL>      Set the log output verbosity. [possible values: trace, debug,
-                                     info, warn, error]
-    -o, --org <ORG>                  The organization slug
-    -p, --project <PROJECT>          The project slug.
-        --quiet                      Do not print any output while preserving correct exit code.
-                                     This flag is currently implemented only for selected
-                                     subcommands. [aliases: silent]
+Commands:
+  archive          Archive a release.
+  delete           Delete a release.
+  finalize         Mark a release as finalized and released.
+  info             Print information about a release.
+  list             List the most recent releases.
+  new              Create a new release.
+  propose-version  Propose a version name for a new release.
+  restore          Restore a release.
+  set-commits      Set commits of a release.
+  help             Print this message or the help of the given subcommand(s)
 
-SUBCOMMANDS:
-    archive            Archive a release.
-    delete             Delete a release.
-    finalize           Mark a release as finalized and released.
-    help               Print this message or the help of the given subcommand(s)
-    info               Print information about a release.
-    list               List the most recent releases.
-    new                Create a new release.
-    propose-version    Propose a version name for a new release.
-    restore            Restore a release.
-    set-commits        Set commits of a release.
+Options:
+  -o, --org <ORG>                The organization slug
+      --header <KEY:VALUE>       Custom headers that should be attached to all requests
+                                 in key:value format.
+  -p, --project <PROJECT>        The project slug.
+      --auth-token <AUTH_TOKEN>  Use the given Sentry auth token.
+      --log-level <LOG_LEVEL>    Set the log output verbosity. [possible values: trace, debug, info,
+                                 warn, error]
+      --quiet                    Do not print any output while preserving correct exit code. This
+                                 flag is currently implemented only for selected subcommands.
+                                 [aliases: silent]
+  -h, --help                     Print help
 
 ```

--- a/tests/integration/_cases/releases/releases-new-help.trycmd
+++ b/tests/integration/_cases/releases/releases-new-help.trycmd
@@ -1,28 +1,26 @@
 ```
 $ sentry-cli releases new -h
 ? success
-sentry-cli[EXE]-releases-new 
 Create a new release.
 
-USAGE:
-    sentry-cli[EXE] releases new [OPTIONS] <VERSION>
+Usage: sentry-cli[EXE] releases new [OPTIONS] <VERSION>
 
-ARGS:
-    <VERSION>    The version of the release
+Arguments:
+  <VERSION>  The version of the release
 
-OPTIONS:
-        --auth-token <AUTH_TOKEN>    Use the given Sentry auth token.
-        --finalize                   Immediately finalize the release. (sets it to released)
-    -h, --help                       Print help information
-        --header <KEY:VALUE>         Custom headers that should be attached to all requests
-                                     in key:value format.
-        --log-level <LOG_LEVEL>      Set the log output verbosity. [possible values: trace, debug,
-                                     info, warn, error]
-    -o, --org <ORG>                  The organization slug
-    -p, --project <PROJECT>          The project slug.
-        --quiet                      Do not print any output while preserving correct exit code.
-                                     This flag is currently implemented only for selected
-                                     subcommands. [aliases: silent]
-        --url <URL>                  Optional URL to the release for information purposes.
+Options:
+  -o, --org <ORG>                The organization slug
+      --url <URL>                Optional URL to the release for information purposes.
+      --finalize                 Immediately finalize the release. (sets it to released)
+      --header <KEY:VALUE>       Custom headers that should be attached to all requests
+                                 in key:value format.
+  -p, --project <PROJECT>        The project slug.
+      --auth-token <AUTH_TOKEN>  Use the given Sentry auth token.
+      --log-level <LOG_LEVEL>    Set the log output verbosity. [possible values: trace, debug, info,
+                                 warn, error]
+      --quiet                    Do not print any output while preserving correct exit code. This
+                                 flag is currently implemented only for selected subcommands.
+                                 [aliases: silent]
+  -h, --help                     Print help
 
 ```

--- a/tests/integration/_cases/releases/releases-no-subcommand.trycmd
+++ b/tests/integration/_cases/releases/releases-no-subcommand.trycmd
@@ -1,35 +1,33 @@
 ```
 $ sentry-cli releases
 ? failed
-sentry-cli[EXE]-releases 
 Manage releases on Sentry.
 
-USAGE:
-    sentry-cli[EXE] releases [OPTIONS] <SUBCOMMAND>
+Usage: sentry-cli[EXE] releases [OPTIONS] <COMMAND>
 
-OPTIONS:
-        --auth-token <AUTH_TOKEN>    Use the given Sentry auth token.
-    -h, --help                       Print help information
-        --header <KEY:VALUE>         Custom headers that should be attached to all requests
-                                     in key:value format.
-        --log-level <LOG_LEVEL>      Set the log output verbosity. [possible values: trace, debug,
-                                     info, warn, error]
-    -o, --org <ORG>                  The organization slug
-    -p, --project <PROJECT>          The project slug.
-        --quiet                      Do not print any output while preserving correct exit code.
-                                     This flag is currently implemented only for selected
-                                     subcommands. [aliases: silent]
+Commands:
+  archive          Archive a release.
+  delete           Delete a release.
+  finalize         Mark a release as finalized and released.
+  info             Print information about a release.
+  list             List the most recent releases.
+  new              Create a new release.
+  propose-version  Propose a version name for a new release.
+  restore          Restore a release.
+  set-commits      Set commits of a release.
+  help             Print this message or the help of the given subcommand(s)
 
-SUBCOMMANDS:
-    archive            Archive a release.
-    delete             Delete a release.
-    finalize           Mark a release as finalized and released.
-    help               Print this message or the help of the given subcommand(s)
-    info               Print information about a release.
-    list               List the most recent releases.
-    new                Create a new release.
-    propose-version    Propose a version name for a new release.
-    restore            Restore a release.
-    set-commits        Set commits of a release.
+Options:
+  -o, --org <ORG>                The organization slug
+      --header <KEY:VALUE>       Custom headers that should be attached to all requests
+                                 in key:value format.
+  -p, --project <PROJECT>        The project slug.
+      --auth-token <AUTH_TOKEN>  Use the given Sentry auth token.
+      --log-level <LOG_LEVEL>    Set the log output verbosity. [possible values: trace, debug, info,
+                                 warn, error]
+      --quiet                    Do not print any output while preserving correct exit code. This
+                                 flag is currently implemented only for selected subcommands.
+                                 [aliases: silent]
+  -h, --help                     Print help
 
 ```

--- a/tests/integration/_cases/send_envelope/send_envelope-help.trycmd
+++ b/tests/integration/_cases/send_envelope/send_envelope-help.trycmd
@@ -1,42 +1,41 @@
 ```
 $ sentry-cli send-envelope --help
 ? success
-sentry-cli[EXE]-send-envelope 
-Send a stored envelope to Sentry.{n}{n}This command will validate and attempt to send an envelope to
-Sentry. Due to network errors, rate limits or sampling the envelope is not guaranteed to actually
-arrive. Check debug output for transmission errors by passing --log-level=debug or setting
-`SENTRY_LOG_LEVEL=debug`.
+Send a stored envelope to Sentry.
 
-USAGE:
-    sentry-cli[EXE] send-envelope [OPTIONS] <PATH>
+This command will validate and attempt to send an envelope to Sentry. Due to network errors, rate
+limits or sampling the envelope is not guaranteed to actually arrive. Check debug output for
+transmission errors by passing --log-level=debug or setting `SENTRY_LOG_LEVEL=debug`.
 
-ARGS:
-    <PATH>
-            The path or glob to the file(s) in envelope format to send as envelope(s).
+Usage: sentry-cli[EXE] send-envelope [OPTIONS] <PATH>
 
-OPTIONS:
-        --auth-token <AUTH_TOKEN>
-            Use the given Sentry auth token.
+Arguments:
+  <PATH>
+          The path or glob to the file(s) in envelope format to send as envelope(s).
 
-    -h, --help
-            Print help information
+Options:
+      --raw
+          Send envelopes without attempting to parse their contents.
 
-        --header <KEY:VALUE>
-            Custom headers that should be attached to all requests
-            in key:value format.
+      --header <KEY:VALUE>
+          Custom headers that should be attached to all requests
+          in key:value format.
 
-        --log-level <LOG_LEVEL>
-            Set the log output verbosity.
-            
-            [possible values: trace, debug, info, warn, error]
+      --auth-token <AUTH_TOKEN>
+          Use the given Sentry auth token.
 
-        --quiet
-            Do not print any output while preserving correct exit code. This flag is currently
-            implemented only for selected subcommands.
-            
-            [aliases: silent]
+      --log-level <LOG_LEVEL>
+          Set the log output verbosity.
+          
+          [possible values: trace, debug, info, warn, error]
 
-        --raw
-            Send envelopes without attempting to parse their contents.
+      --quiet
+          Do not print any output while preserving correct exit code. This flag is currently
+          implemented only for selected subcommands.
+          
+          [aliases: silent]
+
+  -h, --help
+          Print help (see a summary with '-h')
 
 ```

--- a/tests/integration/_cases/send_envelope/send_envelope-no-file.trycmd
+++ b/tests/integration/_cases/send_envelope/send_envelope-no-file.trycmd
@@ -1,12 +1,11 @@
 ```
 $ sentry-cli send-envelope --log-level=debug
 ? failed
-error: The following required arguments were not provided:
-    <PATH>
+error: the following required arguments were not provided:
+  <PATH>
 
-USAGE:
-    sentry-cli[EXE] send-envelope --log-level <LOG_LEVEL> <PATH>
+Usage: sentry-cli[EXE] send-envelope --log-level <LOG_LEVEL> <PATH>
 
-For more information try --help
+For more information, try '--help'.
 
 ```

--- a/tests/integration/_cases/send_event/send_event-help.trycmd
+++ b/tests/integration/_cases/send_event/send_event-help.trycmd
@@ -1,89 +1,86 @@
 ```
 $ sentry-cli send-event --help
 ? success
-sentry-cli[EXE]-send-event 
-Send a manual event to Sentry.{n}{n}This command will validate input parameters and attempt to send
-an event to Sentry. Due to network errors, rate limits or sampling the event is not guaranteed to
-actually arrive. Check debug output for transmission errors by passing --log-level=debug or setting
-`SENTRY_LOG_LEVEL=debug`.
+Send a manual event to Sentry.
 
-USAGE:
-    sentry-cli[EXE] send-event [OPTIONS] [PATH]
+This command will validate input parameters and attempt to send an event to Sentry. Due to network
+errors, rate limits or sampling the event is not guaranteed to actually arrive. Check debug output
+for transmission errors by passing --log-level=debug or setting `SENTRY_LOG_LEVEL=debug`.
 
-ARGS:
-    <PATH>
-            The path or glob to the file(s) in JSON format to send as event(s). When provided, all
-            other arguments are ignored.
+Usage: sentry-cli[EXE] send-event [OPTIONS] [PATH]
 
-OPTIONS:
-    -a, --message-arg <MESSAGE_ARG>
-            Arguments for the event message.
+Arguments:
+  [PATH]
+          The path or glob to the file(s) in JSON format to send as event(s). When provided, all
+          other arguments are ignored.
 
-        --auth-token <AUTH_TOKEN>
-            Use the given Sentry auth token.
+Options:
+  -l, --level <LEVEL>
+          Optional event severity/log level. (debug|info|warning|error|fatal) [defaults to 'error']
 
-    -d, --dist <DISTRIBUTION>
-            Set the distribution.
+      --header <KEY:VALUE>
+          Custom headers that should be attached to all requests
+          in key:value format.
 
-    -e, --extra <KEY:VALUE>
-            Add extra information (key:value) to the event.
+      --timestamp <TIMESTAMP>
+          Optional event timestamp in one of supported formats: unix timestamp, RFC2822 or RFC3339.
 
-    -E, --env <ENVIRONMENT>
-            Send with a specific environment.
+      --auth-token <AUTH_TOKEN>
+          Use the given Sentry auth token.
 
-    -f, --fingerprint <FINGERPRINT>
-            Change the fingerprint of the event.
+  -r, --release <RELEASE>
+          Optional identifier of the release.
 
-    -h, --help
-            Print help information
+  -d, --dist <DISTRIBUTION>
+          Set the distribution.
 
-        --header <KEY:VALUE>
-            Custom headers that should be attached to all requests
-            in key:value format.
+  -E, --env <ENVIRONMENT>
+          Send with a specific environment.
 
-    -l, --level <LEVEL>
-            Optional event severity/log level. (debug|info|warning|error|fatal) [defaults to
-            'error']
+      --log-level <LOG_LEVEL>
+          Set the log output verbosity.
+          
+          [possible values: trace, debug, info, warn, error]
 
-        --log-level <LOG_LEVEL>
-            Set the log output verbosity.
-            
-            [possible values: trace, debug, info, warn, error]
+      --no-environ
+          Do not send environment variables along
 
-        --logfile <PATH>
-            Send a logfile as breadcrumbs with the event (last 100 records)
+      --quiet
+          Do not print any output while preserving correct exit code. This flag is currently
+          implemented only for selected subcommands.
+          
+          [aliases: silent]
 
-    -m, --message <MESSAGE>
-            The event message.
+  -m, --message <MESSAGE>
+          The event message.
 
-        --no-environ
-            Do not send environment variables along
+  -a, --message-arg <MESSAGE_ARG>
+          Arguments for the event message.
 
-    -p, --platform <PLATFORM>
-            Override the default 'other' platform specifier.
+  -p, --platform <PLATFORM>
+          Override the default 'other' platform specifier.
 
-        --quiet
-            Do not print any output while preserving correct exit code. This flag is currently
-            implemented only for selected subcommands.
-            
-            [aliases: silent]
+  -t, --tag <KEY:VALUE>
+          Add a tag (key:value) to the event.
 
-    -r, --release <RELEASE>
-            Optional identifier of the release.
+  -e, --extra <KEY:VALUE>
+          Add extra information (key:value) to the event.
 
-    -t, --tag <KEY:VALUE>
-            Add a tag (key:value) to the event.
+  -u, --user <KEY:VALUE>
+          Add user information (key:value) to the event. [eg: id:42, username:foo]
 
-        --timestamp <TIMESTAMP>
-            Optional event timestamp in one of supported formats: unix timestamp, RFC2822 or
-            RFC3339.
+  -f, --fingerprint <FINGERPRINT>
+          Change the fingerprint of the event.
 
-    -u, --user <KEY:VALUE>
-            Add user information (key:value) to the event. [eg: id:42, username:foo]
+      --logfile <PATH>
+          Send a logfile as breadcrumbs with the event (last 100 records)
 
-        --with-categories
-            When logfile is provided, this flag will try to assign correct level to extracted log
-            breadcrumbs. It uses standard log format of "category: message". eg. "INFO: Something
-            broke" will be parsed as a breadcrumb "{"level": "info", "message": "Something broke"}"
+      --with-categories
+          When logfile is provided, this flag will try to assign correct level to extracted log
+          breadcrumbs. It uses standard log format of "category: message". eg. "INFO: Something
+          broke" will be parsed as a breadcrumb "{"level": "info", "message": "Something broke"}"
+
+  -h, --help
+          Print help (see a summary with '-h')
 
 ```

--- a/tests/integration/_cases/send_event/send_event-raw-fail.trycmd
+++ b/tests/integration/_cases/send_event/send_event-raw-fail.trycmd
@@ -13,9 +13,9 @@ $ sentry-cli send-event --log-level=debug
 > --fingerprint custom-fingerprint
 > --no-environ
 ? 2
-error: Invalid value "11111111111111111111111111111111111111111111111111111111111111111" for '--dist <DISTRIBUTION>': Invalid distribution name. Distribution name must not be longer than 64 characters.
+error: invalid value '11111111111111111111111111111111111111111111111111111111111111111' for '--dist <DISTRIBUTION>': Invalid distribution name. Distribution name must not be longer than 64 characters.
 
-For more information try --help
+For more information, try '--help'.
 
 ```
 

--- a/tests/integration/_cases/sourcemaps/sourcemaps-explain-help.trycmd
+++ b/tests/integration/_cases/sourcemaps/sourcemaps-explain-help.trycmd
@@ -1,31 +1,29 @@
 ```
 $ sentry-cli sourcemaps explain --help
 ? success
-sentry-cli[EXE]-sourcemaps-explain 
 Explain why sourcemaps are not working for a given event.
 
-USAGE:
-    sentry-cli[EXE] sourcemaps explain [OPTIONS] <EVENT_ID>
+Usage: sentry-cli[EXE] sourcemaps explain [OPTIONS] <EVENT_ID>
 
-ARGS:
-    <EVENT_ID>    ID of an event to be explained.
+Arguments:
+  <EVENT_ID>  ID of an event to be explained.
 
-OPTIONS:
-        --auth-token <AUTH_TOKEN>    Use the given Sentry auth token.
-    -f, --force                      Force full validation flow, even when event is already source
-                                     mapped.
-        --frame <frame>              Position of the frame that should be used for source map
-                                     resolution. [default: 0]
-    -h, --help                       Print help information
-        --header <KEY:VALUE>         Custom headers that should be attached to all requests
-                                     in key:value format.
-        --log-level <LOG_LEVEL>      Set the log output verbosity. [possible values: trace, debug,
-                                     info, warn, error]
-    -o, --org <ORG>                  The organization slug
-    -p, --project <PROJECT>          The project slug.
-        --quiet                      Do not print any output while preserving correct exit code.
-                                     This flag is currently implemented only for selected
-                                     subcommands. [aliases: silent]
-    -r, --release <RELEASE>          The release slug.
+Options:
+      --frame <frame>            Position of the frame that should be used for source map
+                                 resolution. [default: 0]
+  -o, --org <ORG>                The organization slug
+  -f, --force                    Force full validation flow, even when event is already source
+                                 mapped.
+      --header <KEY:VALUE>       Custom headers that should be attached to all requests
+                                 in key:value format.
+  -p, --project <PROJECT>        The project slug.
+      --auth-token <AUTH_TOKEN>  Use the given Sentry auth token.
+  -r, --release <RELEASE>        The release slug.
+      --log-level <LOG_LEVEL>    Set the log output verbosity. [possible values: trace, debug, info,
+                                 warn, error]
+      --quiet                    Do not print any output while preserving correct exit code. This
+                                 flag is currently implemented only for selected subcommands.
+                                 [aliases: silent]
+  -h, --help                     Print help
 
 ```

--- a/tests/integration/_cases/sourcemaps/sourcemaps-explain.trycmd
+++ b/tests/integration/_cases/sourcemaps/sourcemaps-explain.trycmd
@@ -1,12 +1,11 @@
 ```
 $ sentry-cli sourcemaps explain
 ? failed
-error: The following required arguments were not provided:
-    <EVENT_ID>
+error: the following required arguments were not provided:
+  <EVENT_ID>
 
-USAGE:
-    sentry-cli[EXE] sourcemaps explain [OPTIONS] <EVENT_ID>
+Usage: sentry-cli[EXE] sourcemaps explain <EVENT_ID>
 
-For more information try --help
+For more information, try '--help'.
 
 ```

--- a/tests/integration/_cases/sourcemaps/sourcemaps-help.trycmd
+++ b/tests/integration/_cases/sourcemaps/sourcemaps-help.trycmd
@@ -1,30 +1,28 @@
 ```
 $ sentry-cli sourcemaps --help
 ? success
-sentry-cli[EXE]-sourcemaps 
 Manage sourcemaps for Sentry releases.
 
-USAGE:
-    sentry-cli[EXE] sourcemaps [OPTIONS] <SUBCOMMAND>
+Usage: sentry-cli[EXE] sourcemaps [OPTIONS] <COMMAND>
 
-OPTIONS:
-        --auth-token <AUTH_TOKEN>    Use the given Sentry auth token.
-    -h, --help                       Print help information
-        --header <KEY:VALUE>         Custom headers that should be attached to all requests
-                                     in key:value format.
-        --log-level <LOG_LEVEL>      Set the log output verbosity. [possible values: trace, debug,
-                                     info, warn, error]
-    -o, --org <ORG>                  The organization slug
-    -p, --project <PROJECT>          The project slug.
-        --quiet                      Do not print any output while preserving correct exit code.
-                                     This flag is currently implemented only for selected
-                                     subcommands. [aliases: silent]
-    -r, --release <RELEASE>          The release slug.
+Commands:
+  explain  Explain why sourcemaps are not working for a given event.
+  resolve  Resolve sourcemap for a given line/column position.
+  upload   Upload sourcemaps for a release.
+  help     Print this message or the help of the given subcommand(s)
 
-SUBCOMMANDS:
-    explain    Explain why sourcemaps are not working for a given event.
-    help       Print this message or the help of the given subcommand(s)
-    resolve    Resolve sourcemap for a given line/column position.
-    upload     Upload sourcemaps for a release.
+Options:
+  -o, --org <ORG>                The organization slug
+      --header <KEY:VALUE>       Custom headers that should be attached to all requests
+                                 in key:value format.
+  -p, --project <PROJECT>        The project slug.
+      --auth-token <AUTH_TOKEN>  Use the given Sentry auth token.
+  -r, --release <RELEASE>        The release slug.
+      --log-level <LOG_LEVEL>    Set the log output verbosity. [possible values: trace, debug, info,
+                                 warn, error]
+      --quiet                    Do not print any output while preserving correct exit code. This
+                                 flag is currently implemented only for selected subcommands.
+                                 [aliases: silent]
+  -h, --help                     Print help
 
 ```

--- a/tests/integration/_cases/sourcemaps/sourcemaps-no-subcommand.trycmd
+++ b/tests/integration/_cases/sourcemaps/sourcemaps-no-subcommand.trycmd
@@ -1,30 +1,28 @@
 ```
 $ sentry-cli sourcemaps
 ? failed
-sentry-cli[EXE]-sourcemaps 
 Manage sourcemaps for Sentry releases.
 
-USAGE:
-    sentry-cli[EXE] sourcemaps [OPTIONS] <SUBCOMMAND>
+Usage: sentry-cli[EXE] sourcemaps [OPTIONS] <COMMAND>
 
-OPTIONS:
-        --auth-token <AUTH_TOKEN>    Use the given Sentry auth token.
-    -h, --help                       Print help information
-        --header <KEY:VALUE>         Custom headers that should be attached to all requests
-                                     in key:value format.
-        --log-level <LOG_LEVEL>      Set the log output verbosity. [possible values: trace, debug,
-                                     info, warn, error]
-    -o, --org <ORG>                  The organization slug
-    -p, --project <PROJECT>          The project slug.
-        --quiet                      Do not print any output while preserving correct exit code.
-                                     This flag is currently implemented only for selected
-                                     subcommands. [aliases: silent]
-    -r, --release <RELEASE>          The release slug.
+Commands:
+  explain  Explain why sourcemaps are not working for a given event.
+  resolve  Resolve sourcemap for a given line/column position.
+  upload   Upload sourcemaps for a release.
+  help     Print this message or the help of the given subcommand(s)
 
-SUBCOMMANDS:
-    explain    Explain why sourcemaps are not working for a given event.
-    help       Print this message or the help of the given subcommand(s)
-    resolve    Resolve sourcemap for a given line/column position.
-    upload     Upload sourcemaps for a release.
+Options:
+  -o, --org <ORG>                The organization slug
+      --header <KEY:VALUE>       Custom headers that should be attached to all requests
+                                 in key:value format.
+  -p, --project <PROJECT>        The project slug.
+      --auth-token <AUTH_TOKEN>  Use the given Sentry auth token.
+  -r, --release <RELEASE>        The release slug.
+      --log-level <LOG_LEVEL>    Set the log output verbosity. [possible values: trace, debug, info,
+                                 warn, error]
+      --quiet                    Do not print any output while preserving correct exit code. This
+                                 flag is currently implemented only for selected subcommands.
+                                 [aliases: silent]
+  -h, --help                     Print help
 
 ```

--- a/tests/integration/_cases/sourcemaps/sourcemaps-resolve-help.trycmd
+++ b/tests/integration/_cases/sourcemaps/sourcemaps-resolve-help.trycmd
@@ -1,29 +1,27 @@
 ```
 $ sentry-cli sourcemaps resolve --help
 ? success
-sentry-cli[EXE]-sourcemaps-resolve 
 Resolve sourcemap for a given line/column position.
 
-USAGE:
-    sentry-cli[EXE] sourcemaps resolve [OPTIONS] [PATH]
+Usage: sentry-cli[EXE] sourcemaps resolve [OPTIONS] [PATH]
 
-ARGS:
-    <PATH>    The sourcemap to resolve.
+Arguments:
+  [PATH]  The sourcemap to resolve.
 
-OPTIONS:
-        --auth-token <AUTH_TOKEN>    Use the given Sentry auth token.
-    -c, --column <COLUMN>            Column number for minified source.
-    -h, --help                       Print help information
-        --header <KEY:VALUE>         Custom headers that should be attached to all requests
-                                     in key:value format.
-    -l, --line <LINE>                Line number for minified source.
-        --log-level <LOG_LEVEL>      Set the log output verbosity. [possible values: trace, debug,
-                                     info, warn, error]
-    -o, --org <ORG>                  The organization slug
-    -p, --project <PROJECT>          The project slug.
-        --quiet                      Do not print any output while preserving correct exit code.
-                                     This flag is currently implemented only for selected
-                                     subcommands. [aliases: silent]
-    -r, --release <RELEASE>          The release slug.
+Options:
+  -l, --line <LINE>              Line number for minified source.
+  -o, --org <ORG>                The organization slug
+  -c, --column <COLUMN>          Column number for minified source.
+      --header <KEY:VALUE>       Custom headers that should be attached to all requests
+                                 in key:value format.
+  -p, --project <PROJECT>        The project slug.
+      --auth-token <AUTH_TOKEN>  Use the given Sentry auth token.
+  -r, --release <RELEASE>        The release slug.
+      --log-level <LOG_LEVEL>    Set the log output verbosity. [possible values: trace, debug, info,
+                                 warn, error]
+      --quiet                    Do not print any output while preserving correct exit code. This
+                                 flag is currently implemented only for selected subcommands.
+                                 [aliases: silent]
+  -h, --help                     Print help
 
 ```

--- a/tests/integration/_cases/sourcemaps/sourcemaps-upload-help.trycmd
+++ b/tests/integration/_cases/sourcemaps/sourcemaps-upload-help.trycmd
@@ -1,103 +1,78 @@
 ```
 $ sentry-cli sourcemaps upload --help
 ? success
-sentry-cli[EXE]-sourcemaps-upload 
 Upload sourcemaps for a release.
 
-USAGE:
-    sentry-cli[EXE] sourcemaps upload [OPTIONS] [PATHS]...
+Usage: sentry-cli[EXE] sourcemaps upload [OPTIONS] [PATHS]...
 
-ARGS:
-    <PATHS>...    The files to upload.
+Arguments:
+  [PATHS]...  The files to upload.
 
-OPTIONS:
-        --auth-token <AUTH_TOKEN>
-            Use the given Sentry auth token.
-
-        --bundle <BUNDLE>
-            Path to the application bundle (indexed, file, or regular)
-
-        --bundle-sourcemap <BUNDLE_SOURCEMAP>
-            Path to the bundle sourcemap
-
-    -d, --dist <DISTRIBUTION>
-            Optional distribution identifier for the sourcemaps.
-
-        --decompress
-            Enable files gzip decompression prior to upload.
-
-    -h, --help
-            Print help information
-
-        --header <KEY:VALUE>
-            Custom headers that should be attached to all requests
-            in key:value format.
-
-    -i, --ignore <IGNORE>
-            Ignores all files and folders matching the given glob
-
-    -I, --ignore-file <IGNORE_FILE>
-            Ignore all files and folders specified in the given ignore file, e.g. .gitignore.
-
-        --log-level <LOG_LEVEL>
-            Set the log output verbosity. [possible values: trace, debug, info, warn, error]
-
-        --no-dedupe
-            Skip artifacts deduplication prior to uploading. This will force all artifacts to be
-            uploaded, no matter whether they are already present on the server.
-
-        --no-rewrite
-            Disables rewriting of matching sourcemaps. By default the tool will rewrite sources, so
-            that indexed maps are flattened and missing sources are inlined if possible.
-            This fundamentally changes the upload process to be based on sourcemaps and minified
-            files exclusively and comes in handy for setups like react-native that generate
-            sourcemaps that would otherwise not work for sentry.
-
-        --no-sourcemap-reference
-            Disable emitting of automatic sourcemap references.
-            By default the tool will store a 'Sourcemap' header with minified files so that
-            sourcemaps are located automatically if the tool can detect a link. If this causes
-            issues it can be disabled.
-
-    -o, --org <ORG>
-            The organization slug
-
-    -p, --project <PROJECT>
-            The project slug.
-
-        --quiet
-            Do not print any output while preserving correct exit code. This flag is currently
-            implemented only for selected subcommands. [aliases: silent]
-
-    -r, --release <RELEASE>
-            The release slug.
-
-        --strip-common-prefix
-            Similar to --strip-prefix but strips the most common prefix on all sources references.
-
-        --strip-prefix <PREFIX>
-            Strips the given prefix from all sources references inside the upload sourcemaps (paths
-            used within the sourcemap content, to map minified code to it's original source). Only
-            sources that start with the given prefix will be stripped.
-            This will not modify the uploaded sources paths. To do that, point the upload or
-            upload-sourcemaps command to a more precise directory instead.
-
-    -u, --url-prefix <PREFIX>
-            The URL prefix to prepend to all filenames.
-
-        --url-suffix <SUFFIX>
-            The URL suffix to append to all filenames.
-
-        --validate
-            Enable basic sourcemap validation.
-
-        --wait
-            Wait for the server to fully process uploaded files.
-
-    -x, --ext <EXT>
-            Set the file extensions that are considered for upload. This overrides the default
-            extensions. To add an extension, all default extensions must be repeated. Specify once
-            per extension.
-            Defaults to: `--ext=js --ext=map --ext=jsbundle --ext=bundle`
+Options:
+  -o, --org <ORG>
+          The organization slug
+      --header <KEY:VALUE>
+          Custom headers that should be attached to all requests
+          in key:value format.
+  -p, --project <PROJECT>
+          The project slug.
+  -u, --url-prefix <PREFIX>
+          The URL prefix to prepend to all filenames.
+      --auth-token <AUTH_TOKEN>
+          Use the given Sentry auth token.
+  -r, --release <RELEASE>
+          The release slug.
+      --url-suffix <SUFFIX>
+          The URL suffix to append to all filenames.
+  -d, --dist <DISTRIBUTION>
+          Optional distribution identifier for the sourcemaps.
+      --log-level <LOG_LEVEL>
+          Set the log output verbosity. [possible values: trace, debug, info, warn, error]
+      --validate
+          Enable basic sourcemap validation.
+      --decompress
+          Enable files gzip decompression prior to upload.
+      --quiet
+          Do not print any output while preserving correct exit code. This flag is currently
+          implemented only for selected subcommands. [aliases: silent]
+      --wait
+          Wait for the server to fully process uploaded files.
+      --no-sourcemap-reference
+          Disable emitting of automatic sourcemap references.
+          By default the tool will store a 'Sourcemap' header with minified files so that sourcemaps
+          are located automatically if the tool can detect a link. If this causes issues it can be
+          disabled.
+      --no-rewrite
+          Disables rewriting of matching sourcemaps. By default the tool will rewrite sources, so
+          that indexed maps are flattened and missing sources are inlined if possible.
+          This fundamentally changes the upload process to be based on sourcemaps and minified files
+          exclusively and comes in handy for setups like react-native that generate sourcemaps that
+          would otherwise not work for sentry.
+      --strip-prefix <PREFIX>
+          Strips the given prefix from all sources references inside the upload sourcemaps (paths
+          used within the sourcemap content, to map minified code to it's original source). Only
+          sources that start with the given prefix will be stripped.
+          This will not modify the uploaded sources paths. To do that, point the upload or
+          upload-sourcemaps command to a more precise directory instead.
+      --strip-common-prefix
+          Similar to --strip-prefix but strips the most common prefix on all sources references.
+  -i, --ignore <IGNORE>
+          Ignores all files and folders matching the given glob
+  -I, --ignore-file <IGNORE_FILE>
+          Ignore all files and folders specified in the given ignore file, e.g. .gitignore.
+      --bundle <BUNDLE>
+          Path to the application bundle (indexed, file, or regular)
+      --bundle-sourcemap <BUNDLE_SOURCEMAP>
+          Path to the bundle sourcemap
+      --no-dedupe
+          Skip artifacts deduplication prior to uploading. This will force all artifacts to be
+          uploaded, no matter whether they are already present on the server.
+  -x, --ext <EXT>
+          Set the file extensions that are considered for upload. This overrides the default
+          extensions. To add an extension, all default extensions must be repeated. Specify once per
+          extension.
+          Defaults to: `--ext=js --ext=map --ext=jsbundle --ext=bundle`
+  -h, --help
+          Print help
 
 ```

--- a/tests/integration/_cases/sourcemaps/sourcemaps-upload.trycmd
+++ b/tests/integration/_cases/sourcemaps/sourcemaps-upload.trycmd
@@ -1,12 +1,11 @@
 ```
 $ sentry-cli sourcemaps upload
 ? failed
-error: The following required arguments were not provided:
-    <PATHS>...
+error: the following required arguments were not provided:
+  <PATHS>...
 
-USAGE:
-    sentry-cli[EXE] sourcemaps upload <PATHS>...
+Usage: sentry-cli[EXE] sourcemaps upload <PATHS>...
 
-For more information try --help
+For more information, try '--help'.
 
 ```

--- a/tests/integration/_cases/uninstall/uninstall-help.trycmd
+++ b/tests/integration/_cases/uninstall/uninstall-help.trycmd
@@ -1,22 +1,20 @@
 ```
 $ sentry-cli uninstall --help
 ? success
-sentry-cli[EXE]-uninstall 
 Uninstall the sentry-cli executable.
 
-USAGE:
-    sentry-cli[EXE] uninstall [OPTIONS]
+Usage: sentry-cli[EXE] uninstall [OPTIONS]
 
-OPTIONS:
-        --auth-token <AUTH_TOKEN>    Use the given Sentry auth token.
-        --confirm                    Skip uninstall confirmation prompt.
-    -h, --help                       Print help information
-        --header <KEY:VALUE>         Custom headers that should be attached to all requests
-                                     in key:value format.
-        --log-level <LOG_LEVEL>      Set the log output verbosity. [possible values: trace, debug,
-                                     info, warn, error]
-        --quiet                      Do not print any output while preserving correct exit code.
-                                     This flag is currently implemented only for selected
-                                     subcommands. [aliases: silent]
+Options:
+      --confirm                  Skip uninstall confirmation prompt.
+      --header <KEY:VALUE>       Custom headers that should be attached to all requests
+                                 in key:value format.
+      --auth-token <AUTH_TOKEN>  Use the given Sentry auth token.
+      --log-level <LOG_LEVEL>    Set the log output verbosity. [possible values: trace, debug, info,
+                                 warn, error]
+      --quiet                    Do not print any output while preserving correct exit code. This
+                                 flag is currently implemented only for selected subcommands.
+                                 [aliases: silent]
+  -h, --help                     Print help
 
 ```

--- a/tests/integration/_cases/update/update-help.trycmd
+++ b/tests/integration/_cases/update/update-help.trycmd
@@ -1,23 +1,20 @@
 ```
 $ sentry-cli update --help
 ? success
-sentry-cli[EXE]-update 
 Update the sentry-cli executable.
 
-USAGE:
-    sentry-cli[EXE] update [OPTIONS]
+Usage: sentry-cli[EXE] update [OPTIONS]
 
-OPTIONS:
-        --auth-token <AUTH_TOKEN>    Use the given Sentry auth token.
-    -f, --force                      Force the update even if the latest version is already
-                                     installed.
-    -h, --help                       Print help information
-        --header <KEY:VALUE>         Custom headers that should be attached to all requests
-                                     in key:value format.
-        --log-level <LOG_LEVEL>      Set the log output verbosity. [possible values: trace, debug,
-                                     info, warn, error]
-        --quiet                      Do not print any output while preserving correct exit code.
-                                     This flag is currently implemented only for selected
-                                     subcommands. [aliases: silent]
+Options:
+  -f, --force                    Force the update even if the latest version is already installed.
+      --header <KEY:VALUE>       Custom headers that should be attached to all requests
+                                 in key:value format.
+      --auth-token <AUTH_TOKEN>  Use the given Sentry auth token.
+      --log-level <LOG_LEVEL>    Set the log output verbosity. [possible values: trace, debug, info,
+                                 warn, error]
+      --quiet                    Do not print any output while preserving correct exit code. This
+                                 flag is currently implemented only for selected subcommands.
+                                 [aliases: silent]
+  -h, --help                     Print help
 
 ```

--- a/tests/integration/_cases/upload_dif/upload_dif-help.trycmd
+++ b/tests/integration/_cases/upload_dif/upload_dif-help.trycmd
@@ -1,79 +1,72 @@
 ```
 $ sentry-cli upload-dif --help
 ? success
-sentry-cli[EXE]-upload-dif 
 Upload debugging information files.
 
-USAGE:
-    sentry-cli[EXE] upload-dif [OPTIONS] [PATH]...
+Usage: sentry-cli[EXE] upload-dif [OPTIONS] [PATH]...
 
-ARGS:
-    <PATH>...    A path to search recursively for symbol files.
+Arguments:
+  [PATH]...  A path to search recursively for symbol files.
 
-OPTIONS:
-        --auth-token <AUTH_TOKEN>    Use the given Sentry auth token.
-        --derived-data               Search for debug symbols in Xcode's derived data.
-        --force-foreground           Wait for the process to finish.
-                                     By default, the upload process will detach and continue in the
-                                     background when triggered from Xcode.  When an error happens, a
-                                     dialog is shown.  If this parameter is passed Xcode will wait
-                                     for the process to finish before the build finishes and output
-                                     will be shown in the Xcode build output.
-    -h, --help                       Print help information
-        --header <KEY:VALUE>         Custom headers that should be attached to all requests
-                                     in key:value format.
-        --id <ID>                    Search for specific debug identifiers.
-        --il2cpp-mapping             Compute il2cpp line mappings and upload them along with
-                                     sources.
-        --include-sources            Include sources from the local file system and upload them as
-                                     source bundles.
-        --info-plist <PATH>          Optional path to the Info.plist.
-                                     We will try to find this automatically if run from Xcode.
-                                     Providing this information will associate the debug symbols
-                                     with a specific ITC application and build in Sentry.  Note that
-                                     if you provide the plist explicitly it must already be
-                                     processed.
-        --log-level <LOG_LEVEL>      Set the log output verbosity. [possible values: trace, debug,
-                                     info, warn, error]
-        --no-debug                   Do not scan for debugging information. This will usually
-                                     exclude debug companion files. They might still be uploaded, if
-                                     they contain additional processable information (see other
-                                     flags).
-        --no-reprocessing            Do not trigger reprocessing after uploading.
-        --no-sources                 Do not scan for source information. This will usually exclude
-                                     source bundle files. They might still be uploaded, if they
-                                     contain additional processable information (see other flags).
-        --no-unwind                  Do not scan for stack unwinding information. Specify this flag
-                                     for builds with disabled FPO, or when stackwalking occurs on
-                                     the device. This usually excludes executables and dynamic
-                                     libraries. They might still be uploaded, if they contain
-                                     additional processable information (see other flags).
-        --no-upload                  Disable the actual upload.
-                                     This runs all steps for the processing but does not trigger the
-                                     upload (this also automatically disables reprocessing).  This
-                                     is useful if you just want to verify the setup or skip the
-                                     upload in tests.
-        --no-zips                    Do not search in ZIP files.
-    -o, --org <ORG>                  The organization slug
-    -p, --project <PROJECT>          The project slug.
-        --quiet                      Do not print any output while preserving correct exit code.
-                                     This flag is currently implemented only for selected
-                                     subcommands. [aliases: silent]
-        --require-all                Errors if not all identifiers specified with --id could be
-                                     found.
-        --symbol-maps <PATH>         Optional path to BCSymbolMap files which are used to resolve
-                                     hidden symbols in dSYM files downloaded from iTunes Connect.
-                                     This requires the dsymutil tool to be available.  This should
-                                     not be used when using the App Store Connect integration, the
-                                     .bcsymbolmap files needed for the integration are uploaded
-                                     without this option if they are found in the PATH searched for
-                                     symbol files.
-    -t, --type <TYPE>                Only consider debug information files of the given type.  By
-                                     default, all types are considered. [possible values:
-                                     bcsymbolmap, dsym, elf, pe, pdb, portablepdb, sourcebundle,
-                                     breakpad, proguard, wasm]
-        --wait                       Wait for the server to fully process uploaded files. Errors can
-                                     only be displayed if --wait is specified, but this will
-                                     significantly slow down the upload process.
+Options:
+  -o, --org <ORG>                The organization slug
+      --header <KEY:VALUE>       Custom headers that should be attached to all requests
+                                 in key:value format.
+  -p, --project <PROJECT>        The project slug.
+      --auth-token <AUTH_TOKEN>  Use the given Sentry auth token.
+  -t, --type <TYPE>              Only consider debug information files of the given type.  By
+                                 default, all types are considered. [possible values: bcsymbolmap,
+                                 dsym, elf, pe, pdb, portablepdb, sourcebundle, breakpad, proguard,
+                                 wasm]
+      --no-unwind                Do not scan for stack unwinding information. Specify this flag for
+                                 builds with disabled FPO, or when stackwalking occurs on the
+                                 device. This usually excludes executables and dynamic libraries.
+                                 They might still be uploaded, if they contain additional
+                                 processable information (see other flags).
+      --log-level <LOG_LEVEL>    Set the log output verbosity. [possible values: trace, debug, info,
+                                 warn, error]
+      --no-debug                 Do not scan for debugging information. This will usually exclude
+                                 debug companion files. They might still be uploaded, if they
+                                 contain additional processable information (see other flags).
+      --no-sources               Do not scan for source information. This will usually exclude
+                                 source bundle files. They might still be uploaded, if they contain
+                                 additional processable information (see other flags).
+      --quiet                    Do not print any output while preserving correct exit code. This
+                                 flag is currently implemented only for selected subcommands.
+                                 [aliases: silent]
+      --id <ID>                  Search for specific debug identifiers.
+      --require-all              Errors if not all identifiers specified with --id could be found.
+      --symbol-maps <PATH>       Optional path to BCSymbolMap files which are used to resolve hidden
+                                 symbols in dSYM files downloaded from iTunes Connect.  This
+                                 requires the dsymutil tool to be available.  This should not be
+                                 used when using the App Store Connect integration, the .bcsymbolmap
+                                 files needed for the integration are uploaded without this option
+                                 if they are found in the PATH searched for symbol files.
+      --derived-data             Search for debug symbols in Xcode's derived data.
+      --no-zips                  Do not search in ZIP files.
+      --info-plist <PATH>        Optional path to the Info.plist.
+                                 We will try to find this automatically if run from Xcode.
+                                 Providing this information will associate the debug symbols with a
+                                 specific ITC application and build in Sentry.  Note that if you
+                                 provide the plist explicitly it must already be processed.
+      --no-reprocessing          Do not trigger reprocessing after uploading.
+      --no-upload                Disable the actual upload.
+                                 This runs all steps for the processing but does not trigger the
+                                 upload (this also automatically disables reprocessing).  This is
+                                 useful if you just want to verify the setup or skip the upload in
+                                 tests.
+      --force-foreground         Wait for the process to finish.
+                                 By default, the upload process will detach and continue in the
+                                 background when triggered from Xcode.  When an error happens, a
+                                 dialog is shown.  If this parameter is passed Xcode will wait for
+                                 the process to finish before the build finishes and output will be
+                                 shown in the Xcode build output.
+      --include-sources          Include sources from the local file system and upload them as
+                                 source bundles.
+      --wait                     Wait for the server to fully process uploaded files. Errors can
+                                 only be displayed if --wait is specified, but this will
+                                 significantly slow down the upload process.
+      --il2cpp-mapping           Compute il2cpp line mappings and upload them along with sources.
+  -h, --help                     Print help
 
 ```

--- a/tests/integration/_cases/upload_proguard/upload_proguard-help.trycmd
+++ b/tests/integration/_cases/upload_proguard/upload_proguard-help.trycmd
@@ -1,77 +1,54 @@
 ```
 $ sentry-cli upload-proguard --help
 ? success
-sentry-cli[EXE]-upload-proguard 
 Upload ProGuard mapping files to a project.
 
-USAGE:
-    sentry-cli[EXE] upload-proguard [OPTIONS] [PATH]...
+Usage: sentry-cli[EXE] upload-proguard [OPTIONS] [PATH]...
 
-ARGS:
-    <PATH>...    The path to the mapping files.
+Arguments:
+  [PATH]...  The path to the mapping files.
 
-OPTIONS:
-        --android-manifest <PATH>
-            Read version and version code from an Android manifest file.
-
-        --app-id <APP_ID>
-            Optionally associate the mapping files with an application ID.
-            If you have multiple apps in one sentry project, you can then easily tell them apart.
-
-        --auth-token <AUTH_TOKEN>
-            Use the given Sentry auth token.
-
-    -h, --help
-            Print help information
-
-        --header <KEY:VALUE>
-            Custom headers that should be attached to all requests
-            in key:value format.
-
-        --log-level <LOG_LEVEL>
-            Set the log output verbosity. [possible values: trace, debug, info, warn, error]
-
-        --no-reprocessing
-            Do not trigger reprocessing after upload.
-
-        --no-upload
-            Disable the actual upload.
-            This runs all steps for the processing but does not trigger the upload (this also
-            automatically disables reprocessing).  This is useful if you just want to verify the
-            mapping files and write the proguard UUIDs into a properties file.
-
-    -o, --org <ORG>
-            The organization slug
-
-    -p, --project <PROJECT>
-            The project slug.
-
-        --platform <PLATFORM>
-            Optionally defines the platform for the app association. [defaults to 'android']
-
-        --quiet
-            Do not print any output while preserving correct exit code. This flag is currently
-            implemented only for selected subcommands. [aliases: silent]
-
-        --require-one
-            Requires at least one file to upload or the command will error.
-
-    -u, --uuid <UUID>
-            Explicitly override the UUID of the mapping file with another one.
-            This should be used with caution as it means that you can upload multiple mapping files
-            if you don't take care.  This however can be useful if you have a build process in which
-            you need to know the UUID of the proguard file before it was created.  If you upload a
-            file with a forced UUID you can only upload a single proguard file.
-
-        --version <VERSION>
-            Optionally associate the mapping files with a human readable version.
-            This helps you understand which ProGuard files go with which version of your app.
-
-        --version-code <VERSION_CODE>
-            Optionally associate the mapping files with a version code.
-            This helps you understand which ProGuard files go with which version of your app.
-
-        --write-properties <PATH>
-            Write the UUIDs for the processed mapping files into the given properties file.
+Options:
+  -o, --org <ORG>                    The organization slug
+      --header <KEY:VALUE>           Custom headers that should be attached to all requests
+                                     in key:value format.
+  -p, --project <PROJECT>            The project slug.
+      --auth-token <AUTH_TOKEN>      Use the given Sentry auth token.
+      --version <VERSION>            Optionally associate the mapping files with a human readable
+                                     version.
+                                     This helps you understand which ProGuard files go with which
+                                     version of your app.
+      --version-code <VERSION_CODE>  Optionally associate the mapping files with a version code.
+                                     This helps you understand which ProGuard files go with which
+                                     version of your app.
+      --app-id <APP_ID>              Optionally associate the mapping files with an application ID.
+                                     If you have multiple apps in one sentry project, you can then
+                                     easily tell them apart.
+      --log-level <LOG_LEVEL>        Set the log output verbosity. [possible values: trace, debug,
+                                     info, warn, error]
+      --platform <PLATFORM>          Optionally defines the platform for the app association.
+                                     [defaults to 'android']
+      --quiet                        Do not print any output while preserving correct exit code.
+                                     This flag is currently implemented only for selected
+                                     subcommands. [aliases: silent]
+      --no-reprocessing              Do not trigger reprocessing after upload.
+      --no-upload                    Disable the actual upload.
+                                     This runs all steps for the processing but does not trigger the
+                                     upload (this also automatically disables reprocessing).  This
+                                     is useful if you just want to verify the mapping files and
+                                     write the proguard UUIDs into a properties file.
+      --android-manifest <PATH>      Read version and version code from an Android manifest file.
+      --write-properties <PATH>      Write the UUIDs for the processed mapping files into the given
+                                     properties file.
+      --require-one                  Requires at least one file to upload or the command will error.
+  -u, --uuid <UUID>                  Explicitly override the UUID of the mapping file with another
+                                     one.
+                                     This should be used with caution as it means that you can
+                                     upload multiple mapping files if you don't take care.  This
+                                     however can be useful if you have a build process in which you
+                                     need to know the UUID of the proguard file before it was
+                                     created.  If you upload a file with a forced UUID you can only
+                                     upload a single proguard file.
+  -h, --help                         Print help
 
 ```

--- a/tests/integration/deploys/new.rs
+++ b/tests/integration/deploys/new.rs
@@ -19,3 +19,20 @@ fn command_deploys_new() {
     );
     register_test("deploys/deploys-new.trycmd");
 }
+
+#[test]
+fn command_releases_deploys_new() {
+    let _server = mock_endpoint(
+        EndpointOptions::new(
+            "POST",
+            "/api/0/organizations/wat-org/releases/wat-release/deploys/",
+            200,
+        )
+        .with_response_file("deploys/post-deploys.json")
+        .with_matcher(Matcher::PartialJson(json!({
+            "environment": "production",
+            "name": "custom-deploy",
+        }))),
+    );
+    register_test("releases/releases-deploys-new.trycmd");
+}


### PR DESCRIPTION
Follows up on #1496 - for some reason, the "version" arg wasn't `global(true)` and yet it still got propagated down the road to subcommands - an "undefined behavior" that stopped working in clap v4

- reapply: clap-rs v4 update
- fix: `releases files` and `releases deploys` version propagation
