### PR TITLE
wip: feat(view-hierarchy): Allow dartsymbols.json file upload

### DIFF
--- a/src/api.rs
+++ b/src/api.rs
@@ -2601,6 +2601,9 @@ pub enum ChunkUploadCapability {
     /// Upload of il2cpp line mappings
     Il2Cpp,
 
+    /// Upload of dartsymbols obfuscation mappings
+    DartSymbols,
+
     /// Any other unsupported capability (ignored)
     Unknown,
 }
@@ -2619,6 +2622,7 @@ impl<'de> Deserialize<'de> for ChunkUploadCapability {
             "sources" => ChunkUploadCapability::Sources,
             "bcsymbolmaps" => ChunkUploadCapability::BcSymbolmap,
             "il2cpp" => ChunkUploadCapability::Il2Cpp,
+            "dartsymbols" => ChunkUploadCapability::DartSymbols,
             _ => ChunkUploadCapability::Unknown,
         })
     }

--- a/src/commands/debug_files/upload.rs
+++ b/src/commands/debug_files/upload.rs
@@ -196,6 +196,12 @@ pub fn make_command(command: Command) -> Command {
                 .action(ArgAction::SetTrue)
                 .help("Compute il2cpp line mappings and upload them along with sources."),
         )
+        .arg(
+            Arg::new("dartsymbols_mapping")
+                .long("dartsymbols-mapping")
+                .action(ArgAction::SetTrue)
+                .help("Upload Dart symbols mapping files for deobfuscation."),
+        )
 }
 
 pub fn execute(matches: &ArgMatches) -> Result<()> {
@@ -257,6 +263,7 @@ pub fn execute(matches: &ArgMatches) -> Result<()> {
 
     upload.include_sources(matches.get_flag("include_sources"));
     upload.il2cpp_mapping(matches.get_flag("il2cpp_mapping"));
+    upload.dartsymbols_mapping(matches.get_flag("dartsymbols_mapping"));
 
     // Configure BCSymbolMap resolution, if possible
     if let Some(symbol_map) = matches.get_one::<String>("symbol_maps") {

--- a/tests/integration/_cases/debug_files/debug_files-upload-help.trycmd
+++ b/tests/integration/_cases/debug_files/debug_files-upload-help.trycmd
@@ -67,6 +67,7 @@ Options:
                                  only be displayed if --wait is specified, but this will
                                  significantly slow down the upload process.
       --il2cpp-mapping           Compute il2cpp line mappings and upload them along with sources.
+      --dartsymbols-mapping      Upload Dart symbols mapping files for deobfuscation.
   -h, --help                     Print help
 
 ```

--- a/tests/integration/_cases/upload_dif/upload_dif-help.trycmd
+++ b/tests/integration/_cases/upload_dif/upload_dif-help.trycmd
@@ -67,6 +67,7 @@ Options:
                                  only be displayed if --wait is specified, but this will
                                  significantly slow down the upload process.
       --il2cpp-mapping           Compute il2cpp line mappings and upload them along with sources.
+      --dartsymbols-mapping      Upload Dart symbols mapping files for deobfuscation.
   -h, --help                     Print help
 
 ```


### PR DESCRIPTION
There's a debug file generated by the Flutter obfuscation process that we want to make use of. We'd like to update `sentry-cli` to detect this file and submit it as a debug file. The corresponding sentry PR is here: https://github.com/getsentry/sentry/pull/45837

I was trying to follow the changes previously added for `il2cpp` in https://github.com/getsentry/sentry-cli/pull/1248/ but my changes diverged as I stepped through some of the code. In its current state, there are issues calculating a uuid when it detects a dartsymbols.json file. I'm not exactly sure how to resolve this so I'm seeking some guidance here.