### PR TITLE
fix(hc): Routes DSym upload requests directly to the region based if possible

### DIFF
--- a/src/api.rs
+++ b/src/api.rs
@@ -1258,7 +1258,7 @@ impl<'a> AuthenticatedApi<'a> {
         let mut form = curl::easy::Form::new();
         form.part("file").file(file).add()?;
 
-        let path = format!(
+        let api_path = format!(
             "/projects/{}/{}/files/dsyms/",
             PathArg(org),
             PathArg(project)
@@ -1266,21 +1266,21 @@ impl<'a> AuthenticatedApi<'a> {
 
         // Attempt to pull the org's region url from the auth token payload,
         // otherwise, fall back to the relative path.
-        let full_path = if let Some(region_url) = self.api.config.get_auth_token_region_url() {
+        let request_url = if let Some(region_url) = self.api.config.get_auth_token_region_url() {
             debug!(
                 "Pulled region data from auth token config {:?}",
                 &region_url
             );
-            match self.api.config.get_api_endpoint(&path, Some(&region_url)) {
+            match self.api.config.get_api_endpoint(&api_path, Some(&region_url)) {
                 Ok(full_region_url) => full_region_url,
                 Err(err) => return Err(ApiError::with_source(ApiErrorKind::BadApiUrl, err)),
             }
         } else {
-            path
+            api_path
         };
 
         let request = self
-            .request(Method::Post, &full_path)?
+            .request(Method::Post, &request_url)?
             .with_form_data(form)?
             .progress_bar_mode(ProgressBarMode::Request)?;
 

--- a/src/api.rs
+++ b/src/api.rs
@@ -1267,7 +1267,10 @@ impl<'a> AuthenticatedApi<'a> {
         // Attempt to pull the org's region url from the auth token payload,
         // otherwise, fall back to the relative path.
         let full_path = if let Some(region_url) = self.api.config.get_auth_token_region_url() {
-            debug!("Pulled region data from auth token config {:?}", &region_url);
+            debug!(
+                "Pulled region data from auth token config {:?}",
+                &region_url
+            );
             match self.api.config.get_api_endpoint(&path, Some(&region_url)) {
                 Ok(full_region_url) => full_region_url,
                 Err(err) => return Err(ApiError::with_source(ApiErrorKind::BadApiUrl, err)),

--- a/src/api.rs
+++ b/src/api.rs
@@ -1271,7 +1271,11 @@ impl<'a> AuthenticatedApi<'a> {
                 "Pulled region data from auth token config {:?}",
                 &region_url
             );
-            match self.api.config.get_api_endpoint(&api_path, Some(&region_url)) {
+            match self
+                .api
+                .config
+                .get_api_endpoint(&api_path, Some(&region_url))
+            {
                 Ok(full_region_url) => full_region_url,
                 Err(err) => return Err(ApiError::with_source(ApiErrorKind::BadApiUrl, err)),
             }

--- a/src/commands/files/upload.rs
+++ b/src/commands/files/upload.rs
@@ -218,6 +218,7 @@ pub fn execute(matches: &ArgMatches) -> Result<()> {
     }
     // Single file upload
     else {
+        //  TODO(Gabe): Delegate to region here as well?
         initialize_legacy_release_upload(context)?;
 
         let name = match matches.get_one::<String>("name") {
@@ -239,6 +240,7 @@ pub fn execute(matches: &ArgMatches) -> Result<()> {
             });
         }
 
+        // TODO(Gabe): Figure out how to delegate to the organization's region if necessary
         if let Some(artifact) = authenticated_api.upload_release_file(
             context,
             &contents,

--- a/src/commands/upload_proguard.rs
+++ b/src/commands/upload_proguard.rs
@@ -245,6 +245,7 @@ pub fn execute(matches: &ArgMatches) -> Result<()> {
     );
 
     let rv = authenticated_api.upload_dif_archive(&org, &project, tf.path())?;
+
     println!(
         "{} Uploaded a total of {} new mapping files",
         style(">").dim(),

--- a/src/config.rs
+++ b/src/config.rs
@@ -518,6 +518,13 @@ impl Config {
                 false
             }
     }
+
+    pub fn get_auth_token_region_url(&self) -> Option<String> {
+        match &self.cached_token_data {
+            Some(cache) => Some(cache.region_url.clone()),
+            _ => None,
+        }
+    }
 }
 
 fn find_global_config_file() -> Result<PathBuf> {

--- a/src/config.rs
+++ b/src/config.rs
@@ -520,10 +520,9 @@ impl Config {
     }
 
     pub fn get_auth_token_region_url(&self) -> Option<String> {
-        match &self.cached_token_data {
-            Some(cache) => Some(cache.region_url.clone()),
-            _ => None,
-        }
+        self.cached_token_data
+            .as_ref()
+            .map(|token_data| token_data.region_url.clone())
     }
 }
 

--- a/src/utils/auth_token/org_auth_token.rs
+++ b/src/utils/auth_token/org_auth_token.rs
@@ -16,7 +16,7 @@ pub struct OrgAuthToken {
 #[allow(dead_code)] // Otherwise, we get a warning about unused fields
 pub struct AuthTokenPayload {
     iat: f64,
-    region_url: String,
+    pub region_url: String,
     pub org: String,
 
     // URL may be missing from some old auth tokens, see getsentry/sentry#57123


### PR DESCRIPTION
Updates the `dif_upload` logic to pull the region URL data from the organization auth token specified by the user. If no region URL is found, the method falls back to the previous implementation using a relative path.

This is an alternate solution to the one specified in PR #1983.