### PR TITLE
build: Set npm publish config public

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 "You know what they say. Fool me once, strike one, but fool me twice... strike three." — Michael Scott
 
+## 2.22.1
+
+This release contains no changes and was done for technical purposes.
+
 ## 2.22.0
 
 - feat: Add opt-in code path to use binary distributions instead of downloaded CLI (#1835)

--- a/npm-binary-distributions/darwin/package.json
+++ b/npm-binary-distributions/darwin/package.json
@@ -4,6 +4,9 @@
   "description": "The darwin distribution of the Sentry CLI binary.",
   "repository": "https://github.com/getsentry/sentry-cli",
   "license": "BSD-3-Clause",
+  "publishConfig": {
+    "access": "public"
+  },
   "engines": {
     "node": ">=10"
   },

--- a/npm-binary-distributions/linux-arm/package.json
+++ b/npm-binary-distributions/linux-arm/package.json
@@ -4,6 +4,9 @@
   "description": "The linux arm distribution of the Sentry CLI binary.",
   "repository": "https://github.com/getsentry/sentry-cli",
   "license": "BSD-3-Clause",
+  "publishConfig": {
+    "access": "public"
+  },
   "engines": {
     "node": ">=10"
   },

--- a/npm-binary-distributions/linux-arm64/package.json
+++ b/npm-binary-distributions/linux-arm64/package.json
@@ -4,6 +4,9 @@
   "description": "The linux arm64 distribution of the Sentry CLI binary.",
   "repository": "https://github.com/getsentry/sentry-cli",
   "license": "BSD-3-Clause",
+  "publishConfig": {
+    "access": "public"
+  },
   "engines": {
     "node": ">=10"
   },

--- a/npm-binary-distributions/linux-i686/package.json
+++ b/npm-binary-distributions/linux-i686/package.json
@@ -4,6 +4,9 @@
   "description": "The linux x86 and ia32 distribution of the Sentry CLI binary.",
   "repository": "https://github.com/getsentry/sentry-cli",
   "license": "BSD-3-Clause",
+  "publishConfig": {
+    "access": "public"
+  },
   "engines": {
     "node": ">=10"
   },

--- a/npm-binary-distributions/linux-x64/package.json
+++ b/npm-binary-distributions/linux-x64/package.json
@@ -4,6 +4,9 @@
   "description": "The linux x64 distribution of the Sentry CLI binary.",
   "repository": "https://github.com/getsentry/sentry-cli",
   "license": "BSD-3-Clause",
+  "publishConfig": {
+    "access": "public"
+  },
   "engines": {
     "node": ">=10"
   },

--- a/npm-binary-distributions/win32-i686/package.json
+++ b/npm-binary-distributions/win32-i686/package.json
@@ -4,6 +4,9 @@
   "description": "The windows x86 and ia32 distribution of the Sentry CLI binary.",
   "repository": "https://github.com/getsentry/sentry-cli",
   "license": "BSD-3-Clause",
+  "publishConfig": {
+    "access": "public"
+  },
   "engines": {
     "node": ">=10"
   },

--- a/npm-binary-distributions/win32-x64/package.json
+++ b/npm-binary-distributions/win32-x64/package.json
@@ -4,6 +4,9 @@
   "description": "The windows x64 distribution of the Sentry CLI binary.",
   "repository": "https://github.com/getsentry/sentry-cli",
   "license": "BSD-3-Clause",
+  "publishConfig": {
+    "access": "public"
+  },
   "engines": {
     "node": ">=10"
   },


### PR DESCRIPTION
We need this to be able to publish the packages for the first time