### PR TITLE
chore: reduce realease binary size

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -111,8 +111,9 @@ crossbeam-channel = "0.5.6"
 [target."cfg(windows)".dependencies]
 winapi = "0.3.9"
 
+# We optimize the release build for size.
 [profile.release]
-opt-level = 3
+opt-level = "z"
 panic = "abort"
 strip = true      # Strip symbols from the binary.
 codegen-units = 1 # Parallel compilation prevents some optimizations.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -114,3 +114,6 @@ winapi = "0.3.9"
 [profile.release]
 opt-level = 3
 panic = "abort"
+strip = true      # Strip symbols from the binary.
+codegen-units = 1 # Parallel compilation prevents some optimizations.
+lto = true        # Enable Link-time optimizations to remove dead code.


### PR DESCRIPTION
Sentry CLI is downloaded many times during consumers' CI. Even though the download should be fast in general and the binary size reduction wouldn't have a great effect on individual runs, it does have an effect at the scale it is used at.

Example: macOS arm64 binary size reduction by these changes is about 30 %.
