### PR TITLE
Add "--environment" option to "monitors run" (supplement "-e" shorthand)

### DIFF
--- a/src/commands/monitors/run.rs
+++ b/src/commands/monitors/run.rs
@@ -28,6 +28,7 @@ pub fn make_command(command: Command) -> Command {
         .arg(
             Arg::new("environment")
                 .short('e')
+                .long("environment")
                 .default_value("production")
                 .help("Specify the environment of the monitor."),
         )

--- a/tests/integration/_cases/monitors/monitors-run-environment-long.trycmd
+++ b/tests/integration/_cases/monitors/monitors-run-environment-long.trycmd
@@ -1,0 +1,6 @@
+```
+$ sentry-cli monitors run --environment dev-env foo-monitor -- echo 123
+? success
+123
+
+```

--- a/tests/integration/_cases/monitors/monitors-run-help.trycmd
+++ b/tests/integration/_cases/monitors/monitors-run-help.trycmd
@@ -10,7 +10,7 @@ Arguments:
   <ARGS>...       
 
 Options:
-  -e <environment>
+  -e, --environment <environment>
           Specify the environment of the monitor. [default: production]
       --header <KEY:VALUE>
           Custom headers that should be attached to all requests

--- a/tests/integration/monitors/run.rs
+++ b/tests/integration/monitors/run.rs
@@ -33,6 +33,11 @@ fn command_monitors_run_environment() {
 }
 
 #[test]
+fn command_monitors_run_environment_long() {
+    register_test("monitors/monitors-run-environment-long.trycmd");
+}
+
+#[test]
 fn command_monitors_run_help() {
     register_test("monitors/monitors-run-help.trycmd");
 }


### PR DESCRIPTION
There is `-e` option in `sentry-cli monitors run`, which allows to pass environment name. However, it was missing any non-shorthand variant. This pull request fixes this inconsistency by adding `--environment` as an alternative name for this option.

### Rationale

Some people prefer full option names for their explicitness, especially when writing scripts. All the other shorthand options for `monitors run`, i.e. `-s` and `-h`, have their non-shorthand variants, i.e. `--schedule` and `--help`, respectively.