### PR TITLE
feat(crons): Bring back legacy token-auth checkin API

### DIFF
--- a/src/api.rs
+++ b/src/api.rs
@@ -1457,6 +1457,40 @@ impl Api {
         Ok(rv)
     }
 
+    /// Create a new checkin for a monitor
+    pub fn create_monitor_checkin(
+        &self,
+        monitor_slug: &String,
+        checkin: &ApiCreateMonitorCheckIn,
+    ) -> ApiResult<ApiMonitorCheckIn> {
+        let path = &format!("/monitors/{}/checkins/", PathArg(monitor_slug),);
+        let resp = self.post(path, checkin)?;
+        if resp.status() == 404 {
+            return Err(ApiErrorKind::ResourceNotFound.into());
+        }
+        resp.convert()
+    }
+
+    /// Update a checkin for a monitor
+    pub fn update_monitor_checkin(
+        &self,
+        monitor_slug: &String,
+        checkin_id: &Uuid,
+        checkin: &ApiUpdateMonitorCheckIn,
+    ) -> ApiResult<ApiMonitorCheckIn> {
+        let path = &format!(
+            "/monitors/{}/checkins/{}/",
+            PathArg(monitor_slug),
+            PathArg(checkin_id),
+        );
+        let resp = self.put(path, checkin)?;
+
+        if resp.status() == 404 {
+            return Err(ApiErrorKind::ResourceNotFound.into());
+        }
+        resp.convert()
+    }
+
     /// List all projects associated with an organization
     pub fn list_organization_projects(&self, org: &str) -> ApiResult<Vec<Project>> {
         let mut rv = vec![];
@@ -2430,6 +2464,39 @@ pub struct Monitor {
     pub slug: String,
     pub name: String,
     pub status: String,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ApiMonitorCheckInStatus {
+    Unknown,
+    Ok,
+    InProgress,
+    Error,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct ApiMonitorCheckIn {
+    pub id: Uuid,
+    pub status: Option<ApiMonitorCheckInStatus>,
+    pub duration: Option<u64>,
+    pub environment: Option<String>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct ApiCreateMonitorCheckIn {
+    pub status: ApiMonitorCheckInStatus,
+    pub environment: String,
+}
+
+#[derive(Debug, Serialize, Default)]
+pub struct ApiUpdateMonitorCheckIn {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub status: Option<ApiMonitorCheckInStatus>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub duration: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub environment: Option<String>,
 }
 
 #[derive(Deserialize, Debug)]

--- a/src/commands/monitors/run.rs
+++ b/src/commands/monitors/run.rs
@@ -1,6 +1,6 @@
 use log::warn;
 use std::process;
-use std::time::Instant;
+use std::time::{Duration, Instant};
 use uuid::Uuid;
 
 use anyhow::Result;
@@ -8,6 +8,7 @@ use clap::{Arg, ArgAction, ArgMatches, Command};
 use console::style;
 
 use sentry::protocol::{MonitorCheckIn, MonitorCheckInStatus};
+use sentry::types::Dsn;
 
 use crate::api::{Api, ApiCreateMonitorCheckIn, ApiMonitorCheckInStatus, ApiUpdateMonitorCheckIn};
 use crate::config::Config;
@@ -46,8 +47,118 @@ pub fn make_command(command: Command) -> Command {
         )
 }
 
-pub fn execute(matches: &ArgMatches) -> Result<()> {
+fn run_program(args: Vec<&String>, monitor_slug: &str) -> (bool, Option<i32>, Duration) {
+    let started = Instant::now();
+    let mut p = process::Command::new(args[0]);
+    p.args(&args[1..]);
+    p.env("SENTRY_MONITOR_SLUG", monitor_slug);
+
+    let (success, code) = match p.status() {
+        Ok(status) => (status.success(), status.code()),
+        Err(err) => {
+            eprintln!(
+                "{} could not invoke program '{}': {}",
+                style("error").red(),
+                args[0],
+                err
+            );
+            (false, None)
+        }
+    };
+
+    let elapsed = started.elapsed();
+    (success, code, elapsed)
+}
+
+fn dsn_execute(
+    dsn: Dsn,
+    args: Vec<&String>,
+    monitor_slug: &str,
+    environment: &str,
+) -> (bool, Option<i32>) {
+    let check_in_id = Uuid::new_v4();
+
+    let open_checkin = MonitorCheckIn {
+        check_in_id,
+        monitor_slug: monitor_slug.to_string(),
+        status: MonitorCheckInStatus::InProgress,
+        duration: None,
+        environment: Some(environment.to_string()),
+        monitor_config: None,
+    };
+
+    with_sentry_client(dsn.clone(), |c| c.send_envelope(open_checkin.into()));
+
+    let (success, code, elapsed) = run_program(args, monitor_slug);
+
+    let status = if success {
+        MonitorCheckInStatus::Ok
+    } else {
+        MonitorCheckInStatus::Error
+    };
+
+    let duration = Some(elapsed.as_secs_f64());
+
+    let close_checkin = MonitorCheckIn {
+        check_in_id,
+        monitor_slug: monitor_slug.to_string(),
+        status,
+        duration,
+        environment: Some(environment.to_string()),
+        monitor_config: None,
+    };
+
+    with_sentry_client(dsn, |c| c.send_envelope(close_checkin.into()));
+
+    (success, code)
+}
+
+fn token_execute(
+    args: Vec<&String>,
+    monitor_slug: &str,
+    environment: &str,
+) -> (bool, Option<i32>, Option<anyhow::Error>) {
     let api = Api::current();
+    let monitor_checkin = api.create_monitor_checkin(
+        &monitor_slug.to_owned(),
+        &ApiCreateMonitorCheckIn {
+            status: ApiMonitorCheckInStatus::InProgress,
+            environment: environment.to_string(),
+        },
+    );
+
+    let (success, code, elapsed) = run_program(args, monitor_slug);
+
+    match monitor_checkin {
+        Ok(checkin) => {
+            let status = if success {
+                ApiMonitorCheckInStatus::Ok
+            } else {
+                ApiMonitorCheckInStatus::Error
+            };
+
+            let duration = Some(elapsed.as_secs() * 1000 + u64::from(elapsed.subsec_millis()));
+
+            api.update_monitor_checkin(
+                &monitor_slug.to_owned(),
+                &checkin.id,
+                &ApiUpdateMonitorCheckIn {
+                    status: Some(status),
+                    duration,
+                    environment: Some(environment.to_string()),
+                },
+            )
+            .ok();
+        }
+        Err(e) => {
+            return (success, code, Some(e.into()));
+        }
+    }
+
+    (success, code, None)
+}
+
+pub fn execute(matches: &ArgMatches) -> Result<()> {
     let config = Config::current();
     let dsn = config.get_dsn().ok();
 
@@ -58,118 +169,24 @@ pub fn execute(matches: &ArgMatches) -> Result<()> {
         warn!("Please use DSN auth.");
     }
 
+    let args: Vec<_> = matches.get_many::<String>("args").unwrap().collect();
     let monitor_slug = matches.get_one::<String>("monitor_slug").unwrap();
     let environment = matches.get_one::<String>("environment").unwrap();
-    let allow_failure = matches.get_flag("allow_failure");
-
-    let args: Vec<_> = matches.get_many::<String>("args").unwrap().collect();
-
-    let exec_pgrm = || {
-        let started = Instant::now();
-        let mut p = process::Command::new(args[0]);
-        p.args(&args[1..]);
-        p.env("SENTRY_MONITOR_SLUG", monitor_slug);
-
-        let (success, code) = match p.status() {
-            Ok(status) => (status.success(), status.code()),
-            Err(err) => {
-                eprintln!(
-                    "{} could not invoke program '{}': {}",
-                    style("error").red(),
-                    args[0],
-                    err
-                );
-                (false, None)
-            }
-        };
-
-        let elapsed = started.elapsed();
-        (success, code, elapsed)
-    };
 
     let (success, code) = match dsn {
-        // Use envelope API when dsn is provided. This is the prefered way to create check-ins, the
-        // legacy API will be removed in the next major CLI version.
-        Some(dsn) => {
-            let check_in_id = Uuid::new_v4();
-
-            let open_checkin = MonitorCheckIn {
-                check_in_id,
-                monitor_slug: monitor_slug.to_string(),
-                status: MonitorCheckInStatus::InProgress,
-                duration: None,
-                environment: Some(environment.to_string()),
-                monitor_config: None,
-            };
-
-            with_sentry_client(dsn.clone(), |c| c.send_envelope(open_checkin.into()));
-
-            let (success, code, elapsed) = exec_pgrm();
-
-            let status = if success {
-                MonitorCheckInStatus::Ok
-            } else {
-                MonitorCheckInStatus::Error
-            };
-
-            let duration = Some(elapsed.as_secs_f64());
-
-            let close_checkin = MonitorCheckIn {
-                check_in_id,
-                monitor_slug: monitor_slug.to_string(),
-                status,
-                duration,
-                environment: Some(environment.to_string()),
-                monitor_config: None,
-            };
-
-            with_sentry_client(dsn, |c| c.send_envelope(close_checkin.into()));
-
-            (success, code)
-        }
+        // Use envelope API when dsn is provided. This is the prefered way to create check-ins,
+        // and the legacy API will be removed in the next major CLI version.
+        Some(dsn) => dsn_execute(dsn, args, monitor_slug, environment),
         // Use legacy API when DSN is not provided
         None => {
-            let monitor_checkin = api.create_monitor_checkin(
-                monitor_slug,
-                &ApiCreateMonitorCheckIn {
-                    status: ApiMonitorCheckInStatus::InProgress,
-                    environment: environment.to_string(),
-                },
-            );
-
-            let (success, code, elapsed) = exec_pgrm();
-
-            match monitor_checkin {
-                Ok(checkin) => {
-                    let status = if success {
-                        ApiMonitorCheckInStatus::Ok
-                    } else {
-                        ApiMonitorCheckInStatus::Error
-                    };
-
-                    let duration =
-                        Some(elapsed.as_secs() * 1000 + u64::from(elapsed.subsec_millis()));
-
-                    api.update_monitor_checkin(
-                        monitor_slug,
-                        &checkin.id,
-                        &ApiUpdateMonitorCheckIn {
-                            status: Some(status),
-                            duration,
-                            environment: Some(environment.to_string()),
-                        },
-                    )
-                    .ok();
-                }
-                Err(e) => {
-                    if allow_failure {
-                        print_error(&anyhow::Error::from(e));
-                    } else {
-                        return Err(e.into());
-                    }
+            let (success, code, err) = token_execute(args, monitor_slug, environment);
+            if let Some(e) = err {
+                if matches.get_flag("allow_failure") {
+                    print_error(&e);
+                } else {
+                    return Err(e);
                 }
             }
-
             (success, code)
         }
     };

--- a/src/commands/monitors/run.rs
+++ b/src/commands/monitors/run.rs
@@ -1,3 +1,4 @@
+use log::warn;
 use std::process;
 use std::time::Instant;
 use uuid::Uuid;
@@ -8,9 +9,10 @@ use console::style;
 
 use sentry::protocol::{MonitorCheckIn, MonitorCheckInStatus};
 
+use crate::api::{Api, ApiCreateMonitorCheckIn, ApiMonitorCheckInStatus, ApiUpdateMonitorCheckIn};
 use crate::config::Config;
 use crate::utils::event::with_sentry_client;
-use crate::utils::system::QuietExit;
+use crate::utils::system::{print_error, QuietExit};
 
 pub fn make_command(command: Command) -> Command {
     command
@@ -45,63 +47,132 @@ pub fn make_command(command: Command) -> Command {
 }
 
 pub fn execute(matches: &ArgMatches) -> Result<()> {
+    let api = Api::current();
     let config = Config::current();
-    let dsn = config
-        .get_dsn()
-        .expect("DSN auth is required for monitor execution");
+    let dsn = config.get_dsn().ok();
+
+    // Token based auth is deprecated, prefer DSN style auth for monitor checkins.
+    // Using token based auth *DOES NOT WORK* when using slugs.
+    if dsn.is_none() {
+        warn!("Token auth is deprecated for cron monitor checkins and will be removed in the next major version.");
+        warn!("Please use DSN auth.");
+    }
+
     let monitor_slug = matches.get_one::<String>("monitor_slug").unwrap();
     let environment = matches.get_one::<String>("environment").unwrap();
+    let allow_failure = matches.get_flag("allow_failure");
+
     let args: Vec<_> = matches.get_many::<String>("args").unwrap().collect();
 
-    let check_in_id = Uuid::new_v4();
+    let exec_pgrm = || {
+        let started = Instant::now();
+        let mut p = process::Command::new(args[0]);
+        p.args(&args[1..]);
+        p.env("SENTRY_MONITOR_SLUG", monitor_slug);
 
-    let open_checkin = MonitorCheckIn {
-        check_in_id,
-        monitor_slug: monitor_slug.to_string(),
-        status: MonitorCheckInStatus::InProgress,
-        duration: None,
-        environment: Some(environment.to_string()),
-        monitor_config: None,
+        let (success, code) = match p.status() {
+            Ok(status) => (status.success(), status.code()),
+            Err(err) => {
+                eprintln!(
+                    "{} could not invoke program '{}': {}",
+                    style("error").red(),
+                    args[0],
+                    err
+                );
+                (false, None)
+            }
+        };
+
+        let elapsed = started.elapsed();
+        (success, code, elapsed)
     };
 
-    with_sentry_client(dsn.clone(), |c| c.send_envelope(open_checkin.into()));
+    let (success, code) = match dsn {
+        // Use envelope API when dsn is provided. This is the prefered way to create check-ins, the
+        // legacy API will be removed in the next major CLI version.
+        Some(dsn) => {
+            let check_in_id = Uuid::new_v4();
 
-    let started = Instant::now();
-    let mut p = process::Command::new(args[0]);
-    p.args(&args[1..]);
-    p.env("SENTRY_MONITOR_SLUG", monitor_slug.clone());
+            let open_checkin = MonitorCheckIn {
+                check_in_id,
+                monitor_slug: monitor_slug.to_string(),
+                status: MonitorCheckInStatus::InProgress,
+                duration: None,
+                environment: Some(environment.to_string()),
+                monitor_config: None,
+            };
 
-    let (success, code) = match p.status() {
-        Ok(status) => (status.success(), status.code()),
-        Err(err) => {
-            eprintln!(
-                "{} could not invoke program '{}': {}",
-                style("error").red(),
-                args[0],
-                err
+            with_sentry_client(dsn.clone(), |c| c.send_envelope(open_checkin.into()));
+
+            let (success, code, elapsed) = exec_pgrm();
+
+            let status = if success {
+                MonitorCheckInStatus::Ok
+            } else {
+                MonitorCheckInStatus::Error
+            };
+
+            let duration = Some(elapsed.as_secs_f64());
+
+            let close_checkin = MonitorCheckIn {
+                check_in_id,
+                monitor_slug: monitor_slug.to_string(),
+                status,
+                duration,
+                environment: Some(environment.to_string()),
+                monitor_config: None,
+            };
+
+            with_sentry_client(dsn, |c| c.send_envelope(close_checkin.into()));
+
+            (success, code)
+        }
+        // Use legacy API when DSN is not provided
+        None => {
+            let monitor_checkin = api.create_monitor_checkin(
+                monitor_slug,
+                &ApiCreateMonitorCheckIn {
+                    status: ApiMonitorCheckInStatus::InProgress,
+                    environment: environment.to_string(),
+                },
             );
-            (false, None)
+
+            let (success, code, elapsed) = exec_pgrm();
+
+            match monitor_checkin {
+                Ok(checkin) => {
+                    let status = if success {
+                        ApiMonitorCheckInStatus::Ok
+                    } else {
+                        ApiMonitorCheckInStatus::Error
+                    };
+
+                    let duration =
+                        Some(elapsed.as_secs() * 1000 + u64::from(elapsed.subsec_millis()));
+
+                    api.update_monitor_checkin(
+                        monitor_slug,
+                        &checkin.id,
+                        &ApiUpdateMonitorCheckIn {
+                            status: Some(status),
+                            duration,
+                            environment: Some(environment.to_string()),
+                        },
+                    )
+                    .ok();
+                }
+                Err(e) => {
+                    if allow_failure {
+                        print_error(&anyhow::Error::from(e));
+                    } else {
+                        return Err(e.into());
+                    }
+                }
+            }
+
+            (success, code)
         }
     };
-
-    let status = if success {
-        MonitorCheckInStatus::Ok
-    } else {
-        MonitorCheckInStatus::Error
-    };
-
-    let duration = Some(started.elapsed().as_secs_f64());
-
-    let close_checkin = MonitorCheckIn {
-        check_in_id,
-        monitor_slug: monitor_slug.to_string(),
-        status,
-        duration,
-        environment: Some(environment.to_string()),
-        monitor_config: None,
-    };
-
-    with_sentry_client(dsn, |c| c.send_envelope(close_checkin.into()));
 
     if !success {
         return Err(QuietExit(code.unwrap_or(1)).into());

--- a/tests/integration/_cases/monitors/monitors-run-token-auth-win.trycmd
+++ b/tests/integration/_cases/monitors/monitors-run-token-auth-win.trycmd
@@ -1,0 +1,8 @@
+```
+$ sentry-cli monitors run foo-monitor -- cmd.exe /C echo 123
+? success
+  WARN    [..] Token auth is deprecated for cron monitor checkins and will be removed in the next major version.
+  WARN    [..] Please use DSN auth.
+123
+
+```

--- a/tests/integration/_cases/monitors/monitors-run-token-auth.trycmd
+++ b/tests/integration/_cases/monitors/monitors-run-token-auth.trycmd
@@ -1,0 +1,8 @@
+```
+$ sentry-cli monitors run foo-monitor -- echo 123
+? success
+  WARN    [..] Token auth is deprecated for cron monitor checkins and will be removed in the next major version.
+  WARN    [..] Please use DSN auth.
+123
+
+```

--- a/tests/integration/_responses/monitors/post-monitors-environment.json
+++ b/tests/integration/_responses/monitors/post-monitors-environment.json
@@ -1,6 +1,0 @@
-{
-  "id": "85a34e5a-c0b6-11ec-9d64-0242ac120002",
-  "duration": 1337,
-  "environment": "dev-env",
-  "status": "in_progress"
-}

--- a/tests/integration/monitors/run.rs
+++ b/tests/integration/monitors/run.rs
@@ -1,4 +1,4 @@
-use crate::integration::register_test;
+use crate::integration::{mock_endpoint, register_test, EndpointOptions};
 
 #[test]
 fn command_monitors_run() {
@@ -6,6 +6,19 @@ fn command_monitors_run() {
         register_test("monitors/monitors-run-win.trycmd");
     } else {
         register_test("monitors/monitors-run.trycmd");
+    }
+}
+
+#[test]
+fn command_monitors_run_token_auth() {
+    let _server = mock_endpoint(
+        EndpointOptions::new("POST", "/api/0/monitors/foo-monitor/checkins/", 200)
+            .with_response_file("monitors/post-monitors.json"),
+    );
+    if cfg!(windows) {
+        register_test("monitors/monitors-run-token-auth-win.trycmd").env("SENTRY_DSN", "");
+    } else {
+        register_test("monitors/monitors-run-token-auth.trycmd").env("SENTRY_DSN", "");
     }
 }
 


### PR DESCRIPTION
In https://github.com/getsentry/sentry-cli/pull/1618 we completely dropped support for check-ins via the API using token-auth.

While this method of creating cron monitor check-ins is long deprecated and undocumented, we would prefer to not break any users usages of crons when upgrading a non-major