### PR TITLE
feat(auth): Recognize new format user tokens

### DIFF
--- a/src/utils/auth_token/test.rs
+++ b/src/utils/auth_token/test.rs
@@ -67,10 +67,11 @@ fn test_valid_org_auth_token_missing_url() {
 
 // User auth token tests ----------------------------------------------------
 
-#[test]
-fn test_valid_user_auth_token() {
-    let good_token =
-        String::from("c66aee1348a6e7a0993145d71cf8fa529ed09ee13dd5177b5f692e9f6ca38c30");
+#[rstest]
+#[case::no_prefix("c66aee1348a6e7a0993145d71cf8fa529ed09ee13dd5177b5f692e9f6ca38c30")]
+#[case::with_prefix("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")]
+fn test_valid_user_auth_token(#[case] token_str: &'static str) {
+    let good_token = String::from(token_str);
 
     testing_logger::setup();
     let token = AuthToken::from(good_token.clone());
@@ -138,6 +139,11 @@ fn test_valid_user_auth_token() {
 #[case::invalid_hex("c66aee1348a6g7a0993145d71cf8fa529ed09ee13dd5177b5f692e9f6ca38c30")]
 #[case::sixty_three_characters("c66aee1348a6e7a0993145d71cf8fa529ed09ee13dd5177b5f692e9f6ca38c3")]
 #[case::sixty_five_characters("c66aee1348a6e7a0993145d71cf8fa529ed09ee13dd5177b5f692e9f6ca38c300")]
+#[case::prefix_only("sntryu_")]
+#[case::prefix_sixty_three_characters(
+    "sntryu_c66aee1348a6e7a0993145d71cf8fa529ed09ee13dd5177b5f692e9f6ca38c3"
+)]
+#[case::wrong_prefix("sntryt_c66aee1348a6e7a0993145d71cf8fa529ed09ee13dd5177b5f692e9f6ca38c30")]
 fn test_unknown_auth_token(#[case] token_str: &'static str) {
     testing_logger::setup();
     let token = AuthToken::from(token_str.to_owned());

--- a/src/utils/auth_token/user_auth_token.rs
+++ b/src/utils/auth_token/user_auth_token.rs
@@ -1,6 +1,7 @@
 use super::{AuthTokenParseError, Result};
 
 const USER_TOKEN_BYTES: usize = 32;
+const USER_TOKEN_PREFIX: &str = "sntryu_";
 
 /// Represents a valid User Auth Token.
 #[derive(Debug, Clone)]
@@ -9,7 +10,11 @@ pub struct UserAuthToken(String);
 impl UserAuthToken {
     /// Constructs a new UserAuthToken from a string. Returns an error if the string is not a valid user auth token.
     fn construct_from_string(auth_string: String) -> Result<Self> {
-        let bytes = data_encoding::HEXLOWER_PERMISSIVE.decode(auth_string.as_bytes());
+        let secret_portion = auth_string
+            .strip_prefix(USER_TOKEN_PREFIX)
+            .unwrap_or(&auth_string);
+
+        let bytes = data_encoding::HEXLOWER_PERMISSIVE.decode(secret_portion.as_bytes());
 
         if bytes.is_ok() && bytes.unwrap().len() == USER_TOKEN_BYTES {
             Ok(UserAuthToken(auth_string))


### PR DESCRIPTION
https://github.com/getsentry/sentry/pull/68148 changed user auth tokens, so that they now start with a `sntryu_` prefix. While the CLI correctly handles these new tokens, the CLI issued a warning when using these new format tokens.

This PR updates the CLI's auth token parsing logic to recognize the new user auth token format (in addition to the old format), so that the warning is no longer issued.