### PR TITLE
meta: Revert "meta: Re-enable Python releases"

### DIFF
--- a/.craft.yml
+++ b/.craft.yml
@@ -91,9 +91,6 @@ targets:
         checksums:
           - algorithm: sha256
             format: hex
-  - name: pypi
-  - name: sentry-pypi
-    internalPypiRepo: getsentry/pypi
 requireNames:
   - /^sentry-cli-Darwin-x86_64$/
   - /^sentry-cli-Darwin-arm64$/
@@ -105,4 +102,3 @@ requireNames:
   - /^sentry-cli-Windows-i686.exe$/
   - /^sentry-cli-Windows-x86_64.exe$/
   - /^sentry_cli-.*.tar.gz$/
-  - /^sentry_cli-.*.whl$/


### PR DESCRIPTION
Reverts getsentry/sentry-cli#1932, because releasing with Python releases enabled [still fails](https://github.com/getsentry/publish/actions/runs/7872017223/job/21476396698) 