### PR TITLE
feat(upload): Introduce `--wait-for` option

### DIFF
--- a/src/commands/debug_files/bundle_jvm.rs
+++ b/src/commands/debug_files/bundle_jvm.rs
@@ -2,7 +2,7 @@ use crate::api::Api;
 use crate::config::Config;
 use crate::utils::args::ArgExt;
 use crate::utils::file_search::ReleaseFileSearch;
-use crate::utils::file_upload::{FileUpload, SourceFile, UploadContext};
+use crate::utils::file_upload::{FileUpload, SourceFile, UploadContext, Wait};
 use crate::utils::fs::path_as_url;
 use anyhow::{bail, Context, Result};
 use clap::{Arg, ArgMatches, Command};
@@ -58,7 +58,7 @@ pub fn execute(matches: &ArgMatches) -> Result<()> {
         release: None,
         dist: None,
         note: None,
-        wait: true,
+        wait: Wait::Forever,
         dedupe: false,
         chunk_upload_options: chunk_upload_options.as_ref(),
     };

--- a/src/commands/react_native/appcenter.rs
+++ b/src/commands/react_native/appcenter.rs
@@ -13,7 +13,7 @@ use crate::config::Config;
 use crate::utils::appcenter::{get_appcenter_package, get_react_native_appcenter_release};
 use crate::utils::args::{validate_distribution, ArgExt};
 use crate::utils::file_search::ReleaseFileSearch;
-use crate::utils::file_upload::UploadContext;
+use crate::utils::file_upload::{UploadContext, Wait};
 use crate::utils::sourcemaps::SourceMapProcessor;
 
 pub fn make_command(command: Command) -> Command {
@@ -90,7 +90,18 @@ pub fn make_command(command: Command) -> Command {
             Arg::new("wait")
                 .long("wait")
                 .action(ArgAction::SetTrue)
+                .conflicts_with("wait_for")
                 .help("Wait for the server to fully process uploaded files."),
+        )
+        .arg(
+            Arg::new("wait_for")
+                .long("wait-for")
+                .value_name("SECS")
+                .conflicts_with("wait")
+                .help(
+                    "Wait for the server to fully process uploaded files, \
+                     but at most for the given number of seconds.",
+                ),
         )
 }
 
@@ -168,6 +179,14 @@ pub fn execute(matches: &ArgMatches) -> Result<()> {
 
     let chunk_upload_options = api.get_chunk_upload_options(&org)?;
 
+    let wait = if let Some(secs) = matches.get_one::<u64>("wait_for") {
+        Wait::from_secs(*secs)
+    } else if matches.get_flag("wait") {
+        Wait::Forever
+    } else {
+        Wait::No
+    };
+
     match matches.get_many::<String>("dist") {
         None => {
             println!(
@@ -181,7 +200,7 @@ pub fn execute(matches: &ArgMatches) -> Result<()> {
                 release: Some(&release),
                 dist: None,
                 note: None,
-                wait: matches.get_flag("wait"),
+                wait,
                 dedupe: false,
                 chunk_upload_options: chunk_upload_options.as_ref(),
             })?;
@@ -199,7 +218,7 @@ pub fn execute(matches: &ArgMatches) -> Result<()> {
                     release: Some(&release),
                     dist: Some(dist),
                     note: None,
-                    wait: matches.get_flag("wait"),
+                    wait,
                     dedupe: false,
                     chunk_upload_options: chunk_upload_options.as_ref(),
                 })?;

--- a/src/commands/react_native/xcode.rs
+++ b/src/commands/react_native/xcode.rs
@@ -17,6 +17,7 @@ use crate::config::Config;
 use crate::utils::args::{validate_distribution, ArgExt};
 use crate::utils::file_search::ReleaseFileSearch;
 use crate::utils::file_upload::UploadContext;
+use crate::utils::file_upload::Wait;
 use crate::utils::fs::TempFile;
 use crate::utils::sourcemaps::SourceMapProcessor;
 use crate::utils::system::propagate_exit_status;
@@ -103,7 +104,18 @@ pub fn make_command(command: Command) -> Command {
             Arg::new("wait")
                 .long("wait")
                 .action(ArgAction::SetTrue)
+                .conflicts_with("wait_for")
                 .help("Wait for the server to fully process uploaded files."),
+        )
+        .arg(
+            Arg::new("wait_for")
+                .long("wait-for")
+                .value_name("SECS")
+                .conflicts_with("wait")
+                .help(
+                    "Wait for the server to fully process uploaded files, \
+                     but at most for the given number of seconds.",
+                ),
         )
         .arg(
             Arg::new("no_auto_release")
@@ -283,7 +295,9 @@ pub fn execute(matches: &ArgMatches) -> Result<()> {
             };
 
             // If Hermes emitted source map we have to use it
-            if let (Some(hermes_bundle_path), Some(hermes_sourcemap_path)) = (report.hermes_bundle_path, report.hermes_sourcemap_path) {
+            if let (Some(hermes_bundle_path), Some(hermes_sourcemap_path)) =
+                (report.hermes_bundle_path, report.hermes_sourcemap_path)
+            {
                 bundle_path = hermes_bundle_path.clone();
                 sourcemap_path = hermes_sourcemap_path.clone();
                 println!("Using Hermes bundle and combined source map.");
@@ -323,14 +337,25 @@ pub fn execute(matches: &ArgMatches) -> Result<()> {
         let dist_from_env = env::var("SENTRY_DIST");
         let release_from_env = env::var("SENTRY_RELEASE");
 
-        if dist_from_env.is_err() && release_from_env.is_err() && matches.get_flag("no_auto_release") {
+        let wait = if let Some(secs) = matches.get_one::<u64>("wait_for") {
+            Wait::from_secs(*secs)
+        } else if matches.get_flag("wait") {
+            Wait::Forever
+        } else {
+            Wait::No
+        };
+
+        if dist_from_env.is_err()
+            && release_from_env.is_err()
+            && matches.get_flag("no_auto_release")
+        {
             processor.upload(&UploadContext {
                 org: &org,
                 project: Some(&project),
                 release: None,
                 dist: None,
                 note: None,
-                wait: matches.get_flag("wait"),
+                wait,
                 dedupe: false,
                 chunk_upload_options: chunk_upload_options.as_ref(),
             })?;
@@ -351,7 +376,7 @@ pub fn execute(matches: &ArgMatches) -> Result<()> {
                         release: Some(&release_name),
                         dist: Some(&dist),
                         note: None,
-                        wait: matches.get_flag("wait"),
+                        wait,
                         dedupe: false,
                         chunk_upload_options: chunk_upload_options.as_ref(),
                     })?;
@@ -364,7 +389,7 @@ pub fn execute(matches: &ArgMatches) -> Result<()> {
                             release: Some(&release_name),
                             dist: Some(dist),
                             note: None,
-                            wait: matches.get_flag("wait"),
+                            wait,
                             dedupe: false,
                             chunk_upload_options: chunk_upload_options.as_ref(),
                         })?;
@@ -400,8 +425,10 @@ pub fn wrap_call() -> Result<()> {
     // export:embed is an Expo CLI command (drop in replacement for bundle)
     // if bundle_command is set, ignore the default values
     if args.len() > 1
-      && ((bundle_command.is_err() && (args[1] == "bundle" || args[1] == "ram-bundle" || args[1] == "export:embed"))
-        || (bundle_command.is_ok() && args[1] == bundle_command.unwrap())) {
+        && ((bundle_command.is_err()
+            && (args[1] == "bundle" || args[1] == "ram-bundle" || args[1] == "export:embed"))
+            || (bundle_command.is_ok() && args[1] == bundle_command.unwrap()))
+    {
         let mut iter = args.iter().fuse();
         while let Some(item) = iter.next() {
             if item == "--sourcemap-output" {
@@ -451,8 +478,10 @@ pub fn wrap_call() -> Result<()> {
     // if not packages bundle and sourcemap have to be used for symbolication
     //
     // The compose script can be user defined so we have to check for that
-    } else if args.len() > 1 && (args[0].ends_with("compose-source-maps.js")
-        || (compose_source_maps_path.is_ok() && args[0] == compose_source_maps_path.unwrap())) {
+    } else if args.len() > 1
+        && (args[0].ends_with("compose-source-maps.js")
+            || (compose_source_maps_path.is_ok() && args[0] == compose_source_maps_path.unwrap()))
+    {
         let mut iter = args.iter().fuse();
         while let Some(item) = iter.next() {
             if item == "-o" {
@@ -482,11 +511,13 @@ pub fn wrap_call() -> Result<()> {
         // We have to do it while pretending being the script because of the clean up afterwards
         if let Some(ref packager_sourcemap_path) = sourcemap_report.packager_sourcemap_path {
             let mut packager_sourcemap_file = fs::File::open(packager_sourcemap_path)?;
-            let packager_sourcemap_result: Result<HashMap<String, Value>, serde_json::Error> = serde_json::from_reader(&mut packager_sourcemap_file);
+            let packager_sourcemap_result: Result<HashMap<String, Value>, serde_json::Error> =
+                serde_json::from_reader(&mut packager_sourcemap_file);
 
             let hermes_sourcemap_path = sourcemap_report.hermes_sourcemap_path.as_ref().unwrap();
             let mut hermes_sourcemap_file = fs::File::open(hermes_sourcemap_path)?;
-            let hermes_sourcemap_result: Result<HashMap<String, Value>, serde_json::Error> = serde_json::from_reader(&mut hermes_sourcemap_file);
+            let hermes_sourcemap_result: Result<HashMap<String, Value>, serde_json::Error> =
+                serde_json::from_reader(&mut hermes_sourcemap_file);
 
             if packager_sourcemap_result.is_err() {
                 println!(
@@ -502,9 +533,16 @@ pub fn wrap_call() -> Result<()> {
                 );
             }
 
-            if let (Ok(packager_sourcemap), Ok(mut hermes_sourcemap)) = (packager_sourcemap_result, hermes_sourcemap_result) {
-                if hermes_sourcemap.get("debugId").is_none() && hermes_sourcemap.get("debug_id").is_none() {
-                    if let Some(debug_id) = packager_sourcemap.get("debugId").or_else(|| packager_sourcemap.get("debug_id")) {
+            if let (Ok(packager_sourcemap), Ok(mut hermes_sourcemap)) =
+                (packager_sourcemap_result, hermes_sourcemap_result)
+            {
+                if hermes_sourcemap.get("debugId").is_none()
+                    && hermes_sourcemap.get("debug_id").is_none()
+                {
+                    if let Some(debug_id) = packager_sourcemap
+                        .get("debugId")
+                        .or_else(|| packager_sourcemap.get("debug_id"))
+                    {
                         hermes_sourcemap.insert("debugId".to_string(), debug_id.clone());
                         hermes_sourcemap.insert("debug_id".to_string(), debug_id.clone());
 

--- a/tests/integration/_cases/sourcemaps/sourcemaps-upload-help.trycmd
+++ b/tests/integration/_cases/sourcemaps/sourcemaps-upload-help.trycmd
@@ -39,6 +39,9 @@ Options:
           Enable files gzip decompression prior to upload.
       --wait
           Wait for the server to fully process uploaded files.
+      --wait-for <SECS>
+          Wait for the server to fully process uploaded files, but at most for the given number of
+          seconds.
       --no-sourcemap-reference
           Disable emitting of automatic sourcemap references.
           By default the tool will store a 'Sourcemap' header with minified files so that sourcemaps


### PR DESCRIPTION
Upload commands can now take a new option `--wait-for <SECS>` that behaves like `--wait`, but limits the maximum waiting time to the given number of seconds. This option conflicts with `--wait`.