### PR TITLE
fix(deploys): Use `--project` argument

### DIFF
--- a/src/api.rs
+++ b/src/api.rs
@@ -2610,6 +2610,8 @@ pub struct Deploy {
     pub started: Option<DateTime<Utc>>,
     #[serde(rename = "dateFinished")]
     pub finished: Option<DateTime<Utc>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub projects: Option<Vec<String>>,
 }
 
 impl Deploy {

--- a/src/commands/deploys/new.rs
+++ b/src/commands/deploys/new.rs
@@ -71,6 +71,7 @@ pub fn execute(matches: &ArgMatches) -> Result<()> {
         env: matches.get_one::<String>("env").unwrap().to_string(),
         name: matches.get_one::<String>("name").cloned(),
         url: matches.get_one::<String>("url").cloned(),
+        projects: config.get_projects(matches).ok(),
         ..Default::default()
     };
 


### PR DESCRIPTION
This commit fixes the `deploys new` command to use the `--project` argument. Previously, the `--project` argument was ignored; now, any projects specified with the `--project` argument are sent to Sentry in the request that creates the deploy ([relevant API docs](https://docs.sentry.io/api/releases/create-a-new-deploy-for-an-organization/)).

ref #1927
