### PR TITLE
feat: Prefer org auth token URL over manually provided URL

### DIFF
--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -120,7 +120,7 @@ fn configure_args(config: &mut Config, matches: &ArgMatches) -> Result<()> {
     }
 
     if let Some(url) = matches.get_one::<String>("url") {
-        config.set_base_url(url)?;
+        config.set_base_url(url);
     }
 
     if let Some(headers) = matches.get_many::<String>("headers") {

--- a/tests/integration/_cases/org_tokens/url-mismatch.trycmd
+++ b/tests/integration/_cases/org_tokens/url-mismatch.trycmd
@@ -1,9 +1,7 @@
 ```
 $ sentry-cli --auth-token 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 --url http://example.com sourcemaps upload test_path
 ? failed
-error: Two different url values supplied: `http://localhost:8000` (from token), `http://example.com`.
-
-Add --log-level=[info|debug] or export SENTRY_LOG_LEVEL=[info|debug] to see more output.
-Please attach the full debug log to all bug reports.
+[..]WARN[..] Using http://localhost:8000 (embedded in token) rather than manually-configured URL http://example.com. To use http://example.com, please provide an auth token for this URL.
+...
 
 ```


### PR DESCRIPTION
Previously, we would error when the auth token's embedded URL differed from the manually provided URL. Now, we instead always use the token URL and log a warning.

Closes [#2104](https://github.com/getsentry/sentry-cli/issues/2104)