### PR TITLE
docs: Remove outdated comment

### DIFF
--- a/src/api.rs
+++ b/src/api.rs
@@ -354,9 +354,6 @@ pub struct ApiResponse {
 
 impl Api {
     /// Returns the current api for the thread.
-    ///
-    /// Threads other than the main thread must call `Api::reset` when
-    /// shutting down to prevent `process::exit` from hanging afterwards.
     pub fn current() -> Arc<Api> {
         let mut api_opt = API.lock();
         if let Some(ref api) = *api_opt {


### PR DESCRIPTION
We removed `Api::reset` way back in #489. We should delete this comment that continues to reference `Api::reset`, since it is clearly inaccurate.