### PR TITLE
fix(hybrid-cloud): Adds region fan-out to organizations list command

### DIFF
--- a/src/api.rs
+++ b/src/api.rs
@@ -1515,7 +1515,13 @@ impl Api {
 
     pub fn list_available_regions(&self) -> ApiResult<Vec<Region>> {
         let resp = self.get("/users/me/regions/")?;
-        if resp.status() == 404 || resp.status == 400 {
+        if resp.status() == 404 {
+            // This endpoint may not exist for self-hosted users, so
+            // returning a default of [] seems appropriate.
+            return Ok(vec![]);
+        }
+
+        if resp.status == 400 {
             return Err(ApiErrorKind::ResourceNotFound.into());
         }
 

--- a/src/api.rs
+++ b/src/api.rs
@@ -1521,7 +1521,7 @@ impl Api {
             return Ok(vec![]);
         }
 
-        if resp.status == 400 {
+        if resp.status() == 400 {
             return Err(ApiErrorKind::ResourceNotFound.into());
         }
 

--- a/src/api.rs
+++ b/src/api.rs
@@ -421,10 +421,7 @@ impl Api {
         let (url, auth) = if is_absolute_url(url) {
             (Cow::Borrowed(url), None)
         } else {
-            let host_override = match region {
-                Some(region_config) => Some(region_config.url.as_str()),
-                None => None,
-            };
+            let host_override = region.map(|rg| rg.url.as_str());
 
             (
                 Cow::Owned(match self.config.get_api_endpoint(url, host_override) {

--- a/src/api.rs
+++ b/src/api.rs
@@ -1497,7 +1497,7 @@ impl Api {
             } else {
                 self.get(current_path)?
             };
-            
+
             if resp.status() == 404 || (resp.status() == 400 && !cursor.is_empty()) {
                 if rv.is_empty() {
                     return Err(ApiErrorKind::ResourceNotFound.into());
@@ -3016,7 +3016,5 @@ pub struct Region {
 
 #[derive(Clone, Debug, Deserialize)]
 pub struct RegionResponse {
-    pub regions: Vec<Region>
+    pub regions: Vec<Region>,
 }
-
-

--- a/src/api.rs
+++ b/src/api.rs
@@ -252,6 +252,8 @@ pub enum ApiErrorKind {
     RequestFailed,
     #[error("could not compress data")]
     CompressionFailed,
+    #[error("region prefixes cannot be applied to absolute urls")]
+    InvalidRegionRequest,
 }
 
 #[derive(Debug, thiserror::Error)]
@@ -391,6 +393,57 @@ impl Api {
     /// URL is just a path then it's relative to the configured API host
     /// and authentication is automatically enabled.
     pub fn request(&self, method: Method, url: &str) -> ApiResult<ApiRequest> {
+        let (url, auth) = self.resolve_base_url_and_auth(url, None)?;
+        self.construct_api_request(method, &url, auth)
+    }
+
+    /// Like `request`, but constructs a new `ApiRequest` using the base URL
+    /// plus a region prefix for requests that must be routed to a region.
+    pub fn region_request(
+        &self,
+        method: Method,
+        url: &str,
+        region: &Region,
+    ) -> ApiResult<ApiRequest> {
+        let (url, auth) = self.resolve_base_url_and_auth(url, Some(region))?;
+        self.construct_api_request(method, &url, auth)
+    }
+
+    fn resolve_base_url_and_auth(
+        &self,
+        url: &str,
+        region: Option<&Region>,
+    ) -> ApiResult<(String, Option<&Auth>)> {
+        if is_absolute_url(url) && region.is_some() {
+            return Err(ApiErrorKind::InvalidRegionRequest.into());
+        }
+
+        let (url, auth) = if is_absolute_url(url) {
+            (Cow::Borrowed(url), None)
+        } else {
+            let host_override = match region {
+                Some(region_config) => Some(region_config.url.as_str()),
+                None => None,
+            };
+
+            (
+                Cow::Owned(match self.config.get_api_endpoint(url, host_override) {
+                    Ok(rv) => rv,
+                    Err(err) => return Err(ApiError::with_source(ApiErrorKind::BadApiUrl, err)),
+                }),
+                self.config.get_auth(),
+            )
+        };
+
+        Ok((url.into_owned(), auth))
+    }
+
+    fn construct_api_request(
+        &self,
+        method: Method,
+        url: &str,
+        auth: Option<&Auth>,
+    ) -> ApiResult<ApiRequest> {
         let mut handle = self.pool.get().unwrap();
         handle.reset();
         if !self.config.allow_keepalive() {
@@ -401,17 +454,6 @@ impl Api {
             ssl_opts.no_revoke(true);
         }
         handle.ssl_options(&ssl_opts)?;
-        let (url, auth) = if is_absolute_url(url) {
-            (Cow::Borrowed(url), None)
-        } else {
-            (
-                Cow::Owned(match self.config.get_api_endpoint(url) {
-                    Ok(rv) => rv,
-                    Err(err) => return Err(ApiError::with_source(ApiErrorKind::BadApiUrl, err)),
-                }),
-                self.config.get_auth(),
-            )
-        };
 
         if let Some(proxy_url) = self.config.get_proxy_url() {
             handle.proxy(&proxy_url)?;
@@ -431,7 +473,7 @@ impl Api {
         let env = self.config.get_pipeline_env();
         let headers = self.config.get_headers();
 
-        ApiRequest::create(handle, &method, &url, auth, env, headers)
+        ApiRequest::create(handle, &method, url, auth, env, headers)
     }
 
     /// Convenience method that performs a request using DSN as authentication method.
@@ -445,7 +487,7 @@ impl Api {
         // We resolve an absolute URL to skip default authentication flow.
         let url = self
             .config
-            .get_api_endpoint(url)
+            .get_api_endpoint(url, None)
             .map_err(|err| ApiError::with_source(ApiErrorKind::BadApiUrl, err))?;
 
         let mut request = self
@@ -1443,11 +1485,19 @@ impl Api {
     }
 
     /// List all organizations associated with the authenticated token
-    pub fn list_organizations(&self) -> ApiResult<Vec<Organization>> {
+    /// in the given `Region`. If no `Region` is provided, we assume
+    /// we're issuing a request to a monolith deployment.
+    pub fn list_organizations(&self, region: Option<&Region>) -> ApiResult<Vec<Organization>> {
         let mut rv = vec![];
         let mut cursor = "".to_string();
         loop {
-            let resp = self.get(&format!("/organizations/?cursor={}", QueryArg(&cursor)))?;
+            let current_path = &format!("/organizations/?cursor={}", QueryArg(&cursor));
+            let resp = if let Some(rg) = region {
+                self.region_request(Method::Get, current_path, rg)?.send()?
+            } else {
+                self.get(current_path)?
+            };
+            
             if resp.status() == 404 || (resp.status() == 400 && !cursor.is_empty()) {
                 if rv.is_empty() {
                     return Err(ApiErrorKind::ResourceNotFound.into());
@@ -1464,6 +1514,16 @@ impl Api {
             }
         }
         Ok(rv)
+    }
+
+    pub fn list_available_regions(&self) -> ApiResult<Vec<Region>> {
+        let resp = self.get("/users/me/regions/")?;
+        if resp.status() == 404 || resp.status == 400 {
+            return Err(ApiErrorKind::ResourceNotFound.into());
+        }
+
+        let region_response = resp.convert::<RegionResponse>()?;
+        Ok(region_response.regions)
     }
 
     /// List all monitors associated with an organization
@@ -2947,3 +3007,16 @@ impl fmt::Display for ProcessedEventTag {
         Ok(())
     }
 }
+
+#[derive(Clone, Debug, Deserialize)]
+pub struct Region {
+    pub name: String,
+    pub url: String,
+}
+
+#[derive(Clone, Debug, Deserialize)]
+pub struct RegionResponse {
+    pub regions: Vec<Region>
+}
+
+

--- a/src/api.rs
+++ b/src/api.rs
@@ -252,7 +252,7 @@ pub enum ApiErrorKind {
     RequestFailed,
     #[error("could not compress data")]
     CompressionFailed,
-    #[error("region prefixes cannot be applied to absolute urls")]
+    #[error("region overrides cannot be applied to absolute urls")]
     InvalidRegionRequest,
 }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -271,7 +271,9 @@ impl Config {
 
     /// Returns the API URL for a path
     pub fn get_api_endpoint(&self, path: &str, base_url_override: Option<&str>) -> Result<String> {
-        let base: &str = base_url_override.unwrap_or(self.get_base_url()?).trim_end_matches('/');
+        let base: &str = base_url_override
+            .unwrap_or(self.get_base_url()?)
+            .trim_end_matches('/');
         let path = path.trim_start_matches('/');
         let path = path.trim_start_matches("api/0/");
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -271,7 +271,7 @@ impl Config {
 
     /// Returns the API URL for a path
     pub fn get_api_endpoint(&self, path: &str, base_url_override: Option<&str>) -> Result<String> {
-        let base: &str = base_url_override.unwrap_or(self.get_base_url()?);
+        let base: &str = base_url_override.unwrap_or(self.get_base_url()?).trim_end_matches('/');
         let path = path.trim_start_matches('/');
         let path = path.trim_start_matches("api/0/");
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -270,10 +270,11 @@ impl Config {
     }
 
     /// Returns the API URL for a path
-    pub fn get_api_endpoint(&self, path: &str) -> Result<String> {
-        let base = self.get_base_url()?;
+    pub fn get_api_endpoint(&self, path: &str, base_url_override: Option<&str>) -> Result<String> {
+        let base: &str = base_url_override.unwrap_or(self.get_base_url()?);
         let path = path.trim_start_matches('/');
         let path = path.trim_start_matches("api/0/");
+
         Ok(format!("{}/api/0/{}", base, path))
     }
 
@@ -788,16 +789,23 @@ mod tests {
 
         assert_eq!(
             config
-                .get_api_endpoint("/organizations/test-org/chunk-upload/")
+                .get_api_endpoint("/organizations/test-org/chunk-upload/", None)
                 .unwrap(),
             "https://sentry.io/api/0/organizations/test-org/chunk-upload/"
         );
 
         assert_eq!(
             config
-                .get_api_endpoint("/api/0/organizations/test-org/chunk-upload/")
+                .get_api_endpoint("/api/0/organizations/test-org/chunk-upload/", None)
                 .unwrap(),
             "https://sentry.io/api/0/organizations/test-org/chunk-upload/"
+        );
+
+        assert_eq!(
+            config
+                .get_api_endpoint("/api/0/organizations/test-org/chunk-upload/", Some("https://us.sentry.io/"))
+                .unwrap(),
+            "https://us.sentry.io/api/0/organizations/test-org/chunk-upload/"
         );
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -803,7 +803,10 @@ mod tests {
 
         assert_eq!(
             config
-                .get_api_endpoint("/api/0/organizations/test-org/chunk-upload/", Some("https://us.sentry.io/"))
+                .get_api_endpoint(
+                    "/api/0/organizations/test-org/chunk-upload/",
+                    Some("https://us.sentry.io/")
+                )
                 .unwrap(),
             "https://us.sentry.io/api/0/organizations/test-org/chunk-upload/"
         );

--- a/tests/integration/organizations/list.rs
+++ b/tests/integration/organizations/list.rs
@@ -10,12 +10,12 @@ fn command_organizations_list() {
     );
 
     let region_response = format!(
-        "{{
-            \"regions\": [{{
-                \"name\": \"monolith\",
-                \"url\": \"{}\"
+        r#"{{
+            "regions": [{{
+                "name": "monolith",
+                "url": "{}"
             }}]
-        }}",
+        }}"#,
         server_url(),
     );
 

--- a/tests/integration/organizations/list.rs
+++ b/tests/integration/organizations/list.rs
@@ -1,3 +1,5 @@
+use mockito::server_url;
+
 use crate::integration::{mock_endpoint, register_test, EndpointOptions};
 
 #[test]
@@ -5,6 +7,22 @@ fn command_organizations_list() {
     let _server = mock_endpoint(
         EndpointOptions::new("GET", "/api/0/organizations/?cursor=", 200)
             .with_response_file("organizations/get-organizations.json"),
+    );
+
+    let region_response = format!(
+        "{{
+            \"regions\": [{{
+                \"name\": \"monolith\",
+                \"url\": \"{}\"
+            }}]
+        }}",
+        server_url(),
+    );
+
+    let _mock_regions = mock_endpoint(
+        EndpointOptions::new("GET", "/api/0/users/me/regions/", 200).with_response_body(
+            region_response
+        )
     );
     register_test("organizations/organizations-list.trycmd");
 }

--- a/tests/integration/organizations/list.rs
+++ b/tests/integration/organizations/list.rs
@@ -20,9 +20,8 @@ fn command_organizations_list() {
     );
 
     let _mock_regions = mock_endpoint(
-        EndpointOptions::new("GET", "/api/0/users/me/regions/", 200).with_response_body(
-            region_response
-        )
+        EndpointOptions::new("GET", "/api/0/users/me/regions/", 200)
+            .with_response_body(region_response),
     );
     register_test("organizations/organizations-list.trycmd");
 }


### PR DESCRIPTION
The `organization list` command currently relies on the base `https://sentry.io/api/0/organizations/` route to query the user's active organizations; however, this will stop working when we incorporate multiple regions.

In order to address this, we've added logic to query an active user's regions, then fan-out to each of the individual regions in order to query all active organizations. This list is then combined and sorted by name as per usual.

In order to make this change, some of the underlying URI and request construction code had to be modified to allow overriding the request hostname with the region's hostname.

