### PR TITLE
meta: Disable Python releases

### DIFF
--- a/.craft.yml
+++ b/.craft.yml
@@ -63,9 +63,6 @@ targets:
         checksums:
           - algorithm: sha256
             format: hex
-  - name: pypi
-  - name: sentry-pypi
-    internalPypiRepo: getsentry/pypi
 requireNames:
   - /^sentry-cli-Darwin-x86_64$/
   - /^sentry-cli-Darwin-arm64$/
@@ -77,4 +74,3 @@ requireNames:
   - /^sentry-cli-Windows-i686.exe$/
   - /^sentry-cli-Windows-x86_64.exe$/
   - /^sentry_cli-.*.tar.gz$/
-  - /^sentry_cli-.*.whl$/


### PR DESCRIPTION
Temporarily removes the PyPI targets from Craft. As it stands nearly every Python release of `sentry-cli` fails and this causes trouble for the rest of the release process.

The PyPI issue for diagnosing this is [here](https://github.com/pypi/support/issues/3222). We might also open an upload limit request.