### PR TITLE
meta(vscode): Change editor tab size to 4

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -6,7 +6,7 @@
         "editor.formatOnSave": true
     },
     "eslint.autoFixOnSave": true,
-    "editor.tabSize": 2,
+    "editor.tabSize": 4,
     "editor.codeActionsOnSave": {
         "source.fixAll.eslint": true
     }


### PR DESCRIPTION
Four spaces is [Rust's default](https://rust-lang.github.io/rustfmt/?version=v1.6.0&search=#tab_spaces) and what we use in basically everywhere in the codebase. No clue why we have the tab size set to 2 here.