### PR TITLE
feat(inject): Make sourcemap discovery smarter

### DIFF
--- a/src/utils/sourcemaps.rs
+++ b/src/utils/sourcemaps.rs
@@ -835,7 +835,7 @@ impl SourceMapProcessor {
 
                             let normalized =
                                 inject::normalize_sourcemap_url(source_url, sourcemap_url);
-                            let matches = inject::find_matching_paths(&sourcemaps[..], &normalized);
+                            let matches = inject::find_matching_paths(&sourcemaps, &normalized);
 
                             let sourcemap_url = match &matches[..] {
                                 [] => normalized,

--- a/src/utils/sourcemaps/inject.rs
+++ b/src/utils/sourcemaps/inject.rs
@@ -661,7 +661,7 @@ more text
         let candidates = &[
             "./foo/baz/quux".to_string(),
             "foo/baar/baz/quux".to_string(),
-        ][..];
+        ];
 
         assert_eq!(
             find_matching_paths(candidates, expected),
@@ -672,7 +672,7 @@ more text
             "./foo/baz/quux".to_string(),
             "foo/baar/baz/quux".to_string(),
             "./foo/bar/baz/quux".to_string(),
-        ][..];
+        ];
 
         assert_eq!(find_matching_paths(candidates, expected), vec![expected]);
     }
@@ -683,9 +683,23 @@ more text
         let candidates = &[
             "./foo/bar/baaz/quux".to_string(),
             "foo/baar/baz/quux".to_string(),
-        ][..];
+        ];
 
         assert_eq!(find_matching_paths(candidates, expected), candidates,);
+    }
+
+    #[test]
+    fn test_find_matching_paths_filename() {
+        let expected = "./foo/bar/baz/quux";
+        let candidates = &[
+            "./foo/bar/baz/nop".to_string(),
+            "foo/baar/baz/quux".to_string(),
+        ];
+
+        assert_eq!(
+            find_matching_paths(candidates, expected),
+            ["foo/baar/baz/quux".to_string()]
+        );
     }
 
     #[test]
@@ -693,7 +707,7 @@ more text
         let candidates = &[
             "./project/maps/index.js.map".to_string(),
             "./project/maps/page/index.js.map".to_string(),
-        ][..];
+        ];
 
         assert_eq!(
             find_matching_paths(candidates, "project/code/index.js.map"),

--- a/src/utils/sourcemaps/inject.rs
+++ b/src/utils/sourcemaps/inject.rs
@@ -378,6 +378,59 @@ pub fn normalize_sourcemap_url(source_url: &str, sourcemap_url: &str) -> String 
     format!("{}{}", &joined[..cutoff], clean_path(&joined[cutoff..]))
 }
 
+/// Returns a list of those paths among `candidate_paths` that differ from `expected_path` in
+/// at most one segment (modulo `.` segments).
+///
+/// If `expected_path` occurs among the `candidate_paths`, no other paths will be returned since
+/// that is considered a unique best match.
+///
+/// The intedend usecase is finding sourcemaps even if they reside in a different directory; see
+/// the `test_find_matching_paths_sourcemaps` test for a minimal example.
+pub fn find_matching_paths(candidate_paths: &[String], expected_path: &str) -> Vec<String> {
+    let mut matches = Vec::new();
+    for candidate in candidate_paths {
+        let candidate_segments = candidate
+            .split('/')
+            .filter(|&segment| segment != ".")
+            .collect::<Vec<_>>();
+        let expected_segments = expected_path
+            .split('/')
+            .filter(|&segment| segment != ".")
+            .collect::<Vec<_>>();
+
+        // If there is a candidate that is exactly equal to the goal path,
+        // return only that one.
+        if candidate_segments == expected_segments {
+            return vec![candidate.clone()];
+        }
+
+        let mut candidate_segments = candidate_segments.into_iter().peekable();
+        let mut expected_segments = expected_segments.into_iter().peekable();
+
+        while candidate_segments
+            .peek()
+            .zip(expected_segments.peek())
+            .map_or(false, |(x, y)| x == y)
+        {
+            candidate_segments.next();
+            expected_segments.next();
+        }
+
+        if candidate_segments.next().is_none() || expected_segments.next().is_none() {
+            continue;
+        }
+
+        let candidate_stem = candidate_segments.collect::<Vec<_>>();
+        let expected_stem = expected_segments.collect::<Vec<_>>();
+
+        if candidate_stem == expected_stem {
+            matches.push(candidate.clone());
+        }
+    }
+
+    matches
+}
+
 #[cfg(test)]
 mod tests {
     use std::io::Write;
@@ -386,7 +439,7 @@ mod tests {
 
     use crate::utils::fs::TempFile;
 
-    use super::{fixup_js_file, fixup_sourcemap, normalize_sourcemap_url, replace_sourcemap_url};
+    use super::*;
 
     #[test]
     fn test_fixup_sourcemap() {
@@ -600,5 +653,56 @@ some text
 more text
 "#;
         assert_eq!(std::str::from_utf8(&js_contents).unwrap(), expected);
+    }
+
+    #[test]
+    fn test_find_matching_paths_unique() {
+        let expected = "./foo/bar/baz/quux";
+        let candidates = &[
+            "./foo/baz/quux".to_string(),
+            "foo/baar/baz/quux".to_string(),
+        ][..];
+
+        assert_eq!(
+            find_matching_paths(candidates, expected),
+            vec!["foo/baar/baz/quux"]
+        );
+
+        let candidates = &[
+            "./foo/baz/quux".to_string(),
+            "foo/baar/baz/quux".to_string(),
+            "./foo/bar/baz/quux".to_string(),
+        ][..];
+
+        assert_eq!(find_matching_paths(candidates, expected), vec![expected]);
+    }
+
+    #[test]
+    fn test_find_matching_paths_ambiguous() {
+        let expected = "./foo/bar/baz/quux";
+        let candidates = &[
+            "./foo/bar/baaz/quux".to_string(),
+            "foo/baar/baz/quux".to_string(),
+        ][..];
+
+        assert_eq!(find_matching_paths(candidates, expected), candidates,);
+    }
+
+    #[test]
+    fn test_find_matching_paths_sourcemaps() {
+        let candidates = &[
+            "./project/maps/index.js.map".to_string(),
+            "./project/maps/page/index.js.map".to_string(),
+        ][..];
+
+        assert_eq!(
+            find_matching_paths(candidates, "project/code/index.js.map"),
+            &["./project/maps/index.js.map"]
+        );
+
+        assert_eq!(
+            find_matching_paths(candidates, "project/code/page/index.js.map"),
+            &["./project/maps/page/index.js.map"]
+        );
     }
 }

--- a/src/utils/sourcemaps/inject.rs
+++ b/src/utils/sourcemaps/inject.rs
@@ -388,12 +388,12 @@ pub fn normalize_sourcemap_url(source_url: &str, sourcemap_url: &str) -> String 
 /// the `test_find_matching_paths_sourcemaps` test for a minimal example.
 pub fn find_matching_paths(candidate_paths: &[String], expected_path: &str) -> Vec<String> {
     let mut matches = Vec::new();
+    let expected_segments = expected_path
+        .split('/')
+        .filter(|&segment| segment != ".")
+        .collect::<Vec<_>>();
     for candidate in candidate_paths {
         let candidate_segments = candidate
-            .split('/')
-            .filter(|&segment| segment != ".")
-            .collect::<Vec<_>>();
-        let expected_segments = expected_path
             .split('/')
             .filter(|&segment| segment != ".")
             .collect::<Vec<_>>();
@@ -404,8 +404,8 @@ pub fn find_matching_paths(candidate_paths: &[String], expected_path: &str) -> V
             return vec![candidate.clone()];
         }
 
-        let mut candidate_segments = candidate_segments.into_iter().peekable();
-        let mut expected_segments = expected_segments.into_iter().peekable();
+        let mut candidate_segments = candidate_segments.iter().peekable();
+        let mut expected_segments = expected_segments.iter().peekable();
 
         while candidate_segments
             .peek()

--- a/tests/integration/_cases/sourcemaps/sourcemaps-inject-split-ambiguous.trycmd
+++ b/tests/integration/_cases/sourcemaps/sourcemaps-inject-split-ambiguous.trycmd
@@ -1,0 +1,24 @@
+```
+$ sentry-cli sourcemaps inject ./code ./maps ./maps2 --log-level warn
+? success
+> Searching ./code
+> Found 2 files
+> Searching ./maps
+> Found 2 files
+> Searching ./maps2
+> Found 1 file
+> Analyzing 5 sources
+> Injecting debug ids
+  WARN    [..]-[..]-[..] [..]:[..]:[..].[..] +[..]:[..] Ambiguous matches for sourcemap path ./code/foo/index.js.map:
+  WARN    [..]-[..]-[..] [..]:[..]:[..].[..] +[..]:[..] ./maps/foo/index.js.map
+  WARN    [..]-[..]-[..] [..]:[..]:[..].[..] +[..]:[..] ./maps2/foo/index.js.map
+
+Source Map Debug ID Injection Report
+  Modified: The following source files have been modified to have debug ids
+    [..]-[..]-[..]-[..]-[..] - ./code/foo/index.js
+    [..]-[..]-[..]-[..]-[..] - ./code/index.js
+  Ignored: The following sourcemap files already have debug ids
+    [..]-[..]-[..]-[..]-[..] - ./maps/index.js.map
+
+
+```

--- a/tests/integration/_cases/sourcemaps/sourcemaps-inject-split.trycmd
+++ b/tests/integration/_cases/sourcemaps/sourcemaps-inject-split.trycmd
@@ -1,0 +1,21 @@
+```
+$ sentry-cli sourcemaps inject ./code ./maps
+? success
+> Searching ./code
+> Found 2 files
+> Searching ./maps
+> Found 2 files
+> Analyzing 4 sources
+> Injecting debug ids
+
+Source Map Debug ID Injection Report
+  Modified: The following source files have been modified to have debug ids
+    [..]-[..]-[..]-[..]-[..] - ./code/foo/index.js
+    [..]-[..]-[..]-[..]-[..] - ./code/index.js
+  Modified: The following sourcemap files have been modified to have debug ids
+    [..]-[..]-[..]-[..]-[..] - ./maps/foo/index.js.map
+  Ignored: The following sourcemap files already have debug ids
+    [..]-[..]-[..]-[..]-[..] - ./maps/index.js.map
+
+
+```

--- a/tests/integration/_fixtures/inject_split/code/foo/index.js
+++ b/tests/integration/_fixtures/inject_split/code/foo/index.js
@@ -1,0 +1,1 @@
+//# sourceMappingURL=index.js.map

--- a/tests/integration/_fixtures/inject_split/code/index.js
+++ b/tests/integration/_fixtures/inject_split/code/index.js
@@ -1,0 +1,1 @@
+//# sourceMappingURL=index.js.map

--- a/tests/integration/_fixtures/inject_split/maps/foo/index.js.map
+++ b/tests/integration/_fixtures/inject_split/maps/foo/index.js.map
@@ -1,0 +1,1 @@
+{"version":3,"file":"foo/index.js","mappings":"","sources":[],"sourcesContent":[],"sourceRoot":""}

--- a/tests/integration/_fixtures/inject_split/maps/index.js.map
+++ b/tests/integration/_fixtures/inject_split/maps/index.js.map
@@ -1,0 +1,1 @@
+{"debug_id":"2297b93d-928d-421e-8910-127c786382da","version":3,"file":"index.js","mappings":"","sources":[],"sourcesContent":[],"names":[],"sourceRoot":""}

--- a/tests/integration/_fixtures/inject_split_ambiguous/code/foo/index.js
+++ b/tests/integration/_fixtures/inject_split_ambiguous/code/foo/index.js
@@ -1,0 +1,1 @@
+//# sourceMappingURL=index.js.map

--- a/tests/integration/_fixtures/inject_split_ambiguous/code/index.js
+++ b/tests/integration/_fixtures/inject_split_ambiguous/code/index.js
@@ -1,0 +1,1 @@
+//# sourceMappingURL=index.js.map

--- a/tests/integration/_fixtures/inject_split_ambiguous/maps/foo/index.js.map
+++ b/tests/integration/_fixtures/inject_split_ambiguous/maps/foo/index.js.map
@@ -1,0 +1,1 @@
+{"version":3,"file":"foo/index.js","mappings":"","sources":[],"sourcesContent":[],"sourceRoot":""}

--- a/tests/integration/_fixtures/inject_split_ambiguous/maps/index.js.map
+++ b/tests/integration/_fixtures/inject_split_ambiguous/maps/index.js.map
@@ -1,0 +1,1 @@
+{"debug_id":"2297b93d-928d-421e-8910-127c786382da","version":3,"file":"index.js","mappings":"","sources":[],"sourcesContent":[],"names":[],"sourceRoot":""}

--- a/tests/integration/_fixtures/inject_split_ambiguous/maps2/foo/index.js.map
+++ b/tests/integration/_fixtures/inject_split_ambiguous/maps2/foo/index.js.map
@@ -1,0 +1,1 @@
+{"version":3,"file":"foo/index.js","mappings":"","sources":[],"sourcesContent":[],"sourceRoot":""}

--- a/tests/integration/sourcemaps/inject.rs
+++ b/tests/integration/sourcemaps/inject.rs
@@ -86,3 +86,34 @@ fn command_sourcemaps_inject_output_embedded() {
     let parsed: serde_json::Value = serde_json::from_slice(&decoded).unwrap();
     assert_eq!(parsed["mappings"], ";;;;");
 }
+
+#[test]
+fn command_sourcemaps_inject_output_split() {
+    let testcase_cwd_path = "tests/integration/_cases/sourcemaps/sourcemaps-inject-split.in/";
+    if std::path::Path::new(testcase_cwd_path).exists() {
+        remove_dir_all(testcase_cwd_path).unwrap();
+    }
+    copy_recursively(
+        "tests/integration/_fixtures/inject_split/",
+        testcase_cwd_path,
+    )
+    .unwrap();
+
+    register_test("sourcemaps/sourcemaps-inject-split.trycmd");
+}
+
+#[test]
+fn command_sourcemaps_inject_output_split_ambiguous() {
+    let testcase_cwd_path =
+        "tests/integration/_cases/sourcemaps/sourcemaps-inject-split-ambiguous.in/";
+    if std::path::Path::new(testcase_cwd_path).exists() {
+        remove_dir_all(testcase_cwd_path).unwrap();
+    }
+    copy_recursively(
+        "tests/integration/_fixtures/inject_split_ambiguous/",
+        testcase_cwd_path,
+    )
+    .unwrap();
+
+    register_test("sourcemaps/sourcemaps-inject-split-ambiguous.trycmd");
+}


### PR DESCRIPTION
This generalizes the discovery of sourcemaps when injecting, which should make the command easier to use. In particular, you can now have source and sourcemap files in different directories, but the directory hierarchies need to mirror each other. For example, consider:
```
code/
  index.js -> index.js.map
  child/
    foo.js -> foo.js.map
    index.js -> index.js.map
sourcemaps/
  index.js.map
  foo.js.map
  child/
    index.js.map
```
With this change, each `index.js.map` reference will be matched to its counterpart in the `sourcemaps` directory, but the `foo.js.map` reference would not be resolved because the file is not in the right place. If there is any ambiguity, as in
```
code/
  index.js -> index.js.map
sourcemaps/
  index.js.map
sourcemaps2/
  index.js.map
```
a warning is printed and the sourcemap is treated as not found.

I believe this implementation hits a nice sweet spot between convenience and generality.