### PR TITLE
feat(debug_id): More determinism for JS debug IDs

### DIFF
--- a/src/utils/sourcemaps/inject.rs
+++ b/src/utils/sourcemaps/inject.rs
@@ -136,6 +136,15 @@ pub fn fixup_js_file(js_contents: &mut Vec<u8>, debug_id: DebugId) -> Result<()>
     Ok(())
 }
 
+/// Generates a debug ID from bytes.
+pub fn debug_id_from_bytes_hashed(bytes: &[u8]) -> DebugId {
+    let mut hash = sha1_smol::Sha1::new();
+    hash.update(bytes);
+    let mut sha1_bytes = [0u8; 16];
+    sha1_bytes.copy_from_slice(&hash.digest().bytes()[..16]);
+    DebugId::from_uuid(uuid::Builder::from_sha1_bytes(sha1_bytes).into_uuid())
+}
+
 /// Fixes up a sourcemap file with a debug id.
 ///
 /// If the file already contains a debug id under the `debug_id` key, it is left unmodified.
@@ -157,12 +166,7 @@ pub fn fixup_sourcemap(sourcemap_contents: &mut Vec<u8>) -> Result<(DebugId, boo
         }
 
         None => {
-            let mut hash = sha1_smol::Sha1::new();
-            hash.update(sourcemap_contents);
-            let mut sha1_bytes = [0u8; 16];
-            sha1_bytes.copy_from_slice(&hash.digest().bytes()[..16]);
-            let debug_id =
-                DebugId::from_uuid(uuid::Builder::from_sha1_bytes(sha1_bytes).into_uuid());
+            let debug_id = debug_id_from_bytes_hashed(&sourcemap_contents);
 
             let id = serde_json::to_value(debug_id)?;
             map.insert(SOURCEMAP_DEBUGID_KEY.to_string(), id);

--- a/src/utils/sourcemaps/inject.rs
+++ b/src/utils/sourcemaps/inject.rs
@@ -166,11 +166,9 @@ pub fn fixup_sourcemap(sourcemap_contents: &mut Vec<u8>) -> Result<(DebugId, boo
         }
 
         None => {
-            let debug_id = debug_id_from_bytes_hashed(&sourcemap_contents);
-
+            let debug_id = debug_id_from_bytes_hashed(sourcemap_contents);
             let id = serde_json::to_value(debug_id)?;
             map.insert(SOURCEMAP_DEBUGID_KEY.to_string(), id);
-
             sourcemap_contents.clear();
             serde_json::to_writer(sourcemap_contents, &sourcemap)?;
             Ok((debug_id, true))


### PR DESCRIPTION
This now emits deterministic debug IDs even for when there are no source maps by falling back to content hashing.