### PR TITLE
fix(sourcemaps): don't attempt to treat remote URL as a local file path

### DIFF
--- a/tests/integration/_cases/sourcemaps/sourcemaps-inject-split-ambiguous.trycmd
+++ b/tests/integration/_cases/sourcemaps/sourcemaps-inject-split-ambiguous.trycmd
@@ -9,9 +9,9 @@ $ sentry-cli sourcemaps inject ./code ./maps ./maps2 --log-level warn
 > Found 1 file
 > Analyzing 5 sources
 > Injecting debug ids
-  WARN    [..]-[..]-[..] [..]:[..]:[..].[..] +[..]:[..] Ambiguous matches for sourcemap path ./code/foo/index.js.map:
-  WARN    [..]-[..]-[..] [..]:[..]:[..].[..] +[..]:[..] ./maps/foo/index.js.map
-  WARN    [..]-[..]-[..] [..]:[..]:[..].[..] +[..]:[..] ./maps2/foo/index.js.map
+  WARN    [..]-[..]-[..] [..]:[..]:[..].[..] [..]:[..] Ambiguous matches for sourcemap path ./code/foo/index.js.map:
+  WARN    [..]-[..]-[..] [..]:[..]:[..].[..] [..]:[..] ./maps/foo/index.js.map
+  WARN    [..]-[..]-[..] [..]:[..]:[..].[..] [..]:[..] ./maps2/foo/index.js.map
 
 Source Map Debug ID Injection Report
   Modified: The following source files have been modified to have debug ids

--- a/tests/integration/_cases/sourcemaps/sourcemaps-inject.trycmd
+++ b/tests/integration/_cases/sourcemaps/sourcemaps-inject.trycmd
@@ -2,10 +2,10 @@
 $ sentry-cli sourcemaps inject ./server ./static
 ? success
 > Searching ./server
-> Found 12 files
+> Found 14 files
 > Searching ./static
 > Found 8 files
-> Analyzing 20 sources
+> Analyzing 22 sources
 > Injecting debug ids
 
 Source Map Debug ID Injection Report
@@ -13,6 +13,7 @@ Source Map Debug ID Injection Report
     [..]-[..]-[..]-[..]-[..] - ./server/app/page.js
     [..]-[..]-[..]-[..]-[..] - ./server/chunks/1.js
     [..]-[..]-[..]-[..]-[..] - ./server/dummy_embedded.js
+    [..]-[..]-[..]-[..]-[..] - ./server/dummy_hosted.js
     [..]-[..]-[..]-[..]-[..] - ./server/flight-manifest.js
     [..]-[..]-[..]-[..]-[..] - ./server/pages/_document.js
     [..]-[..]-[..]-[..]-[..] - ./server/pages/api/hello.js
@@ -21,6 +22,7 @@ Source Map Debug ID Injection Report
     [..]-[..]-[..]-[..]-[..] - ./static/chunks/app/head-172ad45600676c06.js
     [..]-[..]-[..]-[..]-[..] - ./static/chunks/pages/asdf-05b39167abbe433b.js
   Modified: The following sourcemap files have been modified to have debug ids
+    [..]-[..]-[..]-[..]-[..] - ./server/dummy_hosted.js.map
     [..]-[..]-[..]-[..]-[..] - ./server/pages/_document.js.map
     [..]-[..]-[..]-[..]-[..] - ./static/chunks/575-bb7d7e0e6de8d623.js.map
   Ignored: The following source files already have debug ids

--- a/tests/integration/_cases/sourcemaps/sourcemaps-upload-some-debugids.trycmd
+++ b/tests/integration/_cases/sourcemaps/sourcemaps-upload-some-debugids.trycmd
@@ -5,14 +5,14 @@ $ sentry-cli sourcemaps upload tests/integration/_fixtures/upload_some_debugids
 > Analyzing 20 sources
 > Rewriting sources
 > Adding source map references
-  WARN    [..]-[..]-[..] [..]:[..]:[..].[..] +[..]:[..] Some source files don't have debug ids:
-  WARN    [..]-[..]-[..] [..]:[..]:[..].[..] +[..]:[..] - ~/server/app/page.js
-  WARN    [..]-[..]-[..] [..]:[..]:[..].[..] +[..]:[..] - ~/server/chunks/1.js
-  WARN    [..]-[..]-[..] [..]:[..]:[..].[..] +[..]:[..] - ~/server/dummy_embedded.js
-  WARN    [..]-[..]-[..] [..]:[..]:[..].[..] +[..]:[..] - ~/server/pages/_document.js
-  WARN    [..]-[..]-[..] [..]:[..]:[..].[..] +[..]:[..] - ~/server/pages/api/hello.js
-  WARN    [..]-[..]-[..] [..]:[..]:[..].[..] +[..]:[..] - ~/static/chunks/575-bb7d7e0e6de8d623.js
-  WARN    [..]-[..]-[..] [..]:[..]:[..].[..] +[..]:[..] - ~/static/chunks/pages/asdf-05b39167abbe433b.js
+  WARN    [..]-[..]-[..] [..]:[..]:[..].[..] [..]:[..] Some source files don't have debug ids:
+  WARN    [..]-[..]-[..] [..]:[..]:[..].[..] [..]:[..] - ~/server/app/page.js
+  WARN    [..]-[..]-[..] [..]:[..]:[..].[..] [..]:[..] - ~/server/chunks/1.js
+  WARN    [..]-[..]-[..] [..]:[..]:[..].[..] [..]:[..] - ~/server/dummy_embedded.js
+  WARN    [..]-[..]-[..] [..]:[..]:[..].[..] [..]:[..] - ~/server/pages/_document.js
+  WARN    [..]-[..]-[..] [..]:[..]:[..].[..] [..]:[..] - ~/server/pages/api/hello.js
+  WARN    [..]-[..]-[..] [..]:[..]:[..].[..] [..]:[..] - ~/static/chunks/575-bb7d7e0e6de8d623.js
+  WARN    [..]-[..]-[..] [..]:[..]:[..].[..] [..]:[..] - ~/static/chunks/pages/asdf-05b39167abbe433b.js
 > Bundled 20 files for upload
 > Bundle ID: [..]-[..]-[..]-[..]-[..]
 > Uploaded files to Sentry

--- a/tests/integration/_fixtures/inject/server/dummy_hosted.js
+++ b/tests/integration/_fixtures/inject/server/dummy_hosted.js
@@ -1,0 +1,1 @@
+//# sourceMappingURL=https://some-static-hosting.example.com/path/to/dummy_embedded.js.map

--- a/tests/integration/_fixtures/inject/server/dummy_hosted.js.map
+++ b/tests/integration/_fixtures/inject/server/dummy_hosted.js.map
@@ -1,0 +1,9 @@
+{
+  "version": 3,
+  "file": "1.js",
+  "mappings": ";;;",
+  "sources": [],
+  "sourcesContent": [],
+  "names": [],
+  "sourceRoot": ""
+}


### PR DESCRIPTION
When a sourceMappingURL is a remote URL (e.g. static storage in an S3 bucket), `sentry-cli sourcemaps inject` was treating it like a normal file path, attempting to "normalize" it with the source path, and producing a bogus url such as `path/to/source/dir/https://some-static-host.example.com/path/to/foo.js.map`, which of course doesn't exist, and thus the sourcemap isn't found and doesn't have the debug id injected - even if it's sitting right there in the local directory, next to its corresponding bundled source file.

With this change, the sourcemap discovery step does not attempt to use the discovered sourcemap URL if it is a remote URL. Instead, it falls back to guessing the sourcemap location based on the source filename and its location.

I also changed a couple trycmd tests to remove the `+` before the timezone offset,
as it causes the tests to fail when the local timezone is west of UTC.

Fixes #1846.