### PR TITLE
Split out progress bar logic from API

### DIFF
--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -32,7 +32,7 @@ use flate2::write::GzEncoder;
 use if_chain::if_chain;
 use lazy_static::lazy_static;
 use log::{debug, info, warn};
-use parking_lot::{Mutex, RwLock};
+use parking_lot::Mutex;
 use regex::{Captures, Regex};
 use sentry::protocol::{Exception, Values};
 use serde::de::{DeserializeOwned, Deserializer};
@@ -48,7 +48,7 @@ use crate::config::{Auth, Config};
 use crate::constants::{ARCH, DEFAULT_URL, EXT, PLATFORM, RELEASE_REGISTRY_LATEST_URL, VERSION};
 use crate::utils::file_upload::UploadContext;
 use crate::utils::http::{self, is_absolute_url};
-use crate::utils::progress::ProgressBar;
+use crate::utils::progress::{ProgressBar, ProgressBarMode};
 use crate::utils::retry::{get_default_backoff, DurationAsMilliseconds};
 use crate::utils::sourcemaps::get_sourcemap_reference_from_headers;
 use crate::utils::ui::{capitalize_string, make_byte_progress_bar};
@@ -60,31 +60,6 @@ use errors::{ApiError, ApiErrorKind, ApiResult, SentryError};
 
 lazy_static! {
     static ref API: Mutex<Option<Arc<Api>>> = Mutex::new(None);
-}
-
-#[derive(Clone)]
-pub enum ProgressBarMode {
-    Disabled,
-    Request,
-    Response,
-    Shared((Arc<ProgressBar>, u64, usize, Arc<RwLock<Vec<u64>>>)),
-}
-
-impl ProgressBarMode {
-    /// Returns if progress bars are generally enabled.
-    pub fn active(&self) -> bool {
-        !matches!(*self, ProgressBarMode::Disabled)
-    }
-
-    /// Returns whether a progress bar should be displayed during upload.
-    pub fn request(&self) -> bool {
-        matches!(*self, ProgressBarMode::Request)
-    }
-
-    /// Returns whether a progress bar should be displayed during download.
-    pub fn response(&self) -> bool {
-        matches!(*self, ProgressBarMode::Response)
-    }
 }
 
 /// Helper for the API access.

--- a/src/commands/files/upload.rs
+++ b/src/commands/files/upload.rs
@@ -10,7 +10,7 @@ use clap::{Arg, ArgAction, ArgMatches, Command};
 use log::warn;
 use symbolic::debuginfo::sourcebundle::SourceFileType;
 
-use crate::api::{Api, ProgressBarMode};
+use crate::api::Api;
 use crate::config::Config;
 use crate::constants::DEFAULT_MAX_WAIT;
 use crate::utils::args::validate_distribution;
@@ -19,6 +19,7 @@ use crate::utils::file_upload::{
     initialize_legacy_release_upload, FileUpload, SourceFile, UploadContext,
 };
 use crate::utils::fs::{decompress_gzip_content, is_gzip_compressed, path_as_url};
+use crate::utils::progress::ProgressBarMode;
 
 pub fn make_command(command: Command) -> Command {
     command

--- a/src/utils/chunks.rs
+++ b/src/utils/chunks.rs
@@ -15,8 +15,8 @@ use rayon::prelude::*;
 use rayon::ThreadPoolBuilder;
 use sha1_smol::Digest;
 
-use crate::api::{Api, ChunkUploadOptions, ProgressBarMode};
-use crate::utils::progress::{ProgressBar, ProgressStyle};
+use crate::api::{Api, ChunkUploadOptions};
+use crate::utils::progress::{ProgressBar, ProgressBarMode, ProgressStyle};
 
 /// Timeout for polling all assemble endpoints.
 pub const ASSEMBLE_POLL_INTERVAL: Duration = Duration::from_millis(1000);

--- a/src/utils/file_upload.rs
+++ b/src/utils/file_upload.rs
@@ -19,11 +19,11 @@ use symbolic::debuginfo::sourcebundle::{SourceBundleWriter, SourceFileInfo, Sour
 use url::Url;
 
 use crate::api::NewRelease;
-use crate::api::{Api, ChunkUploadCapability, ChunkUploadOptions, ProgressBarMode};
+use crate::api::{Api, ChunkUploadCapability, ChunkUploadOptions};
 use crate::constants::DEFAULT_MAX_WAIT;
 use crate::utils::chunks::{upload_chunks, Chunk, ASSEMBLE_POLL_INTERVAL};
 use crate::utils::fs::{get_sha1_checksum, get_sha1_checksums, TempFile};
-use crate::utils::progress::{ProgressBar, ProgressStyle};
+use crate::utils::progress::{ProgressBar, ProgressBarMode, ProgressStyle};
 
 /// Fallback concurrency for release file uploads.
 static DEFAULT_CONCURRENCY: usize = 4;

--- a/src/utils/progress.rs
+++ b/src/utils/progress.rs
@@ -1,3 +1,4 @@
+use parking_lot::RwLock;
 use std::env;
 use std::ops::Deref;
 use std::sync::Arc;
@@ -70,5 +71,30 @@ impl Deref for ProgressBar {
 
     fn deref(&self) -> &Self::Target {
         &self.inner
+    }
+}
+
+#[derive(Clone)]
+pub enum ProgressBarMode {
+    Disabled,
+    Request,
+    Response,
+    Shared((Arc<ProgressBar>, u64, usize, Arc<RwLock<Vec<u64>>>)),
+}
+
+impl ProgressBarMode {
+    /// Returns if progress bars are generally enabled.
+    pub fn active(&self) -> bool {
+        !matches!(*self, ProgressBarMode::Disabled)
+    }
+
+    /// Returns whether a progress bar should be displayed during upload.
+    pub fn request(&self) -> bool {
+        matches!(*self, ProgressBarMode::Request)
+    }
+
+    /// Returns whether a progress bar should be displayed during download.
+    pub fn response(&self) -> bool {
+        matches!(*self, ProgressBarMode::Response)
     }
 }


### PR DESCRIPTION
This code is more closely related to the utils module's progress bar code than to the api code, so we should move it there. 

Ref https://github.com/getsentry/sentry-cli/issues/2008