### PR TITLE
feat(crons): New monitor configuration options

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2396,9 +2396,9 @@ checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 
 [[package]]
 name = "sentry"
-version = "0.31.8"
+version = "0.32.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ce4b57f1b521f674df7a1d200be8ff5d74e3712020ee25b553146657b5377d5"
+checksum = "766448f12e44d68e675d5789a261515c46ac6ccd240abdd451a9c46c84a49523"
 dependencies = [
  "curl",
  "httpdate",
@@ -2409,9 +2409,9 @@ dependencies = [
 
 [[package]]
 name = "sentry-anyhow"
-version = "0.31.8"
+version = "0.32.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8868ca6e513f7a80b394b7e0f4b6071afeebb69e62b5e4aafe37b45e431fac8b"
+checksum = "4da4015667c99f88d68ca7ff02b90c762d6154a4ceb7c02922b9a1dbd3959eeb"
 dependencies = [
  "anyhow",
  "sentry-backtrace",
@@ -2420,9 +2420,9 @@ dependencies = [
 
 [[package]]
 name = "sentry-backtrace"
-version = "0.31.8"
+version = "0.32.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58cc8d4e04a73de8f718dc703943666d03f25d3e9e4d0fb271ca0b8c76dfa00e"
+checksum = "32701cad8b3c78101e1cd33039303154791b0ff22e7802ed8cc23212ef478b45"
 dependencies = [
  "backtrace",
  "once_cell",
@@ -2508,9 +2508,9 @@ dependencies = [
 
 [[package]]
 name = "sentry-contexts"
-version = "0.31.8"
+version = "0.32.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6436c1bad22cdeb02179ea8ef116ffc217797c028927def303bc593d9320c0d1"
+checksum = "17ddd2a91a13805bd8dab4ebf47323426f758c35f7bf24eacc1aded9668f3824"
 dependencies = [
  "hostname",
  "libc",
@@ -2522,9 +2522,9 @@ dependencies = [
 
 [[package]]
 name = "sentry-core"
-version = "0.31.8"
+version = "0.32.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "901f761681f97db3db836ef9e094acdd8756c40215326c194201941947164ef1"
+checksum = "b1189f68d7e7e102ef7171adf75f83a59607fafd1a5eecc9dc06c026ff3bdec4"
 dependencies = [
  "once_cell",
  "rand",
@@ -2535,9 +2535,9 @@ dependencies = [
 
 [[package]]
 name = "sentry-types"
-version = "0.31.8"
+version = "0.32.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da956cca56e0101998c8688bc65ce1a96f00673a0e58e663664023d4c7911e82"
+checksum = "c7173fd594569091f68a7c37a886e202f4d0c1db1e1fa1d18a051ba695b2e2ec"
 dependencies = [
  "debugid",
  "hex",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,7 +58,7 @@ regex = "1.7.3"
 runas = "1.0.0"
 rust-ini = "0.18.0"
 semver = "1.0.16"
-sentry = { version = "0.31.8", default-features = false, features = [
+sentry = { version = "0.32.2", default-features = false, features = [
   "anyhow",
   "curl",
   "contexts",

--- a/src/commands/monitors/run.rs
+++ b/src/commands/monitors/run.rs
@@ -87,6 +87,26 @@ pub fn make_command(command: Command) -> Command {
                     execution schedule's timezone. Requires --schedule.",
                 ),
         )
+        .arg(
+            Arg::new("failure_issue_threshold")
+                .long("failure-issue-threshold")
+                .value_parser(clap::value_parser!(u64).range(1..))
+                .requires("schedule")
+                .help(
+                    "The number of consecutive missed or error check-ins that trigger an \
+                     issue. Requires --schedule.",
+                ),
+        )
+        .arg(
+            Arg::new("recovery_threshold")
+                .long("recovery-threshold")
+                .value_parser(clap::value_parser!(u64).range(1..))
+                .requires("schedule")
+                .help(
+                    "The number of consecutive successful check-ins that resolve an \
+                     issue. Requires --schedule.",
+                ),
+        )
 }
 
 fn run_program(args: Vec<&String>, monitor_slug: &str) -> (bool, Option<i32>, Duration) {
@@ -211,6 +231,8 @@ fn parse_monitor_config_args(matches: &ArgMatches) -> Result<Option<MonitorConfi
         checkin_margin: matches.get_one("checkin_margin").copied(),
         max_runtime: matches.get_one("max_runtime").copied(),
         timezone: matches.get_one("timezone").map(Tz::to_string),
+        failure_issue_threshold: matches.get_one("failure_issue_threshold").copied(),
+        recovery_threshold: matches.get_one("recovery_threshold").copied(),
     }))
 }
 

--- a/tests/integration/_cases/monitors/monitors-run-help.trycmd
+++ b/tests/integration/_cases/monitors/monitors-run-help.trycmd
@@ -34,6 +34,11 @@ Options:
       --timezone <timezone>
           A tz database string (e.g. "Europe/Vienna") representing the monitor's execution
           schedule's timezone. Requires --schedule.
+      --failure-issue-threshold <failure_issue_threshold>
+          The number of consecutive missed or error check-ins that trigger an issue. Requires
+          --schedule.
+      --recovery-threshold <recovery_threshold>
+          The number of consecutive successful check-ins that resolve an issue. Requires --schedule.
   -h, --help
           Print help
 


### PR DESCRIPTION
This PR adds the `--failure-issue-threshold` and `--recovery-threshold` command line arguments. These control the number of consecutive failed cron checkins that trigger issue creation, and the number of consecutive successful cron checkins that trigger issue resolution, respectively.

Fixes GH-1919