### PR TITLE
fix(react-native): Fix RN 0.75 node binary build fail

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -5,7 +5,7 @@
 !package.json
 !README.md
 !LICENSE
-!bin
+!bin/sentry-cli
 !js
 !scripts/install.js
 !checksums.txt

--- a/bin/sentry-cli-dev
+++ b/bin/sentry-cli-dev
@@ -1,13 +1,12 @@
 #!/usr/bin/env node
 
-
 'use strict';
 
 const childProcess = require('child_process');
 const path = require('path');
 
 const child = childProcess
-  .spawn(path.join(__dirname, "../target/debug/sentry-cli"), process.argv.slice(2), {
+  .spawn(path.join(__dirname, '../target/debug/sentry-cli'), process.argv.slice(2), {
     stdio: 'inherit',
   })
   .on('error', (err) => {

--- a/bin/sentry-cli-dev
+++ b/bin/sentry-cli-dev
@@ -1,0 +1,20 @@
+#!/usr/bin/env node
+
+
+'use strict';
+
+const childProcess = require('child_process');
+const path = require('path');
+
+const child = childProcess
+  .spawn(path.join(__dirname, "../target/debug/sentry-cli"), process.argv.slice(2), {
+    stdio: 'inherit',
+  })
+  .on('error', (err) => {
+    console.error(err); // eslint-disable-line no-console
+    process.exit(1);
+  })
+  .on('exit', (code) => process.exit(code));
+
+process.on('SIGTERM', () => child.kill('SIGTERM'));
+process.on('SIGINT', () => child.kill('SIGINT'));

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -95,7 +95,6 @@ fn preexecute_hooks() -> Result<bool> {
     #[cfg(target_os = "macos")]
     fn sentry_react_native_xcode_wrap() -> Result<bool> {
         if let Ok(val) = env::var("__SENTRY_RN_WRAP_XCODE_CALL") {
-            env::remove_var("__SENTRY_RN_WRAP_XCODE_CALL");
             if &val == "1" {
                 crate::commands::react_native::xcode::wrap_call()?;
                 return Ok(true);


### PR DESCRIPTION
- This RP fixes https://github.com/getsentry/sentry-react-native/issues/4036

The change enables wrapped call to execute other child calls.

This is need due to recent RN 0.75 change.
- https://github.com/facebook/react-native/pull/44721/files#diff-16a358d6a9dea8469bfdb899d0990df1c32b8c3b1149c86685bec81f50bd24be

`sentry-cli-fake-node react-native/cli.js config` is called by `sentry-cli-fake-node @react-native-community/cli bundle`

For this we need to allow the recursive wrapped calls. This is currently not an issue as the wrapped call doesn't execute Sentry-CLI binary commands.

---

The added `[sentry-cli-dev](https://github.com/getsentry/sentry-cli/pull/2131/files#diff-03f1f612bbc5cf7f68294e8711ae18b595e02639a86cf9c3c4e633576ca1836c)` makes testing dev build easier in node environments.