### PR TITLE
build: Add placeholder packages for npm binary distributions

### DIFF
--- a/npm-binary-distributions/darwin/bin/sentry-cli
+++ b/npm-binary-distributions/darwin/bin/sentry-cli
@@ -1,0 +1,1 @@
+binary placeholder

--- a/npm-binary-distributions/darwin/package.json
+++ b/npm-binary-distributions/darwin/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@sentry/cli-darwin",
   "version": "2.21.5",
-  "description": "TODO",
+  "description": "The darwin distribution of the Sentry CLI binary.",
   "repository": "https://github.com/getsentry/sentry-cli",
   "license": "BSD-3-Clause",
   "engines": {

--- a/npm-binary-distributions/darwin/package.json
+++ b/npm-binary-distributions/darwin/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "@sentry/cli-darwin",
+  "version": "2.21.5",
+  "description": "TODO",
+  "repository": "https://github.com/getsentry/sentry-cli",
+  "license": "BSD-3-Clause",
+  "engines": {
+    "node": ">=10"
+  },
+  "os": [
+    "darwin"
+  ]
+}

--- a/npm-binary-distributions/linux-arm/bin/sentry-cli
+++ b/npm-binary-distributions/linux-arm/bin/sentry-cli
@@ -1,0 +1,1 @@
+binary placeholder

--- a/npm-binary-distributions/linux-arm/package.json
+++ b/npm-binary-distributions/linux-arm/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@sentry/cli-linux-arm",
   "version": "2.21.5",
-  "description": "TODO",
+  "description": "The linux arm distribution of the Sentry CLI binary.",
   "repository": "https://github.com/getsentry/sentry-cli",
   "license": "BSD-3-Clause",
   "engines": {

--- a/npm-binary-distributions/linux-arm/package.json
+++ b/npm-binary-distributions/linux-arm/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "@sentry/cli-linux-arm",
+  "version": "2.21.5",
+  "description": "TODO",
+  "repository": "https://github.com/getsentry/sentry-cli",
+  "license": "BSD-3-Clause",
+  "engines": {
+    "node": ">=10"
+  },
+  "os": [
+    "linux",
+    "freebsd"
+  ],
+  "cpu": [
+    "arm"
+  ]
+}

--- a/npm-binary-distributions/linux-arm64/bin/sentry-cli
+++ b/npm-binary-distributions/linux-arm64/bin/sentry-cli
@@ -1,0 +1,1 @@
+binary placeholder

--- a/npm-binary-distributions/linux-arm64/package.json
+++ b/npm-binary-distributions/linux-arm64/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "@sentry/cli-linux-arm64",
+  "version": "2.21.5",
+  "description": "TODO",
+  "repository": "https://github.com/getsentry/sentry-cli",
+  "license": "BSD-3-Clause",
+  "engines": {
+    "node": ">=10"
+  },
+  "os": [
+    "linux",
+    "freebsd"
+  ],
+  "cpu": [
+    "arm64"
+  ]
+}

--- a/npm-binary-distributions/linux-arm64/package.json
+++ b/npm-binary-distributions/linux-arm64/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@sentry/cli-linux-arm64",
   "version": "2.21.5",
-  "description": "TODO",
+  "description": "The linux arm64 distribution of the Sentry CLI binary.",
   "repository": "https://github.com/getsentry/sentry-cli",
   "license": "BSD-3-Clause",
   "engines": {

--- a/npm-binary-distributions/linux-i686/bin/sentry-cli
+++ b/npm-binary-distributions/linux-i686/bin/sentry-cli
@@ -1,0 +1,1 @@
+binary placeholder

--- a/npm-binary-distributions/linux-i686/package.json
+++ b/npm-binary-distributions/linux-i686/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "@sentry/cli-linux-i686",
+  "version": "2.21.5",
+  "description": "TODO",
+  "repository": "https://github.com/getsentry/sentry-cli",
+  "license": "BSD-3-Clause",
+  "engines": {
+    "node": ">=10"
+  },
+  "os": [
+    "linux",
+    "freebsd"
+  ],
+  "cpu": [
+    "x86",
+    "ia32"
+  ]
+}

--- a/npm-binary-distributions/linux-i686/package.json
+++ b/npm-binary-distributions/linux-i686/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@sentry/cli-linux-i686",
   "version": "2.21.5",
-  "description": "TODO",
+  "description": "The linux x86 and ia32 distribution of the Sentry CLI binary.",
   "repository": "https://github.com/getsentry/sentry-cli",
   "license": "BSD-3-Clause",
   "engines": {

--- a/npm-binary-distributions/linux-x64/bin/sentry-cli
+++ b/npm-binary-distributions/linux-x64/bin/sentry-cli
@@ -1,0 +1,1 @@
+binary placeholder

--- a/npm-binary-distributions/linux-x64/package.json
+++ b/npm-binary-distributions/linux-x64/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "@sentry/cli-linux-x64",
+  "version": "2.21.5",
+  "description": "TODO",
+  "repository": "https://github.com/getsentry/sentry-cli",
+  "license": "BSD-3-Clause",
+  "engines": {
+    "node": ">=10"
+  },
+  "os": [
+    "linux",
+    "freebsd"
+  ],
+  "cpu": [
+    "x64"
+  ]
+}

--- a/npm-binary-distributions/linux-x64/package.json
+++ b/npm-binary-distributions/linux-x64/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@sentry/cli-linux-x64",
   "version": "2.21.5",
-  "description": "TODO",
+  "description": "The linux x64 distribution of the Sentry CLI binary.",
   "repository": "https://github.com/getsentry/sentry-cli",
   "license": "BSD-3-Clause",
   "engines": {

--- a/npm-binary-distributions/win32-i686/bin/sentry-cli
+++ b/npm-binary-distributions/win32-i686/bin/sentry-cli
@@ -1,0 +1,1 @@
+binary placeholder

--- a/npm-binary-distributions/win32-i686/package.json
+++ b/npm-binary-distributions/win32-i686/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@sentry/cli-win32-i686",
   "version": "2.21.5",
-  "description": "TODO",
+  "description": "The windows x86 and ia32 distribution of the Sentry CLI binary.",
   "repository": "https://github.com/getsentry/sentry-cli",
   "license": "BSD-3-Clause",
   "engines": {

--- a/npm-binary-distributions/win32-i686/package.json
+++ b/npm-binary-distributions/win32-i686/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "@sentry/cli-win32-i686",
+  "version": "2.21.5",
+  "description": "TODO",
+  "repository": "https://github.com/getsentry/sentry-cli",
+  "license": "BSD-3-Clause",
+  "engines": {
+    "node": ">=10"
+  },
+  "os": [
+    "win32"
+  ],
+  "cpu": [
+    "x86",
+    "ia32"
+  ]
+}

--- a/npm-binary-distributions/win32-x64/bin/sentry-cli
+++ b/npm-binary-distributions/win32-x64/bin/sentry-cli
@@ -1,0 +1,1 @@
+binary placeholder

--- a/npm-binary-distributions/win32-x64/package.json
+++ b/npm-binary-distributions/win32-x64/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "@sentry/cli-win32-x64",
+  "version": "2.21.5",
+  "description": "TODO",
+  "repository": "https://github.com/getsentry/sentry-cli",
+  "license": "BSD-3-Clause",
+  "engines": {
+    "node": ">=10"
+  },
+  "os": [
+    "win32"
+  ],
+  "cpu": [
+    "x64"
+  ]
+}

--- a/npm-binary-distributions/win32-x64/package.json
+++ b/npm-binary-distributions/win32-x64/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@sentry/cli-win32-x64",
   "version": "2.21.5",
-  "description": "TODO",
+  "description": "The windows x64 distribution of the Sentry CLI binary.",
   "repository": "https://github.com/getsentry/sentry-cli",
   "license": "BSD-3-Clause",
   "engines": {


### PR DESCRIPTION
Adds packages for binary distributions on npm based on the binaries we currently distribute.

Ref https://github.com/getsentry/sentry-cli/issues/1360#issuecomment-1819270364