### PR TITLE
fix(hc): Adds support for DSYM config driven uploads

### DIFF
--- a/src/commands/files/upload.rs
+++ b/src/commands/files/upload.rs
@@ -218,6 +218,7 @@ pub fn execute(matches: &ArgMatches) -> Result<()> {
     }
     // Single file upload
     else {
+        //  TODO(Gabe): Delegate to region here as well?
         initialize_legacy_release_upload(context)?;
 
         let name = match matches.get_one::<String>("name") {
@@ -239,6 +240,7 @@ pub fn execute(matches: &ArgMatches) -> Result<()> {
             });
         }
 
+        // TODO(Gabe): Figure out how to delegate to the organization's region if necessary
         if let Some(artifact) = authenticated_api.upload_release_file(
             context,
             &contents,

--- a/tests/integration/upload_proguard.rs
+++ b/tests/integration/upload_proguard.rs
@@ -15,6 +15,15 @@ fn command_upload_proguard() {
         )
         .with_response_body("[]"),
     );
+
+    let _dsym_config  = mock_endpoint(
+        EndpointOptions::new(
+            "GET",
+            "/api/0/projects/wat-org/wat-project/files/dsyms/config/",
+            404,
+        ),
+    );
+
     let _reprocessing = mock_endpoint(
         EndpointOptions::new(
             "POST",
@@ -41,5 +50,14 @@ fn command_upload_proguard_no_reprocessing() {
         )
         .with_response_body("[]"),
     );
+
+    let _dsym_config = mock_endpoint(
+        EndpointOptions::new(
+            "GET",
+            "/api/0/projects/wat-org/wat-project/files/dsyms/config/",
+            404,
+        ),
+    );
+
     register_test("upload_proguard/upload_proguard-no-reprocessing.trycmd");
 }

--- a/tests/integration/upload_proguard.rs
+++ b/tests/integration/upload_proguard.rs
@@ -16,13 +16,11 @@ fn command_upload_proguard() {
         .with_response_body("[]"),
     );
 
-    let _dsym_config  = mock_endpoint(
-        EndpointOptions::new(
-            "GET",
-            "/api/0/projects/wat-org/wat-project/files/dsyms/config/",
-            404,
-        ),
-    );
+    let _dsym_config = mock_endpoint(EndpointOptions::new(
+        "GET",
+        "/api/0/projects/wat-org/wat-project/files/dsyms/config/",
+        404,
+    ));
 
     let _reprocessing = mock_endpoint(
         EndpointOptions::new(
@@ -51,13 +49,11 @@ fn command_upload_proguard_no_reprocessing() {
         .with_response_body("[]"),
     );
 
-    let _dsym_config = mock_endpoint(
-        EndpointOptions::new(
-            "GET",
-            "/api/0/projects/wat-org/wat-project/files/dsyms/config/",
-            404,
-        ),
-    );
+    let _dsym_config = mock_endpoint(EndpointOptions::new(
+        "GET",
+        "/api/0/projects/wat-org/wat-project/files/dsyms/config/",
+        404,
+    ));
 
     register_test("upload_proguard/upload_proguard-no-reprocessing.trycmd");
 }


### PR DESCRIPTION
Adds support for the new `/projects/<organization_slug>/files/dsyms/config/` endpoint, which supplies a config object containing a region-specific upload URL.

This change will alleviate issues we've seen with CLI uploads in the past that go through our integration proxy due to referencing the base `https://sentry.io` url.

Because the new endpoint will only be available in SaaS for a bit, and may take some time for self-hosted users to roll it out, I've made the upload process ignore any 404s for config requests while falling back to the old base URL behavior.
