### PR TITLE
feat: Expose `downloadBinary` function to install binary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 "You know what they say. Fool me once, strike one, but fool me twice... strike three." — Michael Scott
 
+## Unreleased
+
+- feat: Expose downloadBinary function to install binary (#1817)
+
 ## 1.76.0
 
 ### Various fixes & improvements

--- a/js/index.d.ts
+++ b/js/index.d.ts
@@ -222,6 +222,13 @@ declare module '@sentry/cli' {
 
     public static getVersion(): string
     public static getPath(): string
+
+    /**
+     * Downloads the CLI binary.
+     * @returns {Promise<void>}
+     */
+    static downloadBinary(logger: { log(...args: unknown[]): void }): Promise<void>;
+
     public execute(args: string[], live: boolean): Promise<string>
   }
 }

--- a/js/index.js
+++ b/js/index.js
@@ -3,6 +3,7 @@
 const pkgInfo = require('../package.json');
 const helper = require('./helper');
 const Releases = require('./releases');
+const install = require('./install');
 
 /**
  * Interface to and wrapper around the `sentry-cli` executable.
@@ -52,6 +53,14 @@ class SentryCli {
    */
   static getPath() {
     return helper.getPath();
+  }
+
+  /**
+   * Downloads the CLI binary.
+   * @returns {Promise<void>}
+   */
+  static downloadBinary() {
+    return install.downloadBinary();
   }
 
   /**

--- a/js/index.js
+++ b/js/index.js
@@ -57,10 +57,11 @@ class SentryCli {
 
   /**
    * Downloads the CLI binary.
+   * @param {any} [configFile] Optional logger to log installation information. Defaults to printing to the terminal.
    * @returns {Promise<void>}
    */
-  static downloadBinary() {
-    return install.downloadBinary();
+  static downloadBinary(logger) {
+    return install.downloadBinary(logger);
   }
 
   /**

--- a/js/install.js
+++ b/js/install.js
@@ -37,7 +37,7 @@ function getLogStream(defaultStream) {
   );
 }
 
-const logger = new Logger(getLogStream('stderr'));
+const ttyLogger = new Logger(getLogStream('stderr'));
 
 const CDN_URL =
   process.env.SENTRYCLI_LOCAL_CDNURL ||
@@ -146,7 +146,7 @@ function getTempFile(cached) {
   return `${cached}.${process.pid}-${Math.random().toString(16).slice(2)}.tmp`;
 }
 
-function validateChecksum(tempPath, name) {
+function validateChecksum(tempPath, name, logger) {
   let storedHash;
   try {
     const checksums = fs.readFileSync(path.join(__dirname, '../checksums.txt'), 'utf8');
@@ -192,7 +192,7 @@ function checkVersion() {
   });
 }
 
-function downloadBinary() {
+function downloadBinary(logger = ttyLogger) {
   if (process.env.SENTRYCLI_SKIP_DOWNLOAD === '1') {
     logger.log(`Skipping download because SENTRYCLI_SKIP_DOWNLOAD=1 detected.`);
     return;
@@ -279,7 +279,7 @@ function downloadBinary() {
           .on('close', () => resolve());
       }).then(() => {
         if (process.env.SENTRYCLI_SKIP_CHECKSUM_VALIDATION !== '1') {
-          validateChecksum(tempPath, name);
+          validateChecksum(tempPath, name, logger);
         }
         fs.copyFileSync(tempPath, cachedPath);
         fs.copyFileSync(tempPath, outputPath);

--- a/js/install.js
+++ b/js/install.js
@@ -48,7 +48,7 @@ const CDN_URL =
   'https://downloads.sentry-cdn.com/sentry-cli';
 
 function shouldRenderProgressBar() {
-  const silentFlag = process.argv.some(v => v === '--silent');
+  const silentFlag = process.argv.some((v) => v === '--silent');
   const silentConfig = process.env.npm_config_loglevel === 'silent';
   // Leave `SENTRY_NO_PROGRESS_BAR` for backwards compatibility
   const silentEnv = process.env.SENTRYCLI_NO_PROGRESS_BAR || process.env.SENTRY_NO_PROGRESS_BAR;
@@ -113,7 +113,7 @@ function createProgressBar(name, total) {
   let pct = null;
   let current = 0;
   return {
-    tick: length => {
+    tick: (length) => {
       current += length;
       const next = Math.round((current / total) * 100);
       if (next > pct) {
@@ -135,11 +135,7 @@ function npmCache() {
 }
 
 function getCachedPath(url) {
-  const digest = crypto
-    .createHash('md5')
-    .update(url)
-    .digest('hex')
-    .slice(0, 6);
+  const digest = crypto.createHash('md5').update(url).digest('hex').slice(0, 6);
 
   return path.join(
     npmCache(),
@@ -149,9 +145,7 @@ function getCachedPath(url) {
 }
 
 function getTempFile(cached) {
-  return `${cached}.${process.pid}-${Math.random()
-    .toString(16)
-    .slice(2)}.tmp`;
+  return `${cached}.${process.pid}-${Math.random().toString(16).slice(2)}.tmp`;
 }
 
 function validateChecksum(tempPath, name) {
@@ -178,10 +172,7 @@ function validateChecksum(tempPath, name) {
     return;
   }
 
-  const currentHash = crypto
-    .createHash('sha256')
-    .update(fs.readFileSync(tempPath))
-    .digest('hex');
+  const currentHash = crypto.createHash('sha256').update(fs.readFileSync(tempPath)).digest('hex');
 
   if (storedHash !== currentHash) {
     fs.unlinkSync(tempPath);
@@ -241,7 +232,7 @@ function downloadBinary() {
     },
     redirect: 'follow',
   })
-    .then(response => {
+    .then((response) => {
       if (!response.ok) {
         throw new Error(
           `Unable to download sentry-cli binary from ${downloadUrl}.\nServer returned ${response.status}: ${response.statusText}.`
@@ -267,11 +258,11 @@ function downloadBinary() {
 
       return new Promise((resolve, reject) => {
         response.body
-          .on('error', e => reject(e))
-          .on('data', chunk => progressBar.tick(chunk.length))
+          .on('error', (e) => reject(e))
+          .on('data', (chunk) => progressBar.tick(chunk.length))
           .pipe(decompressor)
           .pipe(fs.createWriteStream(tempPath, { mode: '0755' }))
-          .on('error', e => reject(e))
+          .on('error', (e) => reject(e))
           .on('close', () => resolve());
       }).then(() => {
         if (process.env.SENTRYCLI_SKIP_CHECKSUM_VALIDATION !== '1') {
@@ -282,7 +273,7 @@ function downloadBinary() {
         fs.unlinkSync(tempPath);
       });
     })
-    .catch(error => {
+    .catch((error) => {
       if (error instanceof fetch.FetchError) {
         throw new Error(
           `Unable to download sentry-cli binary from ${downloadUrl}.\nError code: ${error.code}`
@@ -294,7 +285,7 @@ function downloadBinary() {
 }
 
 function checkVersion() {
-  return helper.execute(['--version']).then(output => {
+  return helper.execute(['--version']).then((output) => {
     const version = output.replace('sentry-cli ', '').trim();
     const expected = process.env.SENTRYCLI_LOCAL_CDNURL ? 'DEV' : pkgInfo.version;
     if (version !== expected) {
@@ -326,7 +317,7 @@ if (process.env.SENTRYCLI_SKIP_DOWNLOAD === '1') {
 downloadBinary()
   .then(() => checkVersion())
   .then(() => process.exit(0))
-  .catch(e => {
+  .catch((e) => {
     // eslint-disable-next-line no-console
     console.error(e.toString());
     process.exit(1);

--- a/scripts/install.js
+++ b/scripts/install.js
@@ -24,7 +24,7 @@ if (process.env.SENTRYCLI_LOCAL_CDNURL) {
 
 downloadBinary()
   .then(() => process.exit(0))
-  .catch((e) => {
+  .catch(e => {
     // eslint-disable-next-line no-console
     console.error(e.toString());
     process.exit(1);

--- a/scripts/install.js
+++ b/scripts/install.js
@@ -1,0 +1,31 @@
+#!/usr/bin/env node
+
+'use strict';
+
+const http = require('http');
+const fs = require('fs');
+const path = require('path');
+const { downloadBinary } = require('../js/install');
+
+if (process.env.SENTRYCLI_LOCAL_CDNURL) {
+  // For testing, mock the CDN by spawning a local server
+  const server = http.createServer((request, response) => {
+    const contents = fs.readFileSync(path.join(__dirname, '../js/__mocks__/sentry-cli'));
+    response.writeHead(200, {
+      'Content-Type': 'application/octet-stream',
+      'Content-Length': String(contents.byteLength),
+    });
+    response.end(contents);
+  });
+
+  server.listen(8999);
+  process.on('exit', () => server.close());
+}
+
+downloadBinary()
+  .then(() => process.exit(0))
+  .catch((e) => {
+    // eslint-disable-next-line no-console
+    console.error(e.toString());
+    process.exit(1);
+  });


### PR DESCRIPTION
We would like to be able to install the CLI manually in downstream dependencies in case postinstall scripts did not get executed.