### PR TITLE
fix(inject): Gate injection on upload behind env var

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 "You know what they say. Fool me once, strike one, but fool me twice... strike three." — Michael Scott
 
+## Unreleased
+
+### Various fixes and improvements
+ - fix: Make sourcemap injection on upload opt-in (#1534)
+
 ## 2.15.1
 
 ### Various fixes and improvements

--- a/src/commands/sourcemaps/upload.rs
+++ b/src/commands/sourcemaps/upload.rs
@@ -1,3 +1,4 @@
+use std::env;
 use std::path::PathBuf;
 
 use anyhow::Result;

--- a/src/commands/sourcemaps/upload.rs
+++ b/src/commands/sourcemaps/upload.rs
@@ -352,7 +352,9 @@ fn process_sources_from_paths(
         }
     }
 
-    if !matches.get_flag("no_inject") {
+    if env::var("SENTRY_FORCE_ARTIFACT_BUNDLES").ok().as_deref() == Some("1")
+        && !matches.get_flag("no_inject")
+    {
         processor.inject_debug_ids(false)?;
     }
 

--- a/tests/integration/_cases/releases/releases-files-upload-sourcemaps.trycmd
+++ b/tests/integration/_cases/releases/releases-files-upload-sourcemaps.trycmd
@@ -1,7 +1,6 @@
 ```
 $ sentry-cli releases files wat-release upload-sourcemaps --url-prefix '~/assets' build/assets --rewrite
 ? success
-> Injecting debug ids
 > Rewriting sources
 > Adding source map references
 > Bundled 0 files for upload

--- a/tests/integration/_cases/sourcemaps/sourcemaps-upload-modern.trycmd
+++ b/tests/integration/_cases/sourcemaps/sourcemaps-upload-modern.trycmd
@@ -4,7 +4,6 @@ $ sentry-cli sourcemaps upload tests/integration/_fixtures/bundle.min.js.map tes
 > Found 1 release file
 > Found 1 release file
 > Analyzing 2 sources
-> Injecting debug ids
 > Rewriting sources
 > Adding source map references
 > Bundled 2 files for upload

--- a/tests/integration/_cases/sourcemaps/sourcemaps-upload-no-dedupe.trycmd
+++ b/tests/integration/_cases/sourcemaps/sourcemaps-upload-no-dedupe.trycmd
@@ -4,7 +4,6 @@ $ sentry-cli sourcemaps upload tests/integration/_fixtures/bundle.min.js.map tes
 > Found 1 release file
 > Found 1 release file
 > Analyzing 2 sources
-> Injecting debug ids
 > Rewriting sources
 > Adding source map references
 > Bundled 2 files for upload

--- a/tests/integration/_cases/sourcemaps/sourcemaps-upload-skip-already-uploaded.trycmd
+++ b/tests/integration/_cases/sourcemaps/sourcemaps-upload-skip-already-uploaded.trycmd
@@ -4,7 +4,6 @@ $ sentry-cli sourcemaps upload tests/integration/_fixtures/bundle.min.js.map tes
 > Found 1 release file
 > Found 1 release file
 > Analyzing 2 sources
-> Injecting debug ids
 > Rewriting sources
 > Adding source map references
 > Bundled 1 file for upload

--- a/tests/integration/_cases/sourcemaps/sourcemaps-upload-successfully-upload-file.trycmd
+++ b/tests/integration/_cases/sourcemaps/sourcemaps-upload-successfully-upload-file.trycmd
@@ -3,7 +3,6 @@ $ sentry-cli sourcemaps upload tests/integration/_fixtures/bundle.min.js.map --r
 ? success
 > Found 1 release file
 > Analyzing 1 sources
-> Injecting debug ids
 > Rewriting sources
 > Adding source map references
 > Bundled 1 file for upload


### PR DESCRIPTION
This disables injection on `sourcemaps upload` unless the env var `SENTRY_FORCE_ARTIFACT_BUNDLES` is set to `1`. Without this, debug ids don't do anything anyway.