### PR TITLE
Add support for $XDG_CONFIG_HOME file

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2279,6 +2279,7 @@ dependencies = [
  "walkdir",
  "which",
  "winapi 0.3.9",
+ "xdg",
  "zip",
 ]
 
@@ -3187,6 +3188,12 @@ name = "windows_x86_64_msvc"
 version = "0.42.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "447660ad36a13288b1db4d4248e857b510e8c3a225c822ba4fb748c0aafecffd"
+
+[[package]]
+name = "xdg"
+version = "2.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "213b7324336b53d2414b2db8537e56544d981803139155afa84f76eeebb7a546"
 
 [[package]]
 name = "yaml-rust"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -73,6 +73,7 @@ username = "0.2.0"
 uuid = { version = "1.3.0", features = ["v4", "serde"] }
 walkdir = "2.3.2"
 which = "4.4.0"
+xdg = "2.5.2"
 zip = "0.6.4"
 data-encoding = "2.3.3"
 magic_string = "0.3.4"

--- a/src/config.rs
+++ b/src/config.rs
@@ -551,12 +551,13 @@ impl Config {
 }
 
 fn find_global_config_file() -> Result<PathBuf> {
-    dirs::home_dir()
-        .ok_or_else(|| format_err!("Could not find home dir"))
-        .map(|mut path| {
-            path.push(CONFIG_RC_FILE_NAME);
-            path
-        })
+    if let Ok(xdg_dirs) = xdg::BaseDirectories::with_prefix("sentry") {
+        xdg_dirs
+            .place_config_file("cli.ini")
+            .or(Err(format_err!("Could not create the config file")))
+    } else {
+        Err(format_err!("Could not find home dir"))
+    }
 }
 
 fn find_project_config_file() -> Option<PathBuf> {


### PR DESCRIPTION
Hi all, this PR adds the support for $XDG_CONFIG_HOME. The default global file is now located at
`$XDG_CONFIG_HOME/sentry/cli.ini` (issue https://github.com/getsentry/sentry-cli/issues/1521).

`env` is still used for local config but `dirs` is still used for `dump_response`, `debug_files` and `cache_dir`. Maybe, at least `cache_dir`, should be moved to `xdg`? 