### PR TITLE
fix(xcode): Only parse Plist when required during RN source maps upload

### DIFF
--- a/src/commands/react_native/xcode.rs
+++ b/src/commands/react_native/xcode.rs
@@ -365,19 +365,7 @@ pub fn execute(matches: &ArgMatches) -> Result<()> {
                 chunk_upload_options: chunk_upload_options.as_ref(),
             })?;
         } else {
-            let (dist, release_name) = match (dist_from_env, release_from_env) {
-                (Ok(dist_env), Ok(release_env)) => {
-                    // Both environment variables are present
-                    (Some(dist_env), Some(release_env))
-                },
-                (Ok(dist_env), Err(_)) => {
-                    // Only dist environment variable is present
-                    (Some(dist_env), None)
-                },
-                (Err(_), Ok(release_env)) => {
-                    // Only release environment variable is present
-                    (None, Some(release_env))
-                },
+            let (dist, release_name) = match (&dist_from_env, &release_from_env) {
                 (Err(_), Err(_)) => {
                     // Neither environment variable is present, attempt to parse Info.plist
                     info!("Parsing Info.plist");
@@ -394,6 +382,8 @@ pub fn execute(matches: &ArgMatches) -> Result<()> {
                         }
                     }
                 }
+                // At least one environment variable is present, use the values from the environment
+                _ => (dist_from_env.ok(), release_from_env.ok()),
             };
 
             match matches.get_many::<String>("dist") {

--- a/src/commands/react_native/xcode.rs
+++ b/src/commands/react_native/xcode.rs
@@ -380,16 +380,17 @@ pub fn execute(matches: &ArgMatches) -> Result<()> {
                 },
                 (Err(_), Err(_)) => {
                     // Neither environment variable is present, attempt to parse Info.plist
+                    info!("Parsing Info.plist");
                     match InfoPlist::discover_from_env() {
                         Ok(Some(plist)) => {
                             // Successfully discovered and parsed Info.plist
                             let dist_string = plist.build().to_string();
                             let release_string = format!("{}@{}+{}", plist.bundle_id(), plist.version(), dist_string);
+                            info!("Parse result from Info.plist: {:?}", &plist);
                             (Some(dist_string), Some(release_string))
                         },
                         _ => {
-                            // Info.plist was not found or an error occurred
-                            (None, None) // Handle the error or absence as needed
+                            bail!("Info.plist was not found or an parsing error occurred");
                         }
                     }
                 }

--- a/tests/integration/_cases/react_native/xcode-upload-source-maps-invalid-plist.trycmd
+++ b/tests/integration/_cases/react_native/xcode-upload-source-maps-invalid-plist.trycmd
@@ -7,7 +7,7 @@ Processing react-native sourcemaps for Sentry upload.
 > Analyzing 2 sources
 > Rewriting sources
 > Adding source map references
-error: Could not find info.plist
+error: Info.plist was not found or an parsing error occurred
 
 Add --log-level=[info|debug] or export SENTRY_LOG_LEVEL=[info|debug] to see more output.
 Please attach the full debug log to all bug reports.

--- a/tests/integration/_cases/react_native/xcode-upload-source-maps-invalid-plist.trycmd
+++ b/tests/integration/_cases/react_native/xcode-upload-source-maps-invalid-plist.trycmd
@@ -1,0 +1,15 @@
+```
+$ CONFIGURATION=Release sentry-cli react-native xcode tests/integration/_fixtures/react_native/react-native-xcode.sh --force-foreground
+? failed
+react-native-xcode.sh called with args: 
+Using React Native Packager bundle and source map.
+Processing react-native sourcemaps for Sentry upload.
+> Analyzing 2 sources
+> Rewriting sources
+> Adding source map references
+error: Could not find info.plist
+
+Add --log-level=[info|debug] or export SENTRY_LOG_LEVEL=[info|debug] to see more output.
+Please attach the full debug log to all bug reports.
+
+```

--- a/tests/integration/_cases/react_native/xcode-upload-source-maps-release_and_dist_from_env.trycmd
+++ b/tests/integration/_cases/react_native/xcode-upload-source-maps-release_and_dist_from_env.trycmd
@@ -1,0 +1,26 @@
+```
+$ CONFIGURATION=Release SENTRY_RELEASE=test-release SENTRY_DIST=test-dist sentry-cli react-native xcode tests/integration/_fixtures/react_native/react-native-xcode.sh --force-foreground
+? success
+react-native-xcode.sh called with args: 
+Using React Native Packager bundle and source map.
+Processing react-native sourcemaps for Sentry upload.
+> Analyzing 2 sources
+> Rewriting sources
+> Adding source map references
+> Bundled 2 files for upload
+> Bundle ID: [..]-[..]-[..]-[..]-[..]
+> Uploaded files to Sentry
+> File upload complete (processing pending on server)
+> Organization: wat-org
+> Project: wat-project
+> Release: test-release
+> Dist: test-dist
+> Upload type: artifact bundle
+
+Source Map Upload Report
+  Scripts
+    ~/react-native-xcode-bundle.js.map
+  Minified Scripts
+    ~/react-native-xcode-bundle.js (sourcemap at react-native-xcode-bundle.map)
+
+```

--- a/tests/integration/_fixtures/react_native/react-native-xcode-bundle.js
+++ b/tests/integration/_fixtures/react_native/react-native-xcode-bundle.js
@@ -1,0 +1,3 @@
+console.log("Fake bundle!");
+
+//# sourceMappingURL=react-native-xcode-bundle.map

--- a/tests/integration/_fixtures/react_native/react-native-xcode-bundle.js.map
+++ b/tests/integration/_fixtures/react_native/react-native-xcode-bundle.js.map
@@ -1,0 +1,1 @@
+{"version":3,"file":"react-native-xcode-bundle.js"}

--- a/tests/integration/_fixtures/react_native/react-native-xcode.sh
+++ b/tests/integration/_fixtures/react_native/react-native-xcode.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+
+echo "react-native-xcode.sh called with args: $@"
+
+echo '{
+  "packager_bundle_path": "tests/integration/_fixtures/react_native/react-native-xcode-bundle.js",
+  "packager_sourcemap_path": "tests/integration/_fixtures/react_native/react-native-xcode-bundle.js.map"
+}' > "$SENTRY_RN_SOURCEMAP_REPORT"

--- a/tests/integration/react_native/mod.rs
+++ b/tests/integration/react_native/mod.rs
@@ -1,6 +1,8 @@
 #[cfg(target_os = "macos")]
 use crate::integration::register_test;
 
+mod xcode;
+
 #[test]
 #[cfg(target_os = "macos")]
 fn xcode_wrap_call_minimum() {

--- a/tests/integration/react_native/xcode.rs
+++ b/tests/integration/react_native/xcode.rs
@@ -1,0 +1,29 @@
+use mockito::Mock;
+
+#[cfg(target_os = "macos")]
+use crate::integration::register_test;
+#[cfg(target_os = "macos")]
+use crate::integration::{mock_common_upload_endpoints, ChunkOptions, ServerBehavior};
+
+#[test]
+#[cfg(target_os = "macos")]
+fn xcode_upload_source_maps_missing_plist() {
+    let _upload_endpoints =
+        mock_common_upload_endpoints(ServerBehavior::Modern, ChunkOptions::default());
+    register_test("react_native/xcode-upload-source-maps-invalid-plist.trycmd");
+}
+
+#[test]
+#[cfg(target_os = "macos")]
+fn xcode_upload_source_maps_release_and_dist_from_env() {
+    let upload_endpoints =
+        mock_common_upload_endpoints(ServerBehavior::Modern, ChunkOptions::default());
+    register_test("react_native/xcode-upload-source-maps-release_and_dist_from_env.trycmd");
+    assert_endpoints(&upload_endpoints);
+}
+
+pub fn assert_endpoints(mocks: &[Mock]) {
+    for mock in mocks {
+        mock.assert();
+    }
+}

--- a/tests/integration/react_native/xcode.rs
+++ b/tests/integration/react_native/xcode.rs
@@ -1,5 +1,5 @@
+#[cfg(target_os = "macos")]
 use mockito::Mock;
-
 #[cfg(target_os = "macos")]
 use crate::integration::register_test;
 #[cfg(target_os = "macos")]
@@ -22,6 +22,7 @@ fn xcode_upload_source_maps_release_and_dist_from_env() {
     assert_endpoints(&upload_endpoints);
 }
 
+#[cfg(target_os = "macos")]
 pub fn assert_endpoints(mocks: &[Mock]) {
     for mock in mocks {
         mock.assert();

--- a/tests/integration/react_native/xcode.rs
+++ b/tests/integration/react_native/xcode.rs
@@ -1,9 +1,9 @@
 #[cfg(target_os = "macos")]
-use mockito::Mock;
-#[cfg(target_os = "macos")]
 use crate::integration::register_test;
 #[cfg(target_os = "macos")]
 use crate::integration::{mock_common_upload_endpoints, ChunkOptions, ServerBehavior};
+#[cfg(target_os = "macos")]
+use mockito::Mock;
 
 #[test]
 #[cfg(target_os = "macos")]


### PR DESCRIPTION
- this fix enables a workaround for https://github.com/getsentry/sentry-cli/issues/1936

If users use debug IDs and auto-release reading is disabled, we don't have to read and part Info.plist.

The same applies when users use ENV to set release and dist 