### PR TITLE
fix: Handle queries and fragments in sourcemap URLs

### DIFF
--- a/tests/integration/_fixtures/inject/server/chunks/1.js
+++ b/tests/integration/_fixtures/inject/server/chunks/1.js
@@ -1,1 +1,1 @@
-//# sourceMappingURL=1.js.map
+//# sourceMappingURL=1.js.map?v=1.31.2

--- a/tests/integration/_fixtures/inject/server/pages/_document.js
+++ b/tests/integration/_fixtures/inject/server/pages/_document.js
@@ -1,1 +1,1 @@
-//# sourceMappingURL=_document.js.map
+//# sourceMappingURL=_document.js.map#here


### PR DESCRIPTION
This manually strips away query strings and fragments from source mapping URLs, making sure that the sourcemap file is correctly associated with the source file.