### PR TITLE
ref(crons): Prefer DSN based auth

### DIFF
--- a/src/api.rs
+++ b/src/api.rs
@@ -2463,7 +2463,7 @@ pub enum MonitorCheckinStatus {
 #[derive(Debug, Deserialize)]
 pub struct MonitorCheckIn {
     pub id: Uuid,
-    pub status: MonitorCheckinStatus,
+    pub status: Option<MonitorCheckinStatus>,
     pub duration: Option<u64>,
 }
 

--- a/src/commands/monitors/run.rs
+++ b/src/commands/monitors/run.rs
@@ -1,3 +1,4 @@
+use log::warn;
 use std::process;
 use std::time::Instant;
 
@@ -6,6 +7,7 @@ use clap::{Arg, ArgAction, ArgMatches, Command};
 use console::style;
 
 use crate::api::{Api, CreateMonitorCheckIn, MonitorCheckinStatus, UpdateMonitorCheckIn};
+use crate::config::{Auth, Config};
 use crate::utils::system::{print_error, QuietExit};
 
 pub fn make_command(command: Command) -> Command {
@@ -35,6 +37,13 @@ pub fn make_command(command: Command) -> Command {
 
 pub fn execute(matches: &ArgMatches) -> Result<()> {
     let api = Api::current();
+    let config = Config::current();
+
+    // Token based auth is deprecated, prefer DSN style auth for monitor checkins. Using token
+    // based auth DOES NOT WORK when using slugs!!
+    if !matches!(config.get_auth(), Some(Auth::Dsn(_))) {
+        warn!("Token auth is dprecated for cron monitor checkins. Please use DSN auth.");
+    }
 
     let monitor_slug = matches.get_one::<String>("monitor_slug").unwrap();
 

--- a/tests/integration/_cases/monitors/monitors-run-token-auth-win.trycmd
+++ b/tests/integration/_cases/monitors/monitors-run-token-auth-win.trycmd
@@ -1,0 +1,8 @@
+```
+$ unset SENTRY_AUTH_TOKEN
+$ SENTRY_DSN=abcd sentry-cli monitors run foo-monitor -- cmd.exe /C echo 123
+? success
+  WARN    [..] Token auth is dprecated for cron monitor checkins. Please use DSN auth.
+123
+
+```

--- a/tests/integration/_cases/monitors/monitors-run-token-auth.trycmd
+++ b/tests/integration/_cases/monitors/monitors-run-token-auth.trycmd
@@ -1,0 +1,8 @@
+```
+$ unset SENTRY_AUTH_TOKEN
+$ SENTRY_DSN=abcd sentry-cli monitors run foo-monitor -- echo 123
+? success
+  WARN    [..] Token auth is dprecated for cron monitor checkins. Please use DSN auth.
+123
+
+```

--- a/tests/integration/monitors/run.rs
+++ b/tests/integration/monitors/run.rs
@@ -1,25 +1,55 @@
-use crate::integration::{mock_endpoint, register_test, EndpointOptions};
+use crate::integration::{
+    mock_endpoint, register_test, register_test_with_opts, AuthMode, EndpointOptions,
+    RegisterOptions,
+};
 
 #[test]
 fn command_monitors_run() {
+    // TODO: How do I turn off token auth and force DSN auth in the tests?
+
+    let _server = mock_endpoint(
+        EndpointOptions::new("POST", "/api/0/monitors/foo-monitor/checkins/", 200)
+            .with_response_file("monitors/post-monitors.json"),
+    );
+
+    let opts = RegisterOptions {
+        auth_mode: AuthMode::Dsn,
+    };
+
+    if cfg!(windows) {
+        register_test_with_opts("monitors/monitors-run-win.trycmd", opts);
+    } else {
+        register_test_with_opts("monitors/monitors-run.trycmd", opts);
+    }
+}
+
+#[test]
+fn command_monitors_run_token_auth() {
     let _server = mock_endpoint(
         EndpointOptions::new("POST", "/api/0/monitors/foo-monitor/checkins/", 200)
             .with_response_file("monitors/post-monitors.json"),
     );
     if cfg!(windows) {
-        register_test("monitors/monitors-run-win.trycmd");
+        register_test("monitors/monitors-run-token-auth-win.trycmd");
     } else {
-        register_test("monitors/monitors-run.trycmd");
+        register_test("monitors/monitors-run-token-auth.trycmd");
     }
 }
 
 #[test]
 fn command_monitors_run_env() {
+    // TODO: How do I turn off token auth and force DSN auth in the tests?
+
     let _server = mock_endpoint(
         EndpointOptions::new("POST", "/api/0/monitors/foo-monitor/checkins/", 200)
             .with_response_file("monitors/post-monitors.json"),
     );
-    register_test("monitors/monitors-run-env.trycmd");
+    register_test_with_opts(
+        "monitors/monitors-run-env.trycmd",
+        RegisterOptions {
+            auth_mode: AuthMode::Dsn,
+        },
+    );
 }
 
 #[test]


### PR DESCRIPTION
Updates the cron monitors run command to prefer using DSN auth, including spitting out a warning when DSN Auth is not used.

Requires https://github.com/getsentry/sentry-cli/pull/1543