### PR TITLE
test: Allow auth method to be specified in tests

### DIFF
--- a/tests/integration/_cases/info/info-json-no-defaults.trycmd
+++ b/tests/integration/_cases/info/info-json-no-defaults.trycmd
@@ -11,7 +11,7 @@ $ sentry-cli info --config-status-json
     "type": "token",
     "successful": true
   },
-  "have_dsn": true
+  "have_dsn": false
 }
 
 ```

--- a/tests/integration/_cases/info/info-json.trycmd
+++ b/tests/integration/_cases/info/info-json.trycmd
@@ -11,7 +11,7 @@ $ sentry-cli info --config-status-json
     "type": "token",
     "successful": true
   },
-  "have_dsn": true
+  "have_dsn": false
 }
 
 ```

--- a/tests/integration/send_envelope.rs
+++ b/tests/integration/send_envelope.rs
@@ -1,21 +1,41 @@
-use crate::integration::register_test;
+use crate::integration::{register_test_with_opts, AuthMode, RegisterOptions};
 
 #[test]
 fn command_send_envelope_help() {
-    register_test("send_envelope/send_envelope-help.trycmd");
+    register_test_with_opts(
+        "send_envelope/send_envelope-help.trycmd",
+        RegisterOptions {
+            auth_mode: AuthMode::Dsn,
+        },
+    );
 }
 
 #[test]
 fn command_send_envelope_no_file() {
-    register_test("send_envelope/send_envelope-no-file.trycmd");
+    register_test_with_opts(
+        "send_envelope/send_envelope-no-file.trycmd",
+        RegisterOptions {
+            auth_mode: AuthMode::Dsn,
+        },
+    );
 }
 
 #[test]
 fn command_send_envelope_file() {
-    register_test("send_envelope/send_envelope-file.trycmd");
+    register_test_with_opts(
+        "send_envelope/send_envelope-file.trycmd",
+        RegisterOptions {
+            auth_mode: AuthMode::Dsn,
+        },
+    );
 }
 
 #[test]
 fn command_send_envelope_with_logging() {
-    register_test("send_envelope/send_envelope-file-log.trycmd");
+    register_test_with_opts(
+        "send_envelope/send_envelope-file-log.trycmd",
+        RegisterOptions {
+            auth_mode: AuthMode::Dsn,
+        },
+    );
 }

--- a/tests/integration/send_event.rs
+++ b/tests/integration/send_event.rs
@@ -1,8 +1,13 @@
-use crate::integration::register_test;
+use crate::integration::{register_test_with_opts, AuthMode, RegisterOptions};
 
 #[test]
 fn command_send_event_help() {
-    register_test("send_event/send_event-help.trycmd");
+    register_test_with_opts(
+        "send_event/send_event-help.trycmd",
+        RegisterOptions {
+            auth_mode: AuthMode::Dsn,
+        },
+    );
 }
 
 // I have no idea why this is timing out on Windows.
@@ -11,15 +16,30 @@ fn command_send_event_help() {
 #[cfg(not(windows))]
 #[test]
 fn command_send_event_raw() {
-    register_test("send_event/send_event-raw.trycmd");
+    register_test_with_opts(
+        "send_event/send_event-raw.trycmd",
+        RegisterOptions {
+            auth_mode: AuthMode::Dsn,
+        },
+    );
 }
 
 #[test]
 fn command_send_event_file() {
-    register_test("send_event/send_event-file.trycmd");
+    register_test_with_opts(
+        "send_event/send_event-file.trycmd",
+        RegisterOptions {
+            auth_mode: AuthMode::Dsn,
+        },
+    );
 }
 
 #[test]
 fn command_send_event_raw_fail() {
-    register_test("send_event/send_event-raw-fail.trycmd");
+    register_test_with_opts(
+        "send_event/send_event-raw-fail.trycmd",
+        RegisterOptions {
+            auth_mode: AuthMode::Dsn,
+        },
+    );
 }


### PR DESCRIPTION
Prior to this there was now way to specify that you wanted to use DSN auth or token auth. This makes things more clear.