### PR TITLE
Prefer `--url` argument over empty auth token URL

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -63,7 +63,7 @@ impl Config {
         let default_url = get_default_url(&ini);
         let token_url = token_embedded_data
             .as_ref()
-            .and_then(|td| Some(td.url.as_str()))
+            .map(|td| td.url.as_str())
             .unwrap_or_default();
 
         let url = match (default_url.as_str(), token_url) {
@@ -173,11 +173,7 @@ impl Config {
             Some(Auth::Token(ref val)) => {
                 self.cached_token_data = val.payload().cloned();
 
-                if let Some(token_url) = self
-                    .cached_token_data
-                    .as_ref()
-                    .and_then(|td| Some(td.url.as_str()))
-                {
+                if let Some(token_url) = self.cached_token_data.as_ref().map(|td| td.url.as_str()) {
                     self.cached_base_url = token_url.to_string();
                 }
 
@@ -211,7 +207,7 @@ impl Config {
         let token_url = self
             .cached_token_data
             .as_ref()
-            .and_then(|td| Some(td.url.as_str()))
+            .map(|td| td.url.as_str())
             .unwrap_or_default();
 
         if !token_url.is_empty() && url != token_url {

--- a/src/utils/auth_token/test.rs
+++ b/src/utils/auth_token/test.rs
@@ -33,7 +33,7 @@ fn test_valid_org_auth_token() {
 
     let payload = token.payload().unwrap();
     assert_eq!(payload.org, "sentry");
-    assert_eq!(payload.url, Some(String::from("http://localhost:8000")));
+    assert_eq!(payload.url, "http://localhost:8000");
 
     assert_eq!(good_token, token.to_string());
 
@@ -56,7 +56,7 @@ fn test_valid_org_auth_token_missing_url() {
 
     let payload = token.payload().unwrap();
     assert_eq!(payload.org, "sentry");
-    assert!(payload.url.is_none());
+    assert!(payload.url.is_empty());
 
     assert_eq!(good_token, token.to_string());
 

--- a/tests/integration/_cases/org_tokens/url-mismatch-empty-token.trycmd
+++ b/tests/integration/_cases/org_tokens/url-mismatch-empty-token.trycmd
@@ -1,0 +1,8 @@
+This auth token has an empty URL. We expect the --url argument to take precedence here
+```
+$ sentry-cli --auth-token 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 --url https://sentry.example.com info
+? failed
+Sentry Server: https://sentry.example.com
+...
+
+```

--- a/tests/integration/org_tokens.rs
+++ b/tests/integration/org_tokens.rs
@@ -24,3 +24,8 @@ fn org_token_org_match() {
 fn org_token_url_works() {
     register_test("org_tokens/url-works.trycmd");
 }
+
+#[test]
+fn org_token_url_mismatch_empty_token() {
+    register_test("org_tokens/url-mismatch-empty-token.trycmd");
+}


### PR DESCRIPTION
With this change, the CLI will treat an org auth token that specifies an empty URL the same way as an org auth token that is not specifying a URL at all.

We implemented this change in behavior by changing the type of the `url` in the `AuthTokenPayload` from an `Option<String>` to a `String`. In cases where the `url` previously would have been set to `None`, the `url` will now be set to an empty string. Uses of the `AuthTokenPayload`'s `url` field have been updated to treat empty strings the way they previously treated `None` values.

Fixes GH-1913