### PR TITLE
fix: Redact auth tokens when logging CLI args

### DIFF
--- a/src/utils/auth_token/auth_token_impl.rs
+++ b/src/utils/auth_token/auth_token_impl.rs
@@ -1,6 +1,6 @@
 //! Defines the AuthToken type, which stores a Sentry auth token.
 
-use super::AuthTokenPayload;
+use super::{AuthTokenPayload, ORG_AUTH_TOKEN_PREFIX, USER_TOKEN_PREFIX};
 use super::{OrgAuthToken, UserAuthToken};
 use std::fmt::{Display, Formatter, Result};
 
@@ -99,4 +99,13 @@ impl AuthTokenInner {
             AuthTokenInner::Unknown(auth_string) => auth_string,
         }
     }
+}
+
+/// Returns whether a given string looks like it might be an auth token.
+/// Specifically, we say a string looks like an auth token when it starts with one of the auth
+/// token prefixes (sntrys_ or sntryu_) or passes the auth token soft validation.
+pub fn looks_like_auth_token(s: &str) -> bool {
+    s.starts_with(ORG_AUTH_TOKEN_PREFIX)
+        || s.starts_with(USER_TOKEN_PREFIX)
+        || AuthToken::from(s).format_recognized()
 }

--- a/src/utils/auth_token/mod.rs
+++ b/src/utils/auth_token/mod.rs
@@ -5,7 +5,7 @@ mod error;
 mod org_auth_token;
 mod user_auth_token;
 
-pub use auth_token_impl::AuthToken;
+pub use auth_token_impl::{looks_like_auth_token, AuthToken};
 pub use org_auth_token::AuthTokenPayload;
 
 use error::{AuthTokenParseError, Result};
@@ -14,3 +14,6 @@ use user_auth_token::UserAuthToken;
 
 #[cfg(test)]
 mod test;
+
+const ORG_AUTH_TOKEN_PREFIX: &str = "sntrys_";
+const USER_TOKEN_PREFIX: &str = "sntryu_";

--- a/src/utils/auth_token/org_auth_token.rs
+++ b/src/utils/auth_token/org_auth_token.rs
@@ -1,7 +1,6 @@
-use super::{AuthTokenParseError, Result};
+use super::{AuthTokenParseError, Result, ORG_AUTH_TOKEN_PREFIX};
 use serde::{Deserialize, Deserializer};
 
-const ORG_AUTH_TOKEN_PREFIX: &str = "sntrys_";
 const ORG_TOKEN_SECRET_BYTES: usize = 32;
 
 /// Represents a valid org auth token.

--- a/src/utils/auth_token/user_auth_token.rs
+++ b/src/utils/auth_token/user_auth_token.rs
@@ -1,7 +1,6 @@
-use super::{AuthTokenParseError, Result};
+use super::{AuthTokenParseError, Result, USER_TOKEN_PREFIX};
 
 const USER_TOKEN_BYTES: usize = 32;
-const USER_TOKEN_PREFIX: &str = "sntryu_";
 
 /// Represents a valid User Auth Token.
 #[derive(Debug, Clone)]

--- a/tests/integration/_cases/token-redacted.trycmd
+++ b/tests/integration/_cases/token-redacted.trycmd
@@ -1,0 +1,9 @@
+```
+$ sentry-cli sourcemaps upload --auth-token not-following-token-format -o asdf -p sntrys_project_looks_like_token ./ --log-level=info
+? failed
+[..]
+[..]
+[..]INFO[..] sentry-cli was invoked with the following command line: "[..]" "sourcemaps" "upload" "--auth-token" (redacted) "-o" "asdf" "-p" (redacted) "./" "--log-level=info"
+...
+
+```

--- a/tests/integration/mod.rs
+++ b/tests/integration/mod.rs
@@ -235,3 +235,8 @@ pub fn assert_endpoints(mocks: &[Mock]) {
         mock.assert();
     }
 }
+
+#[test]
+pub fn token_redacted() {
+    register_test("token-redacted.trycmd");
+}


### PR DESCRIPTION
Redact anything that might be an auth token when logging the command line arguments to console. This occurs only when the log level is set to `info` or `debug`; the default is `warn`.