### PR TITLE
ref(inject): Constrain file search by extensions

### DIFF
--- a/src/commands/sourcemaps/inject.rs
+++ b/src/commands/sourcemaps/inject.rs
@@ -96,11 +96,15 @@ pub fn execute(matches: &ArgMatches) -> Result<()> {
         extensions.push("mjs");
     }
 
+    // Sourcemaps should be discovered regardless of which JavaScript extensions have been selected.
+    extensions.push("map");
+
     for path in paths {
         println!("> Searching {}", path.display());
         let sources = ReleaseFileSearch::new(path)
             .ignore_file(ignore_file)
             .ignores(&ignores)
+            .extensions(extensions.clone())
             .collect_files()?;
         for source in sources {
             let url = path_as_url(&source.path);

--- a/tests/integration/_cases/sourcemaps/sourcemaps-inject.trycmd
+++ b/tests/integration/_cases/sourcemaps/sourcemaps-inject.trycmd
@@ -4,8 +4,8 @@ $ sentry-cli sourcemaps inject ./server ./static
 > Searching ./server
 > Found 12 files
 > Searching ./static
-> Found 9 files
-> Analyzing 21 sources
+> Found 8 files
+> Analyzing 20 sources
 > Injecting debug ids
 
 Source Map Debug ID Injection Report


### PR DESCRIPTION
This limits the initial file search in `sourcemaps inject` to the specified extensions (by default: `js`, `cjs`, `mjs`). The `map` extension is added manually because we definitely want to discover sourcemaps in all cases.