### PR TITLE
ci: Run Clippy with default features

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
         run: cargo fmt --all -- --check
 
       - name: Run Clippy
-        run: cargo clippy --workspace --all-features --tests -- -D clippy::all
+        run: cargo clippy --workspace --tests -- -D clippy::all
 
   test:
     strategy:


### PR DESCRIPTION
We should run Clippy only with the default features. Our features either do nothing (`with_crash_reporting`) or disable compilation of code (`managed`). Therefore, somewhat unintuitively, enabling all features leads to the `update` and `uninstall` command code to not be linted, since these modules are excluded with the `managed` feature. Linting with the default feature set ensures all code is linted.

Partially unblocks #1992