### PR TITLE
feat(api): More specific error message for 401 Sentry errors

### DIFF
--- a/src/api.rs
+++ b/src/api.rs
@@ -219,6 +219,12 @@ impl fmt::Display for SentryError {
         if let Some(ref extra) = self.extra {
             write!(f, "\n  {extra:?}")?;
         }
+        if self.status == 401 {
+            write!(
+                f,
+                "\n\tPlease verify that you copied the auth token correctly!"
+            )?;
+        }
         Ok(())
     }
 }


### PR DESCRIPTION
Add a line to the error message output when a 401 error occurs when communicating with Sentry to instruct users to verify that the auth token was copied correctly. An incorrectly copied auth token is a likely cause of a 401 error.

Fixes GH-1859