### PR TITLE
ref: Fixed new Clippy errors

### DIFF
--- a/src/utils/fs.rs
+++ b/src/utils/fs.rs
@@ -72,6 +72,7 @@ impl TempFile {
             .read(true)
             .write(true)
             .create(true)
+            .truncate(false)
             .open(&self.path)?;
 
         f.rewind().ok();


### PR DESCRIPTION
A new Rust version introduced some new Clippy lints, which are now blocking PRs from merging since our code was violating the new lints. This PR fixes those lints.