### PR TITLE
ref: Emit better log message for fallback postinstall script

### DIFF
--- a/js/helper.js
+++ b/js/helper.js
@@ -147,7 +147,7 @@ To fix this, avoid copying the "node_modules" folder, and instead freshly instal
     } else {
       throw new Error(`Sentry CLI binary for this platform/architecture not found!
 
-It seems like none of the "@sentry/cli" package's optional dependencies got installed. Please make sure your package manager is configured to install optional dependencies. If you are using npm to install your dependencies, please don't set the "--no-optional" or "--omit=optional" flags. Sentry CLI needs the "optionalDependencies" feature in order to install its binary.`);
+It seems like none of the "@sentry/cli" package's optional dependencies got installed. Please make sure your package manager is configured to install optional dependencies. If you are using npm to install your dependencies, please don't set the "--no-optional", "--ignore-optional", or "--omit=optional" flags. Sentry CLI needs the "optionalDependencies" feature in order to install its binary.`);
     }
   }
 

--- a/scripts/install.js
+++ b/scripts/install.js
@@ -330,8 +330,11 @@ try {
   process.exit(0);
 } catch (e) {
   // Optional dependencies likely didn't get installed - proceed with fallback downloading manually
+  // Log message inspired by esbuild: https://github.com/evanw/esbuild/blob/914f6080c77cfe32a54888caa51ca6ea13873ce9/lib/npm/node-install.ts#L253
   logger.log(
-    `Sentry CLI binary installation via optional dependencies was unsuccessful. Downloading manually instead.`
+    `Sentry CLI failed to locate the "${distributionPackageName}" package after installation!
+
+This can happen if you use an option to disable optional dependencies during installation, like "--no-optional", "--ignore-optional", or "--omit=optional". Sentry CLI uses the "optionalDependencies" package.json feature to install the correct binary for your platform and operating system. This post-install script will now try to work around this by manually downloading the Sentry CLI binary from the Sentry CDN. If this fails, you need to remove the "--no-optional", "--ignore-optional", and "--omit=optional" flags for Sentry CLI to work.`
   );
 
   downloadBinary()


### PR DESCRIPTION
Got inspired by esbuild and wanted to emit a better log message if the optional deps thing doesn't work.