### PR TITLE
Fall back to co-location heuristic if sourcemap url appears remote

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -8,6 +8,6 @@
     "eslint.autoFixOnSave": true,
     "editor.tabSize": 2,
     "editor.codeActionsOnSave": {
-        "source.fixAll.eslint": true
+        "source.fixAll.eslint": "explicit"
     }
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -8,6 +8,6 @@
     "eslint.autoFixOnSave": true,
     "editor.tabSize": 2,
     "editor.codeActionsOnSave": {
-        "source.fixAll.eslint": "explicit"
+        "source.fixAll.eslint": true
     }
 }

--- a/tests/integration/_cases/sourcemaps/sourcemaps-inject.trycmd
+++ b/tests/integration/_cases/sourcemaps/sourcemaps-inject.trycmd
@@ -2,10 +2,10 @@
 $ sentry-cli sourcemaps inject ./server ./static
 ? success
 > Searching ./server
-> Found 14 files
+> Found 16 files
 > Searching ./static
 > Found 8 files
-> Analyzing 22 sources
+> Analyzing 24 sources
 > Injecting debug ids
 
 Source Map Debug ID Injection Report
@@ -14,6 +14,7 @@ Source Map Debug ID Injection Report
     [..]-[..]-[..]-[..]-[..] - ./server/chunks/1.js
     [..]-[..]-[..]-[..]-[..] - ./server/dummy_embedded.js
     [..]-[..]-[..]-[..]-[..] - ./server/dummy_hosted.js
+    [..]-[..]-[..]-[..]-[..] - ./server/dummy_hosted_full.js
     [..]-[..]-[..]-[..]-[..] - ./server/flight-manifest.js
     [..]-[..]-[..]-[..]-[..] - ./server/pages/_document.js
     [..]-[..]-[..]-[..]-[..] - ./server/pages/api/hello.js
@@ -23,6 +24,7 @@ Source Map Debug ID Injection Report
     [..]-[..]-[..]-[..]-[..] - ./static/chunks/pages/asdf-05b39167abbe433b.js
   Modified: The following sourcemap files have been modified to have debug ids
     [..]-[..]-[..]-[..]-[..] - ./server/dummy_hosted.js.map
+    [..]-[..]-[..]-[..]-[..] - ./server/dummy_hosted_full.js.map
     [..]-[..]-[..]-[..]-[..] - ./server/pages/_document.js.map
     [..]-[..]-[..]-[..]-[..] - ./static/chunks/575-bb7d7e0e6de8d623.js.map
   Ignored: The following source files already have debug ids

--- a/tests/integration/_fixtures/inject/server/dummy_hosted.js
+++ b/tests/integration/_fixtures/inject/server/dummy_hosted.js
@@ -1,1 +1,1 @@
-//# sourceMappingURL=https://some-static-hosting.example.com/path/to/dummy_embedded.js.map
+//# sourceMappingURL=/path/to/dummy_embedded.js.map

--- a/tests/integration/_fixtures/inject/server/dummy_hosted_full.js
+++ b/tests/integration/_fixtures/inject/server/dummy_hosted_full.js
@@ -1,0 +1,1 @@
+//# sourceMappingURL=https://some-static-hosting.example.com/path/to/dummy_embedded.js.map

--- a/tests/integration/_fixtures/inject/server/dummy_hosted_full.js.map
+++ b/tests/integration/_fixtures/inject/server/dummy_hosted_full.js.map
@@ -1,0 +1,9 @@
+{
+  "version": 3,
+  "file": "1.js",
+  "mappings": ";;;",
+  "sources": [],
+  "sourcesContent": [],
+  "names": [],
+  "sourceRoot": ""
+}


### PR DESCRIPTION
Applies a heuristic to guess that a sourcemap URL is a remote URL path (without scheme and domain):
1. The string starts with `/`
2. The string is not a path to an existing local file

Fixes #1870.