### PR TITLE
feat(js): Skip null as option same as undefined

### DIFF
--- a/js/helper.js
+++ b/js/helper.js
@@ -61,7 +61,7 @@ function mockBinaryPath(mockPath) {
 function serializeOptions(schema, options) {
   return Object.keys(schema).reduce((newOptions, option) => {
     const paramValue = options[option];
-    if (paramValue === undefined) {
+    if (paramValue === undefined || paramValue === null) {
       return newOptions;
     }
 


### PR DESCRIPTION
Currently if you pass `{dist: undefined}` or `{release:undefined}` that value is skipped as parameter. However if you pass `{dist:null}` it turns into `--dist null` which just makes no sense. I would vote for removing this footgun and removing null the same way as undefined.

Refs https://github.com/getsentry/action-release/pull/125

Fixes #1578