### PR TITLE
docs: Remove inaccurate and unnecessary comments

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1,14 +1,9 @@
-//! This is the library that powers the `sentry-cli` tool.  The primary
-//! exported function is `main` which is directly invoked from the
-//! compiled binary that links against this library.
-
 mod api;
 mod commands;
 mod config;
 mod constants;
 mod utils;
 
-/// Executes the command line application and exits the process.
 pub fn main() {
     commands::main()
 }


### PR DESCRIPTION
The Sentry CLI is not a library, and we probably don't need a comment for our 1-line `main` function.