### PR TITLE
ref(inject): Improve injection report output

### DIFF
--- a/src/utils/file_search.rs
+++ b/src/utils/file_search.rs
@@ -110,7 +110,7 @@ impl ReleaseFileSearch {
 
     pub fn collect_files(&self) -> Result<Vec<ReleaseFileMatch>> {
         let progress_style = ProgressStyle::default_spinner().template(
-            "{spinner} Searching for release files...\
+            "{spinner} Searching for files...\
         \n  found {prefix:.yellow} {msg:.dim}",
         );
 
@@ -186,7 +186,7 @@ impl ReleaseFileSearch {
 
         pb.finish_and_clear();
         println!(
-            "{} Found {} release {}",
+            "{} Found {} {}",
             style(">").dim(),
             style(collected.len()).yellow(),
             match collected.len() {

--- a/src/utils/file_upload.rs
+++ b/src/utils/file_upload.rs
@@ -294,13 +294,13 @@ fn upload_files_chunked(
     pb.finish_with_duration("Optimizing");
 
     let progress_style = ProgressStyle::default_bar().template(&format!(
-        "{} Uploading release files...\
+        "{} Uploading files...\
        \n{{wide_bar}}  {{bytes}}/{{total_bytes}} ({{eta}})",
         style(">").dim(),
     ));
 
     upload_chunks(&chunks, options, progress_style)?;
-    println!("{} Uploaded release files to Sentry", style(">").dim());
+    println!("{} Uploaded files to Sentry", style(">").dim());
 
     let progress_style = ProgressStyle::default_spinner().template("{spinner} Processing files...");
 

--- a/src/utils/sourcemaps.rs
+++ b/src/utils/sourcemaps.rs
@@ -781,6 +781,8 @@ impl SourceMapProcessor {
 
         if !report.is_empty() {
             println!("{report}");
+        } else {
+            println!("> Nothing to inject")
         }
 
         Ok(())

--- a/tests/integration/_cases/sourcemaps/sourcemaps-inject-nofiles.trycmd
+++ b/tests/integration/_cases/sourcemaps/sourcemaps-inject-nofiles.trycmd
@@ -1,7 +1,7 @@
 ```
 $ sentry-cli sourcemaps inject ./nonexisting
 ? success
-> Found 0 release files
+> Found 0 files
 > Injecting debug ids
 > Nothing to inject
 

--- a/tests/integration/_cases/sourcemaps/sourcemaps-inject-nofiles.trycmd
+++ b/tests/integration/_cases/sourcemaps/sourcemaps-inject-nofiles.trycmd
@@ -1,0 +1,8 @@
+```
+$ sentry-cli sourcemaps inject ./nonexisting
+? success
+> Found 0 release files
+> Injecting debug ids
+> Nothing to inject
+
+```

--- a/tests/integration/_cases/sourcemaps/sourcemaps-inject-nomappings.trycmd
+++ b/tests/integration/_cases/sourcemaps/sourcemaps-inject-nomappings.trycmd
@@ -1,8 +1,8 @@
 ```
 $ sentry-cli sourcemaps inject ./server ./static
 ? success
-> Found 11 release files
-> Found 8 release files
+> Found 11 files
+> Found 8 files
 > Analyzing 19 sources
 > Injecting debug ids
 

--- a/tests/integration/_cases/sourcemaps/sourcemaps-inject-nomappings.trycmd
+++ b/tests/integration/_cases/sourcemaps/sourcemaps-inject-nomappings.trycmd
@@ -5,30 +5,28 @@ $ sentry-cli sourcemaps inject ./server ./static
 > Found 8 release files
 > Analyzing 19 sources
 > Injecting debug ids
-Modified: The following source files have been modified to have debug ids
-  - [..]-[..]-[..]-[..]-[..] - ./server/chunks/1.min.js
-  - [..]-[..]-[..]-[..]-[..] - ./server/pages/_document.min.js
-  - [..]-[..]-[..]-[..]-[..] - ./static/chunks/575-bb7d7e0e6de8d623.min.js
-  - [..]-[..]-[..]-[..]-[..] - ./static/chunks/pages/asdf-05b39167abbe433b.min.js
 
-Modified: The following sourcemap files have been modified to have debug ids
-  - [..]-[..]-[..]-[..]-[..] - ./server/pages/_document.js.map
-  - [..]-[..]-[..]-[..]-[..] - ./static/chunks/575-bb7d7e0e6de8d623.js.map
-
-Ignored: The following source files already have debug ids
-  - [..]-[..]-[..]-[..]-[..] - ./server/edge-runtime-webpack.min.js
-  - [..]-[..]-[..]-[..]-[..] - ./static/chunks/app/client/page-d5742c254d9533f8.min.js
-
-Ignored: The following sourcemap files already have debug ids
-  - [..]-[..]-[..]-[..]-[..] - ./server/chunks/1.js.map
-  - [..]-[..]-[..]-[..]-[..] - ./static/chunks/pages/asdf-05b39167abbe433b.js.map
-
-Ignored: The following source files don't have sourcemap references 
-  - ./server/app/page.min.js
-  - ./server/flight-manifest.js
-  - ./server/pages/api/hello.min.js
-  - ./static/chunks/app/client/layout-ba9c3036fc0dba78.js
-  - ./static/chunks/app/head-172ad45600676c06.js
+Source Map Debug ID Injection Report
+  Modified: The following source files have been modified to have debug ids
+    [..]-[..]-[..]-[..]-[..] - ./server/chunks/1.min.js
+    [..]-[..]-[..]-[..]-[..] - ./server/pages/_document.min.js
+    [..]-[..]-[..]-[..]-[..] - ./static/chunks/575-bb7d7e0e6de8d623.min.js
+    [..]-[..]-[..]-[..]-[..] - ./static/chunks/pages/asdf-05b39167abbe433b.min.js
+  Modified: The following sourcemap files have been modified to have debug ids
+    [..]-[..]-[..]-[..]-[..] - ./server/pages/_document.js.map
+    [..]-[..]-[..]-[..]-[..] - ./static/chunks/575-bb7d7e0e6de8d623.js.map
+  Ignored: The following source files already have debug ids
+    [..]-[..]-[..]-[..]-[..] - ./server/edge-runtime-webpack.min.js
+    [..]-[..]-[..]-[..]-[..] - ./static/chunks/app/client/page-d5742c254d9533f8.min.js
+  Ignored: The following sourcemap files already have debug ids
+    [..]-[..]-[..]-[..]-[..] - ./server/chunks/1.js.map
+    [..]-[..]-[..]-[..]-[..] - ./static/chunks/pages/asdf-05b39167abbe433b.js.map
+  Ignored: The following source files don't have sourcemap references 
+    ./server/app/page.min.js
+    ./server/flight-manifest.js
+    ./server/pages/api/hello.min.js
+    ./static/chunks/app/client/layout-ba9c3036fc0dba78.js
+    ./static/chunks/app/head-172ad45600676c06.js
 
 
 ```

--- a/tests/integration/_cases/sourcemaps/sourcemaps-inject.trycmd
+++ b/tests/integration/_cases/sourcemaps/sourcemaps-inject.trycmd
@@ -1,8 +1,8 @@
 ```
 $ sentry-cli sourcemaps inject ./server ./static
 ? success
-> Found 11 release files
-> Found 8 release files
+> Found 11 files
+> Found 8 files
 > Analyzing 19 sources
 > Injecting debug ids
 

--- a/tests/integration/_cases/sourcemaps/sourcemaps-inject.trycmd
+++ b/tests/integration/_cases/sourcemaps/sourcemaps-inject.trycmd
@@ -5,32 +5,29 @@ $ sentry-cli sourcemaps inject ./server ./static
 > Found 8 release files
 > Analyzing 19 sources
 > Injecting debug ids
-Modified: The following source files have been modified to have debug ids
-  - [..]-[..]-[..]-[..]-[..] - ./server/chunks/1.js
-  - [..]-[..]-[..]-[..]-[..] - ./server/pages/_document.js
-  - [..]-[..]-[..]-[..]-[..] - ./static/chunks/575-bb7d7e0e6de8d623.js
-  - [..]-[..]-[..]-[..]-[..] - ./static/chunks/pages/asdf-05b39167abbe433b.js
 
-Modified: The following sourcemap files have been modified to have debug ids
-  - [..]-[..]-[..]-[..]-[..] - ./server/pages/_document.js.map
-  - [..]-[..]-[..]-[..]-[..] - ./static/chunks/575-bb7d7e0e6de8d623.js.map
-
-Ignored: The following source files already have debug ids
-  - [..]-[..]-[..]-[..]-[..] - ./server/edge-runtime-webpack.js
-  - [..]-[..]-[..]-[..]-[..] - ./static/chunks/app/client/page-d5742c254d9533f8.js
-
-Ignored: The following sourcemap files already have debug ids
-  - [..]-[..]-[..]-[..]-[..] - ./server/chunks/1.js.map
-  - [..]-[..]-[..]-[..]-[..] - ./static/chunks/pages/asdf-05b39167abbe433b.js.map
-
-Ignored: The following source files don't have sourcemap references 
-  - ./server/flight-manifest.js
-  - ./static/chunks/app/client/layout-ba9c3036fc0dba78.js
-  - ./static/chunks/app/head-172ad45600676c06.js
-
-Ignored: The following source files refer to sourcemaps that couldn't be found
-  - ./server/app/page.js
-  - ./server/pages/api/hello.js
+Source Map Debug ID Injection Report
+  Modified: The following source files have been modified to have debug ids
+    [..]-[..]-[..]-[..]-[..] - ./server/chunks/1.js
+    [..]-[..]-[..]-[..]-[..] - ./server/pages/_document.js
+    [..]-[..]-[..]-[..]-[..] - ./static/chunks/575-bb7d7e0e6de8d623.js
+    [..]-[..]-[..]-[..]-[..] - ./static/chunks/pages/asdf-05b39167abbe433b.js
+  Modified: The following sourcemap files have been modified to have debug ids
+    [..]-[..]-[..]-[..]-[..] - ./server/pages/_document.js.map
+    [..]-[..]-[..]-[..]-[..] - ./static/chunks/575-bb7d7e0e6de8d623.js.map
+  Ignored: The following source files already have debug ids
+    [..]-[..]-[..]-[..]-[..] - ./server/edge-runtime-webpack.js
+    [..]-[..]-[..]-[..]-[..] - ./static/chunks/app/client/page-d5742c254d9533f8.js
+  Ignored: The following sourcemap files already have debug ids
+    [..]-[..]-[..]-[..]-[..] - ./server/chunks/1.js.map
+    [..]-[..]-[..]-[..]-[..] - ./static/chunks/pages/asdf-05b39167abbe433b.js.map
+  Ignored: The following source files don't have sourcemap references 
+    ./server/flight-manifest.js
+    ./static/chunks/app/client/layout-ba9c3036fc0dba78.js
+    ./static/chunks/app/head-172ad45600676c06.js
+  Ignored: The following source files refer to sourcemaps that couldn't be found
+    ./server/app/page.js
+    ./server/pages/api/hello.js
 
 
 ```

--- a/tests/integration/_cases/sourcemaps/sourcemaps-upload-modern.trycmd
+++ b/tests/integration/_cases/sourcemaps/sourcemaps-upload-modern.trycmd
@@ -1,13 +1,13 @@
 ```
 $ sentry-cli sourcemaps upload tests/integration/_fixtures/bundle.min.js.map tests/integration/_fixtures/vendor.min.js.map
 ? success
-> Found 1 release file
-> Found 1 release file
+> Found 1 file
+> Found 1 file
 > Analyzing 2 sources
 > Rewriting sources
 > Adding source map references
 > Bundled 2 files for upload
-> Uploaded release files to Sentry
+> Uploaded files to Sentry
 > File upload complete (processing pending on server)
 > Organization: wat-org
 > Project: wat-project

--- a/tests/integration/_cases/sourcemaps/sourcemaps-upload-no-dedupe.trycmd
+++ b/tests/integration/_cases/sourcemaps/sourcemaps-upload-no-dedupe.trycmd
@@ -1,13 +1,13 @@
 ```
 $ sentry-cli sourcemaps upload tests/integration/_fixtures/bundle.min.js.map tests/integration/_fixtures/vendor.min.js.map --release=wat-release --no-dedupe
 ? success
-> Found 1 release file
-> Found 1 release file
+> Found 1 file
+> Found 1 file
 > Analyzing 2 sources
 > Rewriting sources
 > Adding source map references
 > Bundled 2 files for upload
-> Uploaded release files to Sentry
+> Uploaded files to Sentry
 > File upload complete (processing pending on server)
 > Organization: wat-org
 > Project: wat-project

--- a/tests/integration/_cases/sourcemaps/sourcemaps-upload-skip-already-uploaded.trycmd
+++ b/tests/integration/_cases/sourcemaps/sourcemaps-upload-skip-already-uploaded.trycmd
@@ -1,13 +1,13 @@
 ```
 $ sentry-cli sourcemaps upload tests/integration/_fixtures/bundle.min.js.map tests/integration/_fixtures/vendor.min.js.map --release=wat-release
 ? success
-> Found 1 release file
-> Found 1 release file
+> Found 1 file
+> Found 1 file
 > Analyzing 2 sources
 > Rewriting sources
 > Adding source map references
 > Bundled 1 file for upload
-> Uploaded release files to Sentry
+> Uploaded files to Sentry
 > File upload complete (processing pending on server)
 > Organization: wat-org
 > Project: wat-project

--- a/tests/integration/_cases/sourcemaps/sourcemaps-upload-successfully-upload-file.trycmd
+++ b/tests/integration/_cases/sourcemaps/sourcemaps-upload-successfully-upload-file.trycmd
@@ -1,12 +1,12 @@
 ```
 $ sentry-cli sourcemaps upload tests/integration/_fixtures/bundle.min.js.map --release=wat-release
 ? success
-> Found 1 release file
+> Found 1 file
 > Analyzing 1 sources
 > Rewriting sources
 > Adding source map references
 > Bundled 1 file for upload
-> Uploaded release files to Sentry
+> Uploaded files to Sentry
 > File upload complete (processing pending on server)
 > Organization: wat-org
 > Project: wat-project

--- a/tests/integration/sourcemaps/inject.rs
+++ b/tests/integration/sourcemaps/inject.rs
@@ -1,4 +1,4 @@
-use std::fs::remove_dir_all;
+use std::fs::{self, remove_dir_all};
 
 use crate::integration::{copy_recursively, register_test};
 
@@ -31,4 +31,15 @@ fn command_sourcemaps_inject_output_nomappings() {
     .unwrap();
 
     register_test("sourcemaps/sourcemaps-inject-nomappings.trycmd");
+}
+
+#[test]
+fn command_sourcemaps_inject_output_nofiles() {
+    let testcase_cwd_path = "tests/integration/_cases/sourcemaps/sourcemaps-inject-nofiles.in/";
+    if std::path::Path::new(testcase_cwd_path).exists() {
+        remove_dir_all(testcase_cwd_path).unwrap();
+    }
+    fs::create_dir_all(std::path::Path::new(testcase_cwd_path).join("nonexisting")).unwrap();
+
+    register_test("sourcemaps/sourcemaps-inject-nofiles.trycmd");
 }


### PR DESCRIPTION
Made the report exactly the same as we have one for Source Map upload. Including formatting, indentations and colors.
Also reports when there was no injections performed.

Reformatted:
```
> Found 19 release files
> Analyzing 19 sources
> Analyzing completed in 0.09s
> Injecting debug ids

Source Map Debug ID Injection Report
  Modified: The following source files have been modified to have debug ids
    2297b93d-928d-421e-8910-127c786382da - tests/integration/_fixtures/inject/server/chunks/1.js
    049a6b25-335d-4d9e-b857-d5c05c079a40 - tests/integration/_fixtures/inject/server/pages/_document.js
    6faf72f2-6ac7-4b71-be01-f744fede7d1a - tests/integration/_fixtures/inject/static/chunks/575-bb7d7e0e6de8d623.js
    2297b93d-928d-421e-8910-127c786382df - tests/integration/_fixtures/inject/static/chunks/pages/asdf-05b39167abbe433b.js
  Modified: The following sourcemap files have been modified to have debug ids
    049a6b25-335d-4d9e-b857-d5c05c079a40 - tests/integration/_fixtures/inject/server/pages/_document.js.map
    6faf72f2-6ac7-4b71-be01-f744fede7d1a - tests/integration/_fixtures/inject/static/chunks/575-bb7d7e0e6de8d623.js.map
  Ignored: The following source files already have debug ids
    2297b93d-928d-421e-8910-127c786382dd - tests/integration/_fixtures/inject/server/edge-runtime-webpack.js
    2297b93d-928d-421e-8910-127c786382df - tests/integration/_fixtures/inject/static/chunks/app/client/page-d5742c254d9533f8.js
  Ignored: The following sourcemap files already have debug ids
    2297b93d-928d-421e-8910-127c786382da - tests/integration/_fixtures/inject/server/chunks/1.js.map
    2297b93d-928d-421e-8910-127c786382df - tests/integration/_fixtures/inject/static/chunks/pages/asdf-05b39167abbe433b.js.map
  Ignored: The following source files don't have sourcemap references
    tests/integration/_fixtures/inject/server/flight-manifest.js
    tests/integration/_fixtures/inject/static/chunks/app/client/layout-ba9c3036fc0dba78.js
    tests/integration/_fixtures/inject/static/chunks/app/head-172ad45600676c06.js
  Ignored: The following source files refer to sourcemaps that couldn't be found
    tests/integration/_fixtures/inject/server/app/page.js
    tests/integration/_fixtures/inject/server/pages/api/hello.js
```

Empty:
```
> Found 0 release files
> Injecting debug ids
> Nothing to inject
```

<img width="907" alt="image" src="https://user-images.githubusercontent.com/1523305/229087920-af10fdee-a194-4c3d-95f7-b9574cb50986.png">

Fixes https://github.com/getsentry/sentry-cli/issues/1553