### PR TITLE
ref: Remove custom ctrl-c handling code

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -10,5 +10,5 @@ pub mod utils;
 
 /// Executes the command line application and exits the process.
 pub fn main() {
-    utils::system::run_or_interrupt(commands::main);
+    commands::main()
 }

--- a/src/utils/system.rs
+++ b/src/utils/system.rs
@@ -8,7 +8,6 @@ use lazy_static::lazy_static;
 use regex::{Captures, Regex};
 
 use crate::config::Config;
-#[cfg(not(windows))]
 
 /// Propagate an exit status outwarts
 pub fn propagate_exit_status(status: process::ExitStatus) {

--- a/src/utils/system.rs
+++ b/src/utils/system.rs
@@ -9,55 +9,6 @@ use regex::{Captures, Regex};
 
 use crate::config::Config;
 #[cfg(not(windows))]
-use crate::utils::xcode::launched_from_xcode;
-
-#[cfg(not(windows))]
-pub fn run_or_interrupt<F>(f: F)
-where
-    F: FnOnce() + Send + 'static,
-{
-    // See: https://github.com/getsentry/sentry-cli/pull/1104
-    if launched_from_xcode() {
-        f();
-        return;
-    }
-
-    let (tx, rx) = crossbeam_channel::bounded(100);
-    let mut signals = signal_hook::iterator::Signals::new([
-        signal_hook::consts::SIGTERM,
-        signal_hook::consts::SIGINT,
-    ])
-    .unwrap();
-
-    {
-        let tx = tx.clone();
-        std::thread::spawn(move || {
-            f();
-            tx.send(0).ok();
-        });
-    }
-
-    std::thread::spawn(move || {
-        for signal in signals.forever() {
-            tx.send(signal).ok();
-        }
-    });
-
-    if let Ok(signal) = rx.recv() {
-        if signal == signal_hook::consts::SIGINT {
-            eprintln!("Interrupted!");
-        }
-    }
-}
-
-#[cfg(windows)]
-pub fn run_or_interrupt<F>(f: F)
-where
-    F: FnOnce(),
-    F: Send + 'static,
-{
-    f();
-}
 
 /// Propagate an exit status outwarts
 pub fn propagate_exit_status(status: process::ExitStatus) {


### PR DESCRIPTION
The default ctrl-c handling should be sufficient, since we don't perform any clean-up logic on ctrl-c. The only change in behavior following this change is that we will no longer print "Interrupted" when ctrl-c is pressed; however, this is a small change that likely most users will not even notice.