### PR TITLE
ci: Downgrade to `actions/download-artifact@v3`

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -87,7 +87,7 @@ jobs:
     runs-on: macos-latest
 
     steps:
-      - uses: actions/download-artifact@v4.1.7
+      - uses: actions/download-artifact@v3
         with:
           name: ${{ github.sha }}
 
@@ -150,7 +150,7 @@ jobs:
           node-version: '20.10.0'
 
       - name: Download compiled binaries
-        uses: actions/download-artifact@v4.1.7
+        uses: actions/download-artifact@v3
         with:
           name: ${{ github.sha }}
 
@@ -196,11 +196,11 @@ jobs:
       - uses: actions/setup-python@v4
         with:
           python-version: '3.11'
-      - uses: actions/download-artifact@v4.1.7
+      - uses: actions/download-artifact@v3
         with:
           name: ${{ github.sha }}
           path: binaries
-      - uses: actions/download-artifact@v4.1.7
+      - uses: actions/download-artifact@v3
         with:
           name: ${{ github.sha }}-python-base
           path: python-base
@@ -219,7 +219,7 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: '20.10.0'
-      - uses: actions/download-artifact@v4.1.7
+      - uses: actions/download-artifact@v3
         with:
           name: ${{ github.sha }}
           path: binary-artifacts


### PR DESCRIPTION
Since we use `actions/upload-artifact@v3`, we cannot upgrade to `actions/download-artifact@v4` quite yet.