### PR TITLE
fix: derive default to make clippy happy

### DIFF
--- a/src/api.rs
+++ b/src/api.rs
@@ -2481,9 +2481,10 @@ pub enum ChunkHashAlgorithm {
     Sha1,
 }
 
-#[derive(Debug, Clone, Copy, Ord, PartialOrd, Eq, PartialEq)]
+#[derive(Debug, Clone, Copy, Ord, PartialOrd, Eq, PartialEq, Default)]
 pub enum ChunkCompression {
     /// No compression should be applied
+    #[default]
     Uncompressed = 0,
     /// GZIP compression (including header)
     Gzip = 10,
@@ -2498,12 +2499,6 @@ impl ChunkCompression {
             ChunkCompression::Gzip => "file_gzip",
             ChunkCompression::Brotli => "file_brotli",
         }
-    }
-}
-
-impl Default for ChunkCompression {
-    fn default() -> Self {
-        ChunkCompression::Uncompressed
     }
 }
 


### PR DESCRIPTION
Clippy changed in latest rust version, gotta go with the flow.