### PR TITLE
fix: Don't require config to be set in print_error

### DIFF
--- a/src/utils/system.rs
+++ b/src/utils/system.rs
@@ -127,7 +127,9 @@ pub fn print_error(err: &Error) {
         .skip(1)
         .for_each(|cause| eprintln!("  {} {}", style("caused by:").dim(), cause));
 
-    if Config::current().get_log_level() < log::LevelFilter::Info {
+    if Config::current_opt().map_or(true, |config| {
+        config.get_log_level() < log::LevelFilter::Info
+    }) {
         eprintln!();
         eprintln!("{}", style("Add --log-level=[info|debug] or export SENTRY_LOG_LEVEL=[info|debug] to see more output.").dim());
         eprintln!(


### PR DESCRIPTION
Since errors can occur before the config is set, requiring a config to print errors is a bad idea.