### PR TITLE
fix(rn): Remove hermesc envs if hermes is disabled

### DIFF
--- a/src/commands/react_native/xcode.rs
+++ b/src/commands/react_native/xcode.rs
@@ -275,7 +275,6 @@ pub fn execute(matches: &ArgMatches) -> Result<()> {
             command
                 .env("NODE_BINARY", env::current_exe()?.to_str().unwrap())
                 .env("SENTRY_RN_REAL_NODE_BINARY", &node)
-
                 .env(
                     "SENTRY_RN_SOURCEMAP_REPORT",
                     report_file.path().to_str().unwrap(),

--- a/src/commands/react_native/xcode.rs
+++ b/src/commands/react_native/xcode.rs
@@ -1,11 +1,13 @@
 use std::collections::HashMap;
 use std::env;
 use std::fs;
+use std::path::Path;
 use std::path::PathBuf;
 use std::process;
 
 use anyhow::{bail, Result};
 use chrono::Duration;
+use clap::command;
 use clap::{Arg, ArgAction, ArgMatches, Command};
 use if_chain::if_chain;
 use log::info;
@@ -146,6 +148,13 @@ fn find_hermesc() -> String {
     format!("{}/hermes-engine/destroot/bin/hermesc", pods_root_path)
 }
 
+/// Check if Hermes is enabled based its executable existence in the installed pods
+/// The same as RN Tooling does it https://github.com/facebook/react-native/blob/435245978122d34a78014600562517c3bf96f92e/scripts/react-native-xcode.sh#L98C11-L98C11
+/// We ignore `USE_HERMES` as its behavior is not consistent between 0.65 - 0.72 and it the later versions it was removed as user override.
+fn is_hermes_enabled(hermesc: &String) -> bool {
+  return Path::new(hermesc).exists();
+}
+
 pub fn execute(matches: &ArgMatches) -> Result<()> {
     let config = Config::current();
     let (org, project) = config.get_org_and_project(matches)?;
@@ -263,16 +272,24 @@ pub fn execute(matches: &ArgMatches) -> Result<()> {
         // With that we we then have all the information we need to invoke the
         // upload process.
         } else {
-            let rv = process::Command::new(&script)
+            let mut command= process::Command::new(&script);
+            command
                 .env("NODE_BINARY", env::current_exe()?.to_str().unwrap())
                 .env("SENTRY_RN_REAL_NODE_BINARY", &node)
-                .env("HERMES_CLI_PATH", env::current_exe()?.to_str().unwrap())
-                .env("SENTRY_RN_REAL_HERMES_CLI_PATH", &hermesc)
+
                 .env(
                     "SENTRY_RN_SOURCEMAP_REPORT",
                     report_file.path().to_str().unwrap(),
                 )
-                .env("__SENTRY_RN_WRAP_XCODE_CALL", "1")
+                .env("__SENTRY_RN_WRAP_XCODE_CALL", "1");
+
+            if is_hermes_enabled(&hermesc) {
+                command
+                    .env("HERMES_CLI_PATH", env::current_exe()?.to_str().unwrap())
+                    .env("SENTRY_RN_REAL_HERMES_CLI_PATH", &hermesc);
+            }
+
+            let rv = command
                 .spawn()?
                 .wait()?;
             propagate_exit_status(rv);
@@ -307,7 +324,7 @@ pub fn execute(matches: &ArgMatches) -> Result<()> {
             } else {
                 bundle_path = packager_bundle_path;
                 sourcemap_path = packager_sourcemap_path;
-                println!("Using React Native Packager bundle and combined source map.");
+                println!("Using React Native Packager bundle and source map.");
             }
             bundle_url = format!("~/{}", bundle_path.file_name().unwrap().to_string_lossy());
             sourcemap_url = format!(

--- a/src/commands/react_native/xcode.rs
+++ b/src/commands/react_native/xcode.rs
@@ -7,7 +7,6 @@ use std::process;
 
 use anyhow::{bail, Result};
 use chrono::Duration;
-use clap::command;
 use clap::{Arg, ArgAction, ArgMatches, Command};
 use if_chain::if_chain;
 use log::info;

--- a/src/commands/react_native/xcode.rs
+++ b/src/commands/react_native/xcode.rs
@@ -151,7 +151,7 @@ fn find_hermesc() -> String {
 /// The same as RN Tooling does it https://github.com/facebook/react-native/blob/435245978122d34a78014600562517c3bf96f92e/scripts/react-native-xcode.sh#L98C11-L98C11
 /// We ignore `USE_HERMES` as its behavior is not consistent between 0.65 - 0.72 and it the later versions it was removed as user override.
 fn is_hermes_enabled(hermesc: &String) -> bool {
-  return Path::new(hermesc).exists();
+    return Path::new(hermesc).exists();
 }
 
 pub fn execute(matches: &ArgMatches) -> Result<()> {
@@ -271,7 +271,7 @@ pub fn execute(matches: &ArgMatches) -> Result<()> {
         // With that we we then have all the information we need to invoke the
         // upload process.
         } else {
-            let mut command= process::Command::new(&script);
+            let mut command = process::Command::new(&script);
             command
                 .env("NODE_BINARY", env::current_exe()?.to_str().unwrap())
                 .env("SENTRY_RN_REAL_NODE_BINARY", &node)
@@ -287,9 +287,7 @@ pub fn execute(matches: &ArgMatches) -> Result<()> {
                     .env("SENTRY_RN_REAL_HERMES_CLI_PATH", &hermesc);
             }
 
-            let rv = command
-                .spawn()?
-                .wait()?;
+            let rv = command.spawn()?.wait()?;
             propagate_exit_status(rv);
 
             if !matches.get_flag("force_foreground") {


### PR DESCRIPTION
If hermesc path is in envs and exists react native tooling assumes hermes is enabled.

Sentry cli puts itself on the path therefore react native tooling always assumes hermes is enabled.


### Todo:
- [x] Test with multiple RN versions.