### PR TITLE
fix(deploys): Honor `--project` in `deploys new` subcommand

### DIFF
--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -2360,7 +2360,7 @@ impl fmt::Display for Repo {
 }
 
 #[derive(Serialize, Deserialize, Debug, Default)]
-pub struct Deploy {
+pub struct Deploy<'d> {
     #[serde(rename = "environment")]
     pub env: String,
     pub name: Option<String>,
@@ -2369,9 +2369,11 @@ pub struct Deploy {
     pub started: Option<DateTime<Utc>>,
     #[serde(rename = "dateFinished")]
     pub finished: Option<DateTime<Utc>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub projects: Option<Vec<Cow<'d, str>>>,
 }
 
-impl Deploy {
+impl<'d> Deploy<'d> {
     /// Returns the name of this deploy, defaulting to `"unnamed"`.
     pub fn name(&self) -> &str {
         match self.name.as_deref() {

--- a/src/commands/deploys/new.rs
+++ b/src/commands/deploys/new.rs
@@ -71,6 +71,7 @@ pub fn execute(matches: &ArgMatches) -> Result<()> {
         env: matches.get_one::<String>("env").unwrap().to_string(),
         name: matches.get_one::<String>("name").cloned(),
         url: matches.get_one::<String>("url").cloned(),
+        projects: matches.get_many::<String>("project").map(|x| x.into_iter().map(|x| x.into()).collect()),
         ..Default::default()
     };
 
@@ -90,8 +91,9 @@ pub fn execute(matches: &ArgMatches) -> Result<()> {
     }
 
     let org = config.get_org(matches)?;
-    let created_deploy = api
-        .authenticated()?
+    let authenticated_api = api.authenticated()?;
+
+    let created_deploy = authenticated_api
         .create_deploy(&org, &version, &deploy)?;
 
     println!(


### PR DESCRIPTION
Previously, we ignored the `--project` arguments passed to the `sentry-cli deploys new` command. Regardless of whether any `--project` was provided, the deploy was created for all projects associated with the given release.

Now, we respect the `--project` argument. If provided, we only create the deploy for the project(s) specified. If omitted, the deploy is created for all projects associated with the release, as previously.

Fixes #2156