### PR TITLE
feat(login): Open org auth token creation page

### DIFF
--- a/src/commands/login.rs
+++ b/src/commands/login.rs
@@ -71,11 +71,19 @@ pub fn execute(matches: &ArgMatches) -> Result<()> {
             cfg.set_auth(Auth::Token(token.to_string()))?;
             Ok(())
         })?;
+
         match Api::with_config(test_cfg).get_auth_info() {
             Ok(info) => {
-                // we can unwrap here somewhat safely because we do not permit
-                // signing in with legacy non user bound api keys here.
-                println!("Valid token for user {}", info.user.unwrap().email);
+                match info.user {
+                    Some(user) => {
+                        // Old school user auth token
+                        println!("Valid token for user {}", user.email);
+                    }
+                    None => {
+                        // New org auth token
+                        println!("Valid org token");
+                    }
+                }
                 break;
             }
             Err(err) => {

--- a/src/commands/login.rs
+++ b/src/commands/login.rs
@@ -27,7 +27,10 @@ fn update_config(config: &Config, token: &str) -> Result<()> {
 
 pub fn execute(matches: &ArgMatches) -> Result<()> {
     let config = Config::current();
-    let token_url = format!("{}/api/", config.get_base_url()?);
+    let token_url = format!(
+        "{}/orgredirect/organizations/:orgslug/settings/auth-tokens/",
+        config.get_base_url()?
+    );
     let predefined_token = matches.get_one::<String>("auth_token");
     let has_predefined_token = predefined_token.is_some();
 


### PR DESCRIPTION
This causes the `login` command to open the page for creating org auth tokens.