### PR TITLE
fix(inject): Use File::create to make sure files are truncated

### DIFF
--- a/src/utils/sourcemaps.rs
+++ b/src/utils/sourcemaps.rs
@@ -748,9 +748,7 @@ impl SourceMapProcessor {
                 .push(("debug-id".to_string(), debug_id.to_string()));
 
             if !dry_run && sourcemap_modified {
-                let mut file = std::fs::File::options()
-                    .write(true)
-                    .open(&sourcemap_file.path)?;
+                let mut file = std::fs::File::create(&sourcemap_file.path)?;
                 file.write_all(&sourcemap_file.contents).context(format!(
                     "Failed to write sourcemap file {}",
                     sourcemap_file.path.display()
@@ -786,9 +784,7 @@ impl SourceMapProcessor {
                 .push(("debug-id".to_string(), debug_id.to_string()));
 
             if !dry_run {
-                let mut file = std::fs::File::options()
-                    .write(true)
-                    .open(&source_file.path)?;
+                let mut file = std::fs::File::create(&source_file.path)?;
                 file.write_all(&source_file.contents).context(format!(
                     "Failed to write source file {}",
                     source_file.path.display()

--- a/src/utils/sourcemaps/inject.rs
+++ b/src/utils/sourcemaps/inject.rs
@@ -291,11 +291,23 @@ something else
 
     #[test]
     fn test_fixup_js_file_fs_roundtrip() {
-        let source = r#"//# sourceMappingURL=fake1
+        let source = r#"//# sourceMappingURL=fake
 
 
 some line
-//# sourceMappingURL=fake2
+//# sourceMappingURL=fake
+//# sourceMappingURL=fake
+//# sourceMappingURL=fake
+//# sourceMappingURL=fake
+//# sourceMappingURL=fake
+//# sourceMappingURL=fake
+//# sourceMappingURL=fake
+//# sourceMappingURL=fake
+//# sourceMappingURL=fake
+//# sourceMappingURL=fake
+//# sourceMappingURL=fake
+//# sourceMappingURL=fake
+//# sourceMappingURL=fake
 //# sourceMappingURL=real
 something else"#;
 
@@ -316,11 +328,23 @@ something else"#;
         }
 
         let result = std::fs::read_to_string(temp_file.path()).unwrap();
-        let expected = r#"//# sourceMappingURL=fake1
+        let expected = r#"//# sourceMappingURL=fake
 
 
 some line
-//# sourceMappingURL=fake2
+//# sourceMappingURL=fake
+//# sourceMappingURL=fake
+//# sourceMappingURL=fake
+//# sourceMappingURL=fake
+//# sourceMappingURL=fake
+//# sourceMappingURL=fake
+//# sourceMappingURL=fake
+//# sourceMappingURL=fake
+//# sourceMappingURL=fake
+//# sourceMappingURL=fake
+//# sourceMappingURL=fake
+//# sourceMappingURL=fake
+//# sourceMappingURL=fake
 something else
 !function(){try{var e="undefined"!=typeof window?window:"undefined"!=typeof global?global:"undefined"!=typeof self?self:{},n=(new Error).stack;n&&(e._sentryDebugIds=e._sentryDebugIds||{},e._sentryDebugIds[n]="00000000-0000-0000-0000-000000000000")}catch(e){}}()
 //# debugId=00000000-0000-0000-0000-000000000000


### PR DESCRIPTION
This also fixes the `test_fixup_js_file_fs_roundtrip` test, which was unintentionally lenient. There were too few source mapping comments; even when they were deleted, the file still ended up longer after injection because the injected code snippet is so long.