### PR TITLE
ci: update actions/upload-artifact to v4 with merge

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,8 +2,8 @@ name: Release Build
 
 on:
   push:
-#    branches:
-#      - release/**
+    branches:
+      - release/**
 
 jobs:
   linux:


### PR DESCRIPTION
Retrying upload-artifact v4 update (see https://github.com/getsentry/sentry-cli/pull/2119) by using artifacts/merge to merge together multiple artifacts from different jobs into the single one named github.sha that craft expects.

Summarily, upload-artifact v3 is deprecated but v4 doesn't support mutating an artifact with the name name by uploading different filepaths to the same artifact. Because we need a single artifact "github.sha", we have to use actions/merge to create it. Alternatively craft could be modified but this is the easiest way forward and I like the idea of a unified artifact, it makes craft simpler.

ref: https://github.com/getsentry/craft/issues/552
