### PR TITLE
fix(inject): Inject regardless of whether a sourcemap is present

### DIFF
--- a/src/commands/sourcemaps/inject.rs
+++ b/src/commands/sourcemaps/inject.rs
@@ -12,8 +12,11 @@ pub fn make_command(command: Command) -> Command {
         .about("Fixes up JavaScript source files and sourcemaps with debug ids.")
         .long_about(
             "Fixes up JavaScript source files and sourcemaps with debug ids.{n}{n}\
-            For every JS source file that references a sourcemap, a debug id is generated and \
-            inserted into both files. If the referenced sourcemap already contains a debug id, \
+            For every minified JS source file, a debug id is generated and \
+            inserted into the file. If the source file references a \
+            sourcemap and that sourcemap is locally available, \
+            the debug id will be injected into it as well. \
+            If the referenced sourcemap already contains a debug id, \
             that id is used instead.",
         )
         .arg(
@@ -21,7 +24,9 @@ pub fn make_command(command: Command) -> Command {
                 .value_name("PATHS")
                 .num_args(1..)
                 .action(ArgAction::Append)
-                .help("A path to recursively search for javascript files that should be processed."),
+                .help(
+                    "A path to recursively search for javascript files that should be processed.",
+                ),
         )
         .arg(
             Arg::new("dry_run")

--- a/src/utils/sourcemaps/inject.rs
+++ b/src/utils/sourcemaps/inject.rs
@@ -29,18 +29,6 @@ fn print_section_with_debugid(
     Ok(())
 }
 
-fn print_section_with_path(
-    f: &mut fmt::Formatter<'_>,
-    title: &str,
-    data: &[PathBuf],
-) -> fmt::Result {
-    print_section_title(f, title)?;
-    for path in data.iter().sorted() {
-        writeln!(f, "    {}", path.display())?;
-    }
-    Ok(())
-}
-
 fn print_section_title(f: &mut fmt::Formatter<'_>, title: &str) -> fmt::Result {
     writeln!(f, "  {}", style(title).yellow().bold())
 }
@@ -49,8 +37,6 @@ fn print_section_title(f: &mut fmt::Formatter<'_>, title: &str) -> fmt::Result {
 pub struct InjectReport {
     pub injected: Vec<(PathBuf, DebugId)>,
     pub previously_injected: Vec<(PathBuf, DebugId)>,
-    pub skipped: Vec<PathBuf>,
-    pub missing_sourcemaps: Vec<PathBuf>,
     pub sourcemaps: Vec<(PathBuf, DebugId)>,
     pub skipped_sourcemaps: Vec<(PathBuf, DebugId)>,
 }
@@ -59,8 +45,6 @@ impl InjectReport {
     pub fn is_empty(&self) -> bool {
         self.injected.is_empty()
             && self.previously_injected.is_empty()
-            && self.skipped.is_empty()
-            && self.missing_sourcemaps.is_empty()
             && self.sourcemaps.is_empty()
             && self.skipped_sourcemaps.is_empty()
     }
@@ -103,22 +87,6 @@ impl fmt::Display for InjectReport {
                 f,
                 "Ignored: The following sourcemap files already have debug ids",
                 &self.skipped_sourcemaps,
-            )?;
-        }
-
-        if !self.skipped.is_empty() {
-            print_section_with_path(
-                f,
-                "Ignored: The following source files don't have sourcemap references ",
-                &self.skipped,
-            )?;
-        }
-
-        if !self.missing_sourcemaps.is_empty() {
-            print_section_with_path(
-                f,
-                "Ignored: The following source files refer to sourcemaps that couldn't be found",
-                &self.missing_sourcemaps,
             )?;
         }
 

--- a/tests/integration/_cases/sourcemaps/sourcemaps-inject-help.trycmd
+++ b/tests/integration/_cases/sourcemaps/sourcemaps-inject-help.trycmd
@@ -3,8 +3,9 @@ $ sentry-cli sourcemaps inject --help
 ? success
 Fixes up JavaScript source files and sourcemaps with debug ids.
 
-For every JS source file that references a sourcemap, a debug id is generated and inserted into both
-files. If the referenced sourcemap already contains a debug id, that id is used instead.
+For every minified JS source file, a debug id is generated and inserted into the file. If the source
+file references a sourcemap and that sourcemap is locally available, the debug id will be injected
+into it as well. If the referenced sourcemap already contains a debug id, that id is used instead.
 
 Usage: sentry-cli[EXE] sourcemaps inject [OPTIONS] [PATHS]...
 

--- a/tests/integration/_cases/sourcemaps/sourcemaps-inject-nomappings.trycmd
+++ b/tests/integration/_cases/sourcemaps/sourcemaps-inject-nomappings.trycmd
@@ -8,9 +8,14 @@ $ sentry-cli sourcemaps inject ./server ./static
 
 Source Map Debug ID Injection Report
   Modified: The following source files have been modified to have debug ids
+    [..]-[..]-[..]-[..]-[..] - ./server/app/page.min.js
     [..]-[..]-[..]-[..]-[..] - ./server/chunks/1.min.js
+    [..]-[..]-[..]-[..]-[..] - ./server/flight-manifest.js
     [..]-[..]-[..]-[..]-[..] - ./server/pages/_document.min.js
+    [..]-[..]-[..]-[..]-[..] - ./server/pages/api/hello.min.js
     [..]-[..]-[..]-[..]-[..] - ./static/chunks/575-bb7d7e0e6de8d623.min.js
+    [..]-[..]-[..]-[..]-[..] - ./static/chunks/app/client/layout-ba9c3036fc0dba78.js
+    [..]-[..]-[..]-[..]-[..] - ./static/chunks/app/head-172ad45600676c06.js
     [..]-[..]-[..]-[..]-[..] - ./static/chunks/pages/asdf-05b39167abbe433b.min.js
   Modified: The following sourcemap files have been modified to have debug ids
     [..]-[..]-[..]-[..]-[..] - ./server/pages/_document.js.map
@@ -21,12 +26,6 @@ Source Map Debug ID Injection Report
   Ignored: The following sourcemap files already have debug ids
     [..]-[..]-[..]-[..]-[..] - ./server/chunks/1.js.map
     [..]-[..]-[..]-[..]-[..] - ./static/chunks/pages/asdf-05b39167abbe433b.js.map
-  Ignored: The following source files don't have sourcemap references 
-    ./server/app/page.min.js
-    ./server/flight-manifest.js
-    ./server/pages/api/hello.min.js
-    ./static/chunks/app/client/layout-ba9c3036fc0dba78.js
-    ./static/chunks/app/head-172ad45600676c06.js
 
 
 ```

--- a/tests/integration/_cases/sourcemaps/sourcemaps-inject.trycmd
+++ b/tests/integration/_cases/sourcemaps/sourcemaps-inject.trycmd
@@ -8,10 +8,15 @@ $ sentry-cli sourcemaps inject ./server ./static
 
 Source Map Debug ID Injection Report
   Modified: The following source files have been modified to have debug ids
+    [..]-[..]-[..]-[..]-[..] - ./server/app/page.js
     [..]-[..]-[..]-[..]-[..] - ./server/chunks/1.js
     [..]-[..]-[..]-[..]-[..] - ./server/dummy_embedded.js
+    [..]-[..]-[..]-[..]-[..] - ./server/flight-manifest.js
     [..]-[..]-[..]-[..]-[..] - ./server/pages/_document.js
+    [..]-[..]-[..]-[..]-[..] - ./server/pages/api/hello.js
     [..]-[..]-[..]-[..]-[..] - ./static/chunks/575-bb7d7e0e6de8d623.js
+    [..]-[..]-[..]-[..]-[..] - ./static/chunks/app/client/layout-ba9c3036fc0dba78.js
+    [..]-[..]-[..]-[..]-[..] - ./static/chunks/app/head-172ad45600676c06.js
     [..]-[..]-[..]-[..]-[..] - ./static/chunks/pages/asdf-05b39167abbe433b.js
   Modified: The following sourcemap files have been modified to have debug ids
     [..]-[..]-[..]-[..]-[..] - ./server/pages/_document.js.map
@@ -22,13 +27,6 @@ Source Map Debug ID Injection Report
   Ignored: The following sourcemap files already have debug ids
     [..]-[..]-[..]-[..]-[..] - ./server/chunks/1.js.map
     [..]-[..]-[..]-[..]-[..] - ./static/chunks/pages/asdf-05b39167abbe433b.js.map
-  Ignored: The following source files don't have sourcemap references 
-    ./server/flight-manifest.js
-    ./static/chunks/app/client/layout-ba9c3036fc0dba78.js
-    ./static/chunks/app/head-172ad45600676c06.js
-  Ignored: The following source files refer to sourcemaps that couldn't be found
-    ./server/app/page.js
-    ./server/pages/api/hello.js
 
 
 ```


### PR DESCRIPTION
This removes the checks on whether a source file references a sourcemap and whether that sourcemap can be found in the local file system. Instead, it now

1. always injects minified source files (unless they already have a debug id, of course)
2. injects the same debug id into the sourcemap file, if applicable
3. reuses the debug id in the sourcemap file, if any.