### PR TITLE
fix: Inject files with embedded sourcemaps

### DIFF
--- a/tests/integration/_cases/sourcemaps/sourcemaps-inject.trycmd
+++ b/tests/integration/_cases/sourcemaps/sourcemaps-inject.trycmd
@@ -1,14 +1,15 @@
 ```
 $ sentry-cli sourcemaps inject ./server ./static
 ? success
-> Found 11 files
+> Found 12 files
 > Found 8 files
-> Analyzing 19 sources
+> Analyzing 20 sources
 > Injecting debug ids
 
 Source Map Debug ID Injection Report
   Modified: The following source files have been modified to have debug ids
     [..]-[..]-[..]-[..]-[..] - ./server/chunks/1.js
+    [..]-[..]-[..]-[..]-[..] - ./server/dummy_embedded.js
     [..]-[..]-[..]-[..]-[..] - ./server/pages/_document.js
     [..]-[..]-[..]-[..]-[..] - ./static/chunks/575-bb7d7e0e6de8d623.js
     [..]-[..]-[..]-[..]-[..] - ./static/chunks/pages/asdf-05b39167abbe433b.js

--- a/tests/integration/_fixtures/inject/server/dummy_embedded.js
+++ b/tests/integration/_fixtures/inject/server/dummy_embedded.js
@@ -1,0 +1,1 @@
+//# sourceMappingURL=data:application/json;base64,pretend this is an embedded sourcemap


### PR DESCRIPTION
This injects debug ids into source files with embedded sourcemaps. The test for this is a dummy file added to the injection fixtures—perhaps not the most elegant solution, but it works.