### PR TITLE
Add clarifying comment to RN sourcemaps upload test

### DIFF
--- a/tests/integration/_cases/react_native/xcode-upload-source-maps-release_and_dist_from_env.trycmd
+++ b/tests/integration/_cases/react_native/xcode-upload-source-maps-release_and_dist_from_env.trycmd
@@ -1,3 +1,6 @@
+TODO: ~/react-native-xcode-bundle.js.map should likely be listed under Source Maps in the output. 
+      See https://github.com/getsentry/sentry-cli/issues/1963
+
 ```
 $ CONFIGURATION=Release SENTRY_RELEASE=test-release SENTRY_DIST=test-dist sentry-cli react-native xcode tests/integration/_fixtures/react_native/react-native-xcode.sh --force-foreground
 ? success


### PR DESCRIPTION
The desired behavior of the command being tested is different from what the test specifies. This PR adds a comment to clarify the situation.

Ref #1963 