### PR TITLE
Add ability to send an Event as Raw Envelope

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2159,9 +2159,9 @@ checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 
 [[package]]
 name = "sentry"
-version = "0.29.3"
+version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6f8ce69326daef9d845c3fd17149bd3dbd7caf5dc65dbbad9f5441a40ee407f"
+checksum = "6c3d7f8bf7373e75222452fcdd9347d857452a92d0eec738f941bc4656c5b5df"
 dependencies = [
  "curl",
  "httpdate",
@@ -2172,9 +2172,9 @@ dependencies = [
 
 [[package]]
 name = "sentry-anyhow"
-version = "0.29.3"
+version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a80510663e6b711de2eed521a95dc38435a0e5858397d1acec79185e4a44215b"
+checksum = "9ef7f47c57a1146d553b4976f20e8bba370195a88858bdf6945a63c529549236"
 dependencies = [
  "anyhow",
  "sentry-backtrace",
@@ -2183,9 +2183,9 @@ dependencies = [
 
 [[package]]
 name = "sentry-backtrace"
-version = "0.29.3"
+version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ed6c0254d4cce319800609aa0d41b486ee57326494802045ff27434fc9a2030"
+checksum = "03b7cdefbdca51f1146f0f24a3cb4ecb6428951f030ff5c720cfb5c60bd174c0"
 dependencies = [
  "backtrace",
  "once_cell",
@@ -2265,9 +2265,9 @@ dependencies = [
 
 [[package]]
 name = "sentry-contexts"
-version = "0.29.3"
+version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3277dc5d2812562026f2095c7841f3d61bbe6789159b7da54f41d540787f818"
+checksum = "6af4cb29066e0e8df0cc3111211eb93543ccb09e1ccbe71de6d88b4bb459a2b1"
 dependencies = [
  "hostname",
  "libc",
@@ -2279,9 +2279,9 @@ dependencies = [
 
 [[package]]
 name = "sentry-core"
-version = "0.29.3"
+version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5acbd3da4255938cf0384b6b140e6c07ff65919c26e4d7a989d8d90ee88fa91"
+checksum = "5e781b55761e47a60d1ff326ae8059de22b0e6b0cee68eab1c5912e4fb199a76"
 dependencies = [
  "once_cell",
  "rand",
@@ -2292,9 +2292,9 @@ dependencies = [
 
 [[package]]
 name = "sentry-types"
-version = "0.29.3"
+version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10d8587b12c0b8211bb3066979ee57af6e8657e23cf439dc6c8581fd86de24e8"
+checksum = "d642a04657cc77d8de52ae7c6d93a15cb02284eb219344a89c1e2b26bbaf578c"
 dependencies = [
  "debugid",
  "getrandom",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,7 +57,7 @@ regex = "1.7.1"
 runas = "1.0.0"
 rust-ini = "0.18.0"
 semver = "1.0.16"
-sentry = { version = "0.29.3", default-features = false, features = [
+sentry = { version = "0.31.0", default-features = false, features = [
   "anyhow",
   "curl",
   "contexts",

--- a/src/commands/send_envelope.rs
+++ b/src/commands/send_envelope.rs
@@ -34,7 +34,7 @@ pub fn make_command(command: Command) -> Command {
         )
 }
 
-fn send_raw_envelope(envelope: Envelope, dsn: Dsn) {
+pub fn send_raw_envelope(envelope: Envelope, dsn: Dsn) {
     debug!("{:?}", envelope);
     with_sentry_client(dsn, |c| c.send_envelope(envelope));
 }

--- a/src/commands/send_event.rs
+++ b/src/commands/send_event.rs
@@ -1,7 +1,5 @@
 use std::borrow::Cow;
 use std::env;
-use std::fs::File;
-use std::io::BufReader;
 use std::path::PathBuf;
 use std::time::SystemTime;
 
@@ -202,7 +200,7 @@ pub fn execute(matches: &ArgMatches) -> Result<()> {
                 writeln!(buf, r#"{{"type":"event","length":{}}}"#, raw_event.len())?;
                 buf.extend(raw_event);
                 let envelope = Envelope::from_bytes_raw(buf)?;
-                send_raw_envelope(envelope, dsn);
+                send_raw_envelope(envelope, dsn.clone());
                 id
             } else {
                 let event: Event = serde_json::from_slice(&raw_event)?;

--- a/tests/integration/_cases/send_event/send_event-help.trycmd
+++ b/tests/integration/_cases/send_event/send_event-help.trycmd
@@ -15,18 +15,21 @@ Arguments:
           other arguments are ignored.
 
 Options:
-  -l, --level <LEVEL>
-          Optional event severity/log level. (debug|info|warning|error|fatal) [defaults to 'error']
+      --raw
+          Send events using an envelope without attempting to parse their contents.
 
       --header <KEY:VALUE>
           Custom headers that should be attached to all requests
           in key:value format.
 
-      --timestamp <TIMESTAMP>
-          Optional event timestamp in one of supported formats: unix timestamp, RFC2822 or RFC3339.
+  -l, --level <LEVEL>
+          Optional event severity/log level. (debug|info|warning|error|fatal) [defaults to 'error']
 
       --auth-token <AUTH_TOKEN>
           Use the given Sentry auth token.
+
+      --timestamp <TIMESTAMP>
+          Optional event timestamp in one of supported formats: unix timestamp, RFC2822 or RFC3339.
 
   -r, --release <RELEASE>
           Optional identifier of the release.
@@ -34,22 +37,22 @@ Options:
   -d, --dist <DISTRIBUTION>
           Set the distribution.
 
-  -E, --env <ENVIRONMENT>
-          Send with a specific environment.
-
       --log-level <LOG_LEVEL>
           Set the log output verbosity.
           
           [possible values: trace, debug, info, warn, error]
 
-      --no-environ
-          Do not send environment variables along
+  -E, --env <ENVIRONMENT>
+          Send with a specific environment.
 
       --quiet
           Do not print any output while preserving correct exit code. This flag is currently
           implemented only for selected subcommands.
           
           [aliases: silent]
+
+      --no-environ
+          Do not send environment variables along
 
   -m, --message <MESSAGE>
           The event message.


### PR DESCRIPTION
This does not *fully* deserialize/validate the event JSON, just enough to extract an `event_id` from it. It is then sent as a raw envelope.

Depends on https://github.com/getsentry/sentry-rust/pull/568