### PR TITLE
docs: Clarify why we use `truncate(false)`

### DIFF
--- a/src/utils/fs.rs
+++ b/src/utils/fs.rs
@@ -66,13 +66,17 @@ impl TempFile {
         Ok(TempFile { path: destination })
     }
 
-    /// Opens the tempfile at the beginning.
+    /// Opens the tempfile for reading and writing at the beginning. We create the
+    /// file if it doesn't exist yet, but if the file exists, we don't truncate it.
+    /// The lack of truncation allows us to re-open and read a temp file from the
+    /// beginning. Writing to the file will overwrite the existing content, but existing
+    /// data after the written content will remain.
     pub fn open(&self) -> io::Result<fs::File> {
         let mut f = fs::OpenOptions::new()
             .read(true)
             .write(true)
             .create(true)
-            .truncate(false)
+            .truncate(false) // Allows us to re-open and read a temp file from the beginning
             .open(&self.path)?;
 
         f.rewind().ok();


### PR DESCRIPTION
In #1988, we added an explicit call to `truncate(false)` in our `TempFile` code to resolve a new Clippy lint. This call maintained the code's existing behavior, but [seemed like it may not have been the desired behavior](https://github.com/getsentry/sentry-cli/pull/1988#discussion_r1537306207), so we opened #1989.

After investigating, we found that the `truncate(false)` call indeed provides the desired behavior.

Here, we add some comments to clarify why we use `truncate(false)` in our code.

Resolves #1989.