### PR TITLE
Refactor deploys

### DIFF
--- a/src/api/data_types/deploy.rs
+++ b/src/api/data_types/deploy.rs
@@ -1,0 +1,29 @@
+//! The `Deploy` data type.
+
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use std::borrow::Cow;
+
+#[derive(Serialize, Deserialize, Debug, Default)]
+pub struct Deploy<'d> {
+    #[serde(rename = "environment")]
+    pub env: Cow<'d, str>,
+    pub name: Option<Cow<'d, str>>,
+    pub url: Option<Cow<'d, str>>,
+    #[serde(rename = "dateStarted")]
+    pub started: Option<DateTime<Utc>>,
+    #[serde(rename = "dateFinished")]
+    pub finished: Option<DateTime<Utc>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub projects: Option<Vec<Cow<'d, str>>>,
+}
+
+impl<'d> Deploy<'d> {
+    /// Returns the name of this deploy, defaulting to `"unnamed"`.
+    pub fn name(&self) -> &str {
+        match self.name.as_deref() {
+            Some("") | None => "unnamed",
+            Some(name) => name,
+        }
+    }
+}

--- a/src/api/data_types/mod.rs
+++ b/src/api/data_types/mod.rs
@@ -1,3 +1,7 @@
+//! Data types used in the api module
+
 mod chunking;
+mod deploy;
 
 pub use self::chunking::*;
+pub use self::deploy::*;

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -2362,9 +2362,9 @@ impl fmt::Display for Repo {
 #[derive(Serialize, Deserialize, Debug, Default)]
 pub struct Deploy<'d> {
     #[serde(rename = "environment")]
-    pub env: String,
-    pub name: Option<String>,
-    pub url: Option<String>,
+    pub env: Cow<'d, str>,
+    pub name: Option<Cow<'d, str>>,
+    pub url: Option<Cow<'d, str>>,
     #[serde(rename = "dateStarted")]
     pub started: Option<DateTime<Utc>>,
     #[serde(rename = "dateFinished")]

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -2359,30 +2359,6 @@ impl fmt::Display for Repo {
     }
 }
 
-#[derive(Serialize, Deserialize, Debug, Default)]
-pub struct Deploy<'d> {
-    #[serde(rename = "environment")]
-    pub env: Cow<'d, str>,
-    pub name: Option<Cow<'d, str>>,
-    pub url: Option<Cow<'d, str>>,
-    #[serde(rename = "dateStarted")]
-    pub started: Option<DateTime<Utc>>,
-    #[serde(rename = "dateFinished")]
-    pub finished: Option<DateTime<Utc>>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub projects: Option<Vec<Cow<'d, str>>>,
-}
-
-impl<'d> Deploy<'d> {
-    /// Returns the name of this deploy, defaulting to `"unnamed"`.
-    pub fn name(&self) -> &str {
-        match self.name.as_deref() {
-            Some("") | None => "unnamed",
-            Some(name) => name,
-        }
-    }
-}
-
 #[derive(Debug, Serialize, Clone)]
 pub struct PatchSet {
     pub path: String,

--- a/src/commands/deploys/new.rs
+++ b/src/commands/deploys/new.rs
@@ -68,9 +68,9 @@ pub fn execute(matches: &ArgMatches) -> Result<()> {
     let api = Api::current();
     let version = config.get_release_with_legacy_fallback(matches)?;
     let mut deploy = Deploy {
-        env: matches.get_one::<String>("env").unwrap().to_string(),
-        name: matches.get_one::<String>("name").cloned(),
-        url: matches.get_one::<String>("url").cloned(),
+        env: matches.get_one::<String>("env").unwrap().into(),
+        name: matches.get_one::<String>("name").map(|n| n.into()),
+        url: matches.get_one::<String>("url").map(|u| u.into()),
         projects: matches.get_many::<String>("project").map(|x| x.into_iter().map(|x| x.into()).collect()),
         ..Default::default()
     };


### PR DESCRIPTION
- Use `Cow<str>` rather than `String` in the `Deploy` struct to avoid allocations where unnecessary
- Separate `Deploy` struct into separate module

I have split this PR into two commits which separately implement each of the above changes. It might be easier to review the commits individually.

ref #2077 