### PR TITLE
fix(rn): Upload root bundle source map for ram bundles

### DIFF
--- a/src/utils/sourcemaps.rs
+++ b/src/utils/sourcemaps.rs
@@ -529,16 +529,14 @@ impl SourceMapProcessor {
             bundle_source_url, sourcemap_url
         );
 
-        let sourcemap_content = match self.sources.get(&sourcemap_url) {
-            Some(source) => &source.contents,
-            None => {
-                warn!(
-                    "Cannot find the sourcemap for the RAM bundle using the URL: {}, skipping",
-                    sourcemap_url
-                );
-                return Ok(());
-            }
+        let Some(sourcemap_source) = self.sources.get(&sourcemap_url) else {
+            warn!(
+                "Cannot find the sourcemap for the RAM bundle using the URL: {}, skipping",
+                sourcemap_url
+            );
+            return Ok(());
         };
+        let sourcemap_content = &sourcemap_source.contents;
 
         let sourcemap_index = match sourcemap::decode_slice(sourcemap_content)? {
             sourcemap::DecodedMap::Index(sourcemap_index) => sourcemap_index,
@@ -550,25 +548,25 @@ impl SourceMapProcessor {
 
         // We have to include the bundle sourcemap which is the first section
         // in the bundle source map before the modules maps
-        if let Some(sourcemap_source) = self.sources.get(&sourcemap_url) {
-            if let Some(index_section) = &sourcemap_index.sections().nth(0) {
-                if let Some(index_section) = index_section.get_sourcemap() {
-                    let mut sourcemap_content: Vec<u8> = vec![];
-                    index_section.to_writer(&mut sourcemap_content)?;
-                    self.sources.insert(
-                        sourcemap_url.clone(),
-                        SourceFile {
-                            url: sourcemap_source.url.clone(),
-                            path: sourcemap_source.path.clone(),
-                            contents: sourcemap_content,
-                            ty: SourceFileType::SourceMap,
-                            headers: sourcemap_source.headers.clone(),
-                            messages: sourcemap_source.messages.clone(),
-                            already_uploaded: false,
-                        },
-                    );
-                }
-            }
+        if let Some(index_section) = &sourcemap_index
+            .sections()
+            .nth(0)
+            .and_then(|index_section| index_section.get_sourcemap())
+        {
+            let mut index_sourcemap_content: Vec<u8> = vec![];
+            index_section.to_writer(&mut index_sourcemap_content)?;
+            self.sources.insert(
+                sourcemap_url.clone(),
+                SourceFile {
+                    url: sourcemap_source.url.clone(),
+                    path: sourcemap_source.path.clone(),
+                    contents: index_sourcemap_content,
+                    ty: SourceFileType::SourceMap,
+                    headers: sourcemap_source.headers.clone(),
+                    messages: sourcemap_source.messages.clone(),
+                    already_uploaded: false,
+                },
+            );
         }
 
         let ram_bundle_iter =

--- a/src/utils/sourcemaps.rs
+++ b/src/utils/sourcemaps.rs
@@ -548,7 +548,8 @@ impl SourceMapProcessor {
             }
         };
 
-        // We have to include the bundle sourcemap which is the first section in the bundle source map
+        // We have to include the bundle sourcemap which is the first section
+        // in the bundle source map before the modules maps
         if let Some(sourcemap_source) = self.sources.get(&sourcemap_url) {
             if let Some(index_section) = &sourcemap_index.sections().nth(0) {
                 if let Some(index_section) = index_section.get_sourcemap() {

--- a/tests/integration/_cases/sourcemaps/sourcemaps-upload-file-ram-bundle.trycmd
+++ b/tests/integration/_cases/sourcemaps/sourcemaps-upload-file-ram-bundle.trycmd
@@ -4,7 +4,7 @@ $ sentry-cli sourcemaps upload --bundle tests/integration/_fixtures/file-ram-bun
 > Analyzing 2 sources
 > Rewriting sources
 > Adding source map references
-> Bundled 13 files for upload
+> Bundled 14 files for upload
 > Bundle ID: [..]-[..]-[..]-[..]-[..]
 > Uploaded files to Sentry
 > File upload complete (processing pending on server)
@@ -30,5 +30,6 @@ Source Map Upload Report
     ~/7.js.map
     ~/8.js.map
     ~/9.js.map
+    ~/index.android.bundle.packager.map
 
 ```

--- a/tests/integration/_cases/sourcemaps/sourcemaps-upload-indexed-ram-bundle.trycmd
+++ b/tests/integration/_cases/sourcemaps/sourcemaps-upload-indexed-ram-bundle.trycmd
@@ -4,7 +4,7 @@ $ sentry-cli sourcemaps upload --bundle tests/integration/_fixtures/indexed-ram-
 > Analyzing 2 sources
 > Rewriting sources
 > Adding source map references
-> Bundled 2106 files for upload
+> Bundled 2107 files for upload
 > Bundle ID: [..]-[..]-[..]-[..]-[..]
 > Uploaded files to Sentry
 > File upload complete (processing pending on server)
@@ -2123,5 +2123,6 @@ Source Map Upload Report
     ~/997.js.map
     ~/998.js.map
     ~/999.js.map
+    ~/main.jsbundle.packager.map
 
 ```


### PR DESCRIPTION
- fixes https://github.com/getsentry/sentry-cli/issues/1741

`rust-sourcemap` package only parses modules but doesn't include the root bundle file therefore also doesn't include it's source map.

 