### PR TITLE
ref: Improve error message if a project slug is missing

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -439,7 +439,7 @@ impl Config {
                     .get_from(Some("defaults"), "project")
                     .map(str::to_owned)
             })
-            .ok_or_else(|| format_err!("A project slug is required"))
+            .ok_or_else(|| format_err!("A project slug is required (provide with --project)"))
     }
 
     /// Return the default pipeline env.


### PR DESCRIPTION
We already include the argument in the error message for organisation and release, hence also adding it for project.