### PR TITLE
feat: Validate that auth token provided when needed

### DIFF
--- a/src/api.rs
+++ b/src/api.rs
@@ -739,6 +739,8 @@ impl<'a> AuthenticatedApi<'a> {
         self.api.request(method, url)
     }
 
+    // High-level method implementations
+
     /// Performs an API request to verify the authentication status of the
     /// current token.
     pub fn get_auth_info(&self) -> ApiResult<AuthInfo> {

--- a/src/api.rs
+++ b/src/api.rs
@@ -180,12 +180,15 @@ impl ProgressBarMode {
 }
 
 /// Helper for the API access.
+/// Implements the low-level API access methods, and provides high-level implementations for interacting
+/// with portions of the API that do not require authentication via an auth token.
 pub struct Api {
     config: Arc<Config>,
     pool: r2d2::Pool<CurlConnectionManager>,
 }
 
-/// Wrapper for Api that ensures Auth is provided. Any API requiring auth is called through here.
+/// Wrapper for Api that ensures Auth is provided. AuthenticatedApi provides implementations of high-level
+/// functions that make API requests requiring authentication via auth token.
 pub struct AuthenticatedApi<'a> {
     api: &'a Api,
 }
@@ -404,6 +407,8 @@ impl Api {
         *API.lock() = None;
     }
 
+    /// Creates an AuthenticatedApi referencing this Api instance if an auth token is available.
+    /// If an auth token is not available, returns an error.
     pub fn authenticated(&self) -> ApiResult<AuthenticatedApi> {
         self.try_into()
     }

--- a/src/api.rs
+++ b/src/api.rs
@@ -186,6 +186,9 @@ pub struct Api {
     pool: r2d2::Pool<CurlConnectionManager>,
 }
 
+/// Wrapper for Api that ensures Auth is provided. Any API requiring auth is called through here.
+pub struct AuthenticatedApi<'a>(&'a Api);
+
 #[derive(Debug, thiserror::Error)]
 pub struct SentryError {
     status: u32,
@@ -252,6 +255,10 @@ pub enum ApiErrorKind {
     CompressionFailed,
     #[error("region overrides cannot be applied to absolute urls")]
     InvalidRegionRequest,
+    #[error(
+        "Auth token is required for this request. Please run `sentry-cli login` and try again!"
+    )]
+    AuthMissing,
 }
 
 #[derive(Debug, thiserror::Error)]
@@ -353,6 +360,17 @@ pub struct ApiResponse {
     body: Option<Vec<u8>>,
 }
 
+impl<'a> TryFrom<&'a Api> for AuthenticatedApi<'a> {
+    type Error = ApiError;
+
+    fn try_from(api: &'a Api) -> ApiResult<AuthenticatedApi<'a>> {
+        match api.config.get_auth() {
+            Some(_) => Ok(AuthenticatedApi(api)),
+            None => Err(ApiErrorKind::AuthMissing.into()),
+        }
+    }
+}
+
 impl Api {
     /// Returns the current api for the thread.
     ///
@@ -383,6 +401,19 @@ impl Api {
     /// Utility method that unbinds the current api.
     pub fn dispose_pool() {
         *API.lock() = None;
+    }
+
+    pub fn authenticated(&self) -> ApiResult<AuthenticatedApi> {
+        self.try_into()
+    }
+
+    /// Utility method which returns AuthMissing error if the auth is not provided.
+    /// Should call for all APIs requiring token authentication.
+    fn ensure_auth_provided(&self) -> ApiResult<()> {
+        match self.config.get_auth() {
+            Some(_) => Ok(()),
+            None => Err(ApiErrorKind::AuthMissing.into()),
+        }
     }
 
     // Low Level Methods
@@ -558,529 +589,6 @@ impl Api {
 
     // High Level Methods
 
-    /// Performs an API request to verify the authentication status of the
-    /// current token.
-    pub fn get_auth_info(&self) -> ApiResult<AuthInfo> {
-        self.get("/")?.convert()
-    }
-
-    /// Lists release files for the given `release`, filtered by a set of checksums.
-    /// When empty checksums list is provided, fetches all possible artifacts.
-    pub fn list_release_files_by_checksum(
-        &self,
-        org: &str,
-        project: Option<&str>,
-        release: &str,
-        checksums: &[String],
-    ) -> ApiResult<Vec<Artifact>> {
-        let mut rv = vec![];
-        let mut cursor = "".to_string();
-        loop {
-            let mut path = if let Some(project) = project {
-                format!(
-                    "/projects/{}/{}/releases/{}/files/?cursor={}",
-                    PathArg(org),
-                    PathArg(project),
-                    PathArg(release),
-                    QueryArg(&cursor),
-                )
-            } else {
-                format!(
-                    "/organizations/{}/releases/{}/files/?cursor={}",
-                    PathArg(org),
-                    PathArg(release),
-                    QueryArg(&cursor),
-                )
-            };
-
-            let mut checkums_qs = String::new();
-            for checksum in checksums.iter() {
-                checkums_qs.push_str(&format!("&checksum={}", QueryArg(checksum)));
-            }
-            // We have a 16kb buffer for reach request configured in nginx,
-            // so do not even bother trying if it's too long.
-            // (16_384 limit still leaves us with 384 bytes for the url itself).
-            if !checkums_qs.is_empty() && checkums_qs.len() <= 16_000 {
-                path.push_str(&checkums_qs);
-            }
-
-            let resp = self.get(&path)?;
-            if resp.status() == 404 || (resp.status() == 400 && !cursor.is_empty()) {
-                if rv.is_empty() {
-                    return Err(ApiErrorKind::ReleaseNotFound.into());
-                } else {
-                    break;
-                }
-            }
-
-            let pagination = resp.pagination();
-            rv.extend(resp.convert::<Vec<Artifact>>()?);
-            if let Some(next) = pagination.into_next_cursor() {
-                cursor = next;
-            } else {
-                break;
-            }
-        }
-        Ok(rv)
-    }
-
-    /// Lists all the release files for the given `release`.
-    pub fn list_release_files(
-        &self,
-        org: &str,
-        project: Option<&str>,
-        release: &str,
-    ) -> ApiResult<Vec<Artifact>> {
-        self.list_release_files_by_checksum(org, project, release, &[])
-    }
-
-    /// Get a single release file and store it inside provided descriptor.
-    pub fn get_release_file(
-        &self,
-        org: &str,
-        project: Option<&str>,
-        version: &str,
-        file_id: &str,
-        file_desc: &mut File,
-    ) -> Result<(), ApiError> {
-        let path = if let Some(project) = project {
-            format!(
-                "/projects/{}/{}/releases/{}/files/{}/?download=1",
-                PathArg(org),
-                PathArg(project),
-                PathArg(version),
-                PathArg(file_id)
-            )
-        } else {
-            format!(
-                "/organizations/{}/releases/{}/files/{}/?download=1",
-                PathArg(org),
-                PathArg(version),
-                PathArg(file_id)
-            )
-        };
-
-        let resp = self.download(&path, file_desc)?;
-        if resp.status() == 404 {
-            resp.convert_rnf(ApiErrorKind::ResourceNotFound)
-        } else {
-            Ok(())
-        }
-    }
-
-    /// Get a single release file metadata.
-    pub fn get_release_file_metadata(
-        &self,
-        org: &str,
-        project: Option<&str>,
-        version: &str,
-        file_id: &str,
-    ) -> ApiResult<Option<Artifact>> {
-        let path = if let Some(project) = project {
-            format!(
-                "/projects/{}/{}/releases/{}/files/{}/",
-                PathArg(org),
-                PathArg(project),
-                PathArg(version),
-                PathArg(file_id)
-            )
-        } else {
-            format!(
-                "/organizations/{}/releases/{}/files/{}/",
-                PathArg(org),
-                PathArg(version),
-                PathArg(file_id)
-            )
-        };
-
-        let resp = self.get(&path)?;
-        if resp.status() == 404 {
-            Ok(None)
-        } else {
-            resp.convert()
-        }
-    }
-
-    /// Deletes a single release file.  Returns `true` if the file was
-    /// deleted or `false` otherwise.
-    pub fn delete_release_file(
-        &self,
-        org: &str,
-        project: Option<&str>,
-        version: &str,
-        file_id: &str,
-    ) -> ApiResult<bool> {
-        let path = if let Some(project) = project {
-            format!(
-                "/projects/{}/{}/releases/{}/files/{}/",
-                PathArg(org),
-                PathArg(project),
-                PathArg(version),
-                PathArg(file_id)
-            )
-        } else {
-            format!(
-                "/organizations/{}/releases/{}/files/{}/",
-                PathArg(org),
-                PathArg(version),
-                PathArg(file_id)
-            )
-        };
-
-        let resp = self.delete(&path)?;
-        if resp.status() == 404 {
-            Ok(false)
-        } else {
-            resp.into_result().map(|_| true)
-        }
-    }
-
-    /// Deletes all release files.  Returns `true` if files were
-    /// deleted or `false` otherwise.
-    pub fn delete_release_files(
-        &self,
-        org: &str,
-        project: Option<&str>,
-        version: &str,
-    ) -> ApiResult<bool> {
-        let path = if let Some(project) = project {
-            format!(
-                "/projects/{}/{}/files/source-maps/?name={}",
-                PathArg(org),
-                PathArg(project),
-                PathArg(version)
-            )
-        } else {
-            format!(
-                "/organizations/{}/files/source-maps/?name={}",
-                PathArg(org),
-                PathArg(version)
-            )
-        };
-
-        let resp = self.delete(&path)?;
-        if resp.status() == 404 {
-            Ok(false)
-        } else {
-            resp.into_result().map(|_| true)
-        }
-    }
-
-    /// Uploads a new release file.  The file is loaded directly from the file
-    /// system and uploaded as `name`.
-    pub fn upload_release_file(
-        &self,
-        context: &UploadContext,
-        contents: &[u8],
-        name: &str,
-        headers: Option<&[(String, String)]>,
-        progress_bar_mode: ProgressBarMode,
-    ) -> ApiResult<Option<Artifact>> {
-        let release = context
-            .release()
-            .map_err(|err| ApiError::with_source(ApiErrorKind::ReleaseNotFound, err))?;
-
-        let path = if let Some(project) = context.project {
-            format!(
-                "/projects/{}/{}/releases/{}/files/",
-                PathArg(context.org),
-                PathArg(project),
-                PathArg(release)
-            )
-        } else {
-            format!(
-                "/organizations/{}/releases/{}/files/",
-                PathArg(context.org),
-                PathArg(release)
-            )
-        };
-        let mut form = curl::easy::Form::new();
-
-        let filename = Path::new(name)
-            .file_name()
-            .and_then(OsStr::to_str)
-            .unwrap_or("unknown.bin");
-        form.part("file")
-            .buffer(filename, contents.to_vec())
-            .add()?;
-        form.part("name").contents(name.as_bytes()).add()?;
-        if let Some(dist) = context.dist {
-            form.part("dist").contents(dist.as_bytes()).add()?;
-        }
-
-        if let Some(headers) = headers {
-            for (key, value) in headers {
-                form.part("header")
-                    .contents(format!("{key}:{value}").as_bytes())
-                    .add()?;
-            }
-        }
-
-        let resp = self
-            .request(Method::Post, &path)?
-            .with_form_data(form)?
-            .with_retry(
-                self.config.get_max_retry_count().unwrap(),
-                &[
-                    http::HTTP_STATUS_502_BAD_GATEWAY,
-                    http::HTTP_STATUS_503_SERVICE_UNAVAILABLE,
-                    http::HTTP_STATUS_504_GATEWAY_TIMEOUT,
-                ],
-            )?
-            .progress_bar_mode(progress_bar_mode)?
-            .send()?;
-        if resp.status() == 409 {
-            Ok(None)
-        } else {
-            resp.convert_rnf(ApiErrorKind::ReleaseNotFound)
-        }
-    }
-
-    /// Creates a new release.
-    pub fn new_release(&self, org: &str, release: &NewRelease) -> ApiResult<ReleaseInfo> {
-        // for single project releases use the legacy endpoint that is project bound.
-        // This means we can support both old and new servers.
-        if release.projects.len() == 1 {
-            let path = format!(
-                "/projects/{}/{}/releases/",
-                PathArg(org),
-                PathArg(&release.projects[0])
-            );
-            self.post(&path, release)?
-                .convert_rnf(ApiErrorKind::ProjectNotFound)
-        } else {
-            let path = format!("/organizations/{}/releases/", PathArg(org));
-            self.post(&path, release)?
-                .convert_rnf(ApiErrorKind::OrganizationNotFound)
-        }
-    }
-
-    /// Updates a release.
-    pub fn update_release(
-        &self,
-        org: &str,
-        version: &str,
-        release: &UpdatedRelease,
-    ) -> ApiResult<ReleaseInfo> {
-        if_chain! {
-            if let Some(ref projects) = release.projects;
-            if projects.len() == 1;
-            then {
-                let path = format!("/projects/{}/{}/releases/{}/",
-                    PathArg(org),
-                    PathArg(&projects[0]),
-                    PathArg(version)
-                );
-                self.put(&path, release)?.convert_rnf(ApiErrorKind::ReleaseNotFound)
-            } else {
-                if release.version.is_some() {
-                    let path = format!("/organizations/{}/releases/",
-                                    PathArg(org));
-                    return self.post(&path, release)?.convert_rnf(ApiErrorKind::ReleaseNotFound)
-                }
-
-                let path = format!("/organizations/{}/releases/{}/",
-                                PathArg(org),
-                                PathArg(version));
-                self.put(&path, release)?.convert_rnf(ApiErrorKind::ReleaseNotFound)
-            }
-        }
-    }
-
-    /// Sets release commits
-    pub fn set_release_refs(
-        &self,
-        org: &str,
-        version: &str,
-        refs: Vec<Ref>,
-    ) -> ApiResult<ReleaseInfo> {
-        let update = UpdatedRelease {
-            refs: Some(refs),
-            ..Default::default()
-        };
-        let path = format!(
-            "/organizations/{}/releases/{}/",
-            PathArg(org),
-            PathArg(version)
-        );
-        self.put(&path, &update)?
-            .convert_rnf(ApiErrorKind::ReleaseNotFound)
-    }
-
-    /// Deletes an already existing release.  Returns `true` if it was deleted
-    /// or `false` if not.  The project is needed to support the old deletion
-    /// API.
-    pub fn delete_release(
-        &self,
-        org: &str,
-        project: Option<&str>,
-        version: &str,
-    ) -> ApiResult<bool> {
-        let resp = if let Some(project) = project {
-            self.delete(&format!(
-                "/projects/{}/{}/releases/{}/",
-                PathArg(org),
-                PathArg(project),
-                PathArg(version)
-            ))?
-        } else {
-            self.delete(&format!(
-                "/organizations/{}/releases/{}/",
-                PathArg(org),
-                PathArg(version)
-            ))?
-        };
-        if resp.status() == 404 {
-            Ok(false)
-        } else {
-            resp.into_result().map(|_| true)
-        }
-    }
-
-    /// Looks up a release and returns it.  If it does not exist `None`
-    /// will be returned.
-    pub fn get_release(
-        &self,
-        org: &str,
-        project: Option<&str>,
-        version: &str,
-    ) -> ApiResult<Option<ReleaseInfo>> {
-        let path = if let Some(project) = project {
-            format!(
-                "/projects/{}/{}/releases/{}/",
-                PathArg(org),
-                PathArg(project),
-                PathArg(version)
-            )
-        } else {
-            format!(
-                "/organizations/{}/releases/{}/",
-                PathArg(org),
-                PathArg(version)
-            )
-        };
-        let resp = self.get(&path)?;
-        if resp.status() == 404 {
-            Ok(None)
-        } else {
-            resp.convert()
-        }
-    }
-
-    /// Returns a list of releases for a given project.  This is currently a
-    /// capped list by what the server deems an acceptable default limit.
-    pub fn list_releases(&self, org: &str, project: Option<&str>) -> ApiResult<Vec<ReleaseInfo>> {
-        if let Some(project) = project {
-            let path = format!("/projects/{}/{}/releases/", PathArg(org), PathArg(project));
-            self.get(&path)?
-                .convert_rnf::<Vec<ReleaseInfo>>(ApiErrorKind::ProjectNotFound)
-        } else {
-            let path = format!("/organizations/{}/releases/", PathArg(org));
-            self.get(&path)?
-                .convert_rnf::<Vec<ReleaseInfo>>(ApiErrorKind::OrganizationNotFound)
-        }
-    }
-
-    /// Looks up a release commits and returns it.  If it does not exist `None`
-    /// will be returned.
-    pub fn get_release_commits(
-        &self,
-        org: &str,
-        project: Option<&str>,
-        version: &str,
-    ) -> ApiResult<Option<Vec<ReleaseCommit>>> {
-        let path = if let Some(project) = project {
-            format!(
-                "/projects/{}/{}/releases/{}/commits/",
-                PathArg(org),
-                PathArg(project),
-                PathArg(version)
-            )
-        } else {
-            format!(
-                "/organizations/{}/releases/{}/commits/",
-                PathArg(org),
-                PathArg(version)
-            )
-        };
-        let resp = self.get(&path)?;
-        if resp.status() == 404 {
-            Ok(None)
-        } else {
-            resp.convert()
-        }
-    }
-
-    // Finds the most recent release with commits and returns it.
-    // If it does not exist `None` will be returned.
-    pub fn get_previous_release_with_commits(
-        &self,
-        org: &str,
-        version: &str,
-    ) -> ApiResult<OptionalReleaseInfo> {
-        let path = format!(
-            "/organizations/{}/releases/{}/previous-with-commits/",
-            PathArg(org),
-            PathArg(version)
-        );
-        let resp = self.get(&path)?;
-        if resp.status() == 404 {
-            Ok(OptionalReleaseInfo::None(NoneReleaseInfo {}))
-        } else {
-            resp.convert()
-        }
-    }
-
-    /// Creates a new deploy for a release.
-    pub fn create_deploy(&self, org: &str, version: &str, deploy: &Deploy) -> ApiResult<Deploy> {
-        let path = format!(
-            "/organizations/{}/releases/{}/deploys/",
-            PathArg(org),
-            PathArg(version)
-        );
-
-        self.post(&path, deploy)?
-            .convert_rnf(ApiErrorKind::ReleaseNotFound)
-    }
-
-    /// Lists all deploys for a release
-    pub fn list_deploys(&self, org: &str, version: &str) -> ApiResult<Vec<Deploy>> {
-        let path = format!(
-            "/organizations/{}/releases/{}/deploys/",
-            PathArg(org),
-            PathArg(version)
-        );
-        self.get(&path)?.convert_rnf(ApiErrorKind::ReleaseNotFound)
-    }
-
-    /// Updates a bunch of issues within a project that match a provided filter
-    /// and performs `changes` changes.
-    pub fn bulk_update_issue(
-        &self,
-        org: &str,
-        project: &str,
-        filter: &IssueFilter,
-        changes: &IssueChanges,
-    ) -> ApiResult<bool> {
-        let qs = match filter.get_query_string() {
-            None => {
-                return Ok(false);
-            }
-            Some(qs) => qs,
-        };
-        self.put(
-            &format!(
-                "/projects/{}/{}/issues/?{}",
-                PathArg(org),
-                PathArg(project),
-                qs
-            ),
-            changes,
-        )?
-        .into_result()
-        .map(|_| true)
-    }
-
     /// Finds the latest release for sentry-cli on GitHub.
     pub fn get_latest_sentrycli_release(&self) -> ApiResult<Option<SentryCliRelease>> {
         let resp = self.get(RELEASE_REGISTRY_LATEST_URL)?;
@@ -1111,164 +619,6 @@ impl Api {
             info!("Release registry returned {}", resp.status());
             Ok(None)
         }
-    }
-
-    /// Given a list of checksums for DIFs, this returns a list of those
-    /// that do not exist for the project yet.
-    pub fn find_missing_dif_checksums<I>(
-        &self,
-        org: &str,
-        project: &str,
-        checksums: I,
-    ) -> ApiResult<HashSet<Digest>>
-    where
-        I: IntoIterator<Item = Digest>,
-    {
-        let mut url = format!(
-            "/projects/{}/{}/files/dsyms/unknown/?",
-            PathArg(org),
-            PathArg(project)
-        );
-        for (idx, checksum) in checksums.into_iter().enumerate() {
-            if idx > 0 {
-                url.push('&');
-            }
-            url.push_str("checksums=");
-            url.push_str(&checksum.to_string());
-        }
-
-        let state: MissingChecksumsResponse = self.get(&url)?.convert()?;
-        Ok(state.missing)
-    }
-
-    /// Uploads a ZIP archive containing DIFs from the given path.
-    pub fn upload_dif_archive(
-        &self,
-        org: &str,
-        project: &str,
-        file: &Path,
-    ) -> ApiResult<Vec<DebugInfoFile>> {
-        let path = format!(
-            "/projects/{}/{}/files/dsyms/",
-            PathArg(org),
-            PathArg(project)
-        );
-        let mut form = curl::easy::Form::new();
-        form.part("file").file(file).add()?;
-        self.request(Method::Post, &path)?
-            .with_form_data(form)?
-            .progress_bar_mode(ProgressBarMode::Request)?
-            .send()?
-            .convert()
-    }
-
-    /// Get the server configuration for chunked file uploads.
-    pub fn get_chunk_upload_options(&self, org: &str) -> ApiResult<Option<ChunkUploadOptions>> {
-        let url = format!("/organizations/{}/chunk-upload/", PathArg(org));
-        match self
-            .get(&url)?
-            .convert_rnf::<ChunkUploadOptions>(ApiErrorKind::ChunkUploadNotSupported)
-        {
-            Ok(options) => Ok(Some(options)),
-            Err(error) => {
-                if error.kind() == ApiErrorKind::ChunkUploadNotSupported {
-                    Ok(None)
-                } else {
-                    Err(error)
-                }
-            }
-        }
-    }
-
-    /// Request DIF assembling and processing from chunks.
-    pub fn assemble_difs(
-        &self,
-        org: &str,
-        project: &str,
-        request: &AssembleDifsRequest<'_>,
-    ) -> ApiResult<AssembleDifsResponse> {
-        let url = format!(
-            "/projects/{}/{}/files/difs/assemble/",
-            PathArg(org),
-            PathArg(project)
-        );
-
-        self.request(Method::Post, &url)?
-            .with_json_body(request)?
-            .with_retry(
-                self.config.get_max_retry_count().unwrap(),
-                &[
-                    http::HTTP_STATUS_502_BAD_GATEWAY,
-                    http::HTTP_STATUS_503_SERVICE_UNAVAILABLE,
-                    http::HTTP_STATUS_504_GATEWAY_TIMEOUT,
-                ],
-            )?
-            .send()?
-            .convert_rnf(ApiErrorKind::ProjectNotFound)
-    }
-
-    pub fn assemble_release_artifacts(
-        &self,
-        org: &str,
-        release: &str,
-        checksum: Digest,
-        chunks: &[Digest],
-    ) -> ApiResult<AssembleArtifactsResponse> {
-        let url = format!(
-            "/organizations/{}/releases/{}/assemble/",
-            PathArg(org),
-            PathArg(release)
-        );
-
-        self.request(Method::Post, &url)?
-            .with_json_body(&ChunkedArtifactRequest {
-                checksum,
-                chunks,
-                projects: Vec::new(),
-                version: None,
-                dist: None,
-            })?
-            .with_retry(
-                self.config.get_max_retry_count().unwrap(),
-                &[
-                    http::HTTP_STATUS_502_BAD_GATEWAY,
-                    http::HTTP_STATUS_503_SERVICE_UNAVAILABLE,
-                    http::HTTP_STATUS_504_GATEWAY_TIMEOUT,
-                ],
-            )?
-            .send()?
-            .convert_rnf(ApiErrorKind::ReleaseNotFound)
-    }
-
-    pub fn assemble_artifact_bundle(
-        &self,
-        org: &str,
-        projects: Vec<String>,
-        checksum: Digest,
-        chunks: &[Digest],
-        version: Option<&str>,
-        dist: Option<&str>,
-    ) -> ApiResult<AssembleArtifactsResponse> {
-        let url = format!("/organizations/{}/artifactbundle/assemble/", PathArg(org));
-
-        self.request(Method::Post, &url)?
-            .with_json_body(&ChunkedArtifactRequest {
-                checksum,
-                chunks,
-                projects,
-                version,
-                dist,
-            })?
-            .with_retry(
-                self.config.get_max_retry_count().unwrap(),
-                &[
-                    http::HTTP_STATUS_502_BAD_GATEWAY,
-                    http::HTTP_STATUS_503_SERVICE_UNAVAILABLE,
-                    http::HTTP_STATUS_504_GATEWAY_TIMEOUT,
-                ],
-            )?
-            .send()?
-            .convert_rnf(ApiErrorKind::ReleaseNotFound)
     }
 
     /// Compresses a file with the given compression.
@@ -1354,130 +704,6 @@ impl Api {
         }
     }
 
-    pub fn associate_proguard_mappings(
-        &self,
-        org: &str,
-        project: &str,
-        data: &AssociateProguard,
-    ) -> ApiResult<()> {
-        let path = format!(
-            "/projects/{}/{}/files/proguard-artifact-releases",
-            PathArg(org),
-            PathArg(project)
-        );
-        let resp: ApiResponse = self
-            .request(Method::Post, &path)?
-            .with_json_body(data)?
-            .send()?;
-        if resp.status() == 201 {
-            Ok(())
-        } else if resp.status() == 409 {
-            info!(
-                "Release association for release '{}', UUID '{}' already exists.",
-                data.release_name, data.proguard_uuid
-            );
-            Ok(())
-        } else if resp.status() == 404 {
-            return Err(ApiErrorKind::ResourceNotFound.into());
-        } else {
-            resp.convert()
-        }
-    }
-
-    /// Triggers reprocessing for a project
-    pub fn trigger_reprocessing(&self, org: &str, project: &str) -> ApiResult<bool> {
-        let path = format!(
-            "/projects/{}/{}/reprocessing/",
-            PathArg(org),
-            PathArg(project)
-        );
-        let resp = self
-            .request(Method::Post, &path)?
-            .with_header("Content-Length", "0")?
-            .send()?;
-        if resp.status() == 404 {
-            Ok(false)
-        } else {
-            resp.into_result().map(|_| true)
-        }
-    }
-
-    /// List all organizations associated with the authenticated token
-    /// in the given `Region`. If no `Region` is provided, we assume
-    /// we're issuing a request to a monolith deployment.
-    pub fn list_organizations(&self, region: Option<&Region>) -> ApiResult<Vec<Organization>> {
-        let mut rv = vec![];
-        let mut cursor = "".to_string();
-        loop {
-            let current_path = &format!("/organizations/?cursor={}", QueryArg(&cursor));
-            let resp = if let Some(rg) = region {
-                self.region_request(Method::Get, current_path, rg)?.send()?
-            } else {
-                self.get(current_path)?
-            };
-
-            if resp.status() == 404 || (resp.status() == 400 && !cursor.is_empty()) {
-                if rv.is_empty() {
-                    return Err(ApiErrorKind::ResourceNotFound.into());
-                } else {
-                    break;
-                }
-            }
-            let pagination = resp.pagination();
-            rv.extend(resp.convert::<Vec<Organization>>()?);
-            if let Some(next) = pagination.into_next_cursor() {
-                cursor = next;
-            } else {
-                break;
-            }
-        }
-        Ok(rv)
-    }
-
-    pub fn list_available_regions(&self) -> ApiResult<Vec<Region>> {
-        let resp = self.get("/users/me/regions/")?;
-        if resp.status() == 404 {
-            // This endpoint may not exist for self-hosted users, so
-            // returning a default of [] seems appropriate.
-            return Ok(vec![]);
-        }
-
-        if resp.status() == 400 {
-            return Err(ApiErrorKind::ResourceNotFound.into());
-        }
-
-        let region_response = resp.convert::<RegionResponse>()?;
-        Ok(region_response.regions)
-    }
-
-    /// List all monitors associated with an organization
-    pub fn list_organization_monitors(&self, org: &str) -> ApiResult<Vec<Monitor>> {
-        let mut rv = vec![];
-        let mut cursor = "".to_string();
-        loop {
-            let resp = self.get(&format!(
-                "/organizations/{}/monitors/?cursor={}",
-                PathArg(org),
-                QueryArg(&cursor)
-            ))?;
-            if resp.status() == 404 || (resp.status() == 400 && !cursor.is_empty()) {
-                if rv.is_empty() {
-                    return Err(ApiErrorKind::ResourceNotFound.into());
-                } else {
-                    break;
-                }
-            }
-            let pagination = resp.pagination();
-            rv.extend(resp.convert::<Vec<Monitor>>()?);
-            if let Some(next) = pagination.into_next_cursor() {
-                cursor = next;
-            } else {
-                break;
-            }
-        }
-        Ok(rv)
-    }
-
     /// Create a new checkin for a monitor
     pub fn create_monitor_checkin(
         &self,
@@ -1514,6 +740,8 @@ impl Api {
 
     /// List all projects associated with an organization
     pub fn list_organization_projects(&self, org: &str) -> ApiResult<Vec<Project>> {
+        self.ensure_auth_provided()?;
+
         let mut rv = vec![];
         let mut cursor = "".to_string();
         loop {
@@ -1547,6 +775,8 @@ impl Api {
         project: &str,
         max_pages: usize,
     ) -> ApiResult<Vec<ProcessedEvent>> {
+        self.ensure_auth_provided()?;
+
         let mut rv = vec![];
         let mut cursor = "".to_string();
         let mut requests_no = 0;
@@ -1594,6 +824,8 @@ impl Api {
         max_pages: usize,
         query: Option<String>,
     ) -> ApiResult<Vec<Issue>> {
+        self.ensure_auth_provided()?;
+
         let mut rv = vec![];
         let mut cursor = "".to_string();
         let mut requests_no = 0;
@@ -1641,6 +873,8 @@ impl Api {
 
     /// List all repos associated with an organization
     pub fn list_organization_repos(&self, org: &str) -> ApiResult<Vec<Repo>> {
+        self.ensure_auth_provided()?;
+
         let mut rv = vec![];
         let mut cursor = "".to_string();
         loop {
@@ -1673,6 +907,8 @@ impl Api {
         project: Option<&str>,
         event_id: &str,
     ) -> ApiResult<Option<ProcessedEvent>> {
+        self.ensure_auth_provided()?;
+
         let path = if let Some(project) = project {
             format!(
                 "/projects/{}/{}/events/{}/json/",
@@ -1694,6 +930,862 @@ impl Api {
         } else {
             resp.convert()
         }
+    }
+}
+
+impl<'a> AuthenticatedApi<'a> {
+    /// Performs an API request to verify the authentication status of the
+    /// current token.
+    pub fn get_auth_info(&self) -> ApiResult<AuthInfo> {
+        self.0.get("/")?.convert()
+    }
+
+    /// Lists release files for the given `release`, filtered by a set of checksums.
+    /// When empty checksums list is provided, fetches all possible artifacts.
+    pub fn list_release_files_by_checksum(
+        &self,
+        org: &str,
+        project: Option<&str>,
+        release: &str,
+        checksums: &[String],
+    ) -> ApiResult<Vec<Artifact>> {
+        let mut rv = vec![];
+        let mut cursor = "".to_string();
+        loop {
+            let mut path = if let Some(project) = project {
+                format!(
+                    "/projects/{}/{}/releases/{}/files/?cursor={}",
+                    PathArg(org),
+                    PathArg(project),
+                    PathArg(release),
+                    QueryArg(&cursor),
+                )
+            } else {
+                format!(
+                    "/organizations/{}/releases/{}/files/?cursor={}",
+                    PathArg(org),
+                    PathArg(release),
+                    QueryArg(&cursor),
+                )
+            };
+
+            let mut checkums_qs = String::new();
+            for checksum in checksums.iter() {
+                checkums_qs.push_str(&format!("&checksum={}", QueryArg(checksum)));
+            }
+            // We have a 16kb buffer for reach request configured in nginx,
+            // so do not even bother trying if it's too long.
+            // (16_384 limit still leaves us with 384 bytes for the url itself).
+            if !checkums_qs.is_empty() && checkums_qs.len() <= 16_000 {
+                path.push_str(&checkums_qs);
+            }
+
+            let resp = self.0.get(&path)?;
+            if resp.status() == 404 || (resp.status() == 400 && !cursor.is_empty()) {
+                if rv.is_empty() {
+                    return Err(ApiErrorKind::ReleaseNotFound.into());
+                } else {
+                    break;
+                }
+            }
+
+            let pagination = resp.pagination();
+            rv.extend(resp.convert::<Vec<Artifact>>()?);
+            if let Some(next) = pagination.into_next_cursor() {
+                cursor = next;
+            } else {
+                break;
+            }
+        }
+        Ok(rv)
+    }
+
+    /// Lists all the release files for the given `release`.
+    pub fn list_release_files(
+        &self,
+        org: &str,
+        project: Option<&str>,
+        release: &str,
+    ) -> ApiResult<Vec<Artifact>> {
+        self.list_release_files_by_checksum(org, project, release, &[])
+    }
+
+    /// Get a single release file and store it inside provided descriptor.
+    pub fn get_release_file(
+        &self,
+        org: &str,
+        project: Option<&str>,
+        version: &str,
+        file_id: &str,
+        file_desc: &mut File,
+    ) -> Result<(), ApiError> {
+        self.ensure_auth_provided()?;
+
+        let path = if let Some(project) = project {
+            format!(
+                "/projects/{}/{}/releases/{}/files/{}/?download=1",
+                PathArg(org),
+                PathArg(project),
+                PathArg(version),
+                PathArg(file_id)
+            )
+        } else {
+            format!(
+                "/organizations/{}/releases/{}/files/{}/?download=1",
+                PathArg(org),
+                PathArg(version),
+                PathArg(file_id)
+            )
+        };
+
+        let resp = self.download(&path, file_desc)?;
+        if resp.status() == 404 {
+            resp.convert_rnf(ApiErrorKind::ResourceNotFound)
+        } else {
+            Ok(())
+        }
+    }
+
+    /// Get a single release file metadata.
+    pub fn get_release_file_metadata(
+        &self,
+        org: &str,
+        project: Option<&str>,
+        version: &str,
+        file_id: &str,
+    ) -> ApiResult<Option<Artifact>> {
+        self.ensure_auth_provided()?;
+
+        let path = if let Some(project) = project {
+            format!(
+                "/projects/{}/{}/releases/{}/files/{}/",
+                PathArg(org),
+                PathArg(project),
+                PathArg(version),
+                PathArg(file_id)
+            )
+        } else {
+            format!(
+                "/organizations/{}/releases/{}/files/{}/",
+                PathArg(org),
+                PathArg(version),
+                PathArg(file_id)
+            )
+        };
+
+        let resp = self.get(&path)?;
+        if resp.status() == 404 {
+            Ok(None)
+        } else {
+            resp.convert()
+        }
+    }
+
+    /// Deletes a single release file.  Returns `true` if the file was
+    /// deleted or `false` otherwise.
+    pub fn delete_release_file(
+        &self,
+        org: &str,
+        project: Option<&str>,
+        version: &str,
+        file_id: &str,
+    ) -> ApiResult<bool> {
+        self.ensure_auth_provided()?;
+
+        let path = if let Some(project) = project {
+            format!(
+                "/projects/{}/{}/releases/{}/files/{}/",
+                PathArg(org),
+                PathArg(project),
+                PathArg(version),
+                PathArg(file_id)
+            )
+        } else {
+            format!(
+                "/organizations/{}/releases/{}/files/{}/",
+                PathArg(org),
+                PathArg(version),
+                PathArg(file_id)
+            )
+        };
+
+        let resp = self.delete(&path)?;
+        if resp.status() == 404 {
+            Ok(false)
+        } else {
+            resp.into_result().map(|_| true)
+        }
+    }
+
+    /// Deletes all release files.  Returns `true` if files were
+    /// deleted or `false` otherwise.
+    pub fn delete_release_files(
+        &self,
+        org: &str,
+        project: Option<&str>,
+        version: &str,
+    ) -> ApiResult<()> {
+        self.ensure_auth_provided()?;
+
+        let path = if let Some(project) = project {
+            format!(
+                "/projects/{}/{}/files/source-maps/?name={}",
+                PathArg(org),
+                PathArg(project),
+                PathArg(version)
+            )
+        } else {
+            format!(
+                "/organizations/{}/files/source-maps/?name={}",
+                PathArg(org),
+                PathArg(version)
+            )
+        };
+
+        self.delete(&path)?.into_result().map(|_| ())
+    }
+
+    /// Uploads a new release file.  The file is loaded directly from the file
+    /// system and uploaded as `name`.
+    pub fn upload_release_file(
+        &self,
+        context: &UploadContext,
+        contents: &[u8],
+        name: &str,
+        headers: Option<&[(String, String)]>,
+        progress_bar_mode: ProgressBarMode,
+    ) -> ApiResult<Option<Artifact>> {
+        self.ensure_auth_provided()?;
+
+        let release = context
+            .release()
+            .map_err(|err| ApiError::with_source(ApiErrorKind::ReleaseNotFound, err))?;
+
+        let path = if let Some(project) = context.project {
+            format!(
+                "/projects/{}/{}/releases/{}/files/",
+                PathArg(context.org),
+                PathArg(project),
+                PathArg(release)
+            )
+        } else {
+            format!(
+                "/organizations/{}/releases/{}/files/",
+                PathArg(context.org),
+                PathArg(release)
+            )
+        };
+        let mut form = curl::easy::Form::new();
+
+        let filename = Path::new(name)
+            .file_name()
+            .and_then(OsStr::to_str)
+            .unwrap_or("unknown.bin");
+        form.part("file")
+            .buffer(filename, contents.to_vec())
+            .add()?;
+        form.part("name").contents(name.as_bytes()).add()?;
+        if let Some(dist) = context.dist {
+            form.part("dist").contents(dist.as_bytes()).add()?;
+        }
+
+        if let Some(headers) = headers {
+            for (key, value) in headers {
+                form.part("header")
+                    .contents(format!("{key}:{value}").as_bytes())
+                    .add()?;
+            }
+        }
+
+        let resp = self
+            .request(Method::Post, &path)?
+            .with_form_data(form)?
+            .with_retry(
+                self.config.get_max_retry_count().unwrap(),
+                &[
+                    http::HTTP_STATUS_502_BAD_GATEWAY,
+                    http::HTTP_STATUS_503_SERVICE_UNAVAILABLE,
+                    http::HTTP_STATUS_504_GATEWAY_TIMEOUT,
+                ],
+            )?
+            .progress_bar_mode(progress_bar_mode)?
+            .send()?;
+        if resp.status() == 409 {
+            Ok(None)
+        } else {
+            resp.convert_rnf(ApiErrorKind::ReleaseNotFound)
+        }
+    }
+
+    /// Creates a new release.
+    pub fn new_release(&self, org: &str, release: &NewRelease) -> ApiResult<ReleaseInfo> {
+        self.ensure_auth_provided()?;
+
+        // for single project releases use the legacy endpoint that is project bound.
+        // This means we can support both old and new servers.
+        if release.projects.len() == 1 {
+            let path = format!(
+                "/projects/{}/{}/releases/",
+                PathArg(org),
+                PathArg(&release.projects[0])
+            );
+            self.post(&path, release)?
+                .convert_rnf(ApiErrorKind::ProjectNotFound)
+        } else {
+            let path = format!("/organizations/{}/releases/", PathArg(org));
+            self.post(&path, release)?
+                .convert_rnf(ApiErrorKind::OrganizationNotFound)
+        }
+    }
+
+    /// Updates a release.
+    pub fn update_release(
+        &self,
+        org: &str,
+        version: &str,
+        release: &UpdatedRelease,
+    ) -> ApiResult<ReleaseInfo> {
+        self.ensure_auth_provided()?;
+
+        if_chain! {
+            if let Some(ref projects) = release.projects;
+            if projects.len() == 1;
+            then {
+                let path = format!("/projects/{}/{}/releases/{}/",
+                    PathArg(org),
+                    PathArg(&projects[0]),
+                    PathArg(version)
+                );
+                self.put(&path, release)?.convert_rnf(ApiErrorKind::ReleaseNotFound)
+            } else {
+                if release.version.is_some() {
+                    let path = format!("/organizations/{}/releases/",
+                                    PathArg(org));
+                    return self.post(&path, release)?.convert_rnf(ApiErrorKind::ReleaseNotFound)
+                }
+
+                let path = format!("/organizations/{}/releases/{}/",
+                                PathArg(org),
+                                PathArg(version));
+                self.put(&path, release)?.convert_rnf(ApiErrorKind::ReleaseNotFound)
+            }
+        }
+    }
+
+    /// Sets release commits
+    pub fn set_release_refs(
+        &self,
+        org: &str,
+        version: &str,
+        refs: Vec<Ref>,
+    ) -> ApiResult<ReleaseInfo> {
+        self.ensure_auth_provided()?;
+
+        let update = UpdatedRelease {
+            refs: Some(refs),
+            ..Default::default()
+        };
+        let path = format!(
+            "/organizations/{}/releases/{}/",
+            PathArg(org),
+            PathArg(version)
+        );
+        self.put(&path, &update)?
+            .convert_rnf(ApiErrorKind::ReleaseNotFound)
+    }
+
+    /// Deletes an already existing release.  Returns `true` if it was deleted
+    /// or `false` if not.  The project is needed to support the old deletion
+    /// API.
+    pub fn delete_release(
+        &self,
+        org: &str,
+        project: Option<&str>,
+        version: &str,
+    ) -> ApiResult<bool> {
+        self.ensure_auth_provided()?;
+
+        let resp = if let Some(project) = project {
+            self.delete(&format!(
+                "/projects/{}/{}/releases/{}/",
+                PathArg(org),
+                PathArg(project),
+                PathArg(version)
+            ))?
+        } else {
+            self.delete(&format!(
+                "/organizations/{}/releases/{}/",
+                PathArg(org),
+                PathArg(version)
+            ))?
+        };
+        if resp.status() == 404 {
+            Ok(false)
+        } else {
+            resp.into_result().map(|_| true)
+        }
+    }
+
+    /// Looks up a release and returns it.  If it does not exist `None`
+    /// will be returned.
+    pub fn get_release(
+        &self,
+        org: &str,
+        project: Option<&str>,
+        version: &str,
+    ) -> ApiResult<Option<ReleaseInfo>> {
+        self.ensure_auth_provided()?;
+
+        let path = if let Some(project) = project {
+            format!(
+                "/projects/{}/{}/releases/{}/",
+                PathArg(org),
+                PathArg(project),
+                PathArg(version)
+            )
+        } else {
+            format!(
+                "/organizations/{}/releases/{}/",
+                PathArg(org),
+                PathArg(version)
+            )
+        };
+        let resp = self.get(&path)?;
+        if resp.status() == 404 {
+            Ok(None)
+        } else {
+            resp.convert()
+        }
+    }
+
+    /// Returns a list of releases for a given project.  This is currently a
+    /// capped list by what the server deems an acceptable default limit.
+    pub fn list_releases(&self, org: &str, project: Option<&str>) -> ApiResult<Vec<ReleaseInfo>> {
+        self.ensure_auth_provided()?;
+
+        if let Some(project) = project {
+            let path = format!("/projects/{}/{}/releases/", PathArg(org), PathArg(project));
+            self.get(&path)?
+                .convert_rnf::<Vec<ReleaseInfo>>(ApiErrorKind::ProjectNotFound)
+        } else {
+            let path = format!("/organizations/{}/releases/", PathArg(org));
+            self.get(&path)?
+                .convert_rnf::<Vec<ReleaseInfo>>(ApiErrorKind::OrganizationNotFound)
+        }
+    }
+
+    /// Looks up a release commits and returns it.  If it does not exist `None`
+    /// will be returned.
+    pub fn get_release_commits(
+        &self,
+        org: &str,
+        project: Option<&str>,
+        version: &str,
+    ) -> ApiResult<Option<Vec<ReleaseCommit>>> {
+        self.ensure_auth_provided()?;
+
+        let path = if let Some(project) = project {
+            format!(
+                "/projects/{}/{}/releases/{}/commits/",
+                PathArg(org),
+                PathArg(project),
+                PathArg(version)
+            )
+        } else {
+            format!(
+                "/organizations/{}/releases/{}/commits/",
+                PathArg(org),
+                PathArg(version)
+            )
+        };
+        let resp = self.get(&path)?;
+        if resp.status() == 404 {
+            Ok(None)
+        } else {
+            resp.convert()
+        }
+    }
+
+    // Finds the most recent release with commits and returns it.
+    // If it does not exist `None` will be returned.
+    pub fn get_previous_release_with_commits(
+        &self,
+        org: &str,
+        version: &str,
+    ) -> ApiResult<OptionalReleaseInfo> {
+        self.ensure_auth_provided()?;
+
+        let path = format!(
+            "/organizations/{}/releases/{}/previous-with-commits/",
+            PathArg(org),
+            PathArg(version)
+        );
+        let resp = self.get(&path)?;
+        if resp.status() == 404 {
+            Ok(OptionalReleaseInfo::None(NoneReleaseInfo {}))
+        } else {
+            resp.convert()
+        }
+    }
+
+    /// Creates a new deploy for a release.
+    pub fn create_deploy(&self, org: &str, version: &str, deploy: &Deploy) -> ApiResult<Deploy> {
+        self.ensure_auth_provided()?;
+
+        let path = format!(
+            "/organizations/{}/releases/{}/deploys/",
+            PathArg(org),
+            PathArg(version)
+        );
+
+        self.post(&path, deploy)?
+            .convert_rnf(ApiErrorKind::ReleaseNotFound)
+    }
+
+    /// Lists all deploys for a release
+    pub fn list_deploys(&self, org: &str, version: &str) -> ApiResult<Vec<Deploy>> {
+        self.ensure_auth_provided()?;
+
+        let path = format!(
+            "/organizations/{}/releases/{}/deploys/",
+            PathArg(org),
+            PathArg(version)
+        );
+        self.get(&path)?.convert_rnf(ApiErrorKind::ReleaseNotFound)
+    }
+
+    /// Updates a bunch of issues within a project that match a provided filter
+    /// and performs `changes` changes.
+    pub fn bulk_update_issue(
+        &self,
+        org: &str,
+        project: &str,
+        filter: &IssueFilter,
+        changes: &IssueChanges,
+    ) -> ApiResult<bool> {
+        self.ensure_auth_provided()?;
+
+        let qs = match filter.get_query_string() {
+            None => {
+                return Ok(false);
+            }
+            Some(qs) => qs,
+        };
+        self.put(
+            &format!(
+                "/projects/{}/{}/issues/?{}",
+                PathArg(org),
+                PathArg(project),
+                qs
+            ),
+            changes,
+        )?
+        .into_result()
+        .map(|_| true)
+    }
+
+    /// Given a list of checksums for DIFs, this returns a list of those
+    /// that do not exist for the project yet.
+    pub fn find_missing_dif_checksums<I>(
+        &self,
+        org: &str,
+        project: &str,
+        checksums: I,
+    ) -> ApiResult<HashSet<Digest>>
+    where
+        I: IntoIterator<Item = Digest>,
+    {
+        self.ensure_auth_provided()?;
+
+        let mut url = format!(
+            "/projects/{}/{}/files/dsyms/unknown/?",
+            PathArg(org),
+            PathArg(project)
+        );
+        for (idx, checksum) in checksums.into_iter().enumerate() {
+            if idx > 0 {
+                url.push('&');
+            }
+            url.push_str("checksums=");
+            url.push_str(&checksum.to_string());
+        }
+
+        let state: MissingChecksumsResponse = self.get(&url)?.convert()?;
+        Ok(state.missing)
+    }
+
+    /// Uploads a ZIP archive containing DIFs from the given path.
+    pub fn upload_dif_archive(
+        &self,
+        org: &str,
+        project: &str,
+        file: &Path,
+    ) -> ApiResult<Vec<DebugInfoFile>> {
+        self.ensure_auth_provided()?;
+
+        let path = format!(
+            "/projects/{}/{}/files/dsyms/",
+            PathArg(org),
+            PathArg(project)
+        );
+        let mut form = curl::easy::Form::new();
+        form.part("file").file(file).add()?;
+        self.request(Method::Post, &path)?
+            .with_form_data(form)?
+            .progress_bar_mode(ProgressBarMode::Request)?
+            .send()?
+            .convert()
+    }
+
+    /// Get the server configuration for chunked file uploads.
+    pub fn get_chunk_upload_options(&self, org: &str) -> ApiResult<Option<ChunkUploadOptions>> {
+        self.ensure_auth_provided()?;
+
+        let url = format!("/organizations/{}/chunk-upload/", PathArg(org));
+        match self
+            .get(&url)?
+            .convert_rnf::<ChunkUploadOptions>(ApiErrorKind::ChunkUploadNotSupported)
+        {
+            Ok(options) => Ok(Some(options)),
+            Err(error) => {
+                if error.kind() == ApiErrorKind::ChunkUploadNotSupported {
+                    Ok(None)
+                } else {
+                    Err(error)
+                }
+            }
+        }
+    }
+
+    /// Request DIF assembling and processing from chunks.
+    pub fn assemble_difs(
+        &self,
+        org: &str,
+        project: &str,
+        request: &AssembleDifsRequest<'_>,
+    ) -> ApiResult<AssembleDifsResponse> {
+        self.ensure_auth_provided()?;
+
+        let url = format!(
+            "/projects/{}/{}/files/difs/assemble/",
+            PathArg(org),
+            PathArg(project)
+        );
+
+        self.request(Method::Post, &url)?
+            .with_json_body(request)?
+            .with_retry(
+                self.config.get_max_retry_count().unwrap(),
+                &[
+                    http::HTTP_STATUS_502_BAD_GATEWAY,
+                    http::HTTP_STATUS_503_SERVICE_UNAVAILABLE,
+                    http::HTTP_STATUS_504_GATEWAY_TIMEOUT,
+                ],
+            )?
+            .send()?
+            .convert_rnf(ApiErrorKind::ProjectNotFound)
+    }
+
+    pub fn assemble_release_artifacts(
+        &self,
+        org: &str,
+        release: &str,
+        checksum: Digest,
+        chunks: &[Digest],
+    ) -> ApiResult<AssembleArtifactsResponse> {
+        self.ensure_auth_provided()?;
+
+        let url = format!(
+            "/organizations/{}/releases/{}/assemble/",
+            PathArg(org),
+            PathArg(release)
+        );
+
+        self.request(Method::Post, &url)?
+            .with_json_body(&ChunkedArtifactRequest {
+                checksum,
+                chunks,
+                projects: Vec::new(),
+                version: None,
+                dist: None,
+            })?
+            .with_retry(
+                self.config.get_max_retry_count().unwrap(),
+                &[
+                    http::HTTP_STATUS_502_BAD_GATEWAY,
+                    http::HTTP_STATUS_503_SERVICE_UNAVAILABLE,
+                    http::HTTP_STATUS_504_GATEWAY_TIMEOUT,
+                ],
+            )?
+            .send()?
+            .convert_rnf(ApiErrorKind::ReleaseNotFound)
+    }
+
+    pub fn assemble_artifact_bundle(
+        &self,
+        org: &str,
+        projects: Vec<String>,
+        checksum: Digest,
+        chunks: &[Digest],
+        version: Option<&str>,
+        dist: Option<&str>,
+    ) -> ApiResult<AssembleArtifactsResponse> {
+        self.ensure_auth_provided()?;
+
+        let url = format!("/organizations/{}/artifactbundle/assemble/", PathArg(org));
+
+        self.request(Method::Post, &url)?
+            .with_json_body(&ChunkedArtifactRequest {
+                checksum,
+                chunks,
+                projects,
+                version,
+                dist,
+            })?
+            .with_retry(
+                self.config.get_max_retry_count().unwrap(),
+                &[
+                    http::HTTP_STATUS_502_BAD_GATEWAY,
+                    http::HTTP_STATUS_503_SERVICE_UNAVAILABLE,
+                    http::HTTP_STATUS_504_GATEWAY_TIMEOUT,
+                ],
+            )?
+            .send()?
+            .convert_rnf(ApiErrorKind::ReleaseNotFound)
+    }
+
+    pub fn associate_proguard_mappings(
+        &self,
+        org: &str,
+        project: &str,
+        data: &AssociateProguard,
+    ) -> ApiResult<()> {
+        self.ensure_auth_provided()?;
+
+        let path = format!(
+            "/projects/{}/{}/files/proguard-artifact-releases",
+            PathArg(org),
+            PathArg(project)
+        );
+        let resp: ApiResponse = self
+            .request(Method::Post, &path)?
+            .with_json_body(data)?
+            .send()?;
+        if resp.status() == 201 {
+            Ok(())
+        } else if resp.status() == 409 {
+            info!(
+                "Release association for release '{}', UUID '{}' already exists.",
+                data.release_name, data.proguard_uuid
+            );
+            Ok(())
+        } else if resp.status() == 404 {
+            return Err(ApiErrorKind::ResourceNotFound.into());
+        } else {
+            resp.convert()
+        }
+    }
+
+    /// Triggers reprocessing for a project
+    pub fn trigger_reprocessing(&self, org: &str, project: &str) -> ApiResult<bool> {
+        self.ensure_auth_provided()?;
+
+        let path = format!(
+            "/projects/{}/{}/reprocessing/",
+            PathArg(org),
+            PathArg(project)
+        );
+        let resp = self
+            .request(Method::Post, &path)?
+            .with_header("Content-Length", "0")?
+            .send()?;
+        if resp.status() == 404 {
+            Ok(false)
+        } else {
+            resp.into_result().map(|_| true)
+        }
+    }
+
+    /// List all organizations associated with the authenticated token
+    /// in the given `Region`. If no `Region` is provided, we assume
+    /// we're issuing a request to a monolith deployment.
+    pub fn list_organizations(&self, region: Option<&Region>) -> ApiResult<Vec<Organization>> {
+        self.ensure_auth_provided()?;
+
+        let mut rv = vec![];
+        let mut cursor = "".to_string();
+        loop {
+            let current_path = &format!("/organizations/?cursor={}", QueryArg(&cursor));
+            let resp = if let Some(rg) = region {
+                self.region_request(Method::Get, current_path, rg)?.send()?
+            } else {
+                self.get(current_path)?
+            };
+
+            if resp.status() == 404 || (resp.status() == 400 && !cursor.is_empty()) {
+                if rv.is_empty() {
+                    return Err(ApiErrorKind::ResourceNotFound.into());
+                } else {
+                    break;
+                }
+            }
+            let pagination = resp.pagination();
+            rv.extend(resp.convert::<Vec<Organization>>()?);
+            if let Some(next) = pagination.into_next_cursor() {
+                cursor = next;
+            } else {
+                break;
+            }
+        }
+        Ok(rv)
+    }
+
+    pub fn list_available_regions(&self) -> ApiResult<Vec<Region>> {
+        self.ensure_auth_provided()?;
+
+        let resp = self.get("/users/me/regions/")?;
+        if resp.status() == 404 {
+            // This endpoint may not exist for self-hosted users, so
+            // returning a default of [] seems appropriate.
+            return Ok(vec![]);
+        }
+
+        if resp.status() == 400 {
+            return Err(ApiErrorKind::ResourceNotFound.into());
+        }
+
+        let region_response = resp.convert::<RegionResponse>()?;
+        Ok(region_response.regions)
+    }
+
+    /// List all monitors associated with an organization
+    pub fn list_organization_monitors(&self, org: &str) -> ApiResult<Vec<Monitor>> {
+        self.ensure_auth_provided()?;
+
+        let mut rv = vec![];
+        let mut cursor = "".to_string();
+        loop {
+            let resp = self.get(&format!(
+                "/organizations/{}/monitors/?cursor={}",
+                PathArg(org),
+                QueryArg(&cursor)
+            ))?;
+            if resp.status() == 404 || (resp.status() == 400 && !cursor.is_empty()) {
+                if rv.is_empty() {
+                    return Err(ApiErrorKind::ResourceNotFound.into());
+                } else {
+                    break;
+                }
+            }
+            let pagination = resp.pagination();
+            rv.extend(resp.convert::<Vec<Monitor>>()?);
+            if let Some(next) = pagination.into_next_cursor() {
+                cursor = next;
+            } else {
+                break;
+            }
+        }
+        Ok(rv)
     }
 }
 

--- a/src/commands/debug_files/bundle_jvm.rs
+++ b/src/commands/debug_files/bundle_jvm.rs
@@ -52,7 +52,7 @@ pub fn execute(matches: &ArgMatches) -> Result<()> {
     let org = config.get_org(matches)?;
     let project = config.get_project(matches).ok();
     let api = Api::current();
-    let chunk_upload_options = api.get_chunk_upload_options(&org)?;
+    let chunk_upload_options = api.authenticated()?.get_chunk_upload_options(&org)?;
 
     let context = &UploadContext {
         org: &org,

--- a/src/commands/debug_files/upload.rs
+++ b/src/commands/debug_files/upload.rs
@@ -327,7 +327,7 @@ pub fn execute(matches: &ArgMatches) -> Result<()> {
         // Trigger reprocessing only if requested by user
         if matches.get_flag("no_reprocessing") {
             println!("{} skipped reprocessing", style(">").dim());
-        } else if !api.trigger_reprocessing(&org, &project)? {
+        } else if !api.authenticated()?.trigger_reprocessing(&org, &project)? {
             println!("{} Server does not support reprocessing.", style(">").dim());
         }
 

--- a/src/commands/deploys/list.rs
+++ b/src/commands/deploys/list.rs
@@ -24,7 +24,10 @@ pub fn execute(matches: &ArgMatches) -> Result<()> {
         .add("Name")
         .add("Finished");
 
-    for deploy in api.list_deploys(&config.get_org(matches)?, &version)? {
+    for deploy in api
+        .authenticated()?
+        .list_deploys(&config.get_org(matches)?, &version)?
+    {
         table
             .add_row()
             .add(&deploy.env)

--- a/src/commands/deploys/new.rs
+++ b/src/commands/deploys/new.rs
@@ -90,7 +90,9 @@ pub fn execute(matches: &ArgMatches) -> Result<()> {
     }
 
     let org = config.get_org(matches)?;
-    let created_deploy = api.create_deploy(&org, &version, &deploy)?;
+    let created_deploy = api
+        .authenticated()?
+        .create_deploy(&org, &version, &deploy)?;
 
     println!(
         "Created new deploy {} for '{}'",

--- a/src/commands/events/list.rs
+++ b/src/commands/events/list.rs
@@ -46,7 +46,9 @@ pub fn execute(matches: &ArgMatches) -> Result<()> {
     let pages = *matches.get_one("pages").unwrap();
     let api = Api::current();
 
-    let events = api.list_organization_project_events(&org, &project, pages)?;
+    let events = api
+        .authenticated()?
+        .list_organization_project_events(&org, &project, pages)?;
 
     let mut table = Table::new();
     let title_row = table.title_row().add("Event ID").add("Date").add("Title");

--- a/src/commands/files/delete.rs
+++ b/src/commands/files/delete.rs
@@ -33,11 +33,11 @@ pub fn execute(matches: &ArgMatches) -> Result<()> {
     let org = config.get_org(matches)?;
     let project = config.get_project(matches).ok();
     let api = Api::current();
+    let authenticated_api = api.authenticated()?;
 
     if matches.get_flag("all") {
-        if api.delete_release_files(&org, project.as_deref(), &release)? {
-            println!("All files deleted.");
-        }
+        authenticated_api.delete_release_files(&org, project.as_deref(), &release)?;
+        println!("All files deleted.");
         return Ok(());
     }
 
@@ -45,11 +45,11 @@ pub fn execute(matches: &ArgMatches) -> Result<()> {
         Some(paths) => paths.map(|x| x.into()).collect(),
         None => HashSet::new(),
     };
-    for file in api.list_release_files(&org, project.as_deref(), &release)? {
+    for file in authenticated_api.list_release_files(&org, project.as_deref(), &release)? {
         if !files.contains(&file.name) {
             continue;
         }
-        if api.delete_release_file(&org, project.as_deref(), &release, &file.id)? {
+        if authenticated_api.delete_release_file(&org, project.as_deref(), &release, &file.id)? {
             println!("D {}", file.name);
         }
     }

--- a/src/commands/files/list.rs
+++ b/src/commands/files/list.rs
@@ -26,7 +26,10 @@ pub fn execute(matches: &ArgMatches) -> Result<()> {
         .add("Source Map")
         .add("Size");
 
-    for artifact in api.list_release_files(&org, project.as_deref(), &release)? {
+    for artifact in api
+        .authenticated()?
+        .list_release_files(&org, project.as_deref(), &release)?
+    {
         let row = table.add_row();
         row.add(&artifact.name);
         if let Some(ref dist) = artifact.dist {

--- a/src/commands/files/upload.rs
+++ b/src/commands/files/upload.rs
@@ -127,7 +127,8 @@ pub fn execute(matches: &ArgMatches) -> Result<()> {
     let org = config.get_org(matches)?;
     let project = config.get_project(matches).ok();
     let api = Api::current();
-    let chunk_upload_options = api.get_chunk_upload_options(&org)?;
+    let authenticated_api = api.authenticated()?;
+    let chunk_upload_options = authenticated_api.get_chunk_upload_options(&org)?;
 
     let dist = matches.get_one::<String>("dist").map(String::as_str);
     let mut headers = BTreeMap::new();
@@ -238,7 +239,7 @@ pub fn execute(matches: &ArgMatches) -> Result<()> {
             });
         }
 
-        if let Some(artifact) = api.upload_release_file(
+        if let Some(artifact) = authenticated_api.upload_release_file(
             context,
             &contents,
             name,

--- a/src/commands/info.rs
+++ b/src/commands/info.rs
@@ -94,7 +94,9 @@ pub fn execute(matches: &ArgMatches) -> Result<()> {
     let (org, project) = config.get_org_and_project_defaults();
     let org = org.filter(|s| !s.is_empty());
     let project = project.filter(|s| !s.is_empty());
-    let info_rv = Api::current().authenticated()?.get_auth_info();
+    let info_rv = Api::current()
+        .authenticated()
+        .and_then(|api| api.get_auth_info());
     let mut errors = config.get_auth().is_none() || info_rv.is_err();
 
     // If `no-defaults` is present, only authentication should be verified.

--- a/src/commands/info.rs
+++ b/src/commands/info.rs
@@ -123,19 +123,19 @@ pub fn execute(matches: &ArgMatches) -> Result<()> {
     println!();
     println!("Authentication Info:");
     println!("  Method: {}", describe_auth(config.get_auth()));
-    match info_rv {
-        Ok(info) => {
-            if let Some(ref user) = info.user {
-                println!("  User: {}", user.email);
-            }
-            if let Some(ref auth) = info.auth {
-                println!("  Scopes:");
-                for scope in &auth.scopes {
-                    println!("    - {scope}");
-                }
-            }
-            Ok(())
-        }
-        Err(err) => Err(anyhow::anyhow!(err)),
+
+    let info = info_rv?;
+
+    if let Some(ref user) = info.user {
+        println!("  User: {}", user.email);
     }
+
+    if let Some(ref auth) = info.auth {
+        println!("  Scopes:");
+        for scope in &auth.scopes {
+            println!("    - {scope}");
+        }
+    }
+
+    Ok(())
 }

--- a/src/commands/info.rs
+++ b/src/commands/info.rs
@@ -76,7 +76,8 @@ fn get_config_status_json() -> Result<()> {
         Auth::Token(_) => "token".into(),
         Auth::Key(_) => "api_key".into(),
     });
-    rv.auth.successful = config.get_auth().is_some() && Api::current().get_auth_info().is_ok();
+    rv.auth.successful =
+        config.get_auth().is_some() && Api::current().authenticated()?.get_auth_info().is_ok();
     rv.have_dsn = config.get_dsn().is_ok();
 
     serde_json::to_writer_pretty(&mut io::stdout(), &rv)?;
@@ -93,7 +94,7 @@ pub fn execute(matches: &ArgMatches) -> Result<()> {
     let (org, project) = config.get_org_and_project_defaults();
     let org = org.filter(|s| !s.is_empty());
     let project = project.filter(|s| !s.is_empty());
-    let info_rv = Api::current().get_auth_info();
+    let info_rv = Api::current().authenticated()?.get_auth_info();
     let mut errors = config.get_auth().is_none() || info_rv.is_err();
 
     // If `no-defaults` is present, only authentication should be verified.
@@ -133,15 +134,8 @@ pub fn execute(matches: &ArgMatches) -> Result<()> {
                     println!("    - {scope}");
                 }
             }
+            Ok(())
         }
-        Err(err) => {
-            println!("  (failure on authentication: {err})");
-        }
-    }
-
-    if errors {
-        Err(QuietExit(1).into())
-    } else {
-        Ok(())
+        Err(err) => Err(anyhow::anyhow!(err)),
     }
 }

--- a/src/commands/issues/list.rs
+++ b/src/commands/issues/list.rs
@@ -40,7 +40,9 @@ pub fn execute(matches: &ArgMatches) -> Result<()> {
     let query = matches.get_one::<String>("query").cloned();
     let api = Api::current();
 
-    let issues = api.list_organization_project_issues(&org, &project, pages, query)?;
+    let issues = api
+        .authenticated()?
+        .list_organization_project_issues(&org, &project, pages, query)?;
 
     let mut table = Table::new();
     table

--- a/src/commands/issues/mute.rs
+++ b/src/commands/issues/mute.rs
@@ -22,7 +22,10 @@ pub fn execute(matches: &ArgMatches) -> Result<()> {
 
     changes.new_status = Some("muted".into());
 
-    if Api::current().bulk_update_issue(&org, &project, &filter, &changes)? {
+    if Api::current()
+        .authenticated()?
+        .bulk_update_issue(&org, &project, &filter, &changes)?
+    {
         println!("Updated matching issues.");
         if let Some(status) = changes.new_status.as_ref() {
             println!("  new status: {status}");

--- a/src/commands/issues/resolve.rs
+++ b/src/commands/issues/resolve.rs
@@ -32,7 +32,10 @@ pub fn execute(matches: &ArgMatches) -> Result<()> {
         changes.new_status = Some("resolved".into());
     }
 
-    if Api::current().bulk_update_issue(&org, &project, &filter, &changes)? {
+    if Api::current()
+        .authenticated()?
+        .bulk_update_issue(&org, &project, &filter, &changes)?
+    {
         println!("Updated matching issues.");
         if let Some(status) = changes.new_status.as_ref() {
             println!("  new status: {status}");

--- a/src/commands/issues/unresolve.rs
+++ b/src/commands/issues/unresolve.rs
@@ -22,7 +22,10 @@ pub fn execute(matches: &ArgMatches) -> Result<()> {
 
     changes.new_status = Some("unresolved".into());
 
-    if Api::current().bulk_update_issue(&org, &project, &filter, &changes)? {
+    if Api::current()
+        .authenticated()?
+        .bulk_update_issue(&org, &project, &filter, &changes)?
+    {
         println!("Updated matching issues.");
         if let Some(status) = changes.new_status.as_ref() {
             println!("  new status: {status}");

--- a/src/commands/login.rs
+++ b/src/commands/login.rs
@@ -73,7 +73,7 @@ pub fn execute(matches: &ArgMatches) -> Result<()> {
             Ok(())
         })?;
 
-        match Api::with_config(test_cfg).get_auth_info() {
+        match Api::with_config(test_cfg).authenticated()?.get_auth_info() {
             Ok(info) => {
                 match info.user {
                     Some(user) => {

--- a/src/commands/monitors/list.rs
+++ b/src/commands/monitors/list.rs
@@ -16,7 +16,7 @@ pub fn execute(matches: &ArgMatches) -> Result<()> {
     let config = Config::current();
     let api = Api::current();
     let org = config.get_org(matches)?;
-    let mut monitors = api.list_organization_monitors(&org)?;
+    let mut monitors = api.authenticated()?.list_organization_monitors(&org)?;
     monitors.sort_by_key(|p| (p.name.clone()));
 
     let mut table = Table::new();

--- a/src/commands/organizations/list.rs
+++ b/src/commands/organizations/list.rs
@@ -11,9 +11,10 @@ pub fn make_command(command: Command) -> Command {
 
 pub fn execute(_matches: &ArgMatches) -> Result<()> {
     let api = Api::current();
+    let authenticated_api = api.authenticated()?;
 
     // Query regions available to the current CLI user
-    let regions = api.list_available_regions()?;
+    let regions = authenticated_api.list_available_regions()?;
 
     let mut organizations: Vec<Organization> = vec![];
     debug!("Available regions: {:?}", regions);
@@ -22,10 +23,10 @@ pub fn execute(_matches: &ArgMatches) -> Result<()> {
     // need to check before fanning out.
     if !regions.is_empty() {
         for region in regions {
-            organizations.append(&mut api.list_organizations(Some(&region))?)
+            organizations.append(&mut authenticated_api.list_organizations(Some(&region))?)
         }
     } else {
-        organizations.append(&mut api.list_organizations(None)?)
+        organizations.append(&mut authenticated_api.list_organizations(None)?)
     }
 
     organizations.sort_by_key(|o| o.name.clone().to_lowercase());

--- a/src/commands/projects/list.rs
+++ b/src/commands/projects/list.rs
@@ -13,7 +13,7 @@ pub fn execute(matches: &ArgMatches) -> Result<()> {
     let config = Config::current();
     let api = Api::current();
     let org = config.get_org(matches)?;
-    let mut projects = api.list_organization_projects(&org)?;
+    let mut projects = api.authenticated()?.list_organization_projects(&org)?;
     projects.sort_by_key(|p| {
         (
             p.team.as_ref().map_or(String::new(), |t| t.name.clone()),

--- a/src/commands/react_native/appcenter.rs
+++ b/src/commands/react_native/appcenter.rs
@@ -180,7 +180,7 @@ pub fn execute(matches: &ArgMatches) -> Result<()> {
     processor.rewrite(&[here_str])?;
     processor.add_sourcemap_references()?;
 
-    let chunk_upload_options = api.get_chunk_upload_options(&org)?;
+    let chunk_upload_options = api.authenticated()?.get_chunk_upload_options(&org)?;
 
     let wait_for_secs = matches.get_one::<u64>("wait_for").copied();
     let wait = matches.get_flag("wait") || wait_for_secs.is_some();

--- a/src/commands/react_native/gradle.rs
+++ b/src/commands/react_native/gradle.rs
@@ -113,7 +113,7 @@ pub fn execute(matches: &ArgMatches) -> Result<()> {
     processor.add_debug_id_references()?;
 
     let version = matches.get_one::<String>("release");
-    let chunk_upload_options = api.get_chunk_upload_options(&org)?;
+    let chunk_upload_options = api.authenticated()?.get_chunk_upload_options(&org)?;
 
     let wait_for_secs = matches.get_one::<u64>("wait_for").copied();
     let wait = matches.get_flag("wait") || wait_for_secs.is_some();

--- a/src/commands/react_native/xcode.rs
+++ b/src/commands/react_native/xcode.rs
@@ -346,7 +346,7 @@ pub fn execute(matches: &ArgMatches) -> Result<()> {
         processor.add_debug_id_references()?;
 
         let api = Api::current();
-        let chunk_upload_options = api.get_chunk_upload_options(&org)?;
+        let chunk_upload_options = api.authenticated()?.get_chunk_upload_options(&org)?;
 
         let dist_from_env = env::var("SENTRY_DIST");
         let release_from_env = env::var("SENTRY_RELEASE");

--- a/src/commands/releases/archive.rs
+++ b/src/commands/releases/archive.rs
@@ -17,7 +17,7 @@ pub fn execute(matches: &ArgMatches) -> Result<()> {
     let api = Api::current();
     let version = matches.get_one::<String>("version").unwrap();
 
-    let info_rv = api.update_release(
+    let info_rv = api.authenticated()?.update_release(
         &config.get_org(matches)?,
         version,
         &UpdatedRelease {

--- a/src/commands/releases/delete.rs
+++ b/src/commands/releases/delete.rs
@@ -18,7 +18,11 @@ pub fn execute(matches: &ArgMatches) -> Result<()> {
     let version = matches.get_one::<String>("version").unwrap();
     let project = config.get_project(matches).ok();
 
-    if api.delete_release(&config.get_org(matches)?, project.as_deref(), version)? {
+    if api.authenticated()?.delete_release(
+        &config.get_org(matches)?,
+        project.as_deref(),
+        version,
+    )? {
         println!("Deleted release {version}!");
     } else {
         println!("Did nothing. Release with this version ({version}) does not exist.");

--- a/src/commands/releases/finalize.rs
+++ b/src/commands/releases/finalize.rs
@@ -38,7 +38,7 @@ pub fn execute(matches: &ArgMatches) -> Result<()> {
     let api = Api::current();
     let version = matches.get_one::<String>("version").unwrap();
 
-    api.update_release(
+    api.authenticated()?.update_release(
         &config.get_org(matches)?,
         version,
         &UpdatedRelease {

--- a/src/commands/releases/info.rs
+++ b/src/commands/releases/info.rs
@@ -31,11 +31,12 @@ pub fn make_command(command: Command) -> Command {
 
 pub fn execute(matches: &ArgMatches) -> Result<()> {
     let api = Api::current();
+    let authenticated_api = api.authenticated()?;
     let version = matches.get_one::<String>("version").unwrap();
     let config = Config::current();
     let org = config.get_org(matches)?;
     let project = config.get_project(matches).ok();
-    let release = api.get_release(&org, project.as_deref(), version)?;
+    let release = authenticated_api.get_release(&org, project.as_deref(), version)?;
 
     if is_quiet_mode() {
         if release.is_none() {
@@ -83,7 +84,9 @@ pub fn execute(matches: &ArgMatches) -> Result<()> {
         }
 
         if matches.get_flag("show_commits") {
-            if let Ok(Some(commits)) = api.get_release_commits(&org, project.as_deref(), version) {
+            if let Ok(Some(commits)) =
+                authenticated_api.get_release_commits(&org, project.as_deref(), version)
+            {
                 if !commits.is_empty() {
                     data_row.add(
                         commits

--- a/src/commands/releases/list.rs
+++ b/src/commands/releases/list.rs
@@ -44,7 +44,9 @@ pub fn execute(matches: &ArgMatches) -> Result<()> {
     let config = Config::current();
     let api = Api::current();
     let project = config.get_project(matches).ok();
-    let releases = api.list_releases(&config.get_org(matches)?, project.as_deref())?;
+    let releases = api
+        .authenticated()?
+        .list_releases(&config.get_org(matches)?, project.as_deref())?;
 
     if matches.get_flag("raw") {
         let versions = releases

--- a/src/commands/releases/new.rs
+++ b/src/commands/releases/new.rs
@@ -32,7 +32,7 @@ pub fn execute(matches: &ArgMatches) -> Result<()> {
     let api = Api::current();
     let version = matches.get_one::<String>("version").unwrap();
 
-    api.new_release(
+    api.authenticated()?.new_release(
         &config.get_org(matches)?,
         &NewRelease {
             version: version.to_owned(),

--- a/src/commands/releases/restore.rs
+++ b/src/commands/releases/restore.rs
@@ -17,7 +17,7 @@ pub fn execute(matches: &ArgMatches) -> Result<()> {
     let api = Api::current();
     let version = matches.get_one::<String>("version").unwrap();
 
-    let info_rv = api.update_release(
+    let info_rv = api.authenticated()?.update_release(
         &config.get_org(matches)?,
         version,
         &UpdatedRelease {

--- a/src/commands/repos/list.rs
+++ b/src/commands/repos/list.rs
@@ -14,7 +14,7 @@ pub fn execute(matches: &ArgMatches) -> Result<()> {
 
     let config = Config::current();
     let org = config.get_org(matches)?;
-    let repos = api.list_organization_repos(&org)?;
+    let repos = api.authenticated()?.list_organization_repos(&org)?;
 
     let mut table = Table::new();
     table.title_row().add("Name").add("Provider").add("URL");

--- a/src/commands/sourcemaps/upload.rs
+++ b/src/commands/sourcemaps/upload.rs
@@ -417,7 +417,7 @@ pub fn execute(matches: &ArgMatches) -> Result<()> {
     let (org, project) = config.get_org_and_project(matches)?;
     let api = Api::current();
     let mut processor = SourceMapProcessor::new();
-    let mut chunk_upload_options = api.get_chunk_upload_options(&org)?;
+    let mut chunk_upload_options = api.authenticated()?.get_chunk_upload_options(&org)?;
 
     if matches.get_flag("use_artifact_bundle")
         || env::var("SENTRY_FORCE_ARTIFACT_BUNDLES").ok().as_deref() == Some("1")

--- a/src/commands/upload_proguard.rs
+++ b/src/commands/upload_proguard.rs
@@ -143,6 +143,7 @@ pub fn make_command(command: Command) -> Command {
 
 pub fn execute(matches: &ArgMatches) -> Result<()> {
     let api = Api::current();
+    let authenticated_api = api.authenticated()?;
 
     let paths: Vec<_> = match matches.get_many::<String>("paths") {
         Some(paths) => paths.collect(),
@@ -243,7 +244,7 @@ pub fn execute(matches: &ArgMatches) -> Result<()> {
         org, project
     );
 
-    let rv = api.upload_dif_archive(&org, &project, tf.path())?;
+    let rv = authenticated_api.upload_dif_archive(&org, &project, tf.path())?;
     println!(
         "{} Uploaded a total of {} new mapping files",
         style(">").dim(),
@@ -272,7 +273,7 @@ pub fn execute(matches: &ArgMatches) -> Result<()> {
 
         for mapping in &mappings {
             let uuid = forced_uuid.unwrap_or(&mapping.uuid);
-            api.associate_proguard_mappings(
+            authenticated_api.associate_proguard_mappings(
                 &org,
                 &project,
                 &AssociateProguard {
@@ -285,7 +286,7 @@ pub fn execute(matches: &ArgMatches) -> Result<()> {
 
     // If wanted trigger reprocessing
     if !matches.get_flag("no_reprocessing") && !matches.get_flag("no_upload") {
-        if !api.trigger_reprocessing(&org, &project)? {
+        if !authenticated_api.trigger_reprocessing(&org, &project)? {
             println!(
                 "{} Server does not support reprocessing. Not triggering.",
                 style(">").dim()

--- a/src/utils/sourcemaps.rs
+++ b/src/utils/sourcemaps.rs
@@ -797,7 +797,7 @@ impl SourceMapProcessor {
 
         let api = Api::current();
 
-        if let Ok(Ok(artifacts)) = api.authenticated().map(|api| {
+        if let Ok(artifacts) = api.authenticated().and_then(|api| {
             api.list_release_files_by_checksum(
                 context.org,
                 context.project,

--- a/src/utils/sourcemaps.rs
+++ b/src/utils/sourcemaps.rs
@@ -797,12 +797,14 @@ impl SourceMapProcessor {
 
         let api = Api::current();
 
-        if let Ok(artifacts) = api.list_release_files_by_checksum(
-            context.org,
-            context.project,
-            release,
-            &sources_checksums,
-        ) {
+        if let Ok(Ok(artifacts)) = api.authenticated().map(|api| {
+            api.list_release_files_by_checksum(
+                context.org,
+                context.project,
+                release,
+                &sources_checksums,
+            )
+        }) {
             let already_uploaded_checksums: HashSet<_> = artifacts
                 .into_iter()
                 .filter_map(|artifact| Digest::from_str(&artifact.sha1).ok())

--- a/tests/integration/_cases/info/info-no-token.trycmd
+++ b/tests/integration/_cases/info/info-no-token.trycmd
@@ -1,6 +1,12 @@
 ```
 $ sentry-cli info
 ? failed
+Sentry Server: https://sentry.io
+Default Organization: -
+Default Project: -
+
+Authentication Info:
+  Method: Unauthorized
 error: Auth token is required for this request. Please run `sentry-cli login` and try again!
 
 Add --log-level=[info|debug] or export SENTRY_LOG_LEVEL=[info|debug] to see more output.

--- a/tests/integration/_cases/info/info-no-token.trycmd
+++ b/tests/integration/_cases/info/info-no-token.trycmd
@@ -1,11 +1,9 @@
 ```
 $ sentry-cli info
 ? failed
-Sentry Server: https://sentry.io
-Default Organization: -
-Default Project: -
+error: Auth token is required for this request. Please run `sentry-cli login` and try again!
 
-Authentication Info:
-  Method: Unauthorized
+Add --log-level=[info|debug] or export SENTRY_LOG_LEVEL=[info|debug] to see more output.
+Please attach the full debug log to all bug reports.
 
 ```


### PR DESCRIPTION
Previously, if users ran a Sentry CLI command that required authentication via an auth token, the CLI would make the API request, which would fail with a 403 error because the user did not provide any authentication. With this change, we locally validate that the auth token is present whenever it is required, and if it is missing, we do not perform the API request. 

This change is implemented by creating a new struct called `AuthenticatedApi` in the `api.rs` file. The `AuthenticatedApi` holds a reference to an `Api` struct, whose config has been verified to have a non-None auth. An `authenticated` function has been added to the `Api` struct. This function ensures the `Api` it is called on has an auth, and if it does, it returns an `Ok` containing an `AuthenticatedApi` wrapping the `&Api`; otherwise, `authenticated` returns an error. 

All high-level `Api` functions, which call API endpoints requiring authentication (most of the high-level `Api` functions require authentication), have been moved to `AuthenticatedApi`. `Api` now only implements the low-level API functions and the high-level functions that call endpoints which don't require token authentication. All calls to the moved high-level functions have been updated by adding an `authenticated()?` call before calling methods requiring authentication.

Fixes GH-1905