### PR TITLE
fix(inject): Clear buffer before writing sourcemap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 "You know what they say. Fool me once, strike one, but fool me twice... strike three." — Michael Scott
 
+## Unreleased
+
+### Various fixes and improvements
+ - fix: Properly overwrite the sourcemap when injecting (#1525)
+
 ## 2.15.0
 
 ### Various fixes & improvements


### PR DESCRIPTION
Writing to a vector of bytes does not overwrite it, it appends. Thus, when injecting a debug id into a sourcemap file, we must clear the buffer before writing the modified contents.

Fixes #1524.