### PR TITLE
fix(publish): Adjust craft config to re-enable v1 releases

### DIFF
--- a/.craft.yml
+++ b/.craft.yml
@@ -76,5 +76,3 @@ requireNames:
   - /^sentry-cli-Linux-aarch64$/
   - /^sentry-cli-Windows-i686.exe$/
   - /^sentry-cli-Windows-x86_64.exe$/
-  - /^sentry_cli-.*.tar.gz$/
-  - /^sentry_cli-.*.whl$/


### PR DESCRIPTION
The 1.76.0 release [failed](https://github.com/getsentry/publish/actions/runs/4786405506/jobs/8510307740#step:10:93) because the craft config was adjusted in https://github.com/getsentry/sentry-cli/pull/1494. Craft always checks out the craft config from the head of the default branch. Therefore, the config no longer permits a v1 release because the `sentry_cli-2.17.4.tar.gz` is missing in the v1 release artifacts. 

This PR removes the requiredness check for two artifacts introduced in v2. I'm pretty sure that with this "fix" we should be good but feel free to close this PR if you have a more elegant solution.

In the long-run, we should definitely change the behaviour in craft to pull the config from the merge target (or release branch) instead of always pulling the default branche's config. Also, by then, we should re-introduce the required check for the two files.