### PR TITLE
meta: Update version pin README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ If you are on OS X or Linux, you can use the automated downloader which will fet
 We do, however, encourage you to pin the specific version of the CLI, so your builds are always reproducible.
 To do that, you can use the exact same method, with an additional version specifier:
 
-    curl -sL https://sentry.io/get-cli/ | SENTRY_CLI_VERSION=2.0.4 bash
+    curl -sL https://sentry.io/get-cli/ | SENTRY_CLI_VERSION=2.33.1 bash
 
 This will automatically download the correct version of `sentry-cli` for your operating system and install it. If necessary, it will prompt for your admin password for `sudo`. For a different installation location or for systems without `sudo` (like Windows), you can `export INSTALL_DIR=/custom/installation/path` before running this command.
 


### PR DESCRIPTION
The version pin we include in our example for pinning the CLI version is quite old. Let's increase it to the latest version.

Perhaps, in the future, we can automate this change in our release pipeline. For now, though, it is probably enough to make sure we periodically update this, especially after any important fixes.