### PR TITLE
meta: Disable Python releases

### DIFF
--- a/.craft.yml
+++ b/.craft.yml
@@ -91,9 +91,6 @@ targets:
         checksums:
           - algorithm: sha256
             format: hex
-  - name: pypi
-  - name: sentry-pypi
-    internalPypiRepo: getsentry/pypi
 requireNames:
   - /^sentry-cli-Darwin-x86_64$/
   - /^sentry-cli-Darwin-arm64$/
@@ -105,4 +102,3 @@ requireNames:
   - /^sentry-cli-Windows-i686.exe$/
   - /^sentry-cli-Windows-x86_64.exe$/
   - /^sentry_cli-.*.tar.gz$/
-  - /^sentry_cli-.*.whl$/


### PR DESCRIPTION
Disabling Python releases temporarily to work around https://github.com/getsentry/craft/issues/529 until the issue is fixed.