### PR TITLE
fix: Merge "Scripts" and "Minified Scripts" under sourcemaps upload report

### DIFF
--- a/src/utils/sourcemaps.rs
+++ b/src/utils/sourcemaps.rs
@@ -409,22 +409,18 @@ impl SourceMapProcessor {
 
         println!();
         println!("{}", style(title).dim().bold());
-        let mut sect = None;
+        let mut current_section = None;
 
         for source in sources {
-            if Some(source.ty) != sect {
-                println!(
-                    "  {}",
-                    style(match source.ty {
-                        SourceFileType::Source => "Scripts",
-                        SourceFileType::MinifiedSource => "Minified Scripts",
-                        SourceFileType::SourceMap => "Source Maps",
-                        SourceFileType::IndexedRamBundle => "Indexed RAM Bundles (expanded)",
-                    })
-                    .yellow()
-                    .bold()
-                );
-                sect = Some(source.ty);
+            let section_title = match source.ty {
+                SourceFileType::Source | SourceFileType::MinifiedSource => "Scripts",
+                SourceFileType::SourceMap => "Source Maps",
+                SourceFileType::IndexedRamBundle => "Indexed RAM Bundles (expanded)",
+            };
+
+            if Some(section_title) != current_section {
+                println!("  {}", style(section_title).yellow().bold());
+                current_section = Some(section_title);
             }
 
             if source.already_uploaded {
@@ -437,7 +433,7 @@ impl SourceMapProcessor {
 
             let mut pieces = Vec::new();
 
-            if source.ty == SourceFileType::MinifiedSource {
+            if [SourceFileType::Source, SourceFileType::MinifiedSource].contains(&source.ty) {
                 if let Some(sm_ref) = get_sourcemap_ref(source) {
                     let sm_url = sm_ref.get_url();
                     if sm_url.starts_with("data:") {

--- a/tests/integration/_cases/react_native/xcode-upload-source-maps-release_and_dist_from_env.trycmd
+++ b/tests/integration/_cases/react_native/xcode-upload-source-maps-release_and_dist_from_env.trycmd
@@ -19,8 +19,7 @@ Processing react-native sourcemaps for Sentry upload.
 
 Source Map Upload Report
   Scripts
-    ~/react-native-xcode-bundle.js.map
-  Minified Scripts
+    ~/react-native-xcode-bundle.js.map (no sourcemap ref)
     ~/react-native-xcode-bundle.js (sourcemap at react-native-xcode-bundle.map)
 
 ```

--- a/tests/integration/_cases/sourcemaps/sourcemaps-upload-file-hermes-bundle-reference-debug-id.trycmd
+++ b/tests/integration/_cases/sourcemaps/sourcemaps-upload-file-hermes-bundle-reference-debug-id.trycmd
@@ -16,7 +16,7 @@ $ sentry-cli sourcemaps upload --bundle tests/integration/_fixtures/file-hermes-
 > Upload type: artifact bundle
 
 Source Map Upload Report
-  Minified Scripts
+  Scripts
     ~/main.jsbundle (sourcemap at main.jsbundle.map, debug id 6bf97754-15b7-4f17-a726-b2a617eb588c)
   Source Maps
     ~/main.jsbundle.map (debug id 6bf97754-15b7-4f17-a726-b2a617eb588c)

--- a/tests/integration/_cases/sourcemaps/sourcemaps-upload-file-ram-bundle.trycmd
+++ b/tests/integration/_cases/sourcemaps/sourcemaps-upload-file-ram-bundle.trycmd
@@ -15,7 +15,7 @@ $ sentry-cli sourcemaps upload --bundle tests/integration/_fixtures/file-ram-bun
 > Upload type: artifact bundle
 
 Source Map Upload Report
-  Minified Scripts
+  Scripts
     ~/0.js (sourcemap at 0.js.map)
     ~/1.js (sourcemap at 1.js.map)
     ~/10.js (sourcemap at 10.js.map)

--- a/tests/integration/_cases/sourcemaps/sourcemaps-upload-indexed-ram-bundle.trycmd
+++ b/tests/integration/_cases/sourcemaps/sourcemaps-upload-indexed-ram-bundle.trycmd
@@ -15,7 +15,7 @@ $ sentry-cli sourcemaps upload --bundle tests/integration/_fixtures/indexed-ram-
 > Upload type: artifact bundle
 
 Source Map Upload Report
-  Minified Scripts
+  Scripts
     ~/0.js (sourcemap at 0.js.map)
     ~/1.js (sourcemap at 1.js.map)
     ~/10.js (sourcemap at 10.js.map)

--- a/tests/integration/_cases/sourcemaps/sourcemaps-upload-some-debugids.trycmd
+++ b/tests/integration/_cases/sourcemaps/sourcemaps-upload-some-debugids.trycmd
@@ -25,8 +25,7 @@ $ sentry-cli sourcemaps upload tests/integration/_fixtures/upload_some_debugids
 
 Source Map Upload Report
   Scripts
-    ~/server/chunks/flight-server-css-manifest.js
-  Minified Scripts
+    ~/server/chunks/flight-server-css-manifest.js (no sourcemap ref)
     ~/server/app/page.js (sourcemap at page.js.map)
     ~/server/chunks/1.js (sourcemap at 1.js.map)
     ~/server/dummy_embedded.js (embedded sourcemap)


### PR DESCRIPTION
The distinction between "Scripts" and "Minified Scripts" is arbitrary. #1958 already eliminates the distinction for `sourcemaps inject`, and since the same code is also used to distinguish between files to output as "Scripts" and "Minified Scripts," merging #1958 already will cause the two sections to merge in the `sourcemaps upload` output.

However, with #1958, the two sections are merged as "Minified Scripts." If this PR is applied along with #1958 (which is my intention), it will cause the two sections to be merged as "Scripts." However, this PR is also completely independent of #1958 – applied alone, it will have the same effect of merging the "Minified Scripts" and "Scripts" sections of the sourcemaps upload report output under "Scripts."