### PR TITLE
chore: bump curl-sys dependency to 0.4.68

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -528,9 +528,9 @@ dependencies = [
 
 [[package]]
 name = "curl-sys"
-version = "0.4.59+curl-7.86.0"
+version = "0.4.68+curl-8.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6cfce34829f448b08f55b7db6d0009e23e2e86a34e8c2b366269bf5799b4a407"
+checksum = "b4a0d18d88360e374b16b2273c832b5e57258ffc1d4aa4f96b108e0738d5752f"
 dependencies = [
  "cc",
  "libc",
@@ -538,7 +538,7 @@ dependencies = [
  "openssl-sys",
  "pkg-config",
  "vcpkg",
- "winapi 0.3.9",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]


### PR DESCRIPTION
fixes an important issue on Windows, that sporadically would return " [56] Failure when receiving data from the peer"

I suggest merging ASAP, all tests pass. thanks!