### PR TITLE
ref(test): Remove temp files created during integration tests

### DIFF
--- a/tests/integration/_cases/debug_files/debug_files-bundle-jvm-output-not-found.trycmd
+++ b/tests/integration/_cases/debug_files/debug_files-bundle-jvm-output-not-found.trycmd
@@ -1,5 +1,5 @@
 ```
-$ sentry-cli debug-files bundle-jvm --output i-do-not-exist --debug-id 0B693ABA-531C-4EB6-99E4-B7320C3C85DA tests/integration/_fixtures/jvm
+$ sentry-cli debug-files bundle-jvm --output i-do-not-exist --debug-id 0B693ABA-531C-4EB6-99E4-B7320C3C85DA jvm
 ? success
 > Found 2 files
 > Bundled 2 files for upload

--- a/tests/integration/debug_files/bundle_jvm.rs
+++ b/tests/integration/debug_files/bundle_jvm.rs
@@ -10,6 +10,17 @@ fn command_bundle_jvm_help() {
 
 #[test]
 fn command_bundle_jvm_out_not_found_creates_dir() {
+    let testcase_cwd =
+        "tests/integration/_cases/debug_files/debug_files-bundle-jvm-output-not-found.in/";
+    let testcase_cwd_path = std::path::Path::new(testcase_cwd);
+    if testcase_cwd_path.exists() {
+        remove_dir_all(testcase_cwd_path).unwrap();
+    }
+    copy_recursively(
+        "tests/integration/_fixtures/jvm",
+        testcase_cwd_path.join("jvm"),
+    )
+    .unwrap();
     let _upload_endpoints = mock_common_upload_endpoints(ServerBehavior::Legacy);
     register_test("debug_files/debug_files-bundle-jvm-output-not-found.trycmd");
 }


### PR DESCRIPTION
Use testcase-based cwd instead of project root for creating test input 👀 

#skip-changelog