### PR TITLE
fix: Fix spawn ENOENT for vite integration

### DIFF
--- a/js/helper.js
+++ b/js/helper.js
@@ -15,6 +15,7 @@ function getBinaryPath() {
   const parts = [];
   parts.push(__dirname);
   parts.push('..');
+  parts.push('bin');
   parts.push(`sentry-cli${process.platform === 'win32' ? '.exe' : ''}`);
   return path.resolve(...parts);
 }


### PR DESCRIPTION
Fixes vite plugin integration error.

~~~
alexgrozav@Alexs-MacBook-Pro editor-ui % pnpm run build

> n8n-editor-ui@0.188.0 build /Users/alexgrozav/Workspace/n8n/n8n/packages/editor-ui
> cross-env NODE_OPTIONS="--max-old-space-size=8192" vite build

node:internal/errors:478
    ErrorCaptureStackTrace(err);
    ^

Error: spawn /Users/alexgrozav/Workspace/n8n/n8n/node_modules/.pnpm/@sentry+cli@2.16.1/node_modules/@sentry/cli/sentry-cli ENOENT
    at Process.ChildProcess._handle.onexit (node:internal/child_process:285:19)
    at onErrorNT (node:internal/child_process:485:16)
    at processTicksAndRejections (node:internal/process/task_queues:83:21) {
  errno: -2,
  code: 'ENOENT',
  syscall: 'spawn /Users/alexgrozav/Workspace/n8n/n8n/node_modules/.pnpm/@sentry+cli@2.16.1/node_modules/@sentry/cli/sentry-cli',
  path: '/Users/alexgrozav/Workspace/n8n/n8n/node_modules/.pnpm/@sentry+cli@2.16.1/node_modules/@sentry/cli/sentry-cli',
  spawnargs: [ 'releases', 'propose-version' ],
  cmd: '/Users/alexgrozav/Workspace/n8n/n8n/node_modules/.pnpm/@sentry+cli@2.16.1/node_modules/@sentry/cli/sentry-cli releases propose-version'
}
~~~