### PR TITLE
fix: Correctly detect local binary when installing via npm

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 "You know what they say. Fool me once, strike one, but fool me twice... strike three." — Michael Scott
 
+## 2.20.1
+
+### Various fixes and improvements
+
+- fix: Correctly detect local binary when installing via npm (#1695)
+
 ## 2.20.0
 
 ### Various fixes and improvements

--- a/scripts/install.js
+++ b/scripts/install.js
@@ -193,7 +193,9 @@ async function downloadBinary() {
 
   if (process.env.SENTRYCLI_USE_LOCAL === '1') {
     try {
-      const binPath = which.sync('sentry-cli');
+      const binPaths = which.sync('sentry-cli', { all: true });
+      if (!binPaths.length) throw new Error('Binary not found');
+      const binPath = binPaths[binPaths.length - 1];
       logger.log(`Using local binary: ${binPath}`);
       fs.copyFileSync(binPath, outputPath);
       return Promise.resolve();


### PR DESCRIPTION
This fixes the nasty issue when using `npm` to install cli with locally existing binary.
`which` iterates over all possible binaries available in the PATH, and by default it reports the first occurrence. 
This is however problematic when using `npm` since I believe v8, as they started to include all `node_modules/.bin` in the `PATH` when executing npm script, making `npm run install` detect the `bin/sentry-cli` file that we have, which is just a JS proxy to the _actual_ binary.
It works fine when running install script directly in node or using `yarn`, as they don't modify the PATH.

We want the last possible match, eg.
```
/Users/kamilogorek/Desktop/tmp-cli/node_modules/.bin/sentry-cli,/usr/local/bin/sentry-cli
```