### PR TITLE
feat: Log when file not added to source bundle

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2785,9 +2785,9 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "symbolic"
-version = "12.10.1"
+version = "12.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0706ae7a55f896744f7432fe6bd39c75d5101600da8aca9bda2ebd20461940f7"
+checksum = "292c581643734291ad8cb7e405b07b396cd066747ea7002e307f5b122c8bc9fc"
 dependencies = [
  "symbolic-common",
  "symbolic-debuginfo",
@@ -2797,9 +2797,9 @@ dependencies = [
 
 [[package]]
 name = "symbolic-common"
-version = "12.10.1"
+version = "12.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1944ea8afd197111bca0c0edea1e1f56abb3edd030e240c1035cc0e3ff51fec"
+checksum = "9c1db5ac243c7d7f8439eb3b8f0357888b37cf3732957e91383b0ad61756374e"
 dependencies = [
  "debugid",
  "memmap2",
@@ -2810,9 +2810,9 @@ dependencies = [
 
 [[package]]
 name = "symbolic-debuginfo"
-version = "12.10.1"
+version = "12.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8311940c4b7ff9234a3a0dabc0b683a6c43da739a9a3f44744781e465d81bcee"
+checksum = "b1039f8255e7b3c55f7259cf8cf6819664d32bae97127cc6d189c3fdd98ccb80"
 dependencies = [
  "debugid",
  "dmsort",
@@ -2843,9 +2843,9 @@ dependencies = [
 
 [[package]]
 name = "symbolic-il2cpp"
-version = "12.10.1"
+version = "12.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb23700aeaa8fc26d9d3673a458f2cf3052f37f2745f28d661a49afc7e09b4a1"
+checksum = "570b8c476502625009cec6d1a5a82a6bebc010553b27ddace2ec8e6362ed6a6a"
 dependencies = [
  "indexmap",
  "serde_json",
@@ -2855,9 +2855,9 @@ dependencies = [
 
 [[package]]
 name = "symbolic-ppdb"
-version = "12.10.1"
+version = "12.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe4c4111d6af76ff4c251840fcfe1e01ab074866890351ac6cc7d0486c0dc92f"
+checksum = "3f877b26bd3185d90f5bc45a3a6951f63923482b52bb342a7f44eed63adb8ca7"
 dependencies = [
  "flate2",
  "indexmap",
@@ -2871,9 +2871,9 @@ dependencies = [
 
 [[package]]
 name = "symbolic-symcache"
-version = "12.10.1"
+version = "12.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b293cdcc7f493fd7cfde707c53f221c98acaf7295a643fb22333fa6097150c6"
+checksum = "801936fa044ae6853a2616dc1f744a89320e3dbd908a5ade21304d1a3fdaeb79"
 dependencies = [
  "indexmap",
  "symbolic-common",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -69,7 +69,7 @@ serde = { version = "1.0.152", features = ["derive"] }
 serde_json = "1.0.93"
 sha1_smol = { version = "1.0.0", features = ["serde"] }
 sourcemap = { version = "7.0.1", features = ["ram_bundle"] }
-symbolic = { version = "12.10.1", features = ["debuginfo-serde", "il2cpp"] }
+symbolic = { version = "12.11.0", features = ["debuginfo-serde", "il2cpp"] }
 thiserror = "1.0.38"
 url = "2.3.1"
 username = "0.2.0"

--- a/src/commands/debug_files/bundle_sources.rs
+++ b/src/commands/debug_files/bundle_sources.rs
@@ -3,7 +3,7 @@ use std::path::{Path, PathBuf};
 
 use anyhow::Result;
 use clap::{Arg, ArgAction, ArgMatches, Command};
-use log::warn;
+use log::{info, warn};
 use symbolic::debuginfo::sourcebundle::SourceBundleWriter;
 
 use crate::utils::dif::DifFile;
@@ -100,11 +100,13 @@ pub fn execute(matches: &ArgMatches) -> Result<()> {
             // Resolve source files from the object and write their contents into the archive. Skip to
             // upload this bundle if no source could be written. This can happen if there is no file or
             // line information in the object file, or if none of the files could be resolved.
-            let written = writer.write_object_with_filter(
-                &object,
-                &filename.to_string_lossy(),
-                filter_bad_sources,
-            )?;
+            let written = writer
+                .with_skipped_file_callback(|skipped_info| info!("{skipped_info}"))
+                .write_object_with_filter(
+                    &object,
+                    &filename.to_string_lossy(),
+                    filter_bad_sources,
+                )?;
 
             if !written {
                 eprintln!("skipped {orig_path} (no files found)");

--- a/src/utils/dif_upload.rs
+++ b/src/utils/dif_upload.rs
@@ -1185,8 +1185,9 @@ fn create_source_bundles<'a>(
         // Resolve source files from the object and write their contents into the archive. Skip to
         // upload this bundle if no source could be written. This can happen if there is no file or
         // line information in the object file, or if none of the files could be resolved.
-        let written =
-            writer.write_object_with_filter(object, dif.file_name(), filter_bad_sources)?;
+        let written = writer
+            .with_skipped_file_callback(|skipped_info| info!("{skipped_info}"))
+            .write_object_with_filter(object, dif.file_name(), filter_bad_sources)?;
         if !written {
             debug!("No sources found for {}", name);
             continue;


### PR DESCRIPTION
When a file has an invalid (non-UTF-8) encoding, it is skipped from being added to source bundles. Previously, the file was silently skipped. Now, we log when we skip a file.

The logs are emitted at the `info` level, which is hidden by default (default log level is `warn`). To see these logs, users will need to set the log level, for example by passing `--log-level=info`.

Fixes #2135
Fixes #2147 