### PR TITLE
fix(debugIds): Always instantiate global `Error` class in debugId injection snippet

### DIFF
--- a/src/utils/sourcemaps/inject.rs
+++ b/src/utils/sourcemaps/inject.rs
@@ -14,7 +14,7 @@ use magic_string::{GenerateDecodedMapOptions, MagicString};
 use sentry::types::DebugId;
 use sourcemap::SourceMap;
 
-const CODE_SNIPPET_TEMPLATE: &str = r#"!function(){try{var e="undefined"!=typeof window?window:"undefined"!=typeof global?global:"undefined"!=typeof self?self:{},n=(new Error).stack;n&&(e._sentryDebugIds=e._sentryDebugIds||{},e._sentryDebugIds[n]="__SENTRY_DEBUG_ID__")}catch(e){}}();"#;
+const CODE_SNIPPET_TEMPLATE: &str = r#"!function(){try{var e="undefined"!=typeof window?window:"undefined"!=typeof global?global:"undefined"!=typeof self?self:{},n=(new e.Error).stack;n&&(e._sentryDebugIds=e._sentryDebugIds||{},e._sentryDebugIds[n]="__SENTRY_DEBUG_ID__")}catch(e){}}();"#;
 const DEBUGID_PLACEHOLDER: &str = "__SENTRY_DEBUG_ID__";
 const DEBUGID_COMMENT_PREFIX: &str = "//# debugId";
 
@@ -329,7 +329,7 @@ something else"#;
 
         let expected = r#"//# sourceMappingURL=fake1
 
-!function(){try{var e="undefined"!=typeof window?window:"undefined"!=typeof global?global:"undefined"!=typeof self?self:{},n=(new Error).stack;n&&(e._sentryDebugIds=e._sentryDebugIds||{},e._sentryDebugIds[n]="00000000-0000-0000-0000-000000000000")}catch(e){}}();
+!function(){try{var e="undefined"!=typeof window?window:"undefined"!=typeof global?global:"undefined"!=typeof self?self:{},n=(new e.Error).stack;n&&(e._sentryDebugIds=e._sentryDebugIds||{},e._sentryDebugIds[n]="00000000-0000-0000-0000-000000000000")}catch(e){}}();
 some line
 //# sourceMappingURL=fake2
 //# sourceMappingURL=real
@@ -383,7 +383,7 @@ something else"#;
 
 
 
-!function(){try{var e="undefined"!=typeof window?window:"undefined"!=typeof global?global:"undefined"!=typeof self?self:{},n=(new Error).stack;n&&(e._sentryDebugIds=e._sentryDebugIds||{},e._sentryDebugIds[n]="00000000-0000-0000-0000-000000000000")}catch(e){}}();
+!function(){try{var e="undefined"!=typeof window?window:"undefined"!=typeof global?global:"undefined"!=typeof self?self:{},n=(new e.Error).stack;n&&(e._sentryDebugIds=e._sentryDebugIds||{},e._sentryDebugIds[n]="00000000-0000-0000-0000-000000000000")}catch(e){}}();
 some line
 //# sourceMappingURL=fake
 //# sourceMappingURL=fake
@@ -430,7 +430,7 @@ something else"#;
 
   // some other comment
 "use strict";
-!function(){try{var e="undefined"!=typeof window?window:"undefined"!=typeof global?global:"undefined"!=typeof self?self:{},n=(new Error).stack;n&&(e._sentryDebugIds=e._sentryDebugIds||{},e._sentryDebugIds[n]="00000000-0000-0000-0000-000000000000")}catch(e){}}();
+!function(){try{var e="undefined"!=typeof window?window:"undefined"!=typeof global?global:"undefined"!=typeof self?self:{},n=(new e.Error).stack;n&&(e._sentryDebugIds=e._sentryDebugIds||{},e._sentryDebugIds[n]="00000000-0000-0000-0000-000000000000")}catch(e){}}();
  rest of the line
 'use strict';
 some line
@@ -466,7 +466,7 @@ something else"#;
 
   // some other comment
 "use strict";
-!function(){try{var e="undefined"!=typeof window?window:"undefined"!=typeof global?global:"undefined"!=typeof self?self:{},n=(new Error).stack;n&&(e._sentryDebugIds=e._sentryDebugIds||{},e._sentryDebugIds[n]="00000000-0000-0000-0000-000000000000")}catch(e){}}();
+!function(){try{var e="undefined"!=typeof window?window:"undefined"!=typeof global?global:"undefined"!=typeof self?self:{},n=(new e.Error).stack;n&&(e._sentryDebugIds=e._sentryDebugIds||{},e._sentryDebugIds[n]="00000000-0000-0000-0000-000000000000")}catch(e){}}();
  rest of the line
 (this.foo=this.bar||[]).push([[2],[function(e,t,n){"use strict"; […] }
 some line

--- a/tests/integration/_fixtures/inject_bundlers/esbuild/cjs.js.expected
+++ b/tests/integration/_fixtures/inject_bundlers/esbuild/cjs.js.expected
@@ -1,5 +1,5 @@
 "use strict";
-!function(){try{var e="undefined"!=typeof window?window:"undefined"!=typeof global?global:"undefined"!=typeof self?self:{},n=(new Error).stack;n&&(e._sentryDebugIds=e._sentryDebugIds||{},e._sentryDebugIds[n]="a9f9a996-4e6c-5119-b8b8-e64559a6554c")}catch(e){}}();
+!function(){try{var e="undefined"!=typeof window?window:"undefined"!=typeof global?global:"undefined"!=typeof self?self:{},n=(new e.Error).stack;n&&(e._sentryDebugIds=e._sentryDebugIds||{},e._sentryDebugIds[n]="a9f9a996-4e6c-5119-b8b8-e64559a6554c")}catch(e){}}();
 function t(r,o){r(o)}function n(r,o){t(r,o)}function f(r,o){n(r,o)}f(function(o){throw new Error(o)},"boop");
 //# sourceMappingURL=cjs.js.map
 

--- a/tests/integration/_fixtures/inject_bundlers/esbuild/iife.js.expected
+++ b/tests/integration/_fixtures/inject_bundlers/esbuild/iife.js.expected
@@ -1,5 +1,5 @@
 
-!function(){try{var e="undefined"!=typeof window?window:"undefined"!=typeof global?global:"undefined"!=typeof self?self:{},n=(new Error).stack;n&&(e._sentryDebugIds=e._sentryDebugIds||{},e._sentryDebugIds[n]="dd751360-5eae-531d-87f4-5e00c846a9a3")}catch(e){}}();
+!function(){try{var e="undefined"!=typeof window?window:"undefined"!=typeof global?global:"undefined"!=typeof self?self:{},n=(new e.Error).stack;n&&(e._sentryDebugIds=e._sentryDebugIds||{},e._sentryDebugIds[n]="dd751360-5eae-531d-87f4-5e00c846a9a3")}catch(e){}}();
 (()=>{function t(r,o){r(o)}function n(r,o){t(r,o)}function f(r,o){n(r,o)}f(function(o){throw new Error(o)},"boop");})();
 //# sourceMappingURL=iife.js.map
 

--- a/tests/integration/_fixtures/inject_bundlers/rollup/cjs.js.expected
+++ b/tests/integration/_fixtures/inject_bundlers/rollup/cjs.js.expected
@@ -1,5 +1,5 @@
 "use strict";
-!function(){try{var e="undefined"!=typeof window?window:"undefined"!=typeof global?global:"undefined"!=typeof self?self:{},n=(new Error).stack;n&&(e._sentryDebugIds=e._sentryDebugIds||{},e._sentryDebugIds[n]="0b6cf2c0-b31e-5bb4-9e50-a0c0fd4837db")}catch(e){}}();
+!function(){try{var e="undefined"!=typeof window?window:"undefined"!=typeof global?global:"undefined"!=typeof self?self:{},n=(new e.Error).stack;n&&(e._sentryDebugIds=e._sentryDebugIds||{},e._sentryDebugIds[n]="0b6cf2c0-b31e-5bb4-9e50-a0c0fd4837db")}catch(e){}}();
 var n;n=function(n){throw new Error(n)},function(n,o){!function(n,o){n(o)}(n,o)}(n,"boop");
 //# sourceMappingURL=cjs.js.map
 

--- a/tests/integration/_fixtures/inject_bundlers/rollup/iife.js.expected
+++ b/tests/integration/_fixtures/inject_bundlers/rollup/iife.js.expected
@@ -1,5 +1,5 @@
 
-!function(){try{var e="undefined"!=typeof window?window:"undefined"!=typeof global?global:"undefined"!=typeof self?self:{},n=(new Error).stack;n&&(e._sentryDebugIds=e._sentryDebugIds||{},e._sentryDebugIds[n]="6cde0fde-8646-5aa5-90be-6540abac2d15")}catch(e){}}();
+!function(){try{var e="undefined"!=typeof window?window:"undefined"!=typeof global?global:"undefined"!=typeof self?self:{},n=(new e.Error).stack;n&&(e._sentryDebugIds=e._sentryDebugIds||{},e._sentryDebugIds[n]="6cde0fde-8646-5aa5-90be-6540abac2d15")}catch(e){}}();
 !function(){"use strict";var n;n=function(n){throw new Error(n)},function(n,o){!function(n,o){n(o)}(n,o)}(n,"boop")}();
 //# sourceMappingURL=iife.js.map
 

--- a/tests/integration/_fixtures/inject_bundlers/rspack/iife.js.expected
+++ b/tests/integration/_fixtures/inject_bundlers/rspack/iife.js.expected
@@ -1,5 +1,5 @@
 
-!function(){try{var e="undefined"!=typeof window?window:"undefined"!=typeof global?global:"undefined"!=typeof self?self:{},n=(new Error).stack;n&&(e._sentryDebugIds=e._sentryDebugIds||{},e._sentryDebugIds[n]="d50bd339-0bfa-5b90-9c5f-479cf9c0c40c")}catch(e){}}();
+!function(){try{var e="undefined"!=typeof window?window:"undefined"!=typeof global?global:"undefined"!=typeof self?self:{},n=(new e.Error).stack;n&&(e._sentryDebugIds=e._sentryDebugIds||{},e._sentryDebugIds[n]="d50bd339-0bfa-5b90-9c5f-479cf9c0c40c")}catch(e){}}();
 !function(){var e={62:function(e,r,t){"use strict";function n(e,r){e(r)}Object.defineProperty(r,"__esModule",{value:!0}),Object.defineProperty(r,"bar",{enumerable:!0,get:function(){return n}})},447:function(e,r,t){"use strict";Object.defineProperty(r,"__esModule",{value:!0}),Object.defineProperty(r,"foo",{enumerable:!0,get:function(){return o}});var n=t("62");function o(e,r){(0,n.bar)(e,r)}},151:function(e,r,t){"use strict";Object.defineProperty(r,"__esModule",{value:!0});var n,o,u=t("447");n=function(e){throw Error(e)},o="boop",(0,u.foo)(n,o)}},r={};!function t(n){var o=r[n];if(void 0!==o)return o.exports;var u=r[n]={exports:{}};return e[n](u,u.exports,t),u.exports}("151")}();
 //# sourceMappingURL=iife.js.map
 //# debugId=d50bd339-0bfa-5b90-9c5f-479cf9c0c40c

--- a/tests/integration/_fixtures/inject_bundlers/vite/cjs.js.expected
+++ b/tests/integration/_fixtures/inject_bundlers/vite/cjs.js.expected
@@ -1,5 +1,5 @@
 "use strict";
-!function(){try{var e="undefined"!=typeof window?window:"undefined"!=typeof global?global:"undefined"!=typeof self?self:{},n=(new Error).stack;n&&(e._sentryDebugIds=e._sentryDebugIds||{},e._sentryDebugIds[n]="c2fca958-c33e-5626-90a1-c6ce633b1f55")}catch(e){}}();
+!function(){try{var e="undefined"!=typeof window?window:"undefined"!=typeof global?global:"undefined"!=typeof self?self:{},n=(new e.Error).stack;n&&(e._sentryDebugIds=e._sentryDebugIds||{},e._sentryDebugIds[n]="c2fca958-c33e-5626-90a1-c6ce633b1f55")}catch(e){}}();
 function t(n,o){n(o)}function r(n,o){t(n,o)}function c(n,o){r(n,o)}c(function(o){throw new Error(o)},"boop");
 //# sourceMappingURL=cjs.js.map
 

--- a/tests/integration/_fixtures/inject_bundlers/vite/iife.js.expected
+++ b/tests/integration/_fixtures/inject_bundlers/vite/iife.js.expected
@@ -1,5 +1,5 @@
 
-!function(){try{var e="undefined"!=typeof window?window:"undefined"!=typeof global?global:"undefined"!=typeof self?self:{},n=(new Error).stack;n&&(e._sentryDebugIds=e._sentryDebugIds||{},e._sentryDebugIds[n]="61108b96-d9cb-5d14-a1a1-cc066b34c428")}catch(e){}}();
+!function(){try{var e="undefined"!=typeof window?window:"undefined"!=typeof global?global:"undefined"!=typeof self?self:{},n=(new e.Error).stack;n&&(e._sentryDebugIds=e._sentryDebugIds||{},e._sentryDebugIds[n]="61108b96-d9cb-5d14-a1a1-cc066b34c428")}catch(e){}}();
 (function(){"use strict";function t(n,o){n(o)}function c(n,o){t(n,o)}function f(n,o){c(n,o)}f(function(o){throw new Error(o)},"boop")})();
 //# sourceMappingURL=iife.js.map
 

--- a/tests/integration/_fixtures/inject_bundlers/webpack/cjs.js.expected
+++ b/tests/integration/_fixtures/inject_bundlers/webpack/cjs.js.expected
@@ -1,5 +1,5 @@
 "use strict";
-!function(){try{var e="undefined"!=typeof window?window:"undefined"!=typeof global?global:"undefined"!=typeof self?self:{},n=(new Error).stack;n&&(e._sentryDebugIds=e._sentryDebugIds||{},e._sentryDebugIds[n]="feff3330-3acf-5df7-9a95-97b3da52cb8a")}catch(e){}}();
+!function(){try{var e="undefined"!=typeof window?window:"undefined"!=typeof global?global:"undefined"!=typeof self?self:{},n=(new e.Error).stack;n&&(e._sentryDebugIds=e._sentryDebugIds||{},e._sentryDebugIds[n]="feff3330-3acf-5df7-9a95-97b3da52cb8a")}catch(e){}}();
 var __webpack_require__={r:e=>{"undefined"!=typeof Symbol&&Symbol.toStringTag&&Object.defineProperty(e,Symbol.toStringTag,{value:"Module"}),Object.defineProperty(e,"__esModule",{value:!0})}},__webpack_exports__={};function bar(e,o){e(o)}function foo(e,o){bar(e,o)}function wat(e,o){foo(e,o)}__webpack_require__.r(__webpack_exports__),wat((function(e){throw new Error(e)}),"boop"),module.exports=__webpack_exports__;
 //# sourceMappingURL=cjs.js.map
 //# debugId=feff3330-3acf-5df7-9a95-97b3da52cb8a

--- a/tests/integration/_fixtures/inject_bundlers/webpack/iife.js.expected
+++ b/tests/integration/_fixtures/inject_bundlers/webpack/iife.js.expected
@@ -1,5 +1,5 @@
 
-!function(){try{var e="undefined"!=typeof window?window:"undefined"!=typeof global?global:"undefined"!=typeof self?self:{},n=(new Error).stack;n&&(e._sentryDebugIds=e._sentryDebugIds||{},e._sentryDebugIds[n]="397f1037-b958-54cc-bc62-267d5b7aff25")}catch(e){}}();
+!function(){try{var e="undefined"!=typeof window?window:"undefined"!=typeof global?global:"undefined"!=typeof self?self:{},n=(new e.Error).stack;n&&(e._sentryDebugIds=e._sentryDebugIds||{},e._sentryDebugIds[n]="397f1037-b958-54cc-bc62-267d5b7aff25")}catch(e){}}();
 (()=>{"use strict";(function(n,o){!function(n,o){n(o)}(n,"boop")})((function(n){throw new Error(n)}))})();
 //# sourceMappingURL=iife.js.map
 //# debugId=397f1037-b958-54cc-bc62-267d5b7aff25


### PR DESCRIPTION
This PR makes a small change to the JavaScript snippet that's injected into user files to set the debugId.

Previously, we'd instantiate `new Error` in the script, which usually implicitly instantiates `globalThis.Error`. However, if users or frameworks would create their own `Error` class in the very file where the debugId snippet is instantiated, `new Error` would of course take the user-created class rather than the global one. To fix this, this PR now explicitly instantiates the `globalThis.Error` class.

fixes: https://github.com/getsentry/sentry-javascript-bundler-plugins/issues/593