### PR TITLE
meta: Re-enable Python releases

### DIFF
--- a/.craft.yml
+++ b/.craft.yml
@@ -91,6 +91,9 @@ targets:
         checksums:
           - algorithm: sha256
             format: hex
+  - name: pypi
+  - name: sentry-pypi
+    internalPypiRepo: getsentry/pypi
 requireNames:
   - /^sentry-cli-Darwin-x86_64$/
   - /^sentry-cli-Darwin-arm64$/
@@ -102,3 +105,4 @@ requireNames:
   - /^sentry-cli-Windows-i686.exe$/
   - /^sentry-cli-Windows-x86_64.exe$/
   - /^sentry_cli-.*.tar.gz$/
+  - /^sentry_cli-.*.whl$/

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,15 +19,28 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
+      - uses: actions-rs/toolchain@16499b5e05bf2e26879000db0c1d13f7e13fa3af # pin@v1
+        with:
+          toolchain: stable
+          profile: minimal
+          components: clippy, rustfmt
+          override: true
+
       - uses: swatinem/rust-cache@81d053bdb0871dcd3f10763c8cc60d0adc41762b # pin@v1
         with:
           key: ${{ github.job }}
 
       - name: Run Rustfmt
-        run: cargo fmt --all -- --check
+        uses: actions-rs/cargo@844f36862e911db73fe0815f00a4a2602c279505 # pin@v1
+        with:
+          command: fmt
+          args: --all -- --check
 
       - name: Run Clippy
-        run: cargo clippy --workspace --all-features --tests -- -D clippy::all
+        uses: actions-rs/cargo@844f36862e911db73fe0815f00a4a2602c279505 # pin@v1
+        with:
+          command: clippy
+          args: --workspace --all-features --tests -- -D clippy::all
 
   test:
     strategy:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,28 +19,15 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - uses: actions-rs/toolchain@16499b5e05bf2e26879000db0c1d13f7e13fa3af # pin@v1
-        with:
-          toolchain: stable
-          profile: minimal
-          components: clippy, rustfmt
-          override: true
-
       - uses: swatinem/rust-cache@81d053bdb0871dcd3f10763c8cc60d0adc41762b # pin@v1
         with:
           key: ${{ github.job }}
 
       - name: Run Rustfmt
-        uses: actions-rs/cargo@844f36862e911db73fe0815f00a4a2602c279505 # pin@v1
-        with:
-          command: fmt
-          args: --all -- --check
+        run: cargo fmt --all -- --check
 
       - name: Run Clippy
-        uses: actions-rs/cargo@844f36862e911db73fe0815f00a4a2602c279505 # pin@v1
-        with:
-          command: clippy
-          args: --workspace --all-features --tests -- -D clippy::all
+        run: cargo clippy --workspace --all-features --tests -- -D clippy::all
 
   test:
     strategy:


### PR DESCRIPTION
Reverts getsentry/sentry-cli#1779

We previously disabled PyPI releases since they kept failing. This PR re-enables them so we can check whether the problem still exists.

ref #1931 