### PR TITLE
build: Fix CLI in Xcode Cloud by Disabling Link-time Optimizations

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -117,4 +117,3 @@ opt-level = "z"
 panic = "abort"
 strip = true      # Strip symbols from the binary.
 codegen-units = 1 # Parallel compilation prevents some optimizations.
-lto = true        # Enable Link-time optimizations to remove dead code.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -118,3 +118,5 @@ opt-level = "z"
 panic = "abort"
 strip = true      # Strip symbols from the binary.
 codegen-units = 1 # Parallel compilation prevents some optimizations.
+# We do not enable link-time optimizations (lto) because they cause the
+# CLI to timeout when run in Xcode Cloud.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -115,3 +115,4 @@ winapi = "0.3.9"
 [profile.release]
 opt-level = "z"
 panic = "abort"
+codegen-units = 1 # Parallel compilation prevents some optimizations.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -113,5 +113,5 @@ crossbeam-channel = "0.5.6"
 winapi = "0.3.9"
 
 [profile.release]
-opt-level = 3
+opt-level = "z"
 panic = "abort"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -117,3 +117,4 @@ opt-level = "z"
 panic = "abort"
 strip = true      # Strip symbols from the binary.
 codegen-units = 1 # Parallel compilation prevents some optimizations.
+lto = true        # Enable Link-time optimizations to remove dead code.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -115,4 +115,5 @@ winapi = "0.3.9"
 [profile.release]
 opt-level = "z"
 panic = "abort"
+strip = true      # Strip symbols from the binary.
 codegen-units = 1 # Parallel compilation prevents some optimizations.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -112,10 +112,6 @@ crossbeam-channel = "0.5.6"
 [target."cfg(windows)".dependencies]
 winapi = "0.3.9"
 
-# We optimize the release build for size.
 [profile.release]
-opt-level = "z"
+opt-level = 3
 panic = "abort"
-strip = true      # Strip symbols from the binary.
-codegen-units = 1 # Parallel compilation prevents some optimizations.
-lto = true        # Enable Link-time optimizations to remove dead code.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -112,6 +112,7 @@ crossbeam-channel = "0.5.6"
 [target."cfg(windows)".dependencies]
 winapi = "0.3.9"
 
+# We optimize the release build for size.
 [profile.release]
 opt-level = "z"
 panic = "abort"


### PR DESCRIPTION
For whatever reason, when the Sentry CLI is compiled with link-time optimizations enabled, it hangs when run in Xcode Cloud and ends up resulting in a timeout error after c.a. 30 minutes. The CLI appears to run correctly if it is compiled without link-time optimizations, so by disabling these optimizations, we can fix the problem in Xcode Cloud.

Fixes GH-1820