### PR TITLE
fix: Always poll artifact assembly, even if nothing was uploaded

### DIFF
--- a/src/utils/file_upload.rs
+++ b/src/utils/file_upload.rs
@@ -396,18 +396,16 @@ fn upload_files_chunked(
         chunks.retain(|Chunk((digest, _))| response.missing_chunks.contains(digest));
     };
 
-    upload_chunks(&chunks, options, progress_style)?;
-
     if !chunks.is_empty() {
+        upload_chunks(&chunks, options, progress_style)?;
         println!("{} Uploaded files to Sentry", style(">").dim());
-        poll_assemble(checksum, &checksums, context, options)
     } else {
         println!(
             "{} Nothing to upload, all files are on the server",
             style(">").dim()
         );
-        Ok(())
     }
+    poll_assemble(checksum, &checksums, context, options)
 }
 
 fn build_debug_id(files: &SourceFiles) -> DebugId {


### PR DESCRIPTION
This does two things.

1. It moves the call to `upload_chunks` into the case where there are chunks to upload. This is essentially a cosmetic change.
2. It calls `poll_assemble` no matter if chunks had to be uploaded or not. This causes the artifact bundle to be assembled in edge cases where the chunks are already on the server, but the bundle hasn't been assembled.

Part of the fix of #1724.