### PR TITLE
fix(inject): Don't inject non-js files

### DIFF
--- a/src/utils/sourcemaps.rs
+++ b/src/utils/sourcemaps.rs
@@ -302,7 +302,7 @@ impl SourceMapProcessor {
             .collect();
 
         for source in self.sources.values_mut() {
-            if source.ty != SourceFileType::MinifiedSource {
+            if source.ty != SourceFileType::MinifiedSource || !source.url.ends_with("js") {
                 continue;
             }
 
@@ -753,10 +753,7 @@ impl SourceMapProcessor {
             }
 
             let Some(sourcemap_url) = sourcemap_url else {
-                // If there is no sourcemap, inject .js files anyway so they have a debug id.
-                if source_url.ends_with(".js") {
-                    debug_ids.push((source_url.clone(), DebugId::from_uuid(Uuid::new_v4())));
-                }
+                debug_ids.push((source_url.clone(), DebugId::from_uuid(Uuid::new_v4())));
                 continue;
             };
 

--- a/src/utils/sourcemaps.rs
+++ b/src/utils/sourcemaps.rs
@@ -302,7 +302,7 @@ impl SourceMapProcessor {
             .collect();
 
         for source in self.sources.values_mut() {
-            if source.ty != SourceFileType::MinifiedSource || !source.url.ends_with("js") {
+            if source.ty != SourceFileType::MinifiedSource || !source.url.ends_with(".js") {
                 continue;
             }
 

--- a/src/utils/sourcemaps.rs
+++ b/src/utils/sourcemaps.rs
@@ -302,6 +302,7 @@ impl SourceMapProcessor {
             .collect();
 
         for source in self.sources.values_mut() {
+            // Skip everything but minified JS files.
             if source.ty != SourceFileType::MinifiedSource || !source.url.ends_with(".js") {
                 continue;
             }

--- a/src/utils/sourcemaps.rs
+++ b/src/utils/sourcemaps.rs
@@ -753,7 +753,10 @@ impl SourceMapProcessor {
             }
 
             let Some(sourcemap_url) = sourcemap_url else {
-                debug_ids.push((source_url.clone(), DebugId::from_uuid(Uuid::new_v4())));
+                // If there is no sourcemap, inject .js files anyway so they have a debug id.
+                if source_url.ends_with(".js") {
+                    debug_ids.push((source_url.clone(), DebugId::from_uuid(Uuid::new_v4())));
+                }
                 continue;
             };
 


### PR DESCRIPTION
Turns out that injecting every source file with type `MinifiedSource` is wrong—`is_likely_minified_js` can have positives for things that aren't minified js. Therefore we now additionally filter the files to be potentially injected by their extensions, disregarding anything but `.js`.