### PR TITLE
Added default count for large commits

### DIFF
--- a/src/utils/vcs.rs
+++ b/src/utils/vcs.rs
@@ -471,6 +471,7 @@ pub fn get_commits_from_git<'a>(
                 .filter_map(move |id: Result<git2::Oid, git2::Error>| {
                     repo.find_commit(id.ok()?).ok()
                 })
+                .take(default_count)
                 .collect();
 
             // If there is a previous commit but cannot find it in git history


### PR DESCRIPTION
We faced an issue where for some reason our commit history was huge around 45K, sentry-cli set-commits command was in a hung state for this use case. 
When I dig deep I found initial-depth flag (default_count) was not being used to limit the commits `get_commits_from_git` function. Default limit set is 20. 
So to fix that i have added a filter to take only `default_count` number of commits.