### PR TITLE
fix: Return promise from download binary when `SENTRYCLI_SKIP_DOWNLOAD` is set

### DIFF
--- a/js/install.js
+++ b/js/install.js
@@ -195,7 +195,7 @@ function checkVersion() {
 function downloadBinary(logger = ttyLogger) {
   if (process.env.SENTRYCLI_SKIP_DOWNLOAD === '1') {
     logger.log(`Skipping download because SENTRYCLI_SKIP_DOWNLOAD=1 detected.`);
-    return;
+    return Promise.resolve();
   }
 
   const arch = os.arch();


### PR DESCRIPTION
Fixes https://github.com/getsentry/sentry-cli/pull/1817/files#r1432446927