### PR TITLE
Fix new Clippy lints

### DIFF
--- a/src/commands/react_native/xcode.rs
+++ b/src/commands/react_native/xcode.rs
@@ -373,10 +373,15 @@ pub fn execute(matches: &ArgMatches) -> Result<()> {
                         Ok(Some(plist)) => {
                             // Successfully discovered and parsed Info.plist
                             let dist_string = plist.build().to_string();
-                            let release_string = format!("{}@{}+{}", plist.bundle_id(), plist.version(), dist_string);
+                            let release_string = format!(
+                                "{}@{}+{}",
+                                plist.bundle_id(),
+                                plist.version(),
+                                dist_string
+                            );
                             info!("Parse result from Info.plist: {:?}", &plist);
                             (Some(dist_string), Some(release_string))
-                        },
+                        }
                         _ => {
                             bail!("Info.plist was not found or an parsing error occurred");
                         }
@@ -556,9 +561,7 @@ pub fn wrap_call() -> Result<()> {
             if let (Ok(packager_sourcemap), Ok(mut hermes_sourcemap)) =
                 (packager_sourcemap_result, hermes_sourcemap_result)
             {
-                if hermes_sourcemap.get("debugId").is_none()
-                    && hermes_sourcemap.get("debug_id").is_none()
-                {
+                if !hermes_sourcemap.contains_key("debug_id") {
                     if let Some(debug_id) = packager_sourcemap
                         .get("debugId")
                         .or_else(|| packager_sourcemap.get("debug_id"))

--- a/src/config.rs
+++ b/src/config.rs
@@ -217,7 +217,7 @@ impl Config {
             bail!("Two different url values supplied: `{token_url}` (from token), `{url}`.");
         }
 
-        self.cached_base_url = url.to_owned();
+        url.clone_into(&mut self.cached_base_url);
         self.ini
             .set_to(Some("defaults"), "url".into(), self.cached_base_url.clone());
         Ok(())

--- a/src/utils/ui.rs
+++ b/src/utils/ui.rs
@@ -45,14 +45,10 @@ pub fn capitalize_string(s: &str) -> String {
 }
 
 /// Like ``io::copy`` but advances a progress bar set to bytes.
-pub fn copy_with_progress<R: ?Sized, W: ?Sized>(
-    pb: &ProgressBar,
-    reader: &mut R,
-    writer: &mut W,
-) -> io::Result<u64>
+pub fn copy_with_progress<R, W>(pb: &ProgressBar, reader: &mut R, writer: &mut W) -> io::Result<u64>
 where
-    R: Read,
-    W: Write,
+    R: Read + ?Sized,
+    W: Write + ?Sized,
 {
     let mut buf = [0; 16384];
     let mut written = 0;


### PR DESCRIPTION
Fixes three new Clippy lints, added in Rust 1.78.0. See the three individual commits for links to the lints' documentation.