### PR TITLE
fix: Don't fail on duplicate proguard release association

### DIFF
--- a/src/api.rs
+++ b/src/api.rs
@@ -1378,6 +1378,12 @@ impl Api {
             .send()?;
         if resp.status() == 201 {
             Ok(())
+        } else if resp.status() == 409 {
+            info!(
+                "Release association for release '{}', UUID '{}' already exists.",
+                data.release_name, data.proguard_uuid
+            );
+            Ok(())
         } else if resp.status() == 404 {
             return Err(ApiErrorKind::ResourceNotFound.into());
         } else {


### PR DESCRIPTION
As reported on Slack, calling `upload-proguard` twice with the exact same arguments causes an error, even though it's perfectly benign. The issue is that Sentry returns `409` for identical `ProguardArtifactRelease` objects: https://github.com/getsentry/sentry/blob/4882e79cd67363cb40e9d3f08b161783f21eb4e8/src/sentry/api/endpoints/debug_files.py#L136-L151

(Strictly speaking, a duplicate (release, debug file, uuid) triple will cause an error. I don't think the distinction matters in practice.)

We should just log a message in this case and otherwise succeed.