### PR TITLE
fix: Manually download binary if optional dependency binary can't be found after installation

### DIFF
--- a/js/helper.js
+++ b/js/helper.js
@@ -154,7 +154,7 @@ It seems like none of the "@sentry/cli" package's optional dependencies got inst
   return compatibleBinaryPath;
 }
 
-let mockedBinaryPath = undefined;
+let mockedBinaryPath;
 
 /**
  * Overrides the default binary path with a mock value, useful for testing.

--- a/js/helper.js
+++ b/js/helper.js
@@ -1,6 +1,8 @@
 'use strict';
 
 const os = require('os');
+const path = require('path');
+const fs = require('fs');
 const childProcess = require('child_process');
 
 const BINARY_DISTRIBUTIONS = [
@@ -12,6 +14,23 @@ const BINARY_DISTRIBUTIONS = [
   { packageName: '@sentry/cli-win32-x64', subpath: 'bin/sentry-cli.exe' },
   { packageName: '@sentry/cli-win32-i686', subpath: 'bin/sentry-cli.exe' },
 ];
+
+/**
+ * This convoluted function resolves the path to the manually downloaded fallback
+ * `sentry-cli` binary in a way that can't be analysed by @vercel/nft.
+ *
+ * Without this, the binary can be detected as an asset and included by bundlers
+ * that use @vercel/nft.
+ *
+ * @returns {string} The path to the sentry-cli binary
+ */
+function getFallbackBinaryPath() {
+  const parts = [];
+  parts.push(__dirname);
+  parts.push('..');
+  parts.push(`sentry-cli${process.platform === 'win32' ? '.exe' : ''}`);
+  return path.resolve(...parts);
+}
 
 function getDistributionForThisPlatform() {
   const arch = os.arch();
@@ -67,11 +86,25 @@ function getDistributionForThisPlatform() {
 }
 
 /**
- * This convoluted function resolves the path to the `sentry-cli` binary in a
- * way that can't be analysed by @vercel/nft.
+ * Throws an error with a message stating that Sentry CLI doesn't support the current platform.
  *
- * Without this, the binary can be detected as an asset and included by bundlers
- * that use @vercel/nft.
+ * @returns {never} nothing. It throws.
+ */
+function throwUnsupportedPlatformError() {
+  throw new Error(
+    `Unsupported operating system or architecture! Sentry CLI does not work on this architecture.
+
+Sentry CLI supports:
+- Darwin (macOS)
+- Linux and FreeBSD on x64, x86, ia32, arm64, and arm architectures
+- Windows x64, x86, and ia32 architectures`
+  );
+}
+
+/**
+ * Tries to find the installed Sentry CLI binary - either by looking into the relevant
+ * optional dependencies or by trying to resolve the fallback binary.
+ *
  * @returns {string} The path to the sentry-cli binary
  */
 function getBinaryPath() {
@@ -82,14 +115,13 @@ function getBinaryPath() {
   const { packageName, subpath } = getDistributionForThisPlatform();
 
   if (packageName === undefined) {
-    throw new Error(
-      `Unsupported operating system or architecture! Sentry CLI does not work on this architecture.
+    throwUnsupportedPlatformError();
+  }
 
-Sentry CLI supports:
-- Darwin (macOS)
-- Linux and FreeBSD on x64, x86, ia32, arm64, and arm architectures
-- Windows x64, x86, and ia32 architectures`
-    );
+  let fallbackBinaryPath = getFallbackBinaryPath();
+  if (fs.existsSync(fallbackBinaryPath)) {
+    // Since the fallback got installed, the optional dependencies likely didn't get installed, so we just default to the fallback.
+    return fallbackBinaryPath;
   }
 
   let compatibleBinaryPath;
@@ -122,11 +154,7 @@ It seems like none of the "@sentry/cli" package's optional dependencies got inst
   return compatibleBinaryPath;
 }
 
-/**
- * Absolute path to the sentry-cli binary (platform dependent).
- * @type {string}
- */
-let binaryPath = getBinaryPath();
+let mockedBinaryPath = undefined;
 
 /**
  * Overrides the default binary path with a mock value, useful for testing.
@@ -136,7 +164,7 @@ let binaryPath = getBinaryPath();
  */
 // TODO(v3): Remove this function
 function mockBinaryPath(mockPath) {
-  binaryPath = mockPath;
+  mockedBinaryPath = mockPath;
 }
 
 /**
@@ -222,7 +250,7 @@ function prepareCommand(command, schema, options) {
  * @returns {string}
  */
 function getPath() {
-  return binaryPath;
+  return mockedBinaryPath !== undefined ? mockedBinaryPath : getBinaryPath();
 }
 
 /**
@@ -318,4 +346,7 @@ module.exports = {
   mockBinaryPath,
   prepareCommand,
   serializeOptions,
+  getDistributionForThisPlatform,
+  throwUnsupportedPlatformError,
+  getFallbackBinaryPath,
 };

--- a/js/helper.js
+++ b/js/helper.js
@@ -154,6 +154,10 @@ It seems like none of the "@sentry/cli" package's optional dependencies got inst
   return compatibleBinaryPath;
 }
 
+/**
+ * Will be used as the binary path when defined with `mockBinaryPath`.
+ * @type {string | undefined}
+ */
 let mockedBinaryPath;
 
 /**

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "@sentry/cli-win32-x64": "2.23.1"
   },
   "scripts": {
+    "postinstall": "node ./scripts/install.js",
     "fix": "npm-run-all fix:eslint fix:prettier",
     "fix:eslint": "eslint --fix bin/* scripts/**/*.js js/**/*.js",
     "fix:prettier": "prettier --write bin/* scripts/**/*.js js/**/*.js",


### PR DESCRIPTION
Fixes https://github.com/getsentry/sentry-cli/issues/1849 to some degree.

With this PR we re-add a post-install script that will manually download the Sentry CLI binary from our CDN if we cannot find the npm binary distributions that would be installed via optional dependencies.

This will improve the reliability for situations where optional dependencies are not installed (like Vercel apparently).

We still require either postinstall scripts to be enabled, OR optional dependencies to be installed.