### PR TITLE
fix(commands): Remove misleading help messages

### DIFF
--- a/src/commands/send_envelope.rs
+++ b/src/commands/send_envelope.rs
@@ -17,8 +17,7 @@ pub fn make_command(command: Command) -> Command {
             "Send a stored envelope to Sentry.{n}{n}\
              This command will validate and attempt to send an envelope to Sentry. \
              Due to network errors, rate limits or sampling the envelope is not guaranteed to \
-             actually arrive. Check debug output for transmission errors by passing --log-level=\
-             debug or setting `SENTRY_LOG_LEVEL=debug`.",
+             actually arrive.",
         )
         .arg(
             Arg::new("path")

--- a/src/commands/send_event.rs
+++ b/src/commands/send_event.rs
@@ -27,8 +27,7 @@ pub fn make_command(command: Command) -> Command {
             "Send a manual event to Sentry.{n}{n}\
              This command will validate input parameters and attempt to send an event to \
              Sentry. Due to network errors, rate limits or sampling the event is not guaranteed to \
-             actually arrive. Check debug output for transmission errors by passing --log-level=\
-             debug or setting `SENTRY_LOG_LEVEL=debug`.",
+             actually arrive.",
         )
         .arg(
             Arg::new("path")

--- a/tests/integration/_cases/send_envelope/send_envelope-help.trycmd
+++ b/tests/integration/_cases/send_envelope/send_envelope-help.trycmd
@@ -4,8 +4,7 @@ $ sentry-cli send-envelope --help
 Send a stored envelope to Sentry.
 
 This command will validate and attempt to send an envelope to Sentry. Due to network errors, rate
-limits or sampling the envelope is not guaranteed to actually arrive. Check debug output for
-transmission errors by passing --log-level=debug or setting `SENTRY_LOG_LEVEL=debug`.
+limits or sampling the envelope is not guaranteed to actually arrive.
 
 Usage: sentry-cli[EXE] send-envelope [OPTIONS] <PATH>
 

--- a/tests/integration/_cases/send_event/send_event-help.trycmd
+++ b/tests/integration/_cases/send_event/send_event-help.trycmd
@@ -4,8 +4,7 @@ $ sentry-cli send-event --help
 Send a manual event to Sentry.
 
 This command will validate input parameters and attempt to send an event to Sentry. Due to network
-errors, rate limits or sampling the event is not guaranteed to actually arrive. Check debug output
-for transmission errors by passing --log-level=debug or setting `SENTRY_LOG_LEVEL=debug`.
+errors, rate limits or sampling the event is not guaranteed to actually arrive.
 
 Usage: sentry-cli[EXE] send-event [OPTIONS] [PATH]
 


### PR DESCRIPTION
Remove "Check debug output for transmission errors by passing --log-level=debug" from send-envelope's and send-event's help message as this functionality does not seem to exist, e.g., turning off wifi does not give the user any error info. I believe this is a consequence of the actual transmission being handled in sentry-core which does not propagate errors back to sentry-cli. 

Fixes GH-2049