### PR TITLE
feat(xcode): All uploads in foreground

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -439,17 +439,6 @@ impl Config {
         )
     }
 
-    /// Returns true if notifications should be displayed.
-    /// We only use this function in the macOS binary.
-    #[cfg(target_os = "macos")]
-    pub fn show_notifications(&self) -> Result<bool> {
-        Ok(self
-            .ini
-            .get_from(Some("ui"), "show_notifications")
-            .map(|x| x == "true")
-            .unwrap_or(true))
-    }
-
     /// Returns the maximum DIF upload size
     pub fn get_max_dif_archive_size(&self) -> u64 {
         let key = "max_upload_size";

--- a/tests/integration/_cases/debug_files/debug_files-upload-help.trycmd
+++ b/tests/integration/_cases/debug_files/debug_files-upload-help.trycmd
@@ -52,12 +52,6 @@ Options:
                                  This runs all steps for the processing but does not trigger the
                                  upload.  This is useful if you just want to verify the setup or
                                  skip the upload in tests.
-      --force-foreground         Wait for the process to finish.
-                                 By default, the upload process will detach and continue in the
-                                 background when triggered from Xcode.  When an error happens, a
-                                 dialog is shown.  If this parameter is passed Xcode will wait for
-                                 the process to finish before the build finishes and output will be
-                                 shown in the Xcode build output.
       --include-sources          Include sources from the local file system and upload them as
                                  source bundles.
       --wait                     Wait for the server to fully process uploaded files. Errors can

--- a/tests/integration/_cases/upload_dif/upload_dif-help.trycmd
+++ b/tests/integration/_cases/upload_dif/upload_dif-help.trycmd
@@ -52,12 +52,6 @@ Options:
                                  This runs all steps for the processing but does not trigger the
                                  upload.  This is useful if you just want to verify the setup or
                                  skip the upload in tests.
-      --force-foreground         Wait for the process to finish.
-                                 By default, the upload process will detach and continue in the
-                                 background when triggered from Xcode.  When an error happens, a
-                                 dialog is shown.  If this parameter is passed Xcode will wait for
-                                 the process to finish before the build finishes and output will be
-                                 shown in the Xcode build output.
       --include-sources          Include sources from the local file system and upload them as
                                  source bundles.
       --wait                     Wait for the server to fully process uploaded files. Errors can

--- a/tests/integration/_cases/upload_dsym/upload_dsym-help.trycmd
+++ b/tests/integration/_cases/upload_dsym/upload_dsym-help.trycmd
@@ -52,12 +52,6 @@ Options:
                                  This runs all steps for the processing but does not trigger the
                                  upload.  This is useful if you just want to verify the setup or
                                  skip the upload in tests.
-      --force-foreground         Wait for the process to finish.
-                                 By default, the upload process will detach and continue in the
-                                 background when triggered from Xcode.  When an error happens, a
-                                 dialog is shown.  If this parameter is passed Xcode will wait for
-                                 the process to finish before the build finishes and output will be
-                                 shown in the Xcode build output.
       --include-sources          Include sources from the local file system and upload them as
                                  source bundles.
       --wait                     Wait for the server to fully process uploaded files. Errors can


### PR DESCRIPTION
Perform all uploads from Xcode in the foreground. The new behavior is equivalent to the old `--force-foreground` behavior.

Since uploads are now always executed in the foreground, (soft) deprecate the `--force-foreground` option by hiding it in the command help text. The `--force-foreground` option no longer has any effect, but passing it will continue to be possible at least until the next major release to keep the API backwards compatible.

Background functionality is completely removed from Sentry-CLI with this change.

Closes #2166
Fixes #2148