### PR TITLE
meta: Re-enable Python releases

### DIFF
--- a/.craft.yml
+++ b/.craft.yml
@@ -91,6 +91,9 @@ targets:
         checksums:
           - algorithm: sha256
             format: hex
+  - name: pypi
+  - name: sentry-pypi
+    internalPypiRepo: getsentry/pypi
 requireNames:
   - /^sentry-cli-Darwin-x86_64$/
   - /^sentry-cli-Darwin-arm64$/
@@ -102,3 +105,4 @@ requireNames:
   - /^sentry-cli-Windows-i686.exe$/
   - /^sentry-cli-Windows-x86_64.exe$/
   - /^sentry_cli-.*.tar.gz$/
+  - /^sentry_cli-.*.whl$/


### PR DESCRIPTION
The craft issues may have been fixed by getsentry/craft#530. This reverts commit faf5e61c6fd1776647b19577d2fc2ee1345ae10a.