### PR TITLE
ref(api): Simplify pagination code

### DIFF
--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -1471,8 +1471,7 @@ impl<'a> AuthenticatedApi<'a> {
             if resp.status() == 404 {
                 break;
             } else {
-                let next = resp.next_pagination_cursor();
-                if let Some(next) = next {
+                if let Some(next) = resp.next_pagination_cursor() {
                     cursor = next;
                 } else {
                     break;

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -48,7 +48,6 @@ use crate::utils::retry::{get_default_backoff, DurationAsMilliseconds};
 use crate::utils::sourcemaps::get_sourcemap_reference_from_headers;
 use crate::utils::ui::{capitalize_string, make_byte_progress_bar};
 
-use self::pagination::Pagination;
 use encoding::{PathArg, QueryArg};
 
 struct CurlConnectionManager;
@@ -2111,15 +2110,10 @@ impl ApiResponse {
         None
     }
 
-    /// Returns the pagination info
-    fn pagination(&self) -> Pagination<'_> {
-        self.get_header("link")
-            .map(|x| x.into())
-            .unwrap_or_default()
-    }
-
     fn next_pagination_cursor(&self) -> Option<String> {
-        self.pagination().next_cursor().map(|s| s.to_string())
+        self.get_header("link")
+            .and_then(pagination::next_cursor)
+            .map(String::from)
     }
 
     /// Returns true if the response is JSON.

--- a/src/api/pagination.rs
+++ b/src/api/pagination.rs
@@ -1,0 +1,42 @@
+use std::str::FromStr;
+
+use crate::utils::http;
+
+#[derive(Debug, Clone)]
+pub struct Link {
+    results: bool,
+    cursor: String,
+}
+
+#[derive(Debug, Default, Clone)]
+pub struct Pagination {
+    next: Option<Link>,
+}
+
+impl Pagination {
+    pub fn into_next_cursor(self) -> Option<String> {
+        self.next
+            .and_then(|x| if x.results { Some(x.cursor) } else { None })
+    }
+}
+
+impl FromStr for Pagination {
+    type Err = ();
+
+    fn from_str(s: &str) -> Result<Pagination, ()> {
+        let mut rv = Pagination::default();
+        for item in http::parse_link_header(s) {
+            let target = match item.get("rel") {
+                Some(&"next") => &mut rv.next,
+                _ => continue,
+            };
+
+            *target = Some(Link {
+                results: item.get("results") == Some(&"true"),
+                cursor: (*item.get("cursor").unwrap_or(&"")).to_string(),
+            });
+        }
+
+        Ok(rv)
+    }
+}

--- a/src/api/pagination.rs
+++ b/src/api/pagination.rs
@@ -25,11 +25,9 @@ impl<'p> From<&'p str> for Pagination<'p> {
             .iter()
             .rev() // Reversing is necessary for backwards compatibility with a previous implementation
             .find(|item| item.get("rel") == Some(&"next"))
-            .map_or(None, |item| {
-                Some(Link {
-                    results: item.get("results") == Some(&"true"),
-                    cursor: item.get("cursor").unwrap_or(&""),
-                })
+            .map(|item| Link {
+                results: item.get("results") == Some(&"true"),
+                cursor: item.get("cursor").unwrap_or(&""),
             });
 
         Pagination { next }

--- a/src/api/pagination.rs
+++ b/src/api/pagination.rs
@@ -21,15 +21,17 @@ impl<'p> Pagination<'p> {
 
 impl<'p> From<&'p str> for Pagination<'p> {
     fn from(value: &'p str) -> Self {
-        http::parse_link_header(value)
+        let next = http::parse_link_header(value)
             .iter()
             .rev() // Reversing is necessary for backwards compatibility with a previous implementation
             .find(|item| item.get("rel") == Some(&"next"))
-            .map_or(Pagination { next: None }, |item| Pagination {
-                next: Some(Link {
+            .map_or(None, |item| {
+                Some(Link {
                     results: item.get("results") == Some(&"true"),
                     cursor: item.get("cursor").unwrap_or(&""),
-                }),
-            })
+                })
+            });
+
+        Pagination { next }
     }
 }

--- a/src/api/pagination.rs
+++ b/src/api/pagination.rs
@@ -6,7 +6,7 @@ struct Link<'p> {
     cursor: &'p str,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Default, Clone)]
 pub(super) struct Pagination<'p> {
     next: Option<Link<'p>>,
 }

--- a/src/api/pagination.rs
+++ b/src/api/pagination.rs
@@ -6,7 +6,7 @@ struct Link<'p> {
     cursor: &'p str,
 }
 
-#[derive(Debug, Default, Clone)]
+#[derive(Debug, Clone)]
 pub(super) struct Pagination<'p> {
     next: Option<Link<'p>>,
 }


### PR DESCRIPTION
Simplifies pagination logic by removing result that never results in error, and introducing new `next_pagination_cursor` convenience method. Tests added in #2015.

ref #2008