### PR TITLE
build: Vendor OpenSSL on ArmV7

### DIFF
--- a/scripts/build-in-docker.sh
+++ b/scripts/build-in-docker.sh
@@ -9,7 +9,6 @@ DOCKER_RUN_OPTS="
   -v $(pwd):${BUILD_DIR}:ro
   -v $(pwd)/target:${BUILD_DIR}/target
   -v $HOME/.cargo/registry:/root/.cargo/registry
-  -e ARMV7_UNKNOWN_LINUX_MUSLEABI_OPENSSL_NO_VENDOR=1
   ${DOCKER_IMAGE}
 "
 


### PR DESCRIPTION
If we don't vendor OpenSSL on ArmV7, `sentry-cli` won't build (as seen [here](https://github.com/getsentry/sentry-cli/actions/runs/6769700929/job/18396616213)). 