### PR TITLE
feat(xcode): Print redirected output file path when going to the background

### DIFF
--- a/src/utils/xcode.rs
+++ b/src/utils/xcode.rs
@@ -403,9 +403,12 @@ impl<'a> MayDetach<'a> {
             return Ok(false);
         }
 
-        println!("Continuing in background.");
-        show_notification("Sentry", &format!("{} starting", self.task_name))?;
         let output_file = TempFile::create()?;
+
+        println!("Continuing in background.");
+        println!("Output is redirected to {}", output_file.path().display());
+        show_notification("Sentry", &format!("{} starting", self.task_name))?;
+
         daemonize_redirect(
             Some(output_file.path()),
             Some(output_file.path()),


### PR DESCRIPTION
Enabled users to share background logs with us.

Help debug the following issues:
- https://github.com/getsentry/sentry-cli/issues/1895
- https://github.com/getsentry/sentry-cli/issues/1915