### PR TITLE
misc: Add custom issues templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/BUG_REPORT.md
+++ b/.github/ISSUE_TEMPLATE/BUG_REPORT.md
@@ -1,0 +1,20 @@
+---
+name: 🐞 Bug Report
+about: Report a bug in this repo
+---
+
+### Environment
+
+What version of the CLI and what OS are you running?
+
+### Steps to Reproduce
+
+What you did?
+
+### Expected/Actual Result
+
+What you thought would happen and what actually happened?
+
+### Logs
+
+When filing a bug report, please attach debug logs, either by using `--log-level=debug` flag or `SENTRY_LOG_LEVEL=debug` environment variable.

--- a/.github/ISSUE_TEMPLATE/FEATURE_REQUEST.md
+++ b/.github/ISSUE_TEMPLATE/FEATURE_REQUEST.md
@@ -1,0 +1,10 @@
+---
+name: 🧠 Feature Request
+about: Suggest an idea for improving this repo
+---
+
+<!--
+
+Please provide some context on what problem you are trying to solve and how this feature is going to help.
+
+-->

--- a/.github/ISSUE_TEMPLATE/QUESTION.md
+++ b/.github/ISSUE_TEMPLATE/QUESTION.md
@@ -1,0 +1,15 @@
+<!--
+You can have your question reach the wider Sentry community via:
+
+StackOverflow.com with the Sentry tag:
+https://stackoverflow.com/questions/ask
+
+Sentry forum is also a great knowledge base:
+https://forum.sentry.io/
+
+Chat online with other Sentry users:
+https://discord.gg/Ww9hbqr
+
+For paying customers of sentry.io, there's also technical support:
+https://sentry.io/contact/support/
+-->


### PR DESCRIPTION
Original copied from https://github.com/getsentry/.github/tree/main/.github/ISSUE_TEMPLATE with updated `BUG_REPORT.md` template, as you cannot override a single one, and inherit the rest of templates.