### PR TITLE
ref: upgrade git2 so safe.directory is implemented more correctly

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -935,11 +935,11 @@ dependencies = [
 
 [[package]]
 name = "git2"
-version = "0.16.1"
+version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ccf7f68c2995f392c49fffb4f95ae2c873297830eb25c6bc4c114ce8f4562acc"
+checksum = "fbf97ba92db08df386e10c8ede66a2a0369bd277090afd8710e19e38de9ec0cd"
 dependencies = [
- "bitflags 1.3.2",
+ "bitflags 2.4.1",
  "libc",
  "libgit2-sys",
  "log",
@@ -1290,9 +1290,9 @@ checksum = "89d92a4743f9a61002fae18374ed11e7973f530cb3a3255fb354818118b2203c"
 
 [[package]]
 name = "libgit2-sys"
-version = "0.14.2+1.5.1"
+version = "0.16.1+1.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f3d95f6b51075fe9810a7ae22c7095f12b98005ab364d8544797a825ce946a4"
+checksum = "f2a2bb3680b094add03bb3732ec520ece34da31a8cd2d633d1389d0f0fb60d0c"
 dependencies = [
  "cc",
  "libc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,7 @@ encoding = "0.2.33"
 flate2 = { version = "1.0.25", default-features = false, features = [
   "rust_backend",
 ] }
-git2 = { version = "0.16.1", default-features = false }
+git2 = { version = "0.18.1", default-features = false }
 glob = "0.3.1"
 if_chain = "1.0.2"
 ignore = "0.4.20"


### PR DESCRIPTION
perhaps easier than  #1861