### PR TITLE
fix(deploys): Revert "fix(deploys): Use `--project` argument (#1930)"

### DIFF
--- a/src/api.rs
+++ b/src/api.rs
@@ -2610,8 +2610,6 @@ pub struct Deploy {
     pub started: Option<DateTime<Utc>>,
     #[serde(rename = "dateFinished")]
     pub finished: Option<DateTime<Utc>>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub projects: Option<Vec<String>>,
 }
 
 impl Deploy {

--- a/src/commands/deploys/new.rs
+++ b/src/commands/deploys/new.rs
@@ -71,7 +71,6 @@ pub fn execute(matches: &ArgMatches) -> Result<()> {
         env: matches.get_one::<String>("env").unwrap().to_string(),
         name: matches.get_one::<String>("name").cloned(),
         url: matches.get_one::<String>("url").cloned(),
-        projects: config.get_projects(matches).ok(),
         ..Default::default()
     };
 


### PR DESCRIPTION
This reverts commit e11e231bb6b59fb3c5c5e6a235bbe93151bad129, which appears to be causing issues for some users (see #1939)
