### PR TITLE
feat(auth): Allow global config to be located in XDG directory

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -14,6 +14,7 @@ use log::{debug, info, set_max_level, warn};
 use parking_lot::Mutex;
 use sentry::types::Dsn;
 
+use crate::constants::CONFIG_INI_FILE_PATH;
 use crate::constants::DEFAULT_MAX_DIF_ITEM_SIZE;
 use crate::constants::DEFAULT_MAX_DIF_UPLOAD_SIZE;
 use crate::constants::{CONFIG_RC_FILE_NAME, DEFAULT_RETRIES, DEFAULT_URL};
@@ -526,15 +527,14 @@ impl Config {
 }
 
 fn find_global_config_file() -> Result<PathBuf> {
-    dirs::home_dir()
-        .map(|p| p.join(CONFIG_RC_FILE_NAME))
+    let home_dir_file = dirs::home_dir().map(|p| p.join(CONFIG_RC_FILE_NAME));
+    let config_dir_file = dirs::config_dir().map(|p| p.join(CONFIG_INI_FILE_PATH));
+    home_dir_file
+        .clone()
         .filter(|p| p.exists())
-        .or(dirs::config_dir()
-            .map(|p| p.join("sentry/sentrycli.ini"))
-            .filter(|p| p.exists()))
-        .ok_or_else(|| {
-            format_err!("Could not find config file. Please run `sentry-cli login` and try again!")
-        })
+        .or(config_dir_file.filter(|p| p.exists()))
+        .or(home_dir_file)
+        .ok_or_else(|| format_err!("Could not find home dir"))
 }
 
 fn find_project_config_file() -> Option<PathBuf> {

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -14,6 +14,9 @@ pub const VERSION: &str = env!("CARGO_PKG_VERSION");
 /// The name of the configuration file.
 pub const CONFIG_RC_FILE_NAME: &str = ".sentryclirc";
 
+/// The relative path of the configuration file in dirs::config_dir()
+pub const CONFIG_INI_FILE_PATH: &str = "sentry/sentrycli.ini";
+
 /// The release registry URL where the latest released version of sentry-cli can be found
 pub const RELEASE_REGISTRY_LATEST_URL: &str =
     "https://release-registry.services.sentry.io/apps/sentry-cli/latest";


### PR DESCRIPTION
If the global config file does not exist in the home directory, look in the following paths:
- Linux: $XDG_CONFIG_HOME/sentry/sentrycli.ini  and $HOME/.config/sentry/sentrycli.ini
- Mac: $HOME/Library/Application Support/sentry/sentrycli.ini
- Windows: {FOLDERID_RoamingAppData}

This enables users to keep their home dir clean, adhering to standards such as XDG on linux.


Fixes GH-1521