### PR TITLE
Allow the CLI binary path to be overridden

### DIFF
--- a/js/helper.js
+++ b/js/helper.js
@@ -12,6 +12,10 @@ const childProcess = require('child_process');
  * @returns {string} The path to the sentry-cli binary
  */
 function getBinaryPath() {
+  if (process.env.SENTRY_BINARY_PATH) {
+    return process.env.SENTRY_BINARY_PATH;
+  }
+
   const parts = [];
   parts.push(__dirname);
   parts.push('..');


### PR DESCRIPTION
Hey friends 👋🏻 

What do you think about allowing me to provide my own Sentry CLI binary location?