### PR TITLE
fix: Add wasm to supported debug-files upload formats

### DIFF
--- a/src/commands/debug_files/upload.rs
+++ b/src/commands/debug_files/upload.rs
@@ -240,6 +240,7 @@ pub fn execute(matches: &ArgMatches) -> Result<()> {
             "sourcebundle" => upload.filter_format(DifFormat::Object(FileFormat::SourceBundle)),
             "portablepdb" => upload.filter_format(DifFormat::Object(FileFormat::PortablePdb)),
             "jvm" => upload.filter_format(DifFormat::Object(FileFormat::SourceBundle)),
+            "wasm" => upload.filter_format(DifFormat::Object(FileFormat::Wasm)),
             "bcsymbolmap" => {
                 upload.filter_format(DifFormat::BcSymbolMap);
                 upload.filter_format(DifFormat::PList)


### PR DESCRIPTION
Somehow it was missing 👀 

Fixes https://github.com/getsentry/sentry-cli/issues/1682