### PR TITLE
ci: run cargo build on all branches

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,9 +1,13 @@
-name: Release Build
+name: Build
 
 on:
   push:
     branches:
+      - master
+      - 1.x
       - release/**
+
+  pull_request:
 
 jobs:
   linux:


### PR DESCRIPTION
Running the same build workflow on all branches/PRs makes sure you we catch potential errors sooner than on the release branch.

For example: https://github.com/getsentry/sentry-cli/actions/runs/6731317309/job/18295737112#step:3:344 (``error: package `clap_complete v4.4.3` cannot be built because it requires rustc 1.70.0 or newer, while the currently active rustc version is 1.69.0``)