### PR TITLE
fix(xcode): Improve Xcode error msg when config load fails

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -20,7 +20,6 @@ use crate::constants::{CONFIG_RC_FILE_NAME, DEFAULT_RETRIES, DEFAULT_URL};
 use crate::utils::auth_token::AuthToken;
 use crate::utils::auth_token::AuthTokenPayload;
 use crate::utils::http::is_absolute_url;
-use crate::utils::xcode;
 
 /// Represents the auth information
 #[derive(Debug, Clone)]
@@ -579,7 +578,7 @@ fn load_global_config_file() -> Result<(PathBuf, Ini)> {
 fn get_failed_cli_config_load_msg(file_desc: &str) -> String {
     let msg = format!("Failed to load {file_desc}.");
     #[cfg(target_os = "macos")]
-    if xcode::launched_from_xcode() {
+    if crate::utils::xcode::launched_from_xcode() {
         return msg + " Hint: Please ensure that ${SRCROOT}/.sentryclirc is added to the Input Files of this Xcode Build Phases script.";
     }
     msg

--- a/src/config.rs
+++ b/src/config.rs
@@ -579,10 +579,10 @@ fn load_global_config_file() -> Result<(PathBuf, Ini)> {
 }
 
 fn failed_local_config_load_message(file_desc: &str) -> String {
-    let mut msg = format!("Failed to load {file_desc}.");
+    let msg = format!("Failed to load {file_desc}.");
     #[cfg(target_os = "macos")]
     if xcode::launched_from_xcode() {
-        msg.push_str(" Hint: Please ensure that ${SRCROOT}/.sentryclirc is added to the Input Files of this Xcode Build Phases script.");
+        return msg + (" Hint: Please ensure that ${SRCROOT}/.sentryclirc is added to the Input Files of this Xcode Build Phases script.");
     }
     msg
 }


### PR DESCRIPTION
When a user sets up a project in xcode, e.g., by using the wizard, the .sentryclirc config is created in the project folder. However, when this file isn't included in the Input Files of the Xcode script for uploading debug files, an error is thrown  in Xcode which isn't very clear. This commit improves that error message by specifying what the user needs to do.

Fixes GH-1924