### PR TITLE
ref: Extract `MayDetach` wrapped calls into separate methods

### DIFF
--- a/src/commands/debug_files/upload.rs
+++ b/src/commands/debug_files/upload.rs
@@ -2,7 +2,7 @@ use std::collections::BTreeSet;
 use std::str::{self, FromStr};
 use std::time::Duration;
 
-use anyhow::{bail, format_err, Result};
+use anyhow::{bail, format_err, Error, Result};
 use clap::{builder::PossibleValuesParser, Arg, ArgAction, ArgMatches, Command};
 use console::style;
 use itertools::Itertools;
@@ -303,6 +303,12 @@ pub fn execute(matches: &ArgMatches) -> Result<()> {
         return Ok(());
     }
 
+    upload_debug_symbols(matches, upload)
+}
+
+// Execute the upload
+/// Executes the upload of debug symbols, possibly detaching the process.
+fn upload_debug_symbols(matches: &ArgMatches, mut upload: DifUpload) -> Result<(), Error> {
     // Execute the upload
     let (uploaded, has_processing_errors) = upload.upload()?;
 


### PR DESCRIPTION
Done in preparation for #2166, to make that change's diff smaller and easier to understand.