### PR TITLE
How to update in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,14 @@ docker run --rm -u "$(id -u):$(id -g)" -v $(pwd):/work getsentry/sentry-cli --he
 
 This is required due to security issue in older `git` implementations. See [here](https://github.blog/2022-04-12-git-security-vulnerability-announced/) for more details.
 
+## Update
+
+To update sentry-cli to the latest version run:
+
+```sh
+sentry-cli update
+```
+
 ## Compiling
 
 In case you want to compile this yourself, you need to install at minimum the


### PR DESCRIPTION
Explain how to update sentry-cli in the README.md. I always copy `curl -sL https://sentry.io/get-cli/ | bash` into my terminal, and then it prompts me to use `sentry-cli update`. 