### PR TITLE
ref: Allow multiple paths in sourcemaps inject

### DIFF
--- a/src/commands/sourcemaps/inject.rs
+++ b/src/commands/sourcemaps/inject.rs
@@ -17,10 +17,11 @@ pub fn make_command(command: Command) -> Command {
             that id is used instead.",
         )
         .arg(
-            Arg::new("path")
-                .value_name("PATH")
-                .required(true)
-                .help("The path to the javascript files."),
+            Arg::new("paths")
+                .value_name("PATHS")
+                .num_args(1..)
+                .action(ArgAction::Append)
+                .help("Paths to the javascript files to inject."),
         )
         .arg(
             Arg::new("dry_run")
@@ -33,14 +34,20 @@ pub fn make_command(command: Command) -> Command {
 
 pub fn execute(matches: &ArgMatches) -> Result<()> {
     let mut processor = SourceMapProcessor::new();
-    let path: PathBuf = matches.get_one::<String>("path").unwrap().into();
+
+    let paths = matches
+        .get_many::<String>("paths")
+        .unwrap()
+        .map(PathBuf::from);
     let dry_run = matches.get_flag("dry_run");
 
-    let search = ReleaseFileSearch::new(path);
-    let sources = search.collect_files()?;
-    for source in sources {
-        let url = path_as_url(&source.path);
-        processor.add(&url, source)?;
+    for path in paths {
+        let search = ReleaseFileSearch::new(path);
+        let sources = search.collect_files()?;
+        for source in sources {
+            let url = path_as_url(&source.path);
+            processor.add(&url, source)?;
+        }
     }
 
     processor.inject_debug_ids(dry_run)?;

--- a/src/commands/sourcemaps/inject.rs
+++ b/src/commands/sourcemaps/inject.rs
@@ -21,7 +21,7 @@ pub fn make_command(command: Command) -> Command {
                 .value_name("PATHS")
                 .num_args(1..)
                 .action(ArgAction::Append)
-                .help("Paths to the javascript files to inject."),
+                .help("A path to recursively search for javascript files that should be processed."),
         )
         .arg(
             Arg::new("dry_run")

--- a/tests/integration/_cases/sourcemaps/sourcemaps-inject-help.trycmd
+++ b/tests/integration/_cases/sourcemaps/sourcemaps-inject-help.trycmd
@@ -10,7 +10,7 @@ Usage: sentry-cli[EXE] sourcemaps inject [OPTIONS] [PATHS]...
 
 Arguments:
   [PATHS]...
-          Paths to the javascript files to inject.
+          A path to recursively search for javascript files that should be processed.
 
 Options:
       --dry-run

--- a/tests/integration/_cases/sourcemaps/sourcemaps-inject-help.trycmd
+++ b/tests/integration/_cases/sourcemaps/sourcemaps-inject-help.trycmd
@@ -6,11 +6,11 @@ Fixes up JavaScript source files and sourcemaps with debug ids.
 For every JS source file that references a sourcemap, a debug id is generated and inserted into both
 files. If the referenced sourcemap already contains a debug id, that id is used instead.
 
-Usage: sentry-cli[EXE] sourcemaps inject [OPTIONS] <PATH>
+Usage: sentry-cli[EXE] sourcemaps inject [OPTIONS] [PATHS]...
 
 Arguments:
-  <PATH>
-          The path to the javascript files.
+  [PATHS]...
+          Paths to the javascript files to inject.
 
 Options:
       --dry-run

--- a/tests/integration/_cases/sourcemaps/sourcemaps-inject-nomappings.trycmd
+++ b/tests/integration/_cases/sourcemaps/sourcemaps-inject-nomappings.trycmd
@@ -1,7 +1,8 @@
 ```
-$ sentry-cli sourcemaps inject .
+$ sentry-cli sourcemaps inject ./server ./static
 ? success
-> Found 19 release files
+> Found 11 release files
+> Found 8 release files
 > Analyzing 19 sources
 > Injecting debug ids
 Modified: The following source files have been modified to have debug ids

--- a/tests/integration/_cases/sourcemaps/sourcemaps-inject.trycmd
+++ b/tests/integration/_cases/sourcemaps/sourcemaps-inject.trycmd
@@ -1,7 +1,8 @@
 ```
-$ sentry-cli sourcemaps inject .
+$ sentry-cli sourcemaps inject ./server ./static
 ? success
-> Found 19 release files
+> Found 11 release files
+> Found 8 release files
 > Analyzing 19 sources
 > Injecting debug ids
 Modified: The following source files have been modified to have debug ids


### PR DESCRIPTION
The second commit slightly changes the `inject` tests to use multiple paths.

This is required for https://github.com/getsentry/sentry-react-native/issues/2892