### PR TITLE
ci: Skip fallback download in tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,6 +87,7 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
 
+      # We need to skip the fallback download because downloading will fail on release branches because the new version isn't available yet.
       - run: SENTRYCLI_SKIP_DOWNLOAD=1 npm install
 
       # older node versions need an older nft

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,10 +87,10 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
 
-      - run: npm install
+      - run: SENTRYCLI_SKIP_DOWNLOAD=1 npm install
 
       # older node versions need an older nft
-      - run: npm install @vercel/nft@0.22.1
+      - run: SENTRYCLI_SKIP_DOWNLOAD=1 npm install @vercel/nft@0.22.1
         if: matrix.node-version == '10.x' || matrix.node-version == '12.x'
 
       - run: npm test


### PR DESCRIPTION
The download will fail on release branches: https://github.com/getsentry/sentry-cli/actions/runs/7347591741/job/20004278485

Reason being that the new version isn't available yet - meaning optional deps won't be downloaded AND the CDN doesn't host the new version yet, crashing the install script.

This PR should fix that by simply skipping the fallback download for tests.