### PR TITLE
Improve error message when we pass a directory to `debug-files check`

### DIFF
--- a/src/commands/debug_files/check.rs
+++ b/src/commands/debug_files/check.rs
@@ -43,6 +43,14 @@ pub fn make_command(command: Command) -> Command {
 pub fn execute(matches: &ArgMatches) -> Result<()> {
     let path = Path::new(matches.get_one::<String>("path").unwrap());
 
+    if path.is_dir() {
+        anyhow::bail!(
+            "This command can only check individual debug files, but the provided \
+            path leads to a directory. Please a pass a path to an individual file, \
+            instead!"
+        );
+    }
+
     // which types should we consider?
     let ty = matches
         .get_one::<String>("type")

--- a/tests/integration/_cases/debug_files/debug_files-check-directory.trycmd
+++ b/tests/integration/_cases/debug_files/debug_files-check-directory.trycmd
@@ -1,0 +1,7 @@
+```
+$ sentry-cli debug-files check tests/
+? failed
+error: This command can only check individual debug files, but the provided path leads to a directory. Please a pass a path to an individual file, instead!
+...
+
+```

--- a/tests/integration/debug_files/check.rs
+++ b/tests/integration/debug_files/check.rs
@@ -33,3 +33,8 @@ fn command_debug_files_check_no_file_allow_failure_env() {
 fn command_debug_files_check_dll_embedded_ppdb_with_sources() {
     register_test("debug_files/debug_files-check-dll-embedded-ppdb-with-sources.trycmd");
 }
+
+#[test]
+fn command_debug_files_check_directory() {
+    register_test("debug_files/debug_files-check-directory.trycmd");
+}


### PR DESCRIPTION
See #2033.

Currently, the `debug-files check` command only supports checking individual files. However, the error message we emit when passing a directory is a very vague `error: Unsupported file`. This change improves the error message. We should still consider #2033's suggestion of supporting recursive search through directories for this command.