### PR TITLE
feat(rn): Allow custom bundle command in xcode wrap calls

### DIFF
--- a/src/commands/react_native/xcode.rs
+++ b/src/commands/react_native/xcode.rs
@@ -324,8 +324,14 @@ pub fn wrap_call() -> Result<()> {
     let mut args: Vec<_> = env::args().skip(1).collect();
     let mut bundle_path = None;
     let mut sourcemap_path = None;
+    let bundle_command = env::var("SENTRY_RN_BUNDLE_COMMAND");
 
-    if args.len() > 1 && (args[1] == "bundle" || args[1] == "ram-bundle") {
+    // bundle and ram-bundle are React Native CLI commands
+    // export:embed is an Expo CLI command (drop in replacement for bundle)
+    // if bundle_command is set, ignore the default values
+    if args.len() > 1
+      && ((bundle_command.is_err() && (args[1] == "bundle" || args[1] == "ram-bundle" || args[1] == "export:embed"))
+        || (bundle_command.is_ok() && args[1] == bundle_command.unwrap())) {
         let mut iter = args.iter().fuse();
         while let Some(item) = iter.next() {
             if item == "--sourcemap-output" {

--- a/tests/integration/_cases/react_native/xcode-wrap-call-bundle.trycmd
+++ b/tests/integration/_cases/react_native/xcode-wrap-call-bundle.trycmd
@@ -1,5 +1,5 @@
 ```
-$ __SENTRY_RN_WRAP_XCODE_CALL=1 SENTRY_RN_REAL_NODE_BINARY=tests/integration/_fixtures/binary.sh SENTRY_RN_SOURCEMAP_REPORT=rn-sourcemap-report.json sentry-cli rn-cli.js bundle --sourcemap-output source.map.path --bundle-output source.path
+$ __SENTRY_RN_WRAP_XCODE_CALL=1 SENTRY_RN_REAL_NODE_BINARY=tests/integration/_fixtures/binary.sh SENTRY_RN_SOURCEMAP_REPORT=rn-sourcemap-report-bundle.json sentry-cli rn-cli.js bundle --sourcemap-output source.map.path --bundle-output source.path
 ? success
 Binary executed with args: rn-cli.js bundle --sourcemap-output source.map.path --bundle-output source.path
 

--- a/tests/integration/_cases/react_native/xcode-wrap-call-bundle.trycmd
+++ b/tests/integration/_cases/react_native/xcode-wrap-call-bundle.trycmd
@@ -1,0 +1,6 @@
+```
+$ __SENTRY_RN_WRAP_XCODE_CALL=1 SENTRY_RN_REAL_NODE_BINARY=tests/integration/_fixtures/binary.sh SENTRY_RN_SOURCEMAP_REPORT=rn-sourcemap-report.json sentry-cli rn-cli.js bundle --sourcemap-output source.map.path --bundle-output source.path
+? success
+Binary executed with args: rn-cli.js bundle --sourcemap-output source.map.path --bundle-output source.path
+
+```

--- a/tests/integration/_cases/react_native/xcode-wrap-call-custom-bundle.trycmd
+++ b/tests/integration/_cases/react_native/xcode-wrap-call-custom-bundle.trycmd
@@ -1,0 +1,6 @@
+```
+$ __SENTRY_RN_WRAP_XCODE_CALL=1 SENTRY_RN_REAL_NODE_BINARY=tests/integration/_fixtures/binary.sh SENTRY_RN_SOURCEMAP_REPORT=rn-sourcemap-report.json SENTRY_RN_BUNDLE_COMMAND=custom sentry-cli rn-cli.js custom --sourcemap-output source.map.path --bundle-output source.path
+? success
+Binary executed with args: rn-cli.js custom --sourcemap-output source.map.path --bundle-output source.path
+
+```

--- a/tests/integration/_cases/react_native/xcode-wrap-call-custom-bundle.trycmd
+++ b/tests/integration/_cases/react_native/xcode-wrap-call-custom-bundle.trycmd
@@ -1,5 +1,5 @@
 ```
-$ __SENTRY_RN_WRAP_XCODE_CALL=1 SENTRY_RN_REAL_NODE_BINARY=tests/integration/_fixtures/binary.sh SENTRY_RN_SOURCEMAP_REPORT=rn-sourcemap-report.json SENTRY_RN_BUNDLE_COMMAND=custom sentry-cli rn-cli.js custom --sourcemap-output source.map.path --bundle-output source.path
+$ __SENTRY_RN_WRAP_XCODE_CALL=1 SENTRY_RN_REAL_NODE_BINARY=tests/integration/_fixtures/binary.sh SENTRY_RN_SOURCEMAP_REPORT=rn-sourcemap-report-custom-bundle.json SENTRY_RN_BUNDLE_COMMAND=custom sentry-cli rn-cli.js custom --sourcemap-output source.map.path --bundle-output source.path
 ? success
 Binary executed with args: rn-cli.js custom --sourcemap-output source.map.path --bundle-output source.path
 

--- a/tests/integration/_cases/react_native/xcode-wrap-call-expo-export.trycmd
+++ b/tests/integration/_cases/react_native/xcode-wrap-call-expo-export.trycmd
@@ -1,5 +1,5 @@
 ```
-$ __SENTRY_RN_WRAP_XCODE_CALL=1 SENTRY_RN_REAL_NODE_BINARY=tests/integration/_fixtures/binary.sh SENTRY_RN_SOURCEMAP_REPORT=rn-sourcemap-report.json sentry-cli expo-cli.js export:embed --sourcemap-output source.map.path --bundle-output source.path
+$ __SENTRY_RN_WRAP_XCODE_CALL=1 SENTRY_RN_REAL_NODE_BINARY=tests/integration/_fixtures/binary.sh SENTRY_RN_SOURCEMAP_REPORT=rn-sourcemap-report-expo-export.json sentry-cli expo-cli.js export:embed --sourcemap-output source.map.path --bundle-output source.path
 ? success
 Binary executed with args: expo-cli.js export:embed --sourcemap-output source.map.path --bundle-output source.path
 

--- a/tests/integration/_cases/react_native/xcode-wrap-call-expo-export.trycmd
+++ b/tests/integration/_cases/react_native/xcode-wrap-call-expo-export.trycmd
@@ -1,0 +1,6 @@
+```
+$ __SENTRY_RN_WRAP_XCODE_CALL=1 SENTRY_RN_REAL_NODE_BINARY=tests/integration/_fixtures/binary.sh SENTRY_RN_SOURCEMAP_REPORT=rn-sourcemap-report.json sentry-cli expo-cli.js export:embed --sourcemap-output source.map.path --bundle-output source.path
+? success
+Binary executed with args: expo-cli.js export:embed --sourcemap-output source.map.path --bundle-output source.path
+
+```

--- a/tests/integration/_cases/react_native/xcode-wrap-call-minimum.trycmd
+++ b/tests/integration/_cases/react_native/xcode-wrap-call-minimum.trycmd
@@ -1,0 +1,6 @@
+```
+$ __SENTRY_RN_WRAP_XCODE_CALL=1 SENTRY_RN_REAL_NODE_BINARY=tests/integration/_fixtures/binary.sh SENTRY_RN_SOURCEMAP_REPORT=rn-sourcemap-report.json sentry-cli first second
+? success
+Binary executed with args: first second
+
+```

--- a/tests/integration/_cases/react_native/xcode-wrap-call-minimum.trycmd
+++ b/tests/integration/_cases/react_native/xcode-wrap-call-minimum.trycmd
@@ -1,5 +1,5 @@
 ```
-$ __SENTRY_RN_WRAP_XCODE_CALL=1 SENTRY_RN_REAL_NODE_BINARY=tests/integration/_fixtures/binary.sh SENTRY_RN_SOURCEMAP_REPORT=rn-sourcemap-report.json sentry-cli first second
+$ __SENTRY_RN_WRAP_XCODE_CALL=1 SENTRY_RN_REAL_NODE_BINARY=tests/integration/_fixtures/binary.sh SENTRY_RN_SOURCEMAP_REPORT=rn-sourcemap-report-minimum.json sentry-cli first second
 ? success
 Binary executed with args: first second
 

--- a/tests/integration/_fixtures/binary.sh
+++ b/tests/integration/_fixtures/binary.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+echo "Binary executed with args: $@"

--- a/tests/integration/_fixtures/react_native/empty-sourcemap-report.json.expected
+++ b/tests/integration/_fixtures/react_native/empty-sourcemap-report.json.expected
@@ -1,0 +1,1 @@
+{"bundle_path":null,"sourcemap_path":null}

--- a/tests/integration/_fixtures/react_native/full-sourcemap-report.json.expected
+++ b/tests/integration/_fixtures/react_native/full-sourcemap-report.json.expected
@@ -1,0 +1,1 @@
+{"bundle_path":"source.path","sourcemap_path":"source.map.path"}

--- a/tests/integration/mod.rs
+++ b/tests/integration/mod.rs
@@ -10,6 +10,7 @@ mod monitors;
 mod org_tokens;
 mod organizations;
 mod projects;
+mod react_native;
 mod releases;
 mod send_envelope;
 mod send_event;
@@ -18,7 +19,6 @@ mod uninstall;
 mod update;
 mod upload_dif;
 mod upload_proguard;
-mod react_native;
 
 use std::fs;
 use std::io;

--- a/tests/integration/mod.rs
+++ b/tests/integration/mod.rs
@@ -18,6 +18,7 @@ mod uninstall;
 mod update;
 mod upload_dif;
 mod upload_proguard;
+mod react_native;
 
 use std::fs;
 use std::io;

--- a/tests/integration/react_native/mod.rs
+++ b/tests/integration/react_native/mod.rs
@@ -33,10 +33,12 @@ fn xcode_wrap_call_expo_export() {
     clean_up("rn-sourcemap-report-expo-export.json");
 }
 
+#[cfg(target_os = "macos")]
 fn clean_up(path: &str) {
     std::fs::remove_file(path).unwrap();
 }
 
+#[cfg(target_os = "macos")]
 fn assert_full_sourcemap_report(actual: &str) {
     let actual_code = std::fs::read_to_string(actual).unwrap();
     let expected_code = std::fs::read_to_string(
@@ -47,6 +49,7 @@ fn assert_full_sourcemap_report(actual: &str) {
     assert_eq!(actual_code, expected_code);
 }
 
+#[cfg(target_os = "macos")]
 fn assert_empty_sourcemap_report(actual: &str) {
     let actual_code = std::fs::read_to_string(actual).unwrap();
     let expected_code = std::fs::read_to_string(

--- a/tests/integration/react_native/mod.rs
+++ b/tests/integration/react_native/mod.rs
@@ -1,3 +1,4 @@
+#[cfg(target_os = "macos")]
 use crate::integration::register_test;
 
 #[test]
@@ -37,21 +38,21 @@ fn clean_up() {
 }
 
 fn assert_full_sourcemap_report() {
-    let actual_code =
-    std::fs::read_to_string("rn-sourcemap-report.json").unwrap();
-    let expected_code =
-      std::fs::read_to_string("tests/integration/_fixtures/react_native/full-sourcemap-report.json.expected")
-          .unwrap();
+    let actual_code = std::fs::read_to_string("rn-sourcemap-report.json").unwrap();
+    let expected_code = std::fs::read_to_string(
+        "tests/integration/_fixtures/react_native/full-sourcemap-report.json.expected",
+    )
+    .unwrap();
 
     assert_eq!(actual_code, expected_code);
 }
 
 fn assert_empty_sourcemap_report() {
-    let actual_code =
-    std::fs::read_to_string("rn-sourcemap-report.json").unwrap();
-    let expected_code =
-      std::fs::read_to_string("tests/integration/_fixtures/react_native/empty-sourcemap-report.json.expected")
-          .unwrap();
+    let actual_code = std::fs::read_to_string("rn-sourcemap-report.json").unwrap();
+    let expected_code = std::fs::read_to_string(
+        "tests/integration/_fixtures/react_native/empty-sourcemap-report.json.expected",
+    )
+    .unwrap();
 
     assert_eq!(actual_code, expected_code);
 }

--- a/tests/integration/react_native/mod.rs
+++ b/tests/integration/react_native/mod.rs
@@ -33,15 +33,11 @@ fn xcode_wrap_call_expo_export() {
     clean_up("rn-sourcemap-report-expo-export.json");
 }
 
-fn clean_up(
-  path: &str,
-) {
+fn clean_up(path: &str) {
     std::fs::remove_file(path).unwrap();
 }
 
-fn assert_full_sourcemap_report(
-  actual: &str,
-) {
+fn assert_full_sourcemap_report(actual: &str) {
     let actual_code = std::fs::read_to_string(actual).unwrap();
     let expected_code = std::fs::read_to_string(
         "tests/integration/_fixtures/react_native/full-sourcemap-report.json.expected",
@@ -51,9 +47,7 @@ fn assert_full_sourcemap_report(
     assert_eq!(actual_code, expected_code);
 }
 
-fn assert_empty_sourcemap_report(
-  actual: &str,
-) {
+fn assert_empty_sourcemap_report(actual: &str) {
     let actual_code = std::fs::read_to_string(actual).unwrap();
     let expected_code = std::fs::read_to_string(
         "tests/integration/_fixtures/react_native/empty-sourcemap-report.json.expected",

--- a/tests/integration/react_native/mod.rs
+++ b/tests/integration/react_native/mod.rs
@@ -2,43 +2,47 @@
 use crate::integration::register_test;
 
 #[test]
+#[cfg(target_os = "macos")]
 fn xcode_wrap_call_minimum() {
-    #[cfg(target_os = "macos")]
     register_test("react_native/xcode-wrap-call-minimum.trycmd");
-    assert_empty_sourcemap_report();
-    clean_up();
+    assert_empty_sourcemap_report("rn-sourcemap-report-minimum.json");
+    clean_up("rn-sourcemap-report-minimum.json");
 }
 
 #[test]
+#[cfg(target_os = "macos")]
 fn xcode_wrap_call_bundle() {
-    #[cfg(target_os = "macos")]
     register_test("react_native/xcode-wrap-call-bundle.trycmd");
-    assert_full_sourcemap_report();
-    clean_up();
+    assert_full_sourcemap_report("rn-sourcemap-report-bundle.json");
+    clean_up("rn-sourcemap-report-bundle.json");
 }
 
 #[test]
+#[cfg(target_os = "macos")]
 fn xcode_wrap_call_custom_bundle() {
-    #[cfg(target_os = "macos")]
     register_test("react_native/xcode-wrap-call-custom-bundle.trycmd");
-    assert_full_sourcemap_report();
-    clean_up();
+    assert_full_sourcemap_report("rn-sourcemap-report-custom-bundle.json");
+    clean_up("rn-sourcemap-report-custom-bundle.json");
 }
 
 #[test]
+#[cfg(target_os = "macos")]
 fn xcode_wrap_call_expo_export() {
-    #[cfg(target_os = "macos")]
     register_test("react_native/xcode-wrap-call-expo-export.trycmd");
-    assert_full_sourcemap_report();
-    clean_up();
+    assert_full_sourcemap_report("rn-sourcemap-report-expo-export.json");
+    clean_up("rn-sourcemap-report-expo-export.json");
 }
 
-fn clean_up() {
-    std::fs::remove_file("rn-sourcemap-report.json").unwrap();
+fn clean_up(
+  path: &str,
+) {
+    std::fs::remove_file(path).unwrap();
 }
 
-fn assert_full_sourcemap_report() {
-    let actual_code = std::fs::read_to_string("rn-sourcemap-report.json").unwrap();
+fn assert_full_sourcemap_report(
+  actual: &str,
+) {
+    let actual_code = std::fs::read_to_string(actual).unwrap();
     let expected_code = std::fs::read_to_string(
         "tests/integration/_fixtures/react_native/full-sourcemap-report.json.expected",
     )
@@ -47,8 +51,10 @@ fn assert_full_sourcemap_report() {
     assert_eq!(actual_code, expected_code);
 }
 
-fn assert_empty_sourcemap_report() {
-    let actual_code = std::fs::read_to_string("rn-sourcemap-report.json").unwrap();
+fn assert_empty_sourcemap_report(
+  actual: &str,
+) {
+    let actual_code = std::fs::read_to_string(actual).unwrap();
     let expected_code = std::fs::read_to_string(
         "tests/integration/_fixtures/react_native/empty-sourcemap-report.json.expected",
     )

--- a/tests/integration/react_native/mod.rs
+++ b/tests/integration/react_native/mod.rs
@@ -1,0 +1,57 @@
+use crate::integration::register_test;
+
+#[test]
+fn xcode_wrap_call_minimum() {
+    #[cfg(target_os = "macos")]
+    register_test("react_native/xcode-wrap-call-minimum.trycmd");
+    assert_empty_sourcemap_report();
+    clean_up();
+}
+
+#[test]
+fn xcode_wrap_call_bundle() {
+    #[cfg(target_os = "macos")]
+    register_test("react_native/xcode-wrap-call-bundle.trycmd");
+    assert_full_sourcemap_report();
+    clean_up();
+}
+
+#[test]
+fn xcode_wrap_call_custom_bundle() {
+    #[cfg(target_os = "macos")]
+    register_test("react_native/xcode-wrap-call-custom-bundle.trycmd");
+    assert_full_sourcemap_report();
+    clean_up();
+}
+
+#[test]
+fn xcode_wrap_call_expo_export() {
+    #[cfg(target_os = "macos")]
+    register_test("react_native/xcode-wrap-call-expo-export.trycmd");
+    assert_full_sourcemap_report();
+    clean_up();
+}
+
+fn clean_up() {
+    std::fs::remove_file("rn-sourcemap-report.json").unwrap();
+}
+
+fn assert_full_sourcemap_report() {
+    let actual_code =
+    std::fs::read_to_string("rn-sourcemap-report.json").unwrap();
+    let expected_code =
+      std::fs::read_to_string("tests/integration/_fixtures/react_native/full-sourcemap-report.json.expected")
+          .unwrap();
+
+    assert_eq!(actual_code, expected_code);
+}
+
+fn assert_empty_sourcemap_report() {
+    let actual_code =
+    std::fs::read_to_string("rn-sourcemap-report.json").unwrap();
+    let expected_code =
+      std::fs::read_to_string("tests/integration/_fixtures/react_native/empty-sourcemap-report.json.expected")
+          .unwrap();
+
+    assert_eq!(actual_code, expected_code);
+}


### PR DESCRIPTION
Fixes `sentry-expo` issue.
- https://github.com/expo/sentry-expo/issues/364

In Expo SDK 49 new Expo CLI Bundle command was introduced, but current Sentry CLI supports only `bundle` and `ram-bundle` commands.

This PR adds support for `export:embed` from Expo CLI as well as custom bundle command by using env var `SENTRY_RN_BUNDLE_COMMAND`.