### PR TITLE
Revert "chore: bump curl-sys dependency to 0.4.68 (#1815)"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 "You know what they say. Fool me once, strike one, but fool me twice... strike three." — Michael Scott
 
+## Unreleased
+
+- fix: Upload Xcode debug files and source maps background upload (#1896) by @krystofwoldrich
+  - revert: Fixed a `curl` issue on Windows (#1815) by @xpirt
+
 ## 2.25.0
 
 ### Various fixes & improvements

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -561,9 +561,9 @@ dependencies = [
 
 [[package]]
 name = "curl-sys"
-version = "0.4.68+curl-8.4.0"
+version = "0.4.59+curl-7.86.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4a0d18d88360e374b16b2273c832b5e57258ffc1d4aa4f96b108e0738d5752f"
+checksum = "6cfce34829f448b08f55b7db6d0009e23e2e86a34e8c2b366269bf5799b4a407"
 dependencies = [
  "cc",
  "libc",
@@ -571,7 +571,7 @@ dependencies = [
  "openssl-sys",
  "pkg-config",
  "vcpkg",
- "windows-sys 0.48.0",
+ "winapi 0.3.9",
 ]
 
 [[package]]


### PR DESCRIPTION
This reverts commit 6b9b32b4481e79282f14dcfbb52f54f2e59b1d7d.

- This fixes https://github.com/getsentry/sentry-cli/issues/1895

- But it brings a bug back on Windows https://github.com/getsentry/sentry-cli/pull/1815

