### PR TITLE
meta: Revert "meta: Revert "meta: Re-enable Python releases""

### DIFF
--- a/.craft.yml
+++ b/.craft.yml
@@ -91,6 +91,9 @@ targets:
         checksums:
           - algorithm: sha256
             format: hex
+  - name: pypi
+  - name: sentry-pypi
+    internalPypiRepo: getsentry/pypi
 requireNames:
   - /^sentry-cli-Darwin-x86_64$/
   - /^sentry-cli-Darwin-arm64$/
@@ -102,3 +105,4 @@ requireNames:
   - /^sentry-cli-Windows-i686.exe$/
   - /^sentry-cli-Windows-x86_64.exe$/
   - /^sentry_cli-.*.tar.gz$/
+  - /^sentry_cli-.*.whl$/


### PR DESCRIPTION
Reverts getsentry/sentry-cli#1938, thus re-enabling Python releases.

Twine was updated in Craft, so we are hoping that might have fixed the earlier issues we were having with releasing Python packages.