### PR TITLE
build: Use upstream rust-musl-cross docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 ARG BUILD_ARCH=x86_64
 ARG BUILD_LIBC=musl
-FROM getsentry/rust-musl-cross:$BUILD_ARCH-$BUILD_LIBC AS sentry-build
+FROM messense/rust-musl-cross:$BUILD_ARCH-$BUILD_LIBC AS sentry-build
 
 ARG BUILD_ARCH
 ARG BUILD_LIBC

--- a/scripts/build-in-docker.sh
+++ b/scripts/build-in-docker.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -eux
 
-DOCKER_IMAGE="getsentry/rust-musl-cross:${DOCKER_TAG}"
+DOCKER_IMAGE="messense/rust-musl-cross:${DOCKER_TAG}"
 BUILD_DIR="/work"
 
 DOCKER_RUN_OPTS="


### PR DESCRIPTION
As shown in https://github.com/getsentry/sentry-cli/issues/1796, our fork of `rust-musl-cross` is outdated and it is unclear why we still need it.