### PR TITLE
feat: add shell completion generation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -329,6 +329,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "clap_complete"
+version = "4.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3ae8ba90b9d8b007efe66e55e48fb936272f5ca00349b5b0e89877520d35ea7"
+dependencies = [
+ "clap",
+]
+
+[[package]]
 name = "clap_lex"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2223,6 +2232,7 @@ dependencies = [
  "chardet",
  "chrono",
  "clap",
+ "clap_complete",
  "console",
  "crossbeam-channel",
  "curl",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ clap = { version = "4.1.6", default-features = false, features = [
   "usage",
   "error-context",
 ] }
+clap_complete = "4.4.3"
 console = "0.15.5"
 curl = { version = "0.4.44", features = ["static-curl", "static-ssl"] }
 dirs = "4.0.0"

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -4,6 +4,10 @@ use std::env;
 use std::io;
 use std::process;
 
+use anyhow::{bail, Result};
+use clap::{value_parser, Arg, ArgAction, ArgMatches, Command};
+use clap_complete::{generate, Generator, Shell};
+use log::{debug, info, set_logger, set_max_level, LevelFilter};
 use crate::api::Api;
 use crate::config::{Auth, Config};
 use crate::constants::{ARCH, PLATFORM, VERSION};
@@ -11,10 +15,6 @@ use crate::utils::logging::set_quiet_mode;
 use crate::utils::logging::Logger;
 use crate::utils::system::{init_backtrace, load_dotenv, print_error, QuietExit};
 use crate::utils::update::run_sentrycli_update_nagger;
-use anyhow::{bail, Result};
-use clap::{value_parser, Arg, ArgAction, ArgMatches, Command};
-use clap_complete::{generate, Generator, Shell};
-use log::{debug, info, set_logger, set_max_level, LevelFilter};
 
 macro_rules! each_subcommand {
     ($mac:ident) => {

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -8,6 +8,7 @@ use anyhow::{bail, Result};
 use clap::{value_parser, Arg, ArgAction, ArgMatches, Command};
 use clap_complete::{generate, Generator, Shell};
 use log::{debug, info, set_logger, set_max_level, LevelFilter};
+
 use crate::api::Api;
 use crate::config::{Auth, Config};
 use crate::constants::{ARCH, PLATFORM, VERSION};

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -138,7 +138,7 @@ fn app() -> Command {
         .version(VERSION)
         .about(ABOUT)
         .max_term_width(100)
-        .subcommand_required(false)
+        .subcommand_required(true)
         .arg_required_else_help(true)
         .arg(Arg::new("url").value_name("URL").long("url").help(
             "Fully qualified URL to the Sentry server.{n}\
@@ -192,15 +192,18 @@ fn app() -> Command {
               .hide(true)
               .help("Always return 0 exit code."),
         )
-        .arg(
-            Arg::new("completions")
-                .long("completions")
-                .help(
-                    "Print completions for the specified shell.",
-                )
-                .value_parser(value_parser!(Shell)),
+        .subcommand(
+            Command::new("completions")
+            .about("Generate completions for the specified shell.")
+            .arg_required_else_help(true)
+            .arg(
+                Arg::new("shell")
+                    .long("shell")
+                    .help("The shell to print completions for.")
+                    .value_parser(value_parser!(Shell)),
+            )
         )
-}
+    }
 
 fn add_commands(mut app: Command) -> Command {
     macro_rules! add_subcommand {
@@ -270,10 +273,12 @@ pub fn execute() -> Result<()> {
             .join(" ")
     );
 
-    if let Some(generator) = matches.get_one::<Shell>("completions") {
-        eprintln!("Generating completion file for {generator}...");
-        print_completions(*generator, &mut app2);
-        return Ok(())
+    if let Some(argmatches) = matches.subcommand_matches("completions") {
+        if let Some(generator) = argmatches.get_one::<Shell>("shell") {
+            eprintln!("Generating completion file for {generator}...");
+            print_completions(*generator, &mut app2);
+            return Ok(())
+        }
     }
 
     match run_command(&matches) {

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -4,10 +4,6 @@ use std::env;
 use std::io;
 use std::process;
 
-use anyhow::{bail, Result};
-use clap::{value_parser, Arg, ArgAction, ArgMatches, Command};
-use clap_complete::{generate, Generator, Shell};
-use log::{debug, info, set_logger, set_max_level, LevelFilter};
 use crate::api::Api;
 use crate::config::{Auth, Config};
 use crate::constants::{ARCH, PLATFORM, VERSION};
@@ -15,6 +11,10 @@ use crate::utils::logging::set_quiet_mode;
 use crate::utils::logging::Logger;
 use crate::utils::system::{init_backtrace, load_dotenv, print_error, QuietExit};
 use crate::utils::update::run_sentrycli_update_nagger;
+use anyhow::{bail, Result};
+use clap::{Arg, ArgAction, ArgMatches, Command};
+use clap_complete::{generate, Generator, Shell};
+use log::{debug, info, set_logger, set_max_level, LevelFilter};
 
 macro_rules! each_subcommand {
     ($mac:ident) => {
@@ -195,15 +195,14 @@ fn app() -> Command {
         .subcommand(
             Command::new("completions")
             .about("Generate completions for the specified shell.")
-            .arg_required_else_help(true)
-            .arg(
-                Arg::new("shell")
-                    .long("shell")
-                    .help("The shell to print completions for.")
-                    .value_parser(value_parser!(Shell)),
-            )
+            .subcommand_required(true)
+            .subcommand(Command::new("bash"))
+            .subcommand(Command::new("elvish"))
+            .subcommand(Command::new("fish"))
+            .subcommand(Command::new("powershell"))
+            .subcommand(Command::new("zsh"))
         )
-    }
+}
 
 fn add_commands(mut app: Command) -> Command {
     macro_rules! add_subcommand {
@@ -274,11 +273,17 @@ pub fn execute() -> Result<()> {
     if let Some(argmatches) = matches.subcommand_matches("completions") {
         let mut cmd = app();
         cmd = add_commands(cmd);
-        if let Some(generator) = argmatches.get_one::<Shell>("shell") {
-            eprintln!("Generating completion file for {generator}...");
-            print_completions(*generator, &mut cmd);
-            return Ok(())
-        }
+
+        let generator = match argmatches.subcommand_name() {
+            Some("bash") => Shell::Bash,
+            Some("elvish") => Shell::Elvish,
+            Some("fish") => Shell::Fish,
+            Some("powershell") => Shell::PowerShell,
+            Some("zsh") => Shell::Zsh,
+            _ => return Ok(()),
+        };
+        print_completions(generator, &mut cmd);
+        return Ok(());
     }
 
     match run_command(&matches) {

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -273,6 +273,7 @@ pub fn execute() -> Result<()> {
 
     if let Some(argmatches) = matches.subcommand_matches("completions") {
         let mut cmd = app();
+        cmd = add_commands(cmd);
         if let Some(generator) = argmatches.get_one::<Shell>("shell") {
             eprintln!("Generating completion file for {generator}...");
             print_completions(*generator, &mut cmd);

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -243,11 +243,9 @@ pub fn execute() -> Result<()> {
     }
 
     let mut config = Config::from_cli_config()?;
-    let mut app = app();
-    app = add_commands(app);
-    // here to as proof-of-concept, doing it locally gave borrow checker errors
-    let mut app2 = app.clone();
-    let matches = app.get_matches();
+    let mut cmd = app();
+    cmd = add_commands(cmd);
+    let matches = cmd.get_matches();
     configure_args(&mut config, &matches)?;
     set_quiet_mode(matches.get_flag("quiet"));
 
@@ -274,9 +272,10 @@ pub fn execute() -> Result<()> {
     );
 
     if let Some(argmatches) = matches.subcommand_matches("completions") {
+        let mut cmd = app();
         if let Some(generator) = argmatches.get_one::<Shell>("shell") {
             eprintln!("Generating completion file for {generator}...");
-            print_completions(*generator, &mut app2);
+            print_completions(*generator, &mut cmd);
             return Ok(())
         }
     }

--- a/tests/integration/_cases/help/help-windows.trycmd
+++ b/tests/integration/_cases/help/help-windows.trycmd
@@ -10,6 +10,7 @@ to learn more about them.
 Usage: sentry-cli[EXE] [OPTIONS] <COMMAND>
 
 Commands:
+  completions      Generate completions for the specified shell.
   debug-files      Locate, analyze or upload debug information files. [aliases: dif]
   deploys          Manage deployments for Sentry releases.
   events           Manage events on Sentry.

--- a/tests/integration/_cases/help/help.trycmd
+++ b/tests/integration/_cases/help/help.trycmd
@@ -10,6 +10,7 @@ to learn more about them.
 Usage: sentry-cli[EXE] [OPTIONS] <COMMAND>
 
 Commands:
+  completions      Generate completions for the specified shell.
   debug-files      Locate, analyze or upload debug information files. [aliases: dif]
   deploys          Manage deployments for Sentry releases.
   events           Manage events on Sentry.


### PR DESCRIPTION
This adds the ability to generate shell completions to the CLI.

While this PR is not in an ideal form yet, I'd be more than happy to work together to make it fit the used patterns in this repo.
I tried following them, but ran into trouble because the `execute` method for each command did not get a `Command` passed, which this shell completions generator needs.

Here is an example of me using the completions this generates:
https://asciinema.org/a/dsXad2IayVyXJFHKX0GjvRhjH