### PR TITLE
ref: Move debug id injection into SourceMapProcessor

### DIFF
--- a/src/utils/sourcemaps.rs
+++ b/src/utils/sourcemaps.rs
@@ -1,18 +1,19 @@
 //! Provides sourcemap validation functionality.
 use std::collections::{HashMap, HashSet};
 use std::ffi::OsStr;
+use std::io::Write;
 use std::mem;
 use std::path::{Path, PathBuf};
 use std::str;
 use std::str::FromStr;
 
-use anyhow::{bail, Error, Result};
+use anyhow::{bail, Context, Error, Result};
 use console::style;
 use indicatif::ProgressStyle;
 use log::{debug, info, warn};
 use sha1_smol::Digest;
 use symbolic::debuginfo::js::{
-    discover_debug_id, discover_sourcemap_embedded_debug_id, discover_sourcemaps_location,
+    self, discover_debug_id, discover_sourcemap_embedded_debug_id, discover_sourcemaps_location,
 };
 use symbolic::debuginfo::sourcebundle::SourceFileType;
 use url::Url;
@@ -25,6 +26,7 @@ use crate::utils::file_upload::{
 };
 use crate::utils::logging::is_quiet_mode;
 use crate::utils::progress::ProgressBar;
+use crate::utils::sourcemaps::inject::{fixup_js_file, InjectReport};
 
 pub mod inject;
 
@@ -640,6 +642,132 @@ impl SourceMapProcessor {
         uploader.files(&self.sources);
         uploader.upload()?;
         self.dump_log("Source Map Upload Report");
+        Ok(())
+    }
+
+    /// Injects debug ids into minified source files and sourcemaps.
+    ///
+    /// This iterates over contained minified source files and their referenced
+    /// sourcemaps and ties them together with debug ids (either freshly generated
+    /// or already contained in the sourcemap).
+    ///
+    /// If `dry_run` is false, this will modify the source and sourcemap files on disk!
+    pub fn inject_debug_ids(&mut self, dry_run: bool) -> Result<()> {
+        self.flush_pending_sources();
+        let sourcemaps = self
+            .sources
+            .iter()
+            .map(|x| x.1)
+            .filter(|x| x.ty == SourceFileType::SourceMap)
+            .map(|x| x.url.to_string())
+            .collect();
+
+        println!("{} Injecting debug ids", style(">").dim());
+
+        let mut report = InjectReport::default();
+
+        // Step 1: find all references from minified source files to sourcemaps
+        let mut sourcemap_refs = Vec::new();
+
+        for source in self.sources.values() {
+            if source.ty != SourceFileType::MinifiedSource {
+                continue;
+            }
+
+            if let Ok(contents) = std::str::from_utf8(&source.contents) {
+                if let Some(debug_id) = js::discover_debug_id(contents) {
+                    debug!("File {} was previously processed", source.path.display());
+                    report
+                        .previously_injected
+                        .push((source.path.clone(), debug_id));
+                    continue;
+                }
+
+                let sourcemap_url = match js::discover_sourcemaps_location(contents) {
+                    Some(url) => source
+                        .path
+                        .with_file_name(url)
+                        .into_os_string()
+                        .into_string()
+                        .unwrap(),
+                    None => match guess_sourcemap_reference(&sourcemaps, &source.url) {
+                        Ok(url) => url,
+                        Err(_) => {
+                            report.skipped.push(source.path.clone());
+                            continue;
+                        }
+                    },
+                };
+
+                sourcemap_refs.push((source.url.clone(), sourcemap_url));
+            }
+        }
+
+        // Step 2: Produce a debug id for each source file by either reading it from the
+        // sourcemap if its already there or generating a fresh one and writing it to the sourcemap
+        // if it isn't.
+        let mut debug_ids = Vec::new();
+
+        for (source_url, sourcemap_url) in sourcemap_refs {
+            let Some(sourcemap_file) = self.sources.get_mut(&sourcemap_url) else {
+                debug!("Sourcemap file {} not found", sourcemap_url);
+                report.missing_sourcemaps.push(source_url.into());
+                continue;
+            };
+
+            let (debug_id, sourcemap_modified) =
+                inject::fixup_sourcemap(&mut sourcemap_file.contents).context(format!(
+                    "Failed to process {}",
+                    sourcemap_file.path.display()
+                ))?;
+
+            if !dry_run && sourcemap_modified {
+                let mut file = std::fs::File::options()
+                    .write(true)
+                    .open(&sourcemap_file.path)?;
+                file.write_all(&sourcemap_file.contents).context(format!(
+                    "Failed to write sourcemap file {}",
+                    sourcemap_file.path.display()
+                ))?;
+            }
+
+            if sourcemap_modified {
+                report
+                    .sourcemaps
+                    .push((sourcemap_file.path.clone(), debug_id));
+            } else {
+                report
+                    .skipped_sourcemaps
+                    .push((sourcemap_file.path.clone(), debug_id));
+            }
+
+            debug_ids.push((source_url, debug_id));
+        }
+
+        // Step 3: Iterate over the minified sourcemaps again and inject the debug ids.
+        for (source_url, debug_id) in debug_ids {
+            let source_file = self.sources.get_mut(&source_url).unwrap();
+
+            fixup_js_file(&mut source_file.contents, debug_id)
+                .context(format!("Failed to process {}", source_file.path.display()))?;
+
+            if !dry_run {
+                let mut file = std::fs::File::options()
+                    .write(true)
+                    .open(&source_file.path)?;
+                file.write_all(&source_file.contents).context(format!(
+                    "Failed to write source file {}",
+                    source_file.path.display()
+                ))?;
+            }
+
+            report.injected.push((source_file.path.clone(), debug_id));
+        }
+
+        if !report.is_empty() {
+            println!("{report}");
+        }
+
         Ok(())
     }
 }

--- a/src/utils/sourcemaps/inject.rs
+++ b/src/utils/sourcemaps/inject.rs
@@ -1,14 +1,13 @@
 use itertools::Itertools;
-use std::fs::File;
-use std::io::{BufRead, BufReader, Seek, Write};
-use std::path::{Path, PathBuf};
-use std::{fmt, fs};
 
-use anyhow::{bail, Context, Result};
+use std::fmt;
+use std::io::{BufRead, Write};
+use std::path::PathBuf;
+
+use anyhow::{bail, Result};
 use log::debug;
 use sentry::types::DebugId;
 use serde_json::Value;
-use symbolic::debuginfo::js;
 use uuid::Uuid;
 
 const CODE_SNIPPET_TEMPLATE: &str = r#"!function(){try{var e="undefined"!=typeof window?window:"undefined"!=typeof global?global:"undefined"!=typeof self?self:{},n=(new Error).stack;n&&(e._sentryDebugIds=e._sentryDebugIds||{},e._sentryDebugIds[n]="__SENTRY_DEBUG_ID__")}catch(e){}}()"#;
@@ -18,12 +17,23 @@ const DEBUGID_COMMENT_PREFIX: &str = "//# debugId";
 
 #[derive(Debug, Clone, Default)]
 pub struct InjectReport {
-    injected: Vec<(PathBuf, DebugId)>,
-    previously_injected: Vec<(PathBuf, DebugId)>,
-    skipped: Vec<PathBuf>,
-    missing_sourcemaps: Vec<PathBuf>,
-    sourcemaps: Vec<(PathBuf, DebugId)>,
-    skipped_sourcemaps: Vec<(PathBuf, DebugId)>,
+    pub injected: Vec<(PathBuf, DebugId)>,
+    pub previously_injected: Vec<(PathBuf, DebugId)>,
+    pub skipped: Vec<PathBuf>,
+    pub missing_sourcemaps: Vec<PathBuf>,
+    pub sourcemaps: Vec<(PathBuf, DebugId)>,
+    pub skipped_sourcemaps: Vec<(PathBuf, DebugId)>,
+}
+
+impl InjectReport {
+    pub fn is_empty(&self) -> bool {
+        self.injected.is_empty()
+            && self.previously_injected.is_empty()
+            && self.skipped.is_empty()
+            && self.missing_sourcemaps.is_empty()
+            && self.sourcemaps.is_empty()
+            && self.skipped_sourcemaps.is_empty()
+    }
 }
 
 impl fmt::Display for InjectReport {
@@ -92,50 +102,6 @@ impl fmt::Display for InjectReport {
     }
 }
 
-pub fn inject_file(js_path: &Path, report: &mut InjectReport) -> Result<()> {
-    debug!("Processing js file {}", js_path.display());
-
-    let file =
-        fs::read_to_string(js_path).context(format!("Failed to open {}", js_path.display()))?;
-
-    if let Some(debug_id) = js::discover_debug_id(&file) {
-        debug!("File {} was previously processed", js_path.display());
-        report
-            .previously_injected
-            .push((js_path.to_path_buf(), debug_id));
-        return Ok(());
-    }
-
-    let Some(sourcemap_url) = js::discover_sourcemaps_location(&file) else {
-            debug!("File {} does not contain a sourcemap url", js_path.display());
-            report.skipped.push(js_path.to_path_buf());
-            return Ok(());
-        };
-
-    let sourcemap_path = js_path.with_file_name(sourcemap_url);
-
-    if !sourcemap_path.exists() {
-        debug!("Sourcemap file {} not found", sourcemap_path.display());
-        report.missing_sourcemaps.push(js_path.to_path_buf());
-        return Ok(());
-    }
-
-    let (debug_id, sourcemap_modified) = fixup_sourcemap(&sourcemap_path)
-        .context(format!("Failed to process {}", sourcemap_path.display()))?;
-
-    if sourcemap_modified {
-        report.sourcemaps.push((sourcemap_path, debug_id));
-    } else {
-        report.skipped_sourcemaps.push((sourcemap_path, debug_id));
-    }
-
-    fixup_js_file(js_path, debug_id).context(format!("Failed to process {}", js_path.display()))?;
-
-    report.injected.push((js_path.to_path_buf(), debug_id));
-
-    Ok(())
-}
-
 /// Appends the following text to a file:
 /// ```
 ///
@@ -145,32 +111,29 @@ pub fn inject_file(js_path: &Path, report: &mut InjectReport) -> Result<()> {
 /// where `<CODE_SNIPPET>[<debug_id>]`
 /// is `CODE_SNIPPET_TEMPLATE` with `debug_id` substituted for the `__SENTRY_DEBUG_ID__`
 /// placeholder.
-fn fixup_js_file(js_path: &Path, debug_id: DebugId) -> Result<()> {
-    let js_lines = {
-        let js_file = File::open(js_path)?;
-        let js_file = BufReader::new(js_file);
-        let js_lines: Result<Vec<_>, _> = js_file.lines().collect();
-        js_lines?
-    };
+///
+/// Moreover, if a `sourceMappingURL` comment exists in the file, it is moved to the very end.,
+pub fn fixup_js_file(js_contents: &mut Vec<u8>, debug_id: DebugId) -> Result<()> {
+    let js_lines: Result<Vec<String>, _> = js_contents.lines().collect();
 
     let mut sourcemap_comment = None;
-    let mut js_file = File::options().write(true).open(js_path)?;
+    js_contents.clear();
 
-    for line in js_lines.into_iter() {
+    for line in js_lines?.into_iter() {
         if line.starts_with("//# sourceMappingURL=") || line.starts_with("//@ sourceMappingURL=") {
             sourcemap_comment = Some(line);
             continue;
         }
-        writeln!(js_file, "{line}")?;
+        writeln!(js_contents, "{line}")?;
     }
 
     let to_inject = CODE_SNIPPET_TEMPLATE.replace(DEBUGID_PLACEHOLDER, &debug_id.to_string());
-    writeln!(js_file)?;
-    writeln!(js_file, "{to_inject}")?;
-    writeln!(js_file, "{DEBUGID_COMMENT_PREFIX}={debug_id}")?;
+    writeln!(js_contents)?;
+    writeln!(js_contents, "{to_inject}")?;
+    writeln!(js_contents, "{DEBUGID_COMMENT_PREFIX}={debug_id}")?;
 
     if let Some(sourcemap_comment) = sourcemap_comment {
-        write!(js_file, "{sourcemap_comment}")?;
+        write!(js_contents, "{sourcemap_comment}")?;
     }
 
     Ok(())
@@ -182,14 +145,8 @@ fn fixup_js_file(js_path: &Path, debug_id: DebugId) -> Result<()> {
 /// Otherwise, a fresh debug id is inserted under that key.
 ///
 /// In either case, the value of the `debug_id` key is returned.
-fn fixup_sourcemap(sourcemap_path: &Path) -> Result<(DebugId, bool)> {
-    let mut sourcemap_file = File::options()
-        .read(true)
-        .write(true)
-        .open(sourcemap_path)?;
-    let mut sourcemap: Value = serde_json::from_reader(&sourcemap_file)?;
-
-    sourcemap_file.rewind()?;
+pub fn fixup_sourcemap(sourcemap_contents: &mut Vec<u8>) -> Result<(DebugId, bool)> {
+    let mut sourcemap: Value = serde_json::from_slice(sourcemap_contents)?;
 
     let Some(map) = sourcemap.as_object_mut() else {
         bail!("Invalid sourcemap");
@@ -207,7 +164,7 @@ fn fixup_sourcemap(sourcemap_path: &Path) -> Result<(DebugId, bool)> {
             let id = serde_json::to_value(debug_id)?;
             map.insert(SOURCEMAP_DEBUGID_KEY.to_string(), id);
 
-            serde_json::to_writer(&mut sourcemap_file, &sourcemap)?;
+            serde_json::to_writer(sourcemap_contents, &sourcemap)?;
             Ok((debug_id, true))
         }
     }

--- a/tests/integration/_cases/releases/releases-files-upload-sourcemaps.trycmd
+++ b/tests/integration/_cases/releases/releases-files-upload-sourcemaps.trycmd
@@ -1,6 +1,7 @@
 ```
 $ sentry-cli releases files wat-release upload-sourcemaps --url-prefix '~/assets' build/assets --rewrite
 ? success
+> Injecting debug ids
 > Rewriting sources
 > Adding source map references
 > Bundled 0 files for upload

--- a/tests/integration/_cases/sourcemaps/sourcemaps-inject-help.trycmd
+++ b/tests/integration/_cases/sourcemaps/sourcemaps-inject-help.trycmd
@@ -13,6 +13,9 @@ Arguments:
           The path to the javascript files.
 
 Options:
+      --dry-run
+          Don't modify files on disk.
+
   -o, --org <ORG>
           The organization slug
 

--- a/tests/integration/_cases/sourcemaps/sourcemaps-inject.trycmd
+++ b/tests/integration/_cases/sourcemaps/sourcemaps-inject.trycmd
@@ -1,6 +1,9 @@
 ```
 $ sentry-cli sourcemaps inject .
 ? success
+> Found 19 release files
+> Analyzing 19 sources
+> Injecting debug ids
 Modified: The following source files have been modified to have debug ids
   - [..]-[..]-[..]-[..]-[..] - ./server/chunks/1.js
   - [..]-[..]-[..]-[..]-[..] - ./server/pages/_document.js
@@ -20,7 +23,6 @@ Ignored: The following sourcemap files already have debug ids
   - [..]-[..]-[..]-[..]-[..] - ./static/chunks/pages/asdf-05b39167abbe433b.js.map
 
 Ignored: The following source files don't have sourcemap references 
-  - ./server/chunks/flight-server-css-manifest.js
   - ./server/flight-manifest.js
   - ./static/chunks/app/client/layout-ba9c3036fc0dba78.js
   - ./static/chunks/app/head-172ad45600676c06.js

--- a/tests/integration/_cases/sourcemaps/sourcemaps-upload-modern.trycmd
+++ b/tests/integration/_cases/sourcemaps/sourcemaps-upload-modern.trycmd
@@ -2,10 +2,9 @@
 $ sentry-cli sourcemaps upload tests/integration/_fixtures/bundle.min.js.map tests/integration/_fixtures/vendor.min.js.map
 ? success
 > Found 1 release file
-
 > Found 1 release file
-
 > Analyzing 2 sources
+> Injecting debug ids
 > Rewriting sources
 > Adding source map references
 > Bundled 2 files for upload

--- a/tests/integration/_cases/sourcemaps/sourcemaps-upload-no-dedupe.trycmd
+++ b/tests/integration/_cases/sourcemaps/sourcemaps-upload-no-dedupe.trycmd
@@ -2,10 +2,9 @@
 $ sentry-cli sourcemaps upload tests/integration/_fixtures/bundle.min.js.map tests/integration/_fixtures/vendor.min.js.map --release=wat-release --no-dedupe
 ? success
 > Found 1 release file
-
 > Found 1 release file
-
 > Analyzing 2 sources
+> Injecting debug ids
 > Rewriting sources
 > Adding source map references
 > Bundled 2 files for upload

--- a/tests/integration/_cases/sourcemaps/sourcemaps-upload-skip-already-uploaded.trycmd
+++ b/tests/integration/_cases/sourcemaps/sourcemaps-upload-skip-already-uploaded.trycmd
@@ -2,10 +2,9 @@
 $ sentry-cli sourcemaps upload tests/integration/_fixtures/bundle.min.js.map tests/integration/_fixtures/vendor.min.js.map --release=wat-release
 ? success
 > Found 1 release file
-
 > Found 1 release file
-
 > Analyzing 2 sources
+> Injecting debug ids
 > Rewriting sources
 > Adding source map references
 > Bundled 1 file for upload

--- a/tests/integration/_cases/sourcemaps/sourcemaps-upload-successfully-upload-file.trycmd
+++ b/tests/integration/_cases/sourcemaps/sourcemaps-upload-successfully-upload-file.trycmd
@@ -2,8 +2,8 @@
 $ sentry-cli sourcemaps upload tests/integration/_fixtures/bundle.min.js.map --release=wat-release
 ? success
 > Found 1 release file
-
 > Analyzing 1 sources
+> Injecting debug ids
 > Rewriting sources
 > Adding source map references
 > Bundled 1 file for upload


### PR DESCRIPTION
This is unfortunately quite a hefty PR. It moves the logic that injects debug ids into source and sourcemap files into the `SourceMapProcessor` struct. The two places where this functionality is used, in the `upload` and `inject` commands, become very simple as a result.

The primary motivation for this is to leverage the existing logic in `SourceMapProcessor` around guessing a sourcemap reference if a source file doesn't contain a mapping URL comment. All the files are read and modified in the `SourceMapProcessor`'s memory and then written back to the original files on disk.

I also took the liberty of adding a `dry-run` flag to `sourcemaps inject` that will perform the modifications in memory but not write anything to disk. If we wanted we could adapt our test code to use this flag; it would obviate the need for temp dir shenanigans.

Test snapshot differences are fairly light: a few newlines have disappeared, a few new output lines have appeared, and in the `inject` integration test one file is skipped entirely because `SourceMapProcessor` knows(?) that it's not a minified source file.