### PR TITLE
Remove `dsyms/associate` API usage

### DIFF
--- a/src/commands/upload_proguard.rs
+++ b/src/commands/upload_proguard.rs
@@ -152,6 +152,7 @@ pub fn execute(matches: &ArgMatches) -> Result<()> {
     let mut mappings = vec![];
     let mut all_checksums = vec![];
 
+    // TODO: maybe remove this at some point?
     let android_manifest = if let Some(path) = matches.get_one::<String>("android_manifest") {
         Some(AndroidManifest::from_path(path)?)
     } else {
@@ -262,10 +263,8 @@ pub fn execute(matches: &ArgMatches) -> Result<()> {
     }
 
     // update the uuids
-    if let Some(android_manifest) = android_manifest {
-        api.associate_android_proguard_mappings(&org, &project, &android_manifest, all_checksums)?;
-
-    // if values are given associate
+    if android_manifest.is_some() {
+        // if values are given associate
     } else if let Some(app_id) = matches.get_one::<String>("app_id") {
         let version = matches.get_one::<String>("version").unwrap().to_owned();
         let build: Option<String> = matches.get_one::<String>("version_code").cloned();

--- a/src/commands/upload_proguard.rs
+++ b/src/commands/upload_proguard.rs
@@ -14,7 +14,7 @@ use uuid::Uuid;
 use crate::api::Api;
 use crate::api::AssociateProguard;
 use crate::config::Config;
-use crate::utils::android::{dump_proguard_uuids_as_properties, AndroidManifest};
+use crate::utils::android::dump_proguard_uuids_as_properties;
 use crate::utils::args::ArgExt;
 use crate::utils::fs::{get_sha1_checksum, TempFile};
 use crate::utils::system::QuietExit;
@@ -106,6 +106,7 @@ pub fn make_command(command: Command) -> Command {
                 .long("android-manifest")
                 .value_name("PATH")
                 .conflicts_with("app_id")
+                .hide(true)
                 .help("Read version and version code from an Android manifest file."),
         )
         .arg(
@@ -151,13 +152,6 @@ pub fn execute(matches: &ArgMatches) -> Result<()> {
     };
     let mut mappings = vec![];
     let mut all_checksums = vec![];
-
-    // TODO: maybe remove this at some point?
-    let android_manifest = if let Some(path) = matches.get_one::<String>("android_manifest") {
-        Some(AndroidManifest::from_path(path)?)
-    } else {
-        None
-    };
 
     let forced_uuid = matches.get_one::<Uuid>("uuid");
     if forced_uuid.is_some() && paths.len() != 1 {
@@ -262,10 +256,8 @@ pub fn execute(matches: &ArgMatches) -> Result<()> {
         }
     }
 
-    // update the uuids
-    if android_manifest.is_some() {
-        // if values are given associate
-    } else if let Some(app_id) = matches.get_one::<String>("app_id") {
+    // if values are given associate
+    if let Some(app_id) = matches.get_one::<String>("app_id") {
         let version = matches.get_one::<String>("version").unwrap().to_owned();
         let build: Option<String> = matches.get_one::<String>("version_code").cloned();
 

--- a/src/utils/android.rs
+++ b/src/utils/android.rs
@@ -1,77 +1,11 @@
 use std::collections::HashMap;
-use std::fmt;
 use std::fs;
 use std::io;
 use std::path::Path;
 
 use anyhow::{format_err, Result};
-use elementtree::Element;
 use itertools::Itertools;
 use uuid::Uuid;
-
-pub struct AndroidManifest {
-    root: Element,
-}
-
-const ANDROID_NS: &str = "http://schemas.android.com/apk/res/android";
-
-impl AndroidManifest {
-    pub fn from_path<P: AsRef<Path>>(path: P) -> Result<AndroidManifest> {
-        let f = fs::File::open(path.as_ref())?;
-        let root = Element::from_reader(f)?;
-        Ok(AndroidManifest { root })
-    }
-
-    /// Returns the package ID
-    pub fn package(&self) -> &str {
-        self.root.get_attr("package").unwrap_or("unknown")
-    }
-
-    /// Returns a name
-    pub fn name(&self) -> String {
-        // fallback name is the package reformatted
-        self.root
-            .get_attr("package")
-            .unwrap_or("unknown")
-            .rsplit('.')
-            .next()
-            .unwrap()
-            .chars()
-            .enumerate()
-            .map(|(idx, c)| {
-                if idx == 0 {
-                    c.to_uppercase().to_string()
-                } else {
-                    c.to_lowercase().to_string()
-                }
-            })
-            .collect()
-    }
-
-    /// Returns the internal version code for this manifest
-    pub fn version_code(&self) -> &str {
-        self.root
-            .get_attr((ANDROID_NS, "versionCode"))
-            .unwrap_or("0")
-    }
-
-    /// Returns the human readable version number of the manifest
-    pub fn version_name(&self) -> &str {
-        self.root
-            .get_attr((ANDROID_NS, "versionName"))
-            .unwrap_or("0.0")
-    }
-}
-
-impl fmt::Debug for AndroidManifest {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_struct("AndroidManifest")
-            .field("package", &self.package())
-            .field("version_code", &self.version_code())
-            .field("version_name", &self.version_name())
-            .finish()
-    }
-}
 
 pub fn dump_proguard_uuids_as_properties<P: AsRef<Path>>(p: P, uuids: &[Uuid]) -> Result<()> {
     let mut props = match fs::File::open(p.as_ref()) {

--- a/tests/integration/_cases/upload_proguard/upload_proguard-help.trycmd
+++ b/tests/integration/_cases/upload_proguard/upload_proguard-help.trycmd
@@ -37,7 +37,6 @@ Options:
                                      upload (this also automatically disables reprocessing).  This
                                      is useful if you just want to verify the mapping files and
                                      write the proguard UUIDs into a properties file.
-      --android-manifest <PATH>      Read version and version code from an Android manifest file.
       --write-properties <PATH>      Write the UUIDs for the processed mapping files into the given
                                      properties file.
       --require-one                  Requires at least one file to upload or the command will error.


### PR DESCRIPTION
Turns out this API has been deprecated and stubbed out for 5 years now, so it does not make any sense calling it.

See: https://github.com/getsentry/sentry/blob/cd404411c7b52154f5aca73af93e74b908b3ff27/src/sentry/api/endpoints/debug_files.py#L374-L383

I left the PList / Manifest parsing in there for now, as it does validate these files and throws errors. However that can probably also be removed, please advise.