### PR TITLE
feat(auth): Support DSN auth for the API client

### DIFF
--- a/src/api.rs
+++ b/src/api.rs
@@ -1812,6 +1812,10 @@ impl ApiRequest {
                 debug!("using token authentication");
                 self.with_header("Authorization", &format!("Bearer {token}"))
             }
+            Auth::Dsn(ref public_key) => {
+                debug!("using dsn authentication");
+                self.with_header("Authorization", &format!("DSN {public_key}"))
+            }
         }
     }
 

--- a/src/commands/info.rs
+++ b/src/commands/info.rs
@@ -60,6 +60,7 @@ fn describe_auth(auth: Option<&Auth>) -> &str {
         None => "Unauthorized",
         Some(&Auth::Token(_)) => "Auth Token",
         Some(&Auth::Key(_)) => "API Key",
+        Some(&Auth::Dsn(_)) => "DSN",
     }
 }
 
@@ -75,6 +76,7 @@ fn get_config_status_json() -> Result<()> {
     rv.auth.auth_type = config.get_auth().map(|val| match val {
         Auth::Token(_) => "token".into(),
         Auth::Key(_) => "api_key".into(),
+        Auth::Dsn(_) => "dsn".into(),
     });
     rv.auth.successful = config.get_auth().is_some() && Api::current().get_auth_info().is_ok();
     rv.have_dsn = config.get_dsn().is_ok();

--- a/src/config.rs
+++ b/src/config.rs
@@ -24,6 +24,7 @@ use crate::utils::http::is_absolute_url;
 pub enum Auth {
     Key(String),
     Token(String),
+    Dsn(String),
 }
 
 lazy_static! {
@@ -152,6 +153,9 @@ impl Config {
             Some(Auth::Key(ref val)) => {
                 self.ini
                     .set_to(Some("auth"), "api_key".into(), val.to_string());
+            }
+            Some(Auth::Dsn(ref val)) => {
+                self.ini.set_to(Some("auth"), "dsn".into(), val.to_string());
             }
             None => {}
         }
@@ -584,10 +588,14 @@ fn get_default_auth(ini: &Ini) -> Option<Auth> {
         Some(Auth::Token(val))
     } else if let Ok(val) = env::var("SENTRY_API_KEY") {
         Some(Auth::Key(val))
+    } else if let Ok(val) = env::var("SENTRY_DSN") {
+        Some(Auth::Dsn(val))
     } else if let Some(val) = ini.get_from(Some("auth"), "token") {
         Some(Auth::Token(val.to_owned()))
     } else if let Some(val) = ini.get_from(Some("auth"), "api_key") {
         Some(Auth::Key(val.to_owned()))
+    } else if let Some(val) = ini.get_from(Some("auth"), "dsn") {
+        Some(Auth::Dsn(val.to_owned()))
     } else {
         None
     }


### PR DESCRIPTION
This is in support of https://github.com/getsentry/sentry-cli/issues/1537

Explicitly does not add this as a global cli parameter