### PR TITLE
fix(hybrid-cloud): Updates organization list to handle single org fanout

### DIFF
--- a/src/commands/organizations/list.rs
+++ b/src/commands/organizations/list.rs
@@ -20,7 +20,7 @@ pub fn execute(_matches: &ArgMatches) -> Result<()> {
 
     // Self-hosted instances won't have a region instance or prefix, so we
     // need to check before fanning out.
-    if regions.len() > 0 {
+    if !regions.is_empty() {
         for region in regions {
             organizations.append(&mut api.list_organizations(Some(&region))?)
         }

--- a/src/commands/organizations/list.rs
+++ b/src/commands/organizations/list.rs
@@ -20,7 +20,7 @@ pub fn execute(_matches: &ArgMatches) -> Result<()> {
 
     // Self-hosted instances won't have a region instance or prefix, so we
     // need to check before fanning out.
-    if regions.len() > 1 {
+    if regions.len() > 0 {
         for region in regions {
             organizations.append(&mut api.list_organizations(Some(&region))?)
         }


### PR DESCRIPTION
Addresses an edge case with organization listing in SAAS, where a user with a single organization in a non-default region will only be shown organizations in the default region.

