### PR TITLE
ref: Remove proguard from debug-files upload types

### DIFF
--- a/src/commands/debug_files/upload.rs
+++ b/src/commands/debug_files/upload.rs
@@ -4,6 +4,7 @@ use std::str::{self, FromStr};
 use anyhow::{bail, format_err, Result};
 use clap::{builder::PossibleValuesParser, Arg, ArgAction, ArgMatches, Command};
 use console::style;
+use itertools::Itertools;
 use log::info;
 use symbolic::common::DebugId;
 use symbolic::debuginfo::FileFormat;
@@ -20,8 +21,12 @@ use crate::utils::xcode::{InfoPlist, MayDetach};
 static DERIVED_DATA_FOLDER: &str = "Library/Developer/Xcode/DerivedData";
 
 pub fn make_command(command: Command) -> Command {
-    let mut types = vec!["bcsymbolmap"];
-    types.extend(DifType::all_names());
+    let types = DifType::all_names()
+        .iter()
+        .filter(|&name| name != &"proguard")
+        .chain(&["bcsymbolmap"])
+        .sorted_by(|a, b| Ord::cmp(&a, &b))
+        .collect::<Vec<_>>();
 
     command
         .about("Upload debugging information files.")

--- a/tests/integration/_cases/debug_files/debug_files-upload-help.trycmd
+++ b/tests/integration/_cases/debug_files/debug_files-upload-help.trycmd
@@ -16,8 +16,7 @@ Options:
       --auth-token <AUTH_TOKEN>  Use the given Sentry auth token.
   -t, --type <TYPE>              Only consider debug information files of the given type.  By
                                  default, all types are considered. [possible values: bcsymbolmap,
-                                 dsym, elf, pe, pdb, portablepdb, sourcebundle, breakpad, proguard,
-                                 wasm, jvm]
+                                 breakpad, dsym, elf, jvm, pdb, pe, portablepdb, sourcebundle, wasm]
       --no-unwind                Do not scan for stack unwinding information. Specify this flag for
                                  builds with disabled FPO, or when stackwalking occurs on the
                                  device. This usually excludes executables and dynamic libraries.

--- a/tests/integration/_cases/upload_dif/upload_dif-help.trycmd
+++ b/tests/integration/_cases/upload_dif/upload_dif-help.trycmd
@@ -16,8 +16,7 @@ Options:
       --auth-token <AUTH_TOKEN>  Use the given Sentry auth token.
   -t, --type <TYPE>              Only consider debug information files of the given type.  By
                                  default, all types are considered. [possible values: bcsymbolmap,
-                                 dsym, elf, pe, pdb, portablepdb, sourcebundle, breakpad, proguard,
-                                 wasm, jvm]
+                                 breakpad, dsym, elf, jvm, pdb, pe, portablepdb, sourcebundle, wasm]
       --no-unwind                Do not scan for stack unwinding information. Specify this flag for
                                  builds with disabled FPO, or when stackwalking occurs on the
                                  device. This usually excludes executables and dynamic libraries.


### PR DESCRIPTION
Proguard has a standalone method for uploading its mappings, as it has more detailed options that let modify said upload.

Fixes https://github.com/getsentry/sentry-cli/issues/1614