### PR TITLE
ref: Use sourcemap debugid features

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2469,10 +2469,9 @@ dependencies = [
 [[package]]
 name = "sourcemap"
 version = "6.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eed16231c92d0a6f0388f56e0ab2be24ecff1173f8e22f0ea5e074d0525631cb"
 dependencies = [
  "data-encoding",
+ "debugid",
  "if_chain",
  "rustc_version 0.2.3",
  "scroll 0.10.2",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2468,7 +2468,9 @@ dependencies = [
 
 [[package]]
 name = "sourcemap"
-version = "6.2.3"
+version = "6.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8df03d85f2767c45e61b4453eb6144153c80399e4fdd6407a6d16cb87cc0347"
 dependencies = [
  "data-encoding",
  "debugid",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -65,7 +65,7 @@ sentry = { version = "0.31.2", default-features = false, features = [
 serde = { version = "1.0.152", features = ["derive"] }
 serde_json = "1.0.93"
 sha1_smol = { version = "1.0.0", features = ["serde"] }
-sourcemap = { version = "6.2.3", features = ["ram_bundle"], path = "../rust-sourcemap" }
+sourcemap = { version = "6.3.0", features = ["ram_bundle"] }
 symbolic = { version = "12.1.5", features = ["debuginfo-serde", "il2cpp"] }
 thiserror = "1.0.38"
 url = "2.3.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -65,7 +65,7 @@ sentry = { version = "0.31.2", default-features = false, features = [
 serde = { version = "1.0.152", features = ["derive"] }
 serde_json = "1.0.93"
 sha1_smol = { version = "1.0.0", features = ["serde"] }
-sourcemap = { version = "6.2.3", features = ["ram_bundle"] }
+sourcemap = { version = "6.2.3", features = ["ram_bundle"], path = "../rust-sourcemap" }
 symbolic = { version = "12.1.5", features = ["debuginfo-serde", "il2cpp"] }
 thiserror = "1.0.38"
 url = "2.3.1"

--- a/src/utils/sourcemaps.rs
+++ b/src/utils/sourcemaps.rs
@@ -684,7 +684,7 @@ impl SourceMapProcessor {
                 .filter_map(|artifact| Digest::from_str(&artifact.sha1).ok())
                 .collect();
 
-            for mut source in self.sources.values_mut() {
+            for source in self.sources.values_mut() {
                 if let Ok(checksum) = source.checksum() {
                     if already_uploaded_checksums.contains(&checksum) {
                         source.already_uploaded = true;

--- a/src/utils/sourcemaps/inject.rs
+++ b/src/utils/sourcemaps/inject.rs
@@ -7,7 +7,7 @@ use std::fmt;
 use std::io::{BufRead, Write};
 use std::path::PathBuf;
 
-use anyhow::{bail, Result};
+use anyhow::{bail, Context, Result};
 use lazy_static::lazy_static;
 use log::debug;
 use sentry::types::DebugId;
@@ -15,7 +15,6 @@ use serde_json::Value;
 
 const CODE_SNIPPET_TEMPLATE: &str = r#"!function(){try{var e="undefined"!=typeof window?window:"undefined"!=typeof global?global:"undefined"!=typeof self?self:{},n=(new Error).stack;n&&(e._sentryDebugIds=e._sentryDebugIds||{},e._sentryDebugIds[n]="__SENTRY_DEBUG_ID__")}catch(e){}}();"#;
 const DEBUGID_PLACEHOLDER: &str = "__SENTRY_DEBUG_ID__";
-const SOURCEMAP_DEBUGID_KEY: &str = "debug_id";
 const DEBUGID_COMMENT_PREFIX: &str = "//# debugId";
 
 lazy_static! {
@@ -303,27 +302,35 @@ pub fn debug_id_from_bytes_hashed(bytes: &[u8]) -> DebugId {
 ///
 /// In either case, the value of the `debug_id` key is returned.
 pub fn fixup_sourcemap(sourcemap_contents: &mut Vec<u8>) -> Result<(DebugId, bool)> {
-    let mut sourcemap: Value = serde_json::from_slice(sourcemap_contents)?;
+    match sourcemap::decode_slice(sourcemap_contents).context("Invalid sourcemap")? {
+        sourcemap::DecodedMap::Regular(mut sm) => {
+            if let Some(debug_id) = sm.get_debug_id() {
+                debug!("Sourcemap already has a debug id");
+                Ok((debug_id, false))
+            } else {
+                let debug_id = debug_id_from_bytes_hashed(sourcemap_contents);
+                sm.set_debug_id(Some(debug_id));
 
-    let Some(map) = sourcemap.as_object_mut() else {
-        bail!("Invalid sourcemap");
-    };
-
-    match map.get(SOURCEMAP_DEBUGID_KEY) {
-        Some(id) => {
-            let debug_id = serde_json::from_value(id.clone())?;
-            debug!("Sourcemap already has a debug id");
-            Ok((debug_id, false))
+                sourcemap_contents.clear();
+                sm.to_writer(sourcemap_contents)?;
+                Ok((debug_id, true))
+            }
         }
+        sourcemap::DecodedMap::Hermes(mut smh) => {
+            if let Some(debug_id) = smh.get_debug_id() {
+                debug!("Sourcemap already has a debug id");
+                Ok((debug_id, false))
+            } else {
+                let debug_id = debug_id_from_bytes_hashed(sourcemap_contents);
+                smh.set_debug_id(Some(debug_id));
 
-        None => {
-            let debug_id = debug_id_from_bytes_hashed(sourcemap_contents);
-            let id = serde_json::to_value(debug_id)?;
-            map.insert(SOURCEMAP_DEBUGID_KEY.to_string(), id);
-
-            sourcemap_contents.clear();
-            serde_json::to_writer(sourcemap_contents, &sourcemap)?;
-            Ok((debug_id, true))
+                sourcemap_contents.clear();
+                smh.to_writer(sourcemap_contents)?;
+                Ok((debug_id, true))
+            }
+        }
+        sourcemap::DecodedMap::Index(_) => {
+            bail!("DebugId injection is not supported for sourcemap indexes")
         }
     }
 }

--- a/tests/integration/sourcemaps/upload.rs
+++ b/tests/integration/sourcemaps/upload.rs
@@ -127,7 +127,7 @@ fn command_sourcemaps_upload_some_debugids_v2() {
     let upload_endpoints = mock_common_upload_endpoints(
         ServerBehavior::ModernV2,
         ChunkOptions {
-            missing_chunks: vec!["5e102ab3da27af9d1095a9c847d4e92a57fe01af".to_string()],
+            missing_chunks: vec!["ff16e0ac593a74b454cc34814f6249f45a1a2dfe".to_string()],
             chunk_size: 524288,
         },
     );


### PR DESCRIPTION
~Blocked by getting https://github.com/getsentry/rust-sourcemap/pull/66 released.~

This updates the `sourcemap` dependency to 6.3.0 so that we can use the new debug id features. Specifically:
1. Rewriting sourcemaps leaves the debug id alone.
2. Adding a debug id to a sourcemap doesn't require manual JSON parsing anymore.