### PR TITLE
deps: Bump sourcemap to 6.4.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2482,9 +2482,9 @@ dependencies = [
 
 [[package]]
 name = "sourcemap"
-version = "6.4.0"
+version = "6.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9221a6bba3e9cfa7decfe64edf5233311e1bf837ea3234df6e7f35836e1093d"
+checksum = "e4cbf65ca7dc576cf50e21f8d0712d96d4fcfd797389744b7b222a85cdf5bd90"
 dependencies = [
  "data-encoding",
  "debugid",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -65,7 +65,7 @@ sentry = { version = "0.31.2", default-features = false, features = [
 serde = { version = "1.0.152", features = ["derive"] }
 serde_json = "1.0.93"
 sha1_smol = { version = "1.0.0", features = ["serde"] }
-sourcemap = { version = "6.4.0", features = ["ram_bundle"] }
+sourcemap = { version = "6.4.1", features = ["ram_bundle"] }
 symbolic = { version = "12.1.5", features = ["debuginfo-serde", "il2cpp"] }
 thiserror = "1.0.38"
 url = "2.3.1"


### PR DESCRIPTION
Fixes https://github.com/getsentry/sentry-cli/issues/1710