### PR TITLE
fix: install the x64 cli on windows-on-arm hosts

### DIFF
--- a/scripts/install.js
+++ b/scripts/install.js
@@ -84,6 +84,10 @@ function getDownloadUrl(platform, arch) {
     case 'darwin':
       return `${releasesUrl}-Darwin-universal`;
     case 'win32':
+      // Windows arm machines can run x64 binaries
+      if (arch === 'arm64') {
+        archString = 'x86_64';
+      }
       return `${releasesUrl}-Windows-${archString}.exe`;
     case 'linux':
     case 'freebsd':


### PR DESCRIPTION
As in title, currently installing the CLI errored out on windows-on-arm hosts because it tries to install a build that I guess doesn't exist.  This is a temporary workaround until ideally and arm64 build for windows is published.