### PR TITLE
feat: Print bundle id after artifact bundle creation

### DIFF
--- a/src/utils/file_upload.rs
+++ b/src/utils/file_upload.rs
@@ -465,6 +465,12 @@ fn build_artifact_bundle(
         }
     );
 
+    println!(
+        "{} Bundle ID: {}",
+        style(">").dim(),
+        style(debug_id).yellow(),
+    );
+
     Ok(archive)
 }
 

--- a/tests/integration/_cases/debug_files/debug_files-bundle-jvm-input-dir-empty.trycmd
+++ b/tests/integration/_cases/debug_files/debug_files-bundle-jvm-input-dir-empty.trycmd
@@ -3,6 +3,7 @@ $ sentry-cli debug-files bundle-jvm --output . --debug-id 48dee70b-4f3f-4a49-922
 ? success
 > Found 0 files
 > Bundled 0 files for upload
+> Bundle ID: [..]-[..]-[..]-[..]-[..]
 Created ./48dee70b-4f3f-4a49-9223-de441738f7cd.zip
 
 ```

--- a/tests/integration/_cases/debug_files/debug_files-bundle-jvm-output-is-file.trycmd
+++ b/tests/integration/_cases/debug_files/debug_files-bundle-jvm-output-is-file.trycmd
@@ -3,6 +3,7 @@ $ sentry-cli debug-files bundle-jvm --output ./file.txt --debug-id D384DC3B-AB2F
 ? failed
 > Found 2 files
 > Bundled 2 files for upload
+> Bundle ID: [..]-[..]-[..]-[..]-[..]
 error: Unable to write source bundle
   caused by: [..]
 

--- a/tests/integration/_cases/debug_files/debug_files-bundle-jvm-output-not-found.trycmd
+++ b/tests/integration/_cases/debug_files/debug_files-bundle-jvm-output-not-found.trycmd
@@ -3,6 +3,7 @@ $ sentry-cli debug-files bundle-jvm --output i-do-not-exist --debug-id 0B693ABA-
 ? success
 > Found 2 files
 > Bundled 2 files for upload
+> Bundle ID: [..]-[..]-[..]-[..]-[..]
 Created i-do-not-exist/0b693aba-531c-4eb6-99e4-b7320c3c85da.zip
 
 ```

--- a/tests/integration/_cases/debug_files/debug_files-bundle-jvm.trycmd
+++ b/tests/integration/_cases/debug_files/debug_files-bundle-jvm.trycmd
@@ -3,6 +3,7 @@ $ sentry-cli debug-files bundle-jvm --output . --debug-id a4368a48-0880-40d7-9a2
 ? success
 > Found 2 files
 > Bundled 2 files for upload
+> Bundle ID: [..]-[..]-[..]-[..]-[..]
 Created ./a4368a48-0880-40d7-9a26-c9ef5a84d156.zip
 
 ```

--- a/tests/integration/_cases/sourcemaps/sourcemaps-upload-modern.trycmd
+++ b/tests/integration/_cases/sourcemaps/sourcemaps-upload-modern.trycmd
@@ -7,6 +7,7 @@ $ sentry-cli sourcemaps upload tests/integration/_fixtures/bundle.min.js.map tes
 > Rewriting sources
 > Adding source map references
 > Bundled 2 files for upload
+> Bundle ID: [..]-[..]-[..]-[..]-[..]
 > Uploaded files to Sentry
 > File upload complete (processing pending on server)
 > Organization: wat-org

--- a/tests/integration/_cases/sourcemaps/sourcemaps-upload-no-dedupe.trycmd
+++ b/tests/integration/_cases/sourcemaps/sourcemaps-upload-no-dedupe.trycmd
@@ -7,6 +7,7 @@ $ sentry-cli sourcemaps upload tests/integration/_fixtures/bundle.min.js.map tes
 > Rewriting sources
 > Adding source map references
 > Bundled 2 files for upload
+> Bundle ID: [..]-[..]-[..]-[..]-[..]
 > Uploaded files to Sentry
 > File upload complete (processing pending on server)
 > Organization: wat-org

--- a/tests/integration/_cases/sourcemaps/sourcemaps-upload-skip-already-uploaded.trycmd
+++ b/tests/integration/_cases/sourcemaps/sourcemaps-upload-skip-already-uploaded.trycmd
@@ -7,6 +7,7 @@ $ sentry-cli sourcemaps upload tests/integration/_fixtures/bundle.min.js.map tes
 > Rewriting sources
 > Adding source map references
 > Bundled 1 file for upload
+> Bundle ID: [..]-[..]-[..]-[..]-[..]
 > Uploaded files to Sentry
 > File upload complete (processing pending on server)
 > Organization: wat-org

--- a/tests/integration/_cases/sourcemaps/sourcemaps-upload-some-debugids.trycmd
+++ b/tests/integration/_cases/sourcemaps/sourcemaps-upload-some-debugids.trycmd
@@ -14,6 +14,7 @@ $ sentry-cli sourcemaps upload tests/integration/_fixtures/upload_some_debugids
   WARN    [..]-[..]-[..] [..]:[..]:[..].[..] +[..]:[..] - ~/static/chunks/575-bb7d7e0e6de8d623.js
   WARN    [..]-[..]-[..] [..]:[..]:[..].[..] +[..]:[..] - ~/static/chunks/pages/asdf-05b39167abbe433b.js
 > Bundled 20 files for upload
+> Bundle ID: [..]-[..]-[..]-[..]-[..]
 > Uploaded files to Sentry
 > File upload complete (processing pending on server)
 > Organization: wat-org

--- a/tests/integration/_cases/sourcemaps/sourcemaps-upload-successfully-upload-file.trycmd
+++ b/tests/integration/_cases/sourcemaps/sourcemaps-upload-successfully-upload-file.trycmd
@@ -6,6 +6,7 @@ $ sentry-cli sourcemaps upload tests/integration/_fixtures/bundle.min.js.map --r
 > Rewriting sources
 > Adding source map references
 > Bundled 1 file for upload
+> Bundle ID: [..]-[..]-[..]-[..]-[..]
 > Uploaded files to Sentry
 > File upload complete (processing pending on server)
 > Organization: wat-org


### PR DESCRIPTION
This outputs the generated bundle's debug id at the end of `build_artifact_bundle`.