### PR TITLE
meta: Restructure Bug Report Issue Template

### DIFF
--- a/.github/ISSUE_TEMPLATE/BUG_REPORT.md
+++ b/.github/ISSUE_TEMPLATE/BUG_REPORT.md
@@ -11,9 +11,13 @@ What version of the CLI and what OS are you running?
 
 What you did?
 
-### Expected/Actual Result
+### Expected Result
 
-What you thought would happen and what actually happened?
+What you thought would happen?
+
+### Actual Result
+
+What actually happened?
 
 ### Logs
 


### PR DESCRIPTION
This change separates the GitHub Bug Report Issue template's **Expected/Actual Result** section into two separate sections titled **Expected Result** and **Actual Result**. This change should make it easier to tell at a quick glance what the user expected to happen versus what actually happened, and it will hopefully make bug report issues easier for us to understand. We already have separate expected and actual results sections in the getsentry/sentry-python repository, and I find issues with the separated structure easier to read and understand.