### PR TITLE
deps: Update symbolic to 12.4.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2541,9 +2541,9 @@ checksum = "6bdef32e8150c2a081110b42772ffe7d7c9032b606bc226c8260fd97e0976601"
 
 [[package]]
 name = "symbolic"
-version = "12.4.0"
+version = "12.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3b5247a96aeefec188691938459892bffd23f1c3e9900dc08ac5248fe3bf08e"
+checksum = "2a912286ceb858457147868b59790ba9296ae3b178b01de8d628da71c2ddb800"
 dependencies = [
  "symbolic-common",
  "symbolic-debuginfo",
@@ -2553,9 +2553,9 @@ dependencies = [
 
 [[package]]
 name = "symbolic-common"
-version = "12.4.0"
+version = "12.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e0e9bc48b3852f36a84f8d0da275d50cb3c2b88b59b9ec35fdd8b7fa239e37d"
+checksum = "fac08504d60cf5bdffeb8a6a028f1a4868a5da1098bb19eb46239440039163fb"
 dependencies = [
  "debugid",
  "memmap2",
@@ -2566,9 +2566,9 @@ dependencies = [
 
 [[package]]
 name = "symbolic-debuginfo"
-version = "12.4.0"
+version = "12.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ef9a1b95a8ea7b5afb550da0d93ecc706de3ce869a9674fc3bc51fadc019feb"
+checksum = "7f197ae562da1dec76244875041cbd244e517bf6bc88a9537ae874c555b019c7"
 dependencies = [
  "debugid",
  "dmsort",
@@ -2598,9 +2598,9 @@ dependencies = [
 
 [[package]]
 name = "symbolic-il2cpp"
-version = "12.4.0"
+version = "12.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "efaaade4f5b4815046bc327fe7c56f255c18f57de222efaa8212b554319e7303"
+checksum = "ed26a4b1f8891a17ce1962d2c38093431dce2741078f5e7d7efcd13741ca2ff6"
 dependencies = [
  "indexmap 2.0.0",
  "serde_json",
@@ -2610,9 +2610,9 @@ dependencies = [
 
 [[package]]
 name = "symbolic-ppdb"
-version = "12.4.0"
+version = "12.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b95399a30236ac95fd9ce69a008b8a18e58859e9780a13bcb16fda545802f876"
+checksum = "13d6a54ddbea124f82a17564effd044078054f8bab037eb9fcdfee776d5bfbde"
 dependencies = [
  "flate2",
  "indexmap 1.9.2",
@@ -2626,9 +2626,9 @@ dependencies = [
 
 [[package]]
 name = "symbolic-symcache"
-version = "12.4.0"
+version = "12.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4339f37007c0fd6d6dddaf6f04619a4a5d6308e71eabbd45c30e0af124014259"
+checksum = "ea05762ece95fa2bd2b06b389e953fdf7392cf8cbab06314892df71f54815bc6"
 dependencies = [
  "indexmap 2.0.0",
  "symbolic-common",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -66,7 +66,7 @@ serde = { version = "1.0.152", features = ["derive"] }
 serde_json = "1.0.93"
 sha1_smol = { version = "1.0.0", features = ["serde"] }
 sourcemap = { version = "7.0.0", features = ["ram_bundle"] }
-symbolic = { version = "12.4.0", features = ["debuginfo-serde", "il2cpp"] }
+symbolic = { version = "12.4.1", features = ["debuginfo-serde", "il2cpp"] }
 thiserror = "1.0.38"
 url = "2.3.1"
 username = "0.2.0"

--- a/src/utils/file_upload.rs
+++ b/src/utils/file_upload.rs
@@ -663,7 +663,7 @@ mod tests {
         let hash = Sha1::from(buf);
         assert_eq!(
             hash.digest().to_string(),
-            "663a1d13633c6afacf036595cd282e2b34e7f9f5"
+            "d38fb9915de70eec2aa2d0c380b344d89ef540f0"
         );
     }
 }


### PR DESCRIPTION
This pulls in https://github.com/getsentry/symbolic/pull/813.