### PR TITLE
meta: Revert "meta: Temporarily disable npm targets for v1 release (#1903)"

### DIFF
--- a/.craft.yml
+++ b/.craft.yml
@@ -13,27 +13,27 @@ targets:
           cacheControl: public, max-age=600
 
   # Binary distributions on npm
-  # - name: npm
-  #   id: '@sentry/cli-darwin'
-  #   includeNames: /^sentry-cli-darwin-\d.*\.tgz$/
-  # - name: npm
-  #   id: '@sentry/cli-linux-arm'
-  #   includeNames: /^sentry-cli-linux-arm-\d.*\.tgz$/
-  # - name: npm
-  #   id: '@sentry/cli-linux-arm64'
-  #   includeNames: /^sentry-cli-linux-arm64-\d.*\.tgz$/
-  # - name: npm
-  #   id: '@sentry/cli-linux-i686'
-  #   includeNames: /^sentry-cli-linux-i686-\d.*\.tgz$/
-  # - name: npm
-  #   id: '@sentry/cli-linux-x64'
-  #   includeNames: /^sentry-cli-linux-x64-\d.*\.tgz$/
-  # - name: npm
-  #   id: '@sentry/cli-win32-i686'
-  #   includeNames: /^sentry-cli-win32-i686-\d.*\.tgz$/
-  # - name: npm
-  #   id: '@sentry/cli-win32-x64'
-  #   includeNames: /^sentry-cli-win32-x64-\d.*\.tgz$/
+  - name: npm
+    id: '@sentry/cli-darwin'
+    includeNames: /^sentry-cli-darwin-\d.*\.tgz$/
+  - name: npm
+    id: '@sentry/cli-linux-arm'
+    includeNames: /^sentry-cli-linux-arm-\d.*\.tgz$/
+  - name: npm
+    id: '@sentry/cli-linux-arm64'
+    includeNames: /^sentry-cli-linux-arm64-\d.*\.tgz$/
+  - name: npm
+    id: '@sentry/cli-linux-i686'
+    includeNames: /^sentry-cli-linux-i686-\d.*\.tgz$/
+  - name: npm
+    id: '@sentry/cli-linux-x64'
+    includeNames: /^sentry-cli-linux-x64-\d.*\.tgz$/
+  - name: npm
+    id: '@sentry/cli-win32-i686'
+    includeNames: /^sentry-cli-win32-i686-\d.*\.tgz$/
+  - name: npm
+    id: '@sentry/cli-win32-x64'
+    includeNames: /^sentry-cli-win32-x64-\d.*\.tgz$/
 
   # Main Sentry CLI package
   - name: npm


### PR DESCRIPTION
This reverts commit bde2cbd4b450fc85ca73d0a0a872254ad744c028.