### PR TITLE
fix(files): Fail when deleting all files fails with 404 error

### DIFF
--- a/src/api.rs
+++ b/src/api.rs
@@ -742,7 +742,7 @@ impl Api {
         org: &str,
         project: Option<&str>,
         version: &str,
-    ) -> ApiResult<bool> {
+    ) -> ApiResult<()> {
         let path = if let Some(project) = project {
             format!(
                 "/projects/{}/{}/files/source-maps/?name={}",
@@ -758,12 +758,7 @@ impl Api {
             )
         };
 
-        let resp = self.delete(&path)?;
-        if resp.status() == 404 {
-            Ok(false)
-        } else {
-            resp.into_result().map(|_| true)
-        }
+        self.delete(&path)?.into_result().map(|_| ())
     }
 
     /// Uploads a new release file.  The file is loaded directly from the file

--- a/src/commands/files/delete.rs
+++ b/src/commands/files/delete.rs
@@ -35,9 +35,8 @@ pub fn execute(matches: &ArgMatches) -> Result<()> {
     let api = Api::current();
 
     if matches.get_flag("all") {
-        if api.delete_release_files(&org, project.as_deref(), &release)? {
-            println!("All files deleted.");
-        }
+        api.delete_release_files(&org, project.as_deref(), &release)?;
+        println!("All files deleted.");
         return Ok(());
     }
 


### PR DESCRIPTION
For some reason, until now, 404 errors received special treatment when running the `sentry-cli files delete --all` command. Therefore, if for whatever reason, the files could not be deleted due to a 404 error, the command would fail silently. The only indication that anything went wrong would be that the "All files deleted" message would not be printed.

Instead, it would make more sense to print the error message from the Sentry API and fail with a nonzero status, since the CLI has likely failed to accomplish what the user intended for it to accomplish when running the command.

Or, is there any reason why we need to keep the special logic for 404 errors around?