### PR TITLE
docs(id-support): Document that -p and -o arguments accept slugs and IDs

### DIFF
--- a/src/api/errors/api_error.rs
+++ b/src/api/errors/api_error.rs
@@ -24,7 +24,7 @@ pub(in crate::api) enum ApiErrorKind {
     OrganizationNotFound,
     #[error("resource not found")]
     ResourceNotFound,
-    #[error("Project not found. Please check that you entered the project and organization slugs correctly.")]
+    #[error("Project not found. Please check that you entered the project and organization ids or slugs correctly.")]
     ProjectNotFound,
     #[error("release not found")]
     ReleaseNotFound,

--- a/src/api/errors/api_error.rs
+++ b/src/api/errors/api_error.rs
@@ -24,7 +24,7 @@ pub(in crate::api) enum ApiErrorKind {
     OrganizationNotFound,
     #[error("resource not found")]
     ResourceNotFound,
-    #[error("Project not found. Please check that you entered the project and organization ids or slugs correctly.")]
+    #[error("Project not found. Please check that you entered the project and organization IDs or slugs correctly.")]
     ProjectNotFound,
     #[error("release not found")]
     ReleaseNotFound,

--- a/src/config.rs
+++ b/src/config.rs
@@ -339,7 +339,7 @@ impl Config {
                 .get_from(Some("defaults"), "org")
                 .map(str::to_owned)
                 .ok_or_else(|| {
-                    format_err!("An organization id or slug is required (provide with --org)")
+                    format_err!("An organization ID or slug is required (provide with --org)")
                 }),
             (None, Some(cli_org)) => Ok(cli_org),
             (Some(token_org), None) => Ok(token_org.to_string()),

--- a/src/config.rs
+++ b/src/config.rs
@@ -339,7 +339,7 @@ impl Config {
                 .get_from(Some("defaults"), "org")
                 .map(str::to_owned)
                 .ok_or_else(|| {
-                    format_err!("An organization slug is required (provide with --org)")
+                    format_err!("An organization id or slug is required (provide with --org)")
                 }),
             (None, Some(cli_org)) => Ok(cli_org),
             (Some(token_org), None) => Ok(token_org.to_string()),
@@ -407,7 +407,7 @@ impl Config {
                     .get_from(Some("defaults"), "project")
                     .map(str::to_owned)
             })
-            .ok_or_else(|| format_err!("A project slug is required (provide with --project)"))
+            .ok_or_else(|| format_err!("A project id or slug is required (provide with --project)"))
     }
 
     /// Return the default pipeline env.

--- a/src/config.rs
+++ b/src/config.rs
@@ -407,7 +407,7 @@ impl Config {
                     .get_from(Some("defaults"), "project")
                     .map(str::to_owned)
             })
-            .ok_or_else(|| format_err!("A project id or slug is required (provide with --project)"))
+            .ok_or_else(|| format_err!("A project ID or slug is required (provide with --project)"))
     }
 
     /// Return the default pipeline env.

--- a/src/utils/args.rs
+++ b/src/utils/args.rs
@@ -4,7 +4,7 @@ use clap::{Arg, ArgAction, Command};
 
 fn validate_org(v: &str) -> Result<String, String> {
     if v.contains('/') || v == "." || v == ".." || v.contains(' ') {
-        Err("Invalid value for organization. Use the URL slug and not the name!".to_string())
+        Err("Invalid value for organization. Use the URL slug or the ID and not the name!".to_string())
     } else {
         Ok(v.to_owned())
     }
@@ -19,7 +19,7 @@ pub fn validate_project(v: &str) -> Result<String, String> {
         || v.contains('\t')
         || v.contains('\r')
     {
-        Err("Invalid value for project. Use the URL slug and not the name!".to_string())
+        Err("Invalid value for project. Use the URL slug or the ID and not the name!".to_string())
     } else {
         Ok(v.to_owned())
     }
@@ -90,7 +90,7 @@ impl<'a: 'b, 'b> ArgExt for Command {
                 .short('o')
                 .value_parser(validate_org)
                 .global(true)
-                .help("The organization id or slug."),
+                .help("The organization ID or slug."),
         )
     }
 
@@ -107,7 +107,7 @@ impl<'a: 'b, 'b> ArgExt for Command {
                 } else {
                     ArgAction::Set
                 })
-                .help("The project id or slug."),
+                .help("The project ID or slug."),
         )
     }
 

--- a/src/utils/args.rs
+++ b/src/utils/args.rs
@@ -90,7 +90,7 @@ impl<'a: 'b, 'b> ArgExt for Command {
                 .short('o')
                 .value_parser(validate_org)
                 .global(true)
-                .help("The organization slug"),
+                .help("The organization id or slug."),
         )
     }
 
@@ -107,7 +107,7 @@ impl<'a: 'b, 'b> ArgExt for Command {
                 } else {
                     ArgAction::Set
                 })
-                .help("The project slug."),
+                .help("The project id or slug."),
         )
     }
 

--- a/src/utils/args.rs
+++ b/src/utils/args.rs
@@ -4,7 +4,10 @@ use clap::{Arg, ArgAction, Command};
 
 fn validate_org(v: &str) -> Result<String, String> {
     if v.contains('/') || v == "." || v == ".." || v.contains(' ') {
-        Err("Invalid value for organization. Use the URL slug or the ID and not the name!".to_string())
+        Err(
+            "Invalid value for organization. Use the URL slug or the ID and not the name!"
+                .to_string(),
+        )
     } else {
         Ok(v.to_owned())
     }

--- a/tests/integration/_cases/debug_files/debug_files-bundle-jvm-help.trycmd
+++ b/tests/integration/_cases/debug_files/debug_files-bundle-jvm-help.trycmd
@@ -9,10 +9,10 @@ Arguments:
   <PATH>  The directory containing source files to bundle.
 
 Options:
-  -o, --org <ORG>                The organization id or slug.
+  -o, --org <ORG>                The organization ID or slug.
       --header <KEY:VALUE>       Custom headers that should be attached to all requests
                                  in key:value format.
-  -p, --project <PROJECT>        The project id or slug.
+  -p, --project <PROJECT>        The project ID or slug.
       --auth-token <AUTH_TOKEN>  Use the given Sentry auth token.
       --output <PATH>            The path to the output folder.
       --debug-id <UUID>          Debug ID (UUID) to use for the source bundle.

--- a/tests/integration/_cases/debug_files/debug_files-bundle-jvm-help.trycmd
+++ b/tests/integration/_cases/debug_files/debug_files-bundle-jvm-help.trycmd
@@ -12,7 +12,7 @@ Options:
   -o, --org <ORG>                The organization id or slug.
       --header <KEY:VALUE>       Custom headers that should be attached to all requests
                                  in key:value format.
-  -p, --project <PROJECT>        The project id or slug..
+  -p, --project <PROJECT>        The project id or slug.
       --auth-token <AUTH_TOKEN>  Use the given Sentry auth token.
       --output <PATH>            The path to the output folder.
       --debug-id <UUID>          Debug ID (UUID) to use for the source bundle.

--- a/tests/integration/_cases/debug_files/debug_files-bundle-jvm-help.trycmd
+++ b/tests/integration/_cases/debug_files/debug_files-bundle-jvm-help.trycmd
@@ -9,10 +9,10 @@ Arguments:
   <PATH>  The directory containing source files to bundle.
 
 Options:
-  -o, --org <ORG>                The organization slug
+  -o, --org <ORG>                The organization id or slug.
       --header <KEY:VALUE>       Custom headers that should be attached to all requests
                                  in key:value format.
-  -p, --project <PROJECT>        The project slug.
+  -p, --project <PROJECT>        The project id or slug..
       --auth-token <AUTH_TOKEN>  Use the given Sentry auth token.
       --output <PATH>            The path to the output folder.
       --debug-id <UUID>          Debug ID (UUID) to use for the source bundle.

--- a/tests/integration/_cases/debug_files/debug_files-upload-help.trycmd
+++ b/tests/integration/_cases/debug_files/debug_files-upload-help.trycmd
@@ -12,7 +12,7 @@ Options:
   -o, --org <ORG>                The organization id or slug.
       --header <KEY:VALUE>       Custom headers that should be attached to all requests
                                  in key:value format.
-  -p, --project <PROJECT>        The project id or slug..
+  -p, --project <PROJECT>        The project id or slug.
       --auth-token <AUTH_TOKEN>  Use the given Sentry auth token.
   -t, --type <TYPE>              Only consider debug information files of the given type.  By
                                  default, all types are considered. [possible values: bcsymbolmap,

--- a/tests/integration/_cases/debug_files/debug_files-upload-help.trycmd
+++ b/tests/integration/_cases/debug_files/debug_files-upload-help.trycmd
@@ -9,10 +9,10 @@ Arguments:
   [PATH]...  A path to search recursively for symbol files.
 
 Options:
-  -o, --org <ORG>                The organization id or slug.
+  -o, --org <ORG>                The organization ID or slug.
       --header <KEY:VALUE>       Custom headers that should be attached to all requests
                                  in key:value format.
-  -p, --project <PROJECT>        The project id or slug.
+  -p, --project <PROJECT>        The project ID or slug.
       --auth-token <AUTH_TOKEN>  Use the given Sentry auth token.
   -t, --type <TYPE>              Only consider debug information files of the given type.  By
                                  default, all types are considered. [possible values: bcsymbolmap,

--- a/tests/integration/_cases/debug_files/debug_files-upload-help.trycmd
+++ b/tests/integration/_cases/debug_files/debug_files-upload-help.trycmd
@@ -9,10 +9,10 @@ Arguments:
   [PATH]...  A path to search recursively for symbol files.
 
 Options:
-  -o, --org <ORG>                The organization slug
+  -o, --org <ORG>                The organization id or slug.
       --header <KEY:VALUE>       Custom headers that should be attached to all requests
                                  in key:value format.
-  -p, --project <PROJECT>        The project slug.
+  -p, --project <PROJECT>        The project id or slug..
       --auth-token <AUTH_TOKEN>  Use the given Sentry auth token.
   -t, --type <TYPE>              Only consider debug information files of the given type.  By
                                  default, all types are considered. [possible values: bcsymbolmap,

--- a/tests/integration/_cases/deploys/deploys-help.trycmd
+++ b/tests/integration/_cases/deploys/deploys-help.trycmd
@@ -14,7 +14,7 @@ Options:
   -o, --org <ORG>                The organization id or slug.
       --header <KEY:VALUE>       Custom headers that should be attached to all requests
                                  in key:value format.
-  -p, --project <PROJECT>        The project id or slug..
+  -p, --project <PROJECT>        The project id or slug.
       --auth-token <AUTH_TOKEN>  Use the given Sentry auth token.
   -r, --release <RELEASE>        The release slug.
       --log-level <LOG_LEVEL>    Set the log output verbosity. [possible values: trace, debug, info,

--- a/tests/integration/_cases/deploys/deploys-help.trycmd
+++ b/tests/integration/_cases/deploys/deploys-help.trycmd
@@ -11,10 +11,10 @@ Commands:
   help  Print this message or the help of the given subcommand(s)
 
 Options:
-  -o, --org <ORG>                The organization slug
+  -o, --org <ORG>                The organization id or slug.
       --header <KEY:VALUE>       Custom headers that should be attached to all requests
                                  in key:value format.
-  -p, --project <PROJECT>        The project slug.
+  -p, --project <PROJECT>        The project id or slug..
       --auth-token <AUTH_TOKEN>  Use the given Sentry auth token.
   -r, --release <RELEASE>        The release slug.
       --log-level <LOG_LEVEL>    Set the log output verbosity. [possible values: trace, debug, info,

--- a/tests/integration/_cases/deploys/deploys-help.trycmd
+++ b/tests/integration/_cases/deploys/deploys-help.trycmd
@@ -11,10 +11,10 @@ Commands:
   help  Print this message or the help of the given subcommand(s)
 
 Options:
-  -o, --org <ORG>                The organization id or slug.
+  -o, --org <ORG>                The organization ID or slug.
       --header <KEY:VALUE>       Custom headers that should be attached to all requests
                                  in key:value format.
-  -p, --project <PROJECT>        The project id or slug.
+  -p, --project <PROJECT>        The project ID or slug.
       --auth-token <AUTH_TOKEN>  Use the given Sentry auth token.
   -r, --release <RELEASE>        The release slug.
       --log-level <LOG_LEVEL>    Set the log output verbosity. [possible values: trace, debug, info,

--- a/tests/integration/_cases/deploys/deploys-no-subcommand.trycmd
+++ b/tests/integration/_cases/deploys/deploys-no-subcommand.trycmd
@@ -14,7 +14,7 @@ Options:
   -o, --org <ORG>                The organization id or slug.
       --header <KEY:VALUE>       Custom headers that should be attached to all requests
                                  in key:value format.
-  -p, --project <PROJECT>        The project id or slug..
+  -p, --project <PROJECT>        The project id or slug.
       --auth-token <AUTH_TOKEN>  Use the given Sentry auth token.
   -r, --release <RELEASE>        The release slug.
       --log-level <LOG_LEVEL>    Set the log output verbosity. [possible values: trace, debug, info,

--- a/tests/integration/_cases/deploys/deploys-no-subcommand.trycmd
+++ b/tests/integration/_cases/deploys/deploys-no-subcommand.trycmd
@@ -11,10 +11,10 @@ Commands:
   help  Print this message or the help of the given subcommand(s)
 
 Options:
-  -o, --org <ORG>                The organization slug
+  -o, --org <ORG>                The organization id or slug.
       --header <KEY:VALUE>       Custom headers that should be attached to all requests
                                  in key:value format.
-  -p, --project <PROJECT>        The project slug.
+  -p, --project <PROJECT>        The project id or slug..
       --auth-token <AUTH_TOKEN>  Use the given Sentry auth token.
   -r, --release <RELEASE>        The release slug.
       --log-level <LOG_LEVEL>    Set the log output verbosity. [possible values: trace, debug, info,

--- a/tests/integration/_cases/deploys/deploys-no-subcommand.trycmd
+++ b/tests/integration/_cases/deploys/deploys-no-subcommand.trycmd
@@ -11,10 +11,10 @@ Commands:
   help  Print this message or the help of the given subcommand(s)
 
 Options:
-  -o, --org <ORG>                The organization id or slug.
+  -o, --org <ORG>                The organization ID or slug.
       --header <KEY:VALUE>       Custom headers that should be attached to all requests
                                  in key:value format.
-  -p, --project <PROJECT>        The project id or slug.
+  -p, --project <PROJECT>        The project ID or slug.
       --auth-token <AUTH_TOKEN>  Use the given Sentry auth token.
   -r, --release <RELEASE>        The release slug.
       --log-level <LOG_LEVEL>    Set the log output verbosity. [possible values: trace, debug, info,

--- a/tests/integration/_cases/events/events-help.trycmd
+++ b/tests/integration/_cases/events/events-help.trycmd
@@ -10,10 +10,10 @@ Commands:
   help  Print this message or the help of the given subcommand(s)
 
 Options:
-  -o, --org <ORG>                The organization slug
+  -o, --org <ORG>                The organization id or slug.
       --header <KEY:VALUE>       Custom headers that should be attached to all requests
                                  in key:value format.
-  -p, --project <PROJECT>        The project slug.
+  -p, --project <PROJECT>        The project id or slug..
       --auth-token <AUTH_TOKEN>  Use the given Sentry auth token.
       --log-level <LOG_LEVEL>    Set the log output verbosity. [possible values: trace, debug, info,
                                  warn, error]

--- a/tests/integration/_cases/events/events-help.trycmd
+++ b/tests/integration/_cases/events/events-help.trycmd
@@ -13,7 +13,7 @@ Options:
   -o, --org <ORG>                The organization id or slug.
       --header <KEY:VALUE>       Custom headers that should be attached to all requests
                                  in key:value format.
-  -p, --project <PROJECT>        The project id or slug..
+  -p, --project <PROJECT>        The project id or slug.
       --auth-token <AUTH_TOKEN>  Use the given Sentry auth token.
       --log-level <LOG_LEVEL>    Set the log output verbosity. [possible values: trace, debug, info,
                                  warn, error]

--- a/tests/integration/_cases/events/events-help.trycmd
+++ b/tests/integration/_cases/events/events-help.trycmd
@@ -10,10 +10,10 @@ Commands:
   help  Print this message or the help of the given subcommand(s)
 
 Options:
-  -o, --org <ORG>                The organization id or slug.
+  -o, --org <ORG>                The organization ID or slug.
       --header <KEY:VALUE>       Custom headers that should be attached to all requests
                                  in key:value format.
-  -p, --project <PROJECT>        The project id or slug.
+  -p, --project <PROJECT>        The project ID or slug.
       --auth-token <AUTH_TOKEN>  Use the given Sentry auth token.
       --log-level <LOG_LEVEL>    Set the log output verbosity. [possible values: trace, debug, info,
                                  warn, error]

--- a/tests/integration/_cases/events/events-list-help.trycmd
+++ b/tests/integration/_cases/events/events-list-help.trycmd
@@ -6,11 +6,11 @@ List all events in your organization.
 Usage: sentry-cli[EXE] events list [OPTIONS]
 
 Options:
-  -o, --org <ORG>                The organization slug
+  -o, --org <ORG>                The organization id or slug.
   -U, --show-user                Display the Users column.
       --header <KEY:VALUE>       Custom headers that should be attached to all requests
                                  in key:value format.
-  -p, --project <PROJECT>        The project slug.
+  -p, --project <PROJECT>        The project id or slug..
   -T, --show-tags                Display the Tags column.
       --auth-token <AUTH_TOKEN>  Use the given Sentry auth token.
       --max-rows <MAX_ROWS>      Maximum number of rows to print.

--- a/tests/integration/_cases/events/events-list-help.trycmd
+++ b/tests/integration/_cases/events/events-list-help.trycmd
@@ -6,11 +6,11 @@ List all events in your organization.
 Usage: sentry-cli[EXE] events list [OPTIONS]
 
 Options:
-  -o, --org <ORG>                The organization id or slug.
+  -o, --org <ORG>                The organization ID or slug.
   -U, --show-user                Display the Users column.
       --header <KEY:VALUE>       Custom headers that should be attached to all requests
                                  in key:value format.
-  -p, --project <PROJECT>        The project id or slug.
+  -p, --project <PROJECT>        The project ID or slug.
   -T, --show-tags                Display the Tags column.
       --auth-token <AUTH_TOKEN>  Use the given Sentry auth token.
       --max-rows <MAX_ROWS>      Maximum number of rows to print.

--- a/tests/integration/_cases/events/events-list-help.trycmd
+++ b/tests/integration/_cases/events/events-list-help.trycmd
@@ -10,7 +10,7 @@ Options:
   -U, --show-user                Display the Users column.
       --header <KEY:VALUE>       Custom headers that should be attached to all requests
                                  in key:value format.
-  -p, --project <PROJECT>        The project id or slug..
+  -p, --project <PROJECT>        The project id or slug.
   -T, --show-tags                Display the Tags column.
       --auth-token <AUTH_TOKEN>  Use the given Sentry auth token.
       --max-rows <MAX_ROWS>      Maximum number of rows to print.

--- a/tests/integration/_cases/events/events-no-subcommand.trycmd
+++ b/tests/integration/_cases/events/events-no-subcommand.trycmd
@@ -10,10 +10,10 @@ Commands:
   help  Print this message or the help of the given subcommand(s)
 
 Options:
-  -o, --org <ORG>                The organization slug
+  -o, --org <ORG>                The organization id or slug.
       --header <KEY:VALUE>       Custom headers that should be attached to all requests
                                  in key:value format.
-  -p, --project <PROJECT>        The project slug.
+  -p, --project <PROJECT>        The project id or slug..
       --auth-token <AUTH_TOKEN>  Use the given Sentry auth token.
       --log-level <LOG_LEVEL>    Set the log output verbosity. [possible values: trace, debug, info,
                                  warn, error]

--- a/tests/integration/_cases/events/events-no-subcommand.trycmd
+++ b/tests/integration/_cases/events/events-no-subcommand.trycmd
@@ -13,7 +13,7 @@ Options:
   -o, --org <ORG>                The organization id or slug.
       --header <KEY:VALUE>       Custom headers that should be attached to all requests
                                  in key:value format.
-  -p, --project <PROJECT>        The project id or slug..
+  -p, --project <PROJECT>        The project id or slug.
       --auth-token <AUTH_TOKEN>  Use the given Sentry auth token.
       --log-level <LOG_LEVEL>    Set the log output verbosity. [possible values: trace, debug, info,
                                  warn, error]

--- a/tests/integration/_cases/events/events-no-subcommand.trycmd
+++ b/tests/integration/_cases/events/events-no-subcommand.trycmd
@@ -10,10 +10,10 @@ Commands:
   help  Print this message or the help of the given subcommand(s)
 
 Options:
-  -o, --org <ORG>                The organization id or slug.
+  -o, --org <ORG>                The organization ID or slug.
       --header <KEY:VALUE>       Custom headers that should be attached to all requests
                                  in key:value format.
-  -p, --project <PROJECT>        The project id or slug.
+  -p, --project <PROJECT>        The project ID or slug.
       --auth-token <AUTH_TOKEN>  Use the given Sentry auth token.
       --log-level <LOG_LEVEL>    Set the log output verbosity. [possible values: trace, debug, info,
                                  warn, error]

--- a/tests/integration/_cases/issues/issues-help.trycmd
+++ b/tests/integration/_cases/issues/issues-help.trycmd
@@ -14,10 +14,10 @@ Commands:
   help       Print this message or the help of the given subcommand(s)
 
 Options:
-  -o, --org <ORG>                The organization id or slug.
+  -o, --org <ORG>                The organization ID or slug.
       --header <KEY:VALUE>       Custom headers that should be attached to all requests
                                  in key:value format.
-  -p, --project <PROJECT>        The project id or slug.
+  -p, --project <PROJECT>        The project ID or slug.
       --auth-token <AUTH_TOKEN>  Use the given Sentry auth token.
   -s, --status <STATUS>          Select all issues matching a given status. [possible values:
                                  resolved, muted, unresolved]

--- a/tests/integration/_cases/issues/issues-help.trycmd
+++ b/tests/integration/_cases/issues/issues-help.trycmd
@@ -17,7 +17,7 @@ Options:
   -o, --org <ORG>                The organization id or slug.
       --header <KEY:VALUE>       Custom headers that should be attached to all requests
                                  in key:value format.
-  -p, --project <PROJECT>        The project id or slug..
+  -p, --project <PROJECT>        The project id or slug.
       --auth-token <AUTH_TOKEN>  Use the given Sentry auth token.
   -s, --status <STATUS>          Select all issues matching a given status. [possible values:
                                  resolved, muted, unresolved]

--- a/tests/integration/_cases/issues/issues-help.trycmd
+++ b/tests/integration/_cases/issues/issues-help.trycmd
@@ -14,10 +14,10 @@ Commands:
   help       Print this message or the help of the given subcommand(s)
 
 Options:
-  -o, --org <ORG>                The organization slug
+  -o, --org <ORG>                The organization id or slug.
       --header <KEY:VALUE>       Custom headers that should be attached to all requests
                                  in key:value format.
-  -p, --project <PROJECT>        The project slug.
+  -p, --project <PROJECT>        The project id or slug..
       --auth-token <AUTH_TOKEN>  Use the given Sentry auth token.
   -s, --status <STATUS>          Select all issues matching a given status. [possible values:
                                  resolved, muted, unresolved]

--- a/tests/integration/_cases/issues/issues-list-help.trycmd
+++ b/tests/integration/_cases/issues/issues-list-help.trycmd
@@ -7,10 +7,10 @@ Usage: sentry-cli[EXE] issues list [OPTIONS]
 
 Options:
       --max-rows <MAX_ROWS>      Maximum number of rows to print.
-  -o, --org <ORG>                The organization id or slug.
+  -o, --org <ORG>                The organization ID or slug.
       --header <KEY:VALUE>       Custom headers that should be attached to all requests
                                  in key:value format.
-  -p, --project <PROJECT>        The project id or slug.
+  -p, --project <PROJECT>        The project ID or slug.
       --pages <PAGES>            Maximum number of pages to fetch (100 issues/page). [default: 5]
       --auth-token <AUTH_TOKEN>  Use the given Sentry auth token.
       --query <QUERY>            Query to pass at the request. An example is "is:unresolved"

--- a/tests/integration/_cases/issues/issues-list-help.trycmd
+++ b/tests/integration/_cases/issues/issues-list-help.trycmd
@@ -7,10 +7,10 @@ Usage: sentry-cli[EXE] issues list [OPTIONS]
 
 Options:
       --max-rows <MAX_ROWS>      Maximum number of rows to print.
-  -o, --org <ORG>                The organization slug
+  -o, --org <ORG>                The organization id or slug.
       --header <KEY:VALUE>       Custom headers that should be attached to all requests
                                  in key:value format.
-  -p, --project <PROJECT>        The project slug.
+  -p, --project <PROJECT>        The project id or slug..
       --pages <PAGES>            Maximum number of pages to fetch (100 issues/page). [default: 5]
       --auth-token <AUTH_TOKEN>  Use the given Sentry auth token.
       --query <QUERY>            Query to pass at the request. An example is "is:unresolved"

--- a/tests/integration/_cases/issues/issues-list-help.trycmd
+++ b/tests/integration/_cases/issues/issues-list-help.trycmd
@@ -10,7 +10,7 @@ Options:
   -o, --org <ORG>                The organization id or slug.
       --header <KEY:VALUE>       Custom headers that should be attached to all requests
                                  in key:value format.
-  -p, --project <PROJECT>        The project id or slug..
+  -p, --project <PROJECT>        The project id or slug.
       --pages <PAGES>            Maximum number of pages to fetch (100 issues/page). [default: 5]
       --auth-token <AUTH_TOKEN>  Use the given Sentry auth token.
       --query <QUERY>            Query to pass at the request. An example is "is:unresolved"

--- a/tests/integration/_cases/monitors/monitors-list-help.trycmd
+++ b/tests/integration/_cases/monitors/monitors-list-help.trycmd
@@ -6,7 +6,7 @@ List all monitors for an organization.
 Usage: sentry-cli[EXE] monitors list [OPTIONS]
 
 Options:
-  -o, --org <ORG>                The organization slug
+  -o, --org <ORG>                The organization id or slug.
       --header <KEY:VALUE>       Custom headers that should be attached to all requests
                                  in key:value format.
       --auth-token <AUTH_TOKEN>  Use the given Sentry auth token.

--- a/tests/integration/_cases/monitors/monitors-list-help.trycmd
+++ b/tests/integration/_cases/monitors/monitors-list-help.trycmd
@@ -6,7 +6,7 @@ List all monitors for an organization.
 Usage: sentry-cli[EXE] monitors list [OPTIONS]
 
 Options:
-  -o, --org <ORG>                The organization id or slug.
+  -o, --org <ORG>                The organization ID or slug.
       --header <KEY:VALUE>       Custom headers that should be attached to all requests
                                  in key:value format.
       --auth-token <AUTH_TOKEN>  Use the given Sentry auth token.

--- a/tests/integration/_cases/projects/projects-help.trycmd
+++ b/tests/integration/_cases/projects/projects-help.trycmd
@@ -10,7 +10,7 @@ Commands:
   help  Print this message or the help of the given subcommand(s)
 
 Options:
-  -o, --org <ORG>                The organization id or slug.
+  -o, --org <ORG>                The organization ID or slug.
       --header <KEY:VALUE>       Custom headers that should be attached to all requests
                                  in key:value format.
       --auth-token <AUTH_TOKEN>  Use the given Sentry auth token.

--- a/tests/integration/_cases/projects/projects-help.trycmd
+++ b/tests/integration/_cases/projects/projects-help.trycmd
@@ -10,7 +10,7 @@ Commands:
   help  Print this message or the help of the given subcommand(s)
 
 Options:
-  -o, --org <ORG>                The organization slug
+  -o, --org <ORG>                The organization id or slug.
       --header <KEY:VALUE>       Custom headers that should be attached to all requests
                                  in key:value format.
       --auth-token <AUTH_TOKEN>  Use the given Sentry auth token.

--- a/tests/integration/_cases/projects/projects-list-help.trycmd
+++ b/tests/integration/_cases/projects/projects-list-help.trycmd
@@ -6,7 +6,7 @@ List all projects for an organization.
 Usage: sentry-cli[EXE] projects list [OPTIONS]
 
 Options:
-  -o, --org <ORG>                The organization slug
+  -o, --org <ORG>                The organization id or slug.
       --header <KEY:VALUE>       Custom headers that should be attached to all requests
                                  in key:value format.
       --auth-token <AUTH_TOKEN>  Use the given Sentry auth token.

--- a/tests/integration/_cases/projects/projects-list-help.trycmd
+++ b/tests/integration/_cases/projects/projects-list-help.trycmd
@@ -6,7 +6,7 @@ List all projects for an organization.
 Usage: sentry-cli[EXE] projects list [OPTIONS]
 
 Options:
-  -o, --org <ORG>                The organization id or slug.
+  -o, --org <ORG>                The organization ID or slug.
       --header <KEY:VALUE>       Custom headers that should be attached to all requests
                                  in key:value format.
       --auth-token <AUTH_TOKEN>  Use the given Sentry auth token.

--- a/tests/integration/_cases/projects/projects-no-subcommand.trycmd
+++ b/tests/integration/_cases/projects/projects-no-subcommand.trycmd
@@ -10,7 +10,7 @@ Commands:
   help  Print this message or the help of the given subcommand(s)
 
 Options:
-  -o, --org <ORG>                The organization id or slug.
+  -o, --org <ORG>                The organization ID or slug.
       --header <KEY:VALUE>       Custom headers that should be attached to all requests
                                  in key:value format.
       --auth-token <AUTH_TOKEN>  Use the given Sentry auth token.

--- a/tests/integration/_cases/projects/projects-no-subcommand.trycmd
+++ b/tests/integration/_cases/projects/projects-no-subcommand.trycmd
@@ -10,7 +10,7 @@ Commands:
   help  Print this message or the help of the given subcommand(s)
 
 Options:
-  -o, --org <ORG>                The organization slug
+  -o, --org <ORG>                The organization id or slug.
       --header <KEY:VALUE>       Custom headers that should be attached to all requests
                                  in key:value format.
       --auth-token <AUTH_TOKEN>  Use the given Sentry auth token.

--- a/tests/integration/_cases/releases/releases-help.trycmd
+++ b/tests/integration/_cases/releases/releases-help.trycmd
@@ -18,10 +18,10 @@ Commands:
   help             Print this message or the help of the given subcommand(s)
 
 Options:
-  -o, --org <ORG>                The organization slug
+  -o, --org <ORG>                The organization id or slug.
       --header <KEY:VALUE>       Custom headers that should be attached to all requests
                                  in key:value format.
-  -p, --project <PROJECT>        The project slug.
+  -p, --project <PROJECT>        The project id or slug..
       --auth-token <AUTH_TOKEN>  Use the given Sentry auth token.
       --log-level <LOG_LEVEL>    Set the log output verbosity. [possible values: trace, debug, info,
                                  warn, error]

--- a/tests/integration/_cases/releases/releases-help.trycmd
+++ b/tests/integration/_cases/releases/releases-help.trycmd
@@ -18,10 +18,10 @@ Commands:
   help             Print this message or the help of the given subcommand(s)
 
 Options:
-  -o, --org <ORG>                The organization id or slug.
+  -o, --org <ORG>                The organization ID or slug.
       --header <KEY:VALUE>       Custom headers that should be attached to all requests
                                  in key:value format.
-  -p, --project <PROJECT>        The project id or slug.
+  -p, --project <PROJECT>        The project ID or slug.
       --auth-token <AUTH_TOKEN>  Use the given Sentry auth token.
       --log-level <LOG_LEVEL>    Set the log output verbosity. [possible values: trace, debug, info,
                                  warn, error]

--- a/tests/integration/_cases/releases/releases-help.trycmd
+++ b/tests/integration/_cases/releases/releases-help.trycmd
@@ -21,7 +21,7 @@ Options:
   -o, --org <ORG>                The organization id or slug.
       --header <KEY:VALUE>       Custom headers that should be attached to all requests
                                  in key:value format.
-  -p, --project <PROJECT>        The project id or slug..
+  -p, --project <PROJECT>        The project id or slug.
       --auth-token <AUTH_TOKEN>  Use the given Sentry auth token.
       --log-level <LOG_LEVEL>    Set the log output verbosity. [possible values: trace, debug, info,
                                  warn, error]

--- a/tests/integration/_cases/releases/releases-new-help.trycmd
+++ b/tests/integration/_cases/releases/releases-new-help.trycmd
@@ -14,7 +14,7 @@ Options:
       --finalize                 Immediately finalize the release. (sets it to released)
       --header <KEY:VALUE>       Custom headers that should be attached to all requests
                                  in key:value format.
-  -p, --project <PROJECT>        The project id or slug..
+  -p, --project <PROJECT>        The project id or slug.
       --auth-token <AUTH_TOKEN>  Use the given Sentry auth token.
       --log-level <LOG_LEVEL>    Set the log output verbosity. [possible values: trace, debug, info,
                                  warn, error]

--- a/tests/integration/_cases/releases/releases-new-help.trycmd
+++ b/tests/integration/_cases/releases/releases-new-help.trycmd
@@ -9,12 +9,12 @@ Arguments:
   <VERSION>  The version of the release
 
 Options:
-  -o, --org <ORG>                The organization id or slug.
+  -o, --org <ORG>                The organization ID or slug.
       --url <URL>                Optional URL to the release for information purposes.
       --finalize                 Immediately finalize the release. (sets it to released)
       --header <KEY:VALUE>       Custom headers that should be attached to all requests
                                  in key:value format.
-  -p, --project <PROJECT>        The project id or slug.
+  -p, --project <PROJECT>        The project ID or slug.
       --auth-token <AUTH_TOKEN>  Use the given Sentry auth token.
       --log-level <LOG_LEVEL>    Set the log output verbosity. [possible values: trace, debug, info,
                                  warn, error]

--- a/tests/integration/_cases/releases/releases-new-help.trycmd
+++ b/tests/integration/_cases/releases/releases-new-help.trycmd
@@ -9,12 +9,12 @@ Arguments:
   <VERSION>  The version of the release
 
 Options:
-  -o, --org <ORG>                The organization slug
+  -o, --org <ORG>                The organization id or slug.
       --url <URL>                Optional URL to the release for information purposes.
       --finalize                 Immediately finalize the release. (sets it to released)
       --header <KEY:VALUE>       Custom headers that should be attached to all requests
                                  in key:value format.
-  -p, --project <PROJECT>        The project slug.
+  -p, --project <PROJECT>        The project id or slug..
       --auth-token <AUTH_TOKEN>  Use the given Sentry auth token.
       --log-level <LOG_LEVEL>    Set the log output verbosity. [possible values: trace, debug, info,
                                  warn, error]

--- a/tests/integration/_cases/releases/releases-no-subcommand.trycmd
+++ b/tests/integration/_cases/releases/releases-no-subcommand.trycmd
@@ -18,10 +18,10 @@ Commands:
   help             Print this message or the help of the given subcommand(s)
 
 Options:
-  -o, --org <ORG>                The organization slug
+  -o, --org <ORG>                The organization id or slug.
       --header <KEY:VALUE>       Custom headers that should be attached to all requests
                                  in key:value format.
-  -p, --project <PROJECT>        The project slug.
+  -p, --project <PROJECT>        The project id or slug..
       --auth-token <AUTH_TOKEN>  Use the given Sentry auth token.
       --log-level <LOG_LEVEL>    Set the log output verbosity. [possible values: trace, debug, info,
                                  warn, error]

--- a/tests/integration/_cases/releases/releases-no-subcommand.trycmd
+++ b/tests/integration/_cases/releases/releases-no-subcommand.trycmd
@@ -18,10 +18,10 @@ Commands:
   help             Print this message or the help of the given subcommand(s)
 
 Options:
-  -o, --org <ORG>                The organization id or slug.
+  -o, --org <ORG>                The organization ID or slug.
       --header <KEY:VALUE>       Custom headers that should be attached to all requests
                                  in key:value format.
-  -p, --project <PROJECT>        The project id or slug.
+  -p, --project <PROJECT>        The project ID or slug.
       --auth-token <AUTH_TOKEN>  Use the given Sentry auth token.
       --log-level <LOG_LEVEL>    Set the log output verbosity. [possible values: trace, debug, info,
                                  warn, error]

--- a/tests/integration/_cases/releases/releases-no-subcommand.trycmd
+++ b/tests/integration/_cases/releases/releases-no-subcommand.trycmd
@@ -21,7 +21,7 @@ Options:
   -o, --org <ORG>                The organization id or slug.
       --header <KEY:VALUE>       Custom headers that should be attached to all requests
                                  in key:value format.
-  -p, --project <PROJECT>        The project id or slug..
+  -p, --project <PROJECT>        The project id or slug.
       --auth-token <AUTH_TOKEN>  Use the given Sentry auth token.
       --log-level <LOG_LEVEL>    Set the log output verbosity. [possible values: trace, debug, info,
                                  warn, error]

--- a/tests/integration/_cases/sourcemaps/sourcemaps-explain-help.trycmd
+++ b/tests/integration/_cases/sourcemaps/sourcemaps-explain-help.trycmd
@@ -11,12 +11,12 @@ Arguments:
 Options:
       --frame <frame>            Position of the frame that should be used for source map
                                  resolution. [default: 0]
-  -o, --org <ORG>                The organization id or slug.
+  -o, --org <ORG>                The organization ID or slug.
   -f, --force                    Force full validation flow, even when event is already source
                                  mapped.
       --header <KEY:VALUE>       Custom headers that should be attached to all requests
                                  in key:value format.
-  -p, --project <PROJECT>        The project id or slug.
+  -p, --project <PROJECT>        The project ID or slug.
       --auth-token <AUTH_TOKEN>  Use the given Sentry auth token.
   -r, --release <RELEASE>        The release slug.
       --log-level <LOG_LEVEL>    Set the log output verbosity. [possible values: trace, debug, info,

--- a/tests/integration/_cases/sourcemaps/sourcemaps-explain-help.trycmd
+++ b/tests/integration/_cases/sourcemaps/sourcemaps-explain-help.trycmd
@@ -11,12 +11,12 @@ Arguments:
 Options:
       --frame <frame>            Position of the frame that should be used for source map
                                  resolution. [default: 0]
-  -o, --org <ORG>                The organization slug
+  -o, --org <ORG>                The organization id or slug.
   -f, --force                    Force full validation flow, even when event is already source
                                  mapped.
       --header <KEY:VALUE>       Custom headers that should be attached to all requests
                                  in key:value format.
-  -p, --project <PROJECT>        The project slug.
+  -p, --project <PROJECT>        The project id or slug..
       --auth-token <AUTH_TOKEN>  Use the given Sentry auth token.
   -r, --release <RELEASE>        The release slug.
       --log-level <LOG_LEVEL>    Set the log output verbosity. [possible values: trace, debug, info,

--- a/tests/integration/_cases/sourcemaps/sourcemaps-explain-help.trycmd
+++ b/tests/integration/_cases/sourcemaps/sourcemaps-explain-help.trycmd
@@ -16,7 +16,7 @@ Options:
                                  mapped.
       --header <KEY:VALUE>       Custom headers that should be attached to all requests
                                  in key:value format.
-  -p, --project <PROJECT>        The project id or slug..
+  -p, --project <PROJECT>        The project id or slug.
       --auth-token <AUTH_TOKEN>  Use the given Sentry auth token.
   -r, --release <RELEASE>        The release slug.
       --log-level <LOG_LEVEL>    Set the log output verbosity. [possible values: trace, debug, info,

--- a/tests/integration/_cases/sourcemaps/sourcemaps-help.trycmd
+++ b/tests/integration/_cases/sourcemaps/sourcemaps-help.trycmd
@@ -13,10 +13,10 @@ Commands:
   help     Print this message or the help of the given subcommand(s)
 
 Options:
-  -o, --org <ORG>                The organization slug
+  -o, --org <ORG>                The organization id or slug.
       --header <KEY:VALUE>       Custom headers that should be attached to all requests
                                  in key:value format.
-  -p, --project <PROJECT>        The project slug.
+  -p, --project <PROJECT>        The project id or slug..
       --auth-token <AUTH_TOKEN>  Use the given Sentry auth token.
   -r, --release <RELEASE>        The release slug.
       --log-level <LOG_LEVEL>    Set the log output verbosity. [possible values: trace, debug, info,

--- a/tests/integration/_cases/sourcemaps/sourcemaps-help.trycmd
+++ b/tests/integration/_cases/sourcemaps/sourcemaps-help.trycmd
@@ -16,7 +16,7 @@ Options:
   -o, --org <ORG>                The organization id or slug.
       --header <KEY:VALUE>       Custom headers that should be attached to all requests
                                  in key:value format.
-  -p, --project <PROJECT>        The project id or slug..
+  -p, --project <PROJECT>        The project id or slug.
       --auth-token <AUTH_TOKEN>  Use the given Sentry auth token.
   -r, --release <RELEASE>        The release slug.
       --log-level <LOG_LEVEL>    Set the log output verbosity. [possible values: trace, debug, info,

--- a/tests/integration/_cases/sourcemaps/sourcemaps-help.trycmd
+++ b/tests/integration/_cases/sourcemaps/sourcemaps-help.trycmd
@@ -13,10 +13,10 @@ Commands:
   help     Print this message or the help of the given subcommand(s)
 
 Options:
-  -o, --org <ORG>                The organization id or slug.
+  -o, --org <ORG>                The organization ID or slug.
       --header <KEY:VALUE>       Custom headers that should be attached to all requests
                                  in key:value format.
-  -p, --project <PROJECT>        The project id or slug.
+  -p, --project <PROJECT>        The project ID or slug.
       --auth-token <AUTH_TOKEN>  Use the given Sentry auth token.
   -r, --release <RELEASE>        The release slug.
       --log-level <LOG_LEVEL>    Set the log output verbosity. [possible values: trace, debug, info,

--- a/tests/integration/_cases/sourcemaps/sourcemaps-inject-help.trycmd
+++ b/tests/integration/_cases/sourcemaps/sourcemaps-inject-help.trycmd
@@ -28,7 +28,7 @@ Options:
           Ignore all files and folders specified in the given ignore file, e.g. .gitignore.
 
   -p, --project <PROJECT>
-          The project id or slug..
+          The project id or slug.
 
       --auth-token <AUTH_TOKEN>
           Use the given Sentry auth token.

--- a/tests/integration/_cases/sourcemaps/sourcemaps-inject-help.trycmd
+++ b/tests/integration/_cases/sourcemaps/sourcemaps-inject-help.trycmd
@@ -18,7 +18,7 @@ Options:
           Ignores all files and folders matching the given glob
 
   -o, --org <ORG>
-          The organization slug
+          The organization id or slug.
 
       --header <KEY:VALUE>
           Custom headers that should be attached to all requests
@@ -28,7 +28,7 @@ Options:
           Ignore all files and folders specified in the given ignore file, e.g. .gitignore.
 
   -p, --project <PROJECT>
-          The project slug.
+          The project id or slug..
 
       --auth-token <AUTH_TOKEN>
           Use the given Sentry auth token.

--- a/tests/integration/_cases/sourcemaps/sourcemaps-inject-help.trycmd
+++ b/tests/integration/_cases/sourcemaps/sourcemaps-inject-help.trycmd
@@ -18,7 +18,7 @@ Options:
           Ignores all files and folders matching the given glob
 
   -o, --org <ORG>
-          The organization id or slug.
+          The organization ID or slug.
 
       --header <KEY:VALUE>
           Custom headers that should be attached to all requests
@@ -28,7 +28,7 @@ Options:
           Ignore all files and folders specified in the given ignore file, e.g. .gitignore.
 
   -p, --project <PROJECT>
-          The project id or slug.
+          The project ID or slug.
 
       --auth-token <AUTH_TOKEN>
           Use the given Sentry auth token.

--- a/tests/integration/_cases/sourcemaps/sourcemaps-no-subcommand.trycmd
+++ b/tests/integration/_cases/sourcemaps/sourcemaps-no-subcommand.trycmd
@@ -13,10 +13,10 @@ Commands:
   help     Print this message or the help of the given subcommand(s)
 
 Options:
-  -o, --org <ORG>                The organization slug
+  -o, --org <ORG>                The organization id or slug.
       --header <KEY:VALUE>       Custom headers that should be attached to all requests
                                  in key:value format.
-  -p, --project <PROJECT>        The project slug.
+  -p, --project <PROJECT>        The project id or slug..
       --auth-token <AUTH_TOKEN>  Use the given Sentry auth token.
   -r, --release <RELEASE>        The release slug.
       --log-level <LOG_LEVEL>    Set the log output verbosity. [possible values: trace, debug, info,

--- a/tests/integration/_cases/sourcemaps/sourcemaps-no-subcommand.trycmd
+++ b/tests/integration/_cases/sourcemaps/sourcemaps-no-subcommand.trycmd
@@ -16,7 +16,7 @@ Options:
   -o, --org <ORG>                The organization id or slug.
       --header <KEY:VALUE>       Custom headers that should be attached to all requests
                                  in key:value format.
-  -p, --project <PROJECT>        The project id or slug..
+  -p, --project <PROJECT>        The project id or slug.
       --auth-token <AUTH_TOKEN>  Use the given Sentry auth token.
   -r, --release <RELEASE>        The release slug.
       --log-level <LOG_LEVEL>    Set the log output verbosity. [possible values: trace, debug, info,

--- a/tests/integration/_cases/sourcemaps/sourcemaps-no-subcommand.trycmd
+++ b/tests/integration/_cases/sourcemaps/sourcemaps-no-subcommand.trycmd
@@ -13,10 +13,10 @@ Commands:
   help     Print this message or the help of the given subcommand(s)
 
 Options:
-  -o, --org <ORG>                The organization id or slug.
+  -o, --org <ORG>                The organization ID or slug.
       --header <KEY:VALUE>       Custom headers that should be attached to all requests
                                  in key:value format.
-  -p, --project <PROJECT>        The project id or slug.
+  -p, --project <PROJECT>        The project ID or slug.
       --auth-token <AUTH_TOKEN>  Use the given Sentry auth token.
   -r, --release <RELEASE>        The release slug.
       --log-level <LOG_LEVEL>    Set the log output verbosity. [possible values: trace, debug, info,

--- a/tests/integration/_cases/sourcemaps/sourcemaps-resolve-help.trycmd
+++ b/tests/integration/_cases/sourcemaps/sourcemaps-resolve-help.trycmd
@@ -10,11 +10,11 @@ Arguments:
 
 Options:
   -l, --line <LINE>              Line number for minified source.
-  -o, --org <ORG>                The organization id or slug.
+  -o, --org <ORG>                The organization ID or slug.
   -c, --column <COLUMN>          Column number for minified source.
       --header <KEY:VALUE>       Custom headers that should be attached to all requests
                                  in key:value format.
-  -p, --project <PROJECT>        The project id or slug.
+  -p, --project <PROJECT>        The project ID or slug.
       --auth-token <AUTH_TOKEN>  Use the given Sentry auth token.
   -r, --release <RELEASE>        The release slug.
       --log-level <LOG_LEVEL>    Set the log output verbosity. [possible values: trace, debug, info,

--- a/tests/integration/_cases/sourcemaps/sourcemaps-resolve-help.trycmd
+++ b/tests/integration/_cases/sourcemaps/sourcemaps-resolve-help.trycmd
@@ -14,7 +14,7 @@ Options:
   -c, --column <COLUMN>          Column number for minified source.
       --header <KEY:VALUE>       Custom headers that should be attached to all requests
                                  in key:value format.
-  -p, --project <PROJECT>        The project id or slug..
+  -p, --project <PROJECT>        The project id or slug.
       --auth-token <AUTH_TOKEN>  Use the given Sentry auth token.
   -r, --release <RELEASE>        The release slug.
       --log-level <LOG_LEVEL>    Set the log output verbosity. [possible values: trace, debug, info,

--- a/tests/integration/_cases/sourcemaps/sourcemaps-resolve-help.trycmd
+++ b/tests/integration/_cases/sourcemaps/sourcemaps-resolve-help.trycmd
@@ -10,11 +10,11 @@ Arguments:
 
 Options:
   -l, --line <LINE>              Line number for minified source.
-  -o, --org <ORG>                The organization slug
+  -o, --org <ORG>                The organization id or slug.
   -c, --column <COLUMN>          Column number for minified source.
       --header <KEY:VALUE>       Custom headers that should be attached to all requests
                                  in key:value format.
-  -p, --project <PROJECT>        The project slug.
+  -p, --project <PROJECT>        The project id or slug..
       --auth-token <AUTH_TOKEN>  Use the given Sentry auth token.
   -r, --release <RELEASE>        The release slug.
       --log-level <LOG_LEVEL>    Set the log output verbosity. [possible values: trace, debug, info,

--- a/tests/integration/_cases/sourcemaps/sourcemaps-upload-help.trycmd
+++ b/tests/integration/_cases/sourcemaps/sourcemaps-upload-help.trycmd
@@ -10,12 +10,12 @@ Arguments:
 
 Options:
   -o, --org <ORG>
-          The organization slug
+          The organization id or slug.
       --header <KEY:VALUE>
           Custom headers that should be attached to all requests
           in key:value format.
   -p, --project <PROJECT>
-          The project slug.
+          The project id or slug..
   -u, --url-prefix <PREFIX>
           The URL prefix to prepend to all filenames.
       --auth-token <AUTH_TOKEN>

--- a/tests/integration/_cases/sourcemaps/sourcemaps-upload-help.trycmd
+++ b/tests/integration/_cases/sourcemaps/sourcemaps-upload-help.trycmd
@@ -15,7 +15,7 @@ Options:
           Custom headers that should be attached to all requests
           in key:value format.
   -p, --project <PROJECT>
-          The project id or slug..
+          The project id or slug.
   -u, --url-prefix <PREFIX>
           The URL prefix to prepend to all filenames.
       --auth-token <AUTH_TOKEN>

--- a/tests/integration/_cases/sourcemaps/sourcemaps-upload-help.trycmd
+++ b/tests/integration/_cases/sourcemaps/sourcemaps-upload-help.trycmd
@@ -10,12 +10,12 @@ Arguments:
 
 Options:
   -o, --org <ORG>
-          The organization id or slug.
+          The organization ID or slug.
       --header <KEY:VALUE>
           Custom headers that should be attached to all requests
           in key:value format.
   -p, --project <PROJECT>
-          The project id or slug.
+          The project ID or slug.
   -u, --url-prefix <PREFIX>
           The URL prefix to prepend to all filenames.
       --auth-token <AUTH_TOKEN>

--- a/tests/integration/_cases/upload_dif/upload_dif-help.trycmd
+++ b/tests/integration/_cases/upload_dif/upload_dif-help.trycmd
@@ -12,7 +12,7 @@ Options:
   -o, --org <ORG>                The organization id or slug.
       --header <KEY:VALUE>       Custom headers that should be attached to all requests
                                  in key:value format.
-  -p, --project <PROJECT>        The project id or slug..
+  -p, --project <PROJECT>        The project id or slug.
       --auth-token <AUTH_TOKEN>  Use the given Sentry auth token.
   -t, --type <TYPE>              Only consider debug information files of the given type.  By
                                  default, all types are considered. [possible values: bcsymbolmap,

--- a/tests/integration/_cases/upload_dif/upload_dif-help.trycmd
+++ b/tests/integration/_cases/upload_dif/upload_dif-help.trycmd
@@ -9,10 +9,10 @@ Arguments:
   [PATH]...  A path to search recursively for symbol files.
 
 Options:
-  -o, --org <ORG>                The organization id or slug.
+  -o, --org <ORG>                The organization ID or slug.
       --header <KEY:VALUE>       Custom headers that should be attached to all requests
                                  in key:value format.
-  -p, --project <PROJECT>        The project id or slug.
+  -p, --project <PROJECT>        The project ID or slug.
       --auth-token <AUTH_TOKEN>  Use the given Sentry auth token.
   -t, --type <TYPE>              Only consider debug information files of the given type.  By
                                  default, all types are considered. [possible values: bcsymbolmap,

--- a/tests/integration/_cases/upload_dif/upload_dif-help.trycmd
+++ b/tests/integration/_cases/upload_dif/upload_dif-help.trycmd
@@ -9,10 +9,10 @@ Arguments:
   [PATH]...  A path to search recursively for symbol files.
 
 Options:
-  -o, --org <ORG>                The organization slug
+  -o, --org <ORG>                The organization id or slug.
       --header <KEY:VALUE>       Custom headers that should be attached to all requests
                                  in key:value format.
-  -p, --project <PROJECT>        The project slug.
+  -p, --project <PROJECT>        The project id or slug..
       --auth-token <AUTH_TOKEN>  Use the given Sentry auth token.
   -t, --type <TYPE>              Only consider debug information files of the given type.  By
                                  default, all types are considered. [possible values: bcsymbolmap,

--- a/tests/integration/_cases/upload_dsym/upload_dsym-help.trycmd
+++ b/tests/integration/_cases/upload_dsym/upload_dsym-help.trycmd
@@ -12,7 +12,7 @@ Options:
   -o, --org <ORG>                The organization id or slug.
       --header <KEY:VALUE>       Custom headers that should be attached to all requests
                                  in key:value format.
-  -p, --project <PROJECT>        The project id or slug..
+  -p, --project <PROJECT>        The project id or slug.
       --auth-token <AUTH_TOKEN>  Use the given Sentry auth token.
   -t, --type <TYPE>              Only consider debug information files of the given type.  By
                                  default, all types are considered. [possible values: bcsymbolmap,

--- a/tests/integration/_cases/upload_dsym/upload_dsym-help.trycmd
+++ b/tests/integration/_cases/upload_dsym/upload_dsym-help.trycmd
@@ -9,10 +9,10 @@ Arguments:
   [PATH]...  A path to search recursively for symbol files.
 
 Options:
-  -o, --org <ORG>                The organization id or slug.
+  -o, --org <ORG>                The organization ID or slug.
       --header <KEY:VALUE>       Custom headers that should be attached to all requests
                                  in key:value format.
-  -p, --project <PROJECT>        The project id or slug.
+  -p, --project <PROJECT>        The project ID or slug.
       --auth-token <AUTH_TOKEN>  Use the given Sentry auth token.
   -t, --type <TYPE>              Only consider debug information files of the given type.  By
                                  default, all types are considered. [possible values: bcsymbolmap,

--- a/tests/integration/_cases/upload_dsym/upload_dsym-help.trycmd
+++ b/tests/integration/_cases/upload_dsym/upload_dsym-help.trycmd
@@ -9,10 +9,10 @@ Arguments:
   [PATH]...  A path to search recursively for symbol files.
 
 Options:
-  -o, --org <ORG>                The organization slug
+  -o, --org <ORG>                The organization id or slug.
       --header <KEY:VALUE>       Custom headers that should be attached to all requests
                                  in key:value format.
-  -p, --project <PROJECT>        The project slug.
+  -p, --project <PROJECT>        The project id or slug..
       --auth-token <AUTH_TOKEN>  Use the given Sentry auth token.
   -t, --type <TYPE>              Only consider debug information files of the given type.  By
                                  default, all types are considered. [possible values: bcsymbolmap,

--- a/tests/integration/_cases/upload_proguard/upload_proguard-help.trycmd
+++ b/tests/integration/_cases/upload_proguard/upload_proguard-help.trycmd
@@ -9,10 +9,10 @@ Arguments:
   [PATH]...  The path to the mapping files.
 
 Options:
-  -o, --org <ORG>                    The organization id or slug.
+  -o, --org <ORG>                    The organization ID or slug.
       --header <KEY:VALUE>           Custom headers that should be attached to all requests
                                      in key:value format.
-  -p, --project <PROJECT>            The project id or slug.
+  -p, --project <PROJECT>            The project ID or slug.
       --auth-token <AUTH_TOKEN>      Use the given Sentry auth token.
       --version <VERSION>            Optionally associate the mapping files with a human readable
                                      version.

--- a/tests/integration/_cases/upload_proguard/upload_proguard-help.trycmd
+++ b/tests/integration/_cases/upload_proguard/upload_proguard-help.trycmd
@@ -12,7 +12,7 @@ Options:
   -o, --org <ORG>                    The organization id or slug.
       --header <KEY:VALUE>           Custom headers that should be attached to all requests
                                      in key:value format.
-  -p, --project <PROJECT>            The project id or slug..
+  -p, --project <PROJECT>            The project id or slug.
       --auth-token <AUTH_TOKEN>      Use the given Sentry auth token.
       --version <VERSION>            Optionally associate the mapping files with a human readable
                                      version.

--- a/tests/integration/_cases/upload_proguard/upload_proguard-help.trycmd
+++ b/tests/integration/_cases/upload_proguard/upload_proguard-help.trycmd
@@ -9,10 +9,10 @@ Arguments:
   [PATH]...  The path to the mapping files.
 
 Options:
-  -o, --org <ORG>                    The organization slug
+  -o, --org <ORG>                    The organization id or slug.
       --header <KEY:VALUE>           Custom headers that should be attached to all requests
                                      in key:value format.
-  -p, --project <PROJECT>            The project slug.
+  -p, --project <PROJECT>            The project id or slug..
       --auth-token <AUTH_TOKEN>      Use the given Sentry auth token.
       --version <VERSION>            Optionally associate the mapping files with a human readable
                                      version.


### PR DESCRIPTION
With the API changes [we made to support ids as well as slugs](https://vanguard.getsentry.net/p/clyoo0m4a000u12nb53fkxanl), we get the added bonus that our CLI can also support ids.

Turns out the CLI also uses a couple endpoints which passed project slug in the body parameter, so we also had to update them:
https://github.com/getsentry/sentry/pull/74232
https://github.com/getsentry/sentry/pull/74371

With these prs, all the endpoints the CLI uses have ID support.

@szokeasaurusrex  and I had a conversation about how we would like to roll this change out in an [earlier closed pr](https://github.com/getsentry/sentry-cli/pull/2098), and decided that once we support ids in all the CLI commands, we can change all the help strings at once, which is what i am doing here.