### PR TITLE
meta: Revert upload-artifact bump (#2110)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -39,7 +39,7 @@ jobs:
       - name: Rename Binary
         run: mv target/*/release/sentry-cli sentry-cli-Linux-${{ matrix.arch }}
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v3.1.1
         with:
           name: ${{ github.sha }}
           path: sentry-cli-Linux-${{ matrix.arch }}
@@ -76,7 +76,7 @@ jobs:
       - name: Rename Binary
         run: mv target/${{ matrix.target }}/release/sentry-cli sentry-cli-Darwin-${{ matrix.arch }}
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v3.1.1
         with:
           name: ${{ github.sha }}
           path: sentry-cli-Darwin-${{ matrix.arch }}
@@ -94,7 +94,7 @@ jobs:
       - name: Link universal binary
         run: lipo -create -output sentry-cli-Darwin-universal sentry-cli-Darwin-x86_64 sentry-cli-Darwin-arm64
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v3.1.1
         with:
           name: ${{ github.sha }}
           path: sentry-cli-Darwin-universal
@@ -132,7 +132,7 @@ jobs:
       - name: Rename Binary
         run: mv target/release/sentry-cli.exe sentry-cli-Windows-${{ matrix.arch }}.exe
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v3.1.1
         with:
           name: ${{ github.sha }}
           path: sentry-cli-Windows-${{ matrix.arch }}.exe
@@ -162,7 +162,7 @@ jobs:
 
       - run: npm pack
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v3.1.1
         with:
           name: ${{ github.sha }}
           path: '*.tgz'
@@ -182,7 +182,7 @@ jobs:
         with:
           python-version: '3.11'
       - run: python3 -m pip install build && python3 -m build
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v3.1.1
         with:
           name: ${{ github.sha }}-python-base
           path: dist/*
@@ -205,7 +205,7 @@ jobs:
           name: ${{ github.sha }}-python-base
           path: python-base
       - run: scripts/wheels --binaries binaries --base python-base --dest dist
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v3.1.1
         with:
           name: ${{ github.sha }}
           path: dist/*
@@ -244,7 +244,7 @@ jobs:
             cd -
           done
       - name: Upload packaged npm binary distributions
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v3.1.1
         with:
           name: ${{ github.sha }}
           path: npm-binary-distributions/*/*.tgz


### PR DESCRIPTION
This reverts commit d0e87177afc988d0193df75f4dc234ec637fb7da, which bumped `upload-artifact` to version 4.

Due to https://github.com/actions/upload-artifact/issues/478, `upload-artifact` version 4 is incompatible with our current release proces. This change is blocking us from successfully creating [release builds](https://github.com/getsentry/sentry-cli/actions/runs/10213847803).

As a workaround, we will revert this change for now.