### PR TITLE
feat(inject): Add --use-debug-ids flag to force Artifact Bundles usage

### DIFF
--- a/js/helper.js
+++ b/js/helper.js
@@ -170,9 +170,6 @@ async function execute(args, live, silent, configFile, config = {}) {
   if (config.vcsRemote) {
     env.SENTRY_VCS_REMOTE = config.vcsRemote;
   }
-  if (config.forceArtifactBundles) {
-    env.SENTRY_FORCE_ARTIFACT_BUNDLES = config.forceArtifactBundles;
-  }
   if (config.customHeader) {
     env.CUSTOM_HEADER = config.customHeader;
   } else if (config.headers) {

--- a/js/index.d.ts
+++ b/js/index.d.ts
@@ -43,12 +43,6 @@ declare module '@sentry/cli' {
      */
     silent?: boolean;
     /**
-     * Whether to use the debug ID method of uploading source maps.
-     * This value will update `SENTRY_FORCE_ARTIFACT_BUNDLES` env variable.
-     * @experimental
-     */
-    forceArtifactBundles?: string;
-    /**
      * A header added to every outgoing network request.
      * This value will update `CUSTOM_HEADER` env variable.
      */
@@ -129,6 +123,10 @@ declare module '@sentry/cli' {
      * Usually your build number.
      */
     dist?: string;
+    /**
+     * Use new Artifact Bundles upload, that enables use of Debug ID for Source Maps discovery.
+     */
+    useDebugIds?: boolean;
   }
 
   export interface SentryCliNewDeployOptions {

--- a/js/releases/options/uploadSourcemaps.js
+++ b/js/releases/options/uploadSourcemaps.js
@@ -48,4 +48,8 @@ module.exports = {
     param: '--ext',
     type: 'array',
   },
+  useDebugIds: {
+    param: '--use-debug-ids',
+    type: 'boolean',
+  },
 };

--- a/src/api.rs
+++ b/src/api.rs
@@ -1125,15 +1125,7 @@ impl Api {
             .get(&url)?
             .convert_rnf::<ChunkUploadOptions>(ApiErrorKind::ChunkUploadNotSupported)
         {
-            Ok(mut options) => {
-                // TODO: remove this logic after we can trust the server responses
-                if !options.supports(ChunkUploadCapability::ArtifactBundles)
-                    && env::var("SENTRY_FORCE_ARTIFACT_BUNDLES").ok().as_deref() == Some("1")
-                {
-                    options.accept.push(ChunkUploadCapability::ArtifactBundles);
-                }
-                Ok(Some(options))
-            }
+            Ok(options) => Ok(Some(options)),
             Err(error) => {
                 if error.kind() == ApiErrorKind::ChunkUploadNotSupported {
                     Ok(None)

--- a/src/commands/sourcemaps/upload.rs
+++ b/src/commands/sourcemaps/upload.rs
@@ -1,4 +1,3 @@
-use std::env;
 use std::path::PathBuf;
 
 use anyhow::Result;
@@ -6,7 +5,7 @@ use clap::{Arg, ArgAction, ArgMatches, Command};
 use glob::{glob_with, MatchOptions};
 use log::{debug, warn};
 
-use crate::api::Api;
+use crate::api::{Api, ChunkUploadCapability};
 use crate::config::Config;
 use crate::utils::args::validate_distribution;
 use crate::utils::file_search::ReleaseFileSearch;
@@ -180,6 +179,17 @@ pub fn make_command(command: Command) -> Command {
                     Defaults to: `--ext=js --ext=map --ext=jsbundle --ext=bundle`",
                 ),
         )
+        // NOTE: Hidden until we decide to expose it publicly
+        .arg(
+            Arg::new("use_debug_ids")
+                .long("use-debug-ids")
+                .action(ArgAction::SetTrue)
+                .help(
+                    "Use new Artifact Bundles upload, that enables use of Debug ID \
+                    for Source Maps discovery.",
+                )
+                .hide(true),
+        )
         // Legacy flag that has no effect, left hidden for backward compatibility
         .arg(
             Arg::new("rewrite")
@@ -193,17 +203,6 @@ pub fn make_command(command: Command) -> Command {
                 .long("verbose")
                 .action(ArgAction::SetTrue)
                 .short('v')
-                .hide(true),
-        )
-        // NOTE: Hidden until we decide to expose it publicly
-        .arg(
-            Arg::new("no_inject")
-                .long("no-inject")
-                .action(ArgAction::SetTrue)
-                .help(
-                    "Skip injection of debug ids into source files \
-                    and sourcemaps prior to uploading.",
-                )
                 .hide(true),
         )
 }
@@ -353,12 +352,6 @@ fn process_sources_from_paths(
         }
     }
 
-    if env::var("SENTRY_FORCE_ARTIFACT_BUNDLES").ok().as_deref() == Some("1")
-        && !matches.get_flag("no_inject")
-    {
-        processor.inject_debug_ids(false)?;
-    }
-
     if !matches.get_flag("no_rewrite") {
         let prefixes = get_prefixes_from_args(matches);
         processor.rewrite(&prefixes)?;
@@ -381,7 +374,15 @@ pub fn execute(matches: &ArgMatches) -> Result<()> {
     let (org, project) = config.get_org_and_project(matches)?;
     let api = Api::current();
     let mut processor = SourceMapProcessor::new();
-    let chunk_upload_options = api.get_chunk_upload_options(&org)?;
+    let mut chunk_upload_options = api.get_chunk_upload_options(&org)?;
+
+    if matches.get_flag("use_debug_ids") {
+        if let Some(ref mut options) = chunk_upload_options {
+            if !options.supports(ChunkUploadCapability::ArtifactBundles) {
+                options.accept.push(ChunkUploadCapability::ArtifactBundles);
+            }
+        }
+    }
 
     if matches.contains_id("bundle") && matches.contains_id("bundle_sourcemap") {
         process_sources_from_bundle(matches, &mut processor)?;


### PR DESCRIPTION
Name is up for discussion.

- remove `SENTRY_FORCE_ARTIFACT_BUNDLES`
- remove `forceArtifactBundles` from JS API in favor of `useDebugIds`
- restore chunk options endpoint method to the old, non-overriding behavior
- add `--use-debug-ids` flag that overrides the server capability