### PR TITLE
ci: Lint without `actions-rs`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,28 +19,15 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - uses: actions-rs/toolchain@16499b5e05bf2e26879000db0c1d13f7e13fa3af # pin@v1
-        with:
-          toolchain: stable
-          profile: minimal
-          components: clippy, rustfmt
-          override: true
-
       - uses: swatinem/rust-cache@81d053bdb0871dcd3f10763c8cc60d0adc41762b # pin@v1
         with:
           key: ${{ github.job }}
 
       - name: Run Rustfmt
-        uses: actions-rs/cargo@844f36862e911db73fe0815f00a4a2602c279505 # pin@v1
-        with:
-          command: fmt
-          args: --all -- --check
+        run: cargo fmt --all -- --check
 
       - name: Run Clippy
-        uses: actions-rs/cargo@844f36862e911db73fe0815f00a4a2602c279505 # pin@v1
-        with:
-          command: clippy
-          args: --workspace --all-features --tests -- -D clippy::all
+        run: cargo clippy --workspace --all-features --tests -- -D clippy::all
 
   test:
     strategy:


### PR DESCRIPTION
We should lint without `actions-rs`. `actions-rs` is unmaintained, and we can call the necessary Cargo commands directly. `cargo clippy` occasionally fails when run with `actions-rs` even though it does not fail when run locally. Running the Cargo commands directly appears to fix the problem.
