### PR TITLE
chore(ts): add decompress to SentryCliUploadSourceMapsOptions

### DIFF
--- a/js/index.d.ts
+++ b/js/index.d.ts
@@ -88,6 +88,10 @@ declare module '@sentry/cli' {
      */
     sourceMapReference?: boolean;
     /**
+     * Enable files gzip decompression prior to upload.
+     */
+    decompress?: boolean;
+    /**
      * Enable artifacts deduplication prior to uploading. This will skip uploading
      * any artifacts that are already present on the server. Defaults to `true`.
      */


### PR DESCRIPTION
The `decompress` option is listed in https://github.com/getsentry/sentry-cli/blob/ccd2f50d74e509961ffcc26f8a876136d1e5eb6b/js/releases/options/uploadSourcemaps.js#L14-L17 