### PR TITLE
Add support for `SENTRY_RELEASE` in bash-hook

### DIFF
--- a/src/api.rs
+++ b/src/api.rs
@@ -577,7 +577,7 @@ impl Api {
             }
 
             let pagination = resp.pagination();
-            rv.extend(resp.convert::<Vec<Artifact>>()?.into_iter());
+            rv.extend(resp.convert::<Vec<Artifact>>()?);
             if let Some(next) = pagination.into_next_cursor() {
                 cursor = next;
             } else {
@@ -1450,7 +1450,7 @@ impl Api {
                 }
             }
             let pagination = resp.pagination();
-            rv.extend(resp.convert::<Vec<Organization>>()?.into_iter());
+            rv.extend(resp.convert::<Vec<Organization>>()?);
             if let Some(next) = pagination.into_next_cursor() {
                 cursor = next;
             } else {
@@ -1478,7 +1478,7 @@ impl Api {
                 }
             }
             let pagination = resp.pagination();
-            rv.extend(resp.convert::<Vec<Monitor>>()?.into_iter());
+            rv.extend(resp.convert::<Vec<Monitor>>()?);
             if let Some(next) = pagination.into_next_cursor() {
                 cursor = next;
             } else {
@@ -1540,7 +1540,7 @@ impl Api {
                 }
             }
             let pagination = resp.pagination();
-            rv.extend(resp.convert::<Vec<Project>>()?.into_iter());
+            rv.extend(resp.convert::<Vec<Project>>()?);
             if let Some(next) = pagination.into_next_cursor() {
                 cursor = next;
             } else {
@@ -1580,7 +1580,7 @@ impl Api {
             }
 
             let pagination = resp.pagination();
-            rv.extend(resp.convert::<Vec<ProcessedEvent>>()?.into_iter());
+            rv.extend(resp.convert::<Vec<ProcessedEvent>>()?);
 
             if requests_no == max_pages {
                 break;
@@ -1633,7 +1633,7 @@ impl Api {
             }
 
             let pagination = resp.pagination();
-            rv.extend(resp.convert::<Vec<Issue>>()?.into_iter());
+            rv.extend(resp.convert::<Vec<Issue>>()?);
 
             if requests_no == max_pages {
                 break;
@@ -1664,7 +1664,7 @@ impl Api {
                 break;
             } else {
                 let pagination = resp.pagination();
-                rv.extend(resp.convert::<Vec<Repo>>()?.into_iter());
+                rv.extend(resp.convert::<Vec<Repo>>()?);
                 if let Some(next) = pagination.into_next_cursor() {
                     cursor = next;
                 } else {

--- a/src/bashsupport.sh
+++ b/src/bashsupport.sh
@@ -32,7 +32,7 @@ _sentry_err_trap() {
   echo "@exit_code:${_exit_code}" >> "$_SENTRY_TRACEBACK_FILE"
 
   : >> "$_SENTRY_LOG_FILE"
-  export SENTRY_LAST_EVENT=$(___SENTRY_CLI___ bash-hook --send-event --traceback "$_SENTRY_TRACEBACK_FILE" ___SENTRY_TAGS______SENTRY_RELEASE___ --log "$_SENTRY_LOG_FILE" ___SENTRY_NO_ENVIRON___)
+  export SENTRY_LAST_EVENT=$(___SENTRY_CLI___ bash-hook --send-event --traceback "$_SENTRY_TRACEBACK_FILE" ___SENTRY_TAGS___ ___SENTRY_RELEASE___ --log "$_SENTRY_LOG_FILE" ___SENTRY_NO_ENVIRON___)
   rm -f "$_SENTRY_TRACEBACK_FILE" "$_SENTRY_LOG_FILE"
 }
 

--- a/src/commands/bash_hook.rs
+++ b/src/commands/bash_hook.rs
@@ -89,6 +89,9 @@ fn send_event(
 
     let mut event = Event {
         environment: config.get_environment().map(Into::into),
+        release: release.map_or(detect_release_name().ok().map(Into::into), |release| {
+            Some(release).map(Into::into)
+        }),
         sdk: Some(get_sdk_info()),
         user: get_user_name().ok().map(|n| User {
             username: Some(n),
@@ -106,11 +109,6 @@ fn send_event(
             .ok_or_else(|| format_err!("missing tag value"))?;
         event.tags.insert(key.into(), value.into());
     }
-
-    event.release = release.map_or(
-        detect_release_name().ok().map(Into::into),
-        |release| Some(release).map(Into::into),
-    );
 
     if environ {
         event.extra.insert(

--- a/src/commands/bash_hook.rs
+++ b/src/commands/bash_hook.rs
@@ -19,7 +19,7 @@ use crate::utils::releases::detect_release_name;
 
 const BASH_SCRIPT: &str = include_str!("../bashsupport.sh");
 lazy_static! {
-    static ref FRAME_RE: Regex = Regex::new(r#"^(.*?):(.*):(\d+)$"#).unwrap();
+    static ref FRAME_RE: Regex = Regex::new(r"^(.*?):(.*):(\d+)$").unwrap();
 }
 
 pub fn make_command(command: Command) -> Command {

--- a/tests/integration/_cases/bash_hook/bash_hook-help.trycmd
+++ b/tests/integration/_cases/bash_hook/bash_hook-help.trycmd
@@ -6,19 +6,19 @@ Prints out a bash script that does error handling.
 Usage: sentry-cli[EXE] bash-hook [OPTIONS]
 
 Options:
-      --no-exit                    Do not turn on -e (exit immediately) flag automatically
-      --header <KEY:VALUE>         Custom headers that should be attached to all requests
-                                   in key:value format.
-      --no-environ                 Do not send environment variables along
-      --auth-token <AUTH_TOKEN>    Use the given Sentry auth token.
-      --cli <CMD>                  Explicitly set/override the sentry-cli command
-      --log-level <LOG_LEVEL>      Set the log output verbosity. [possible values: trace, debug,
-                                   info, warn, error]
-      --quiet                      Do not print any output while preserving correct exit code. This
-                                   flag is currently implemented only for selected subcommands.
-                                   [aliases: silent]
-      --tag <KEY:VALUE>            Add tags (key:value) to the event.
-      --release <RELEASE_VERSION>  Define release version for the event.
-  -h, --help                       Print help
+      --no-exit                  Do not turn on -e (exit immediately) flag automatically
+      --header <KEY:VALUE>       Custom headers that should be attached to all requests
+                                 in key:value format.
+      --no-environ               Do not send environment variables along
+      --auth-token <AUTH_TOKEN>  Use the given Sentry auth token.
+      --cli <CMD>                Explicitly set/override the sentry-cli command
+      --log-level <LOG_LEVEL>    Set the log output verbosity. [possible values: trace, debug, info,
+                                 warn, error]
+      --quiet                    Do not print any output while preserving correct exit code. This
+                                 flag is currently implemented only for selected subcommands.
+                                 [aliases: silent]
+      --tag <KEY:VALUE>          Add tags (key:value) to the event.
+      --release <RELEASE>        Define release version for the event.
+  -h, --help                     Print help
 
 ```

--- a/tests/integration/_cases/bash_hook/bash_hook-help.trycmd
+++ b/tests/integration/_cases/bash_hook/bash_hook-help.trycmd
@@ -6,18 +6,19 @@ Prints out a bash script that does error handling.
 Usage: sentry-cli[EXE] bash-hook [OPTIONS]
 
 Options:
-      --no-exit                  Do not turn on -e (exit immediately) flag automatically
-      --header <KEY:VALUE>       Custom headers that should be attached to all requests
-                                 in key:value format.
-      --no-environ               Do not send environment variables along
-      --auth-token <AUTH_TOKEN>  Use the given Sentry auth token.
-      --cli <CMD>                Explicitly set/override the sentry-cli command
-      --log-level <LOG_LEVEL>    Set the log output verbosity. [possible values: trace, debug, info,
-                                 warn, error]
-      --quiet                    Do not print any output while preserving correct exit code. This
-                                 flag is currently implemented only for selected subcommands.
-                                 [aliases: silent]
-      --tag <KEY:VALUE>          Add tags (key:value) to the event.
-  -h, --help                     Print help
+      --no-exit                    Do not turn on -e (exit immediately) flag automatically
+      --header <KEY:VALUE>         Custom headers that should be attached to all requests
+                                   in key:value format.
+      --no-environ                 Do not send environment variables along
+      --auth-token <AUTH_TOKEN>    Use the given Sentry auth token.
+      --cli <CMD>                  Explicitly set/override the sentry-cli command
+      --log-level <LOG_LEVEL>      Set the log output verbosity. [possible values: trace, debug,
+                                   info, warn, error]
+      --quiet                      Do not print any output while preserving correct exit code. This
+                                   flag is currently implemented only for selected subcommands.
+                                   [aliases: silent]
+      --tag <KEY:VALUE>            Add tags (key:value) to the event.
+      --release <RELEASE_VERSION>  Define release version for the event.
+  -h, --help                       Print help
 
 ```

--- a/tests/integration/_cases/bash_hook/bash_hook-release-env.trycmd
+++ b/tests/integration/_cases/bash_hook/bash_hook-release-env.trycmd
@@ -1,5 +1,10 @@
-_SENTRY_TRACEBACK_FILE="___SENTRY_TRACEBACK_FILE___"
-_SENTRY_LOG_FILE="___SENTRY_LOG_FILE___"
+```
+$ SENTRY_RELEASE=0.2.0 sentry-cli bash-hook
+? success
+set -e
+
+_SENTRY_TRACEBACK_FILE="[..].traceback"
+_SENTRY_LOG_FILE="[..].out"
 
 if [ "${SENTRY_CLI_NO_EXIT_TRAP-0}" != 1 ]; then
   trap _sentry_exit_trap EXIT
@@ -32,7 +37,7 @@ _sentry_err_trap() {
   echo "@exit_code:${_exit_code}" >> "$_SENTRY_TRACEBACK_FILE"
 
   : >> "$_SENTRY_LOG_FILE"
-  export SENTRY_LAST_EVENT=$(___SENTRY_CLI___ bash-hook --send-event --traceback "$_SENTRY_TRACEBACK_FILE" ___SENTRY_TAGS______SENTRY_RELEASE___ --log "$_SENTRY_LOG_FILE" ___SENTRY_NO_ENVIRON___)
+  export SENTRY_LAST_EVENT=$([CWD]/target/debug/sentry-cli[EXE] bash-hook --send-event --traceback "$_SENTRY_TRACEBACK_FILE" --release "0.2.0" --log "$_SENTRY_LOG_FILE" )
   rm -f "$_SENTRY_TRACEBACK_FILE" "$_SENTRY_LOG_FILE"
 }
 
@@ -56,11 +61,15 @@ _sentry_traceback() {
 : > "$_SENTRY_LOG_FILE"
 
 if command -v perl >/dev/null; then
-  exec \
-    1> >(tee >(perl '-MPOSIX' -ne '$|++; print strftime("%Y-%m-%d %H:%M:%S %z: ", localtime()), "stdout: ", $_;' >> "$_SENTRY_LOG_FILE")) \
+  exec /
+    1> >(tee >(perl '-MPOSIX' -ne '$|++; print strftime("%Y-%m-%d %H:%M:%S %z: ", localtime()), "stdout: ", $_;' >> "$_SENTRY_LOG_FILE")) /
     2> >(tee >(perl '-MPOSIX' -ne '$|++; print strftime("%Y-%m-%d %H:%M:%S %z: ", localtime()), "stderr: ", $_;' >> "$_SENTRY_LOG_FILE") >&2)
 else
-  exec \
-    1> >(tee >(awk '{ system(""); print strftime("%Y-%m-%d %H:%M:%S %z:"), "stdout:", $0; system(""); }' >> "$_SENTRY_LOG_FILE")) \
+  exec /
+    1> >(tee >(awk '{ system(""); print strftime("%Y-%m-%d %H:%M:%S %z:"), "stdout:", $0; system(""); }' >> "$_SENTRY_LOG_FILE")) /
     2> >(tee >(awk '{ system(""); print strftime("%Y-%m-%d %H:%M:%S %z:"), "stderr:", $0; system(""); }' >> "$_SENTRY_LOG_FILE") >&2)
 fi
+
+
+```
+

--- a/tests/integration/_cases/bash_hook/bash_hook-release.trycmd
+++ b/tests/integration/_cases/bash_hook/bash_hook-release.trycmd
@@ -1,5 +1,10 @@
-_SENTRY_TRACEBACK_FILE="___SENTRY_TRACEBACK_FILE___"
-_SENTRY_LOG_FILE="___SENTRY_LOG_FILE___"
+```
+$ sentry-cli bash-hook --release "0.1.0"
+? success
+set -e
+
+_SENTRY_TRACEBACK_FILE="[..].traceback"
+_SENTRY_LOG_FILE="[..].out"
 
 if [ "${SENTRY_CLI_NO_EXIT_TRAP-0}" != 1 ]; then
   trap _sentry_exit_trap EXIT
@@ -32,7 +37,7 @@ _sentry_err_trap() {
   echo "@exit_code:${_exit_code}" >> "$_SENTRY_TRACEBACK_FILE"
 
   : >> "$_SENTRY_LOG_FILE"
-  export SENTRY_LAST_EVENT=$(___SENTRY_CLI___ bash-hook --send-event --traceback "$_SENTRY_TRACEBACK_FILE" ___SENTRY_TAGS______SENTRY_RELEASE___ --log "$_SENTRY_LOG_FILE" ___SENTRY_NO_ENVIRON___)
+  export SENTRY_LAST_EVENT=$([CWD]/target/debug/sentry-cli[EXE] bash-hook --send-event --traceback "$_SENTRY_TRACEBACK_FILE" --release "0.1.0" --log "$_SENTRY_LOG_FILE" )
   rm -f "$_SENTRY_TRACEBACK_FILE" "$_SENTRY_LOG_FILE"
 }
 
@@ -56,11 +61,15 @@ _sentry_traceback() {
 : > "$_SENTRY_LOG_FILE"
 
 if command -v perl >/dev/null; then
-  exec \
-    1> >(tee >(perl '-MPOSIX' -ne '$|++; print strftime("%Y-%m-%d %H:%M:%S %z: ", localtime()), "stdout: ", $_;' >> "$_SENTRY_LOG_FILE")) \
+  exec /
+    1> >(tee >(perl '-MPOSIX' -ne '$|++; print strftime("%Y-%m-%d %H:%M:%S %z: ", localtime()), "stdout: ", $_;' >> "$_SENTRY_LOG_FILE")) /
     2> >(tee >(perl '-MPOSIX' -ne '$|++; print strftime("%Y-%m-%d %H:%M:%S %z: ", localtime()), "stderr: ", $_;' >> "$_SENTRY_LOG_FILE") >&2)
 else
-  exec \
-    1> >(tee >(awk '{ system(""); print strftime("%Y-%m-%d %H:%M:%S %z:"), "stdout:", $0; system(""); }' >> "$_SENTRY_LOG_FILE")) \
+  exec /
+    1> >(tee >(awk '{ system(""); print strftime("%Y-%m-%d %H:%M:%S %z:"), "stdout:", $0; system(""); }' >> "$_SENTRY_LOG_FILE")) /
     2> >(tee >(awk '{ system(""); print strftime("%Y-%m-%d %H:%M:%S %z:"), "stderr:", $0; system(""); }' >> "$_SENTRY_LOG_FILE") >&2)
 fi
+
+
+```
+

--- a/tests/integration/bash_hook.rs
+++ b/tests/integration/bash_hook.rs
@@ -14,3 +14,13 @@ fn command_bash_hook() {
 fn command_bash_hook_tags() {
     register_test("bash_hook/bash_hook-tags.trycmd");
 }
+
+#[test]
+fn command_bash_hook_release() {
+    register_test("bash_hook/bash_hook-release.trycmd");
+}
+
+#[test]
+fn command_bash_hook_release_using_environment() {
+    register_test("bash_hook/bash_hook-release-env.trycmd");
+}

--- a/tests/integration/mod.rs
+++ b/tests/integration/mod.rs
@@ -26,7 +26,7 @@ use std::path::Path;
 use mockito::{mock, server_url, Matcher, Mock};
 use trycmd::TestCases;
 
-pub const UTC_DATE_FORMAT: &str = r#"\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}.\d{6,9}Z"#;
+pub const UTC_DATE_FORMAT: &str = r"\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}.\d{6,9}Z";
 const VERSION: &str = env!("CARGO_PKG_VERSION");
 
 pub fn register_test(path: &str) -> TestCases {


### PR DESCRIPTION
This PR adds support for `SENTRY_RELEASE` variable in the `bash-hook` command.
It adds `--release` argument in the command but the environment variable is
still available, so it checks the value from env first.

Resolves https://github.com/getsentry/sentry-cli/issues/1674
