### PR TITLE
fix(crons): Run `monitors run` program on check-in failure

### DIFF
--- a/src/commands/monitors/run.rs
+++ b/src/commands/monitors/run.rs
@@ -140,7 +140,11 @@ fn execute_checkin(
     };
 
     let envelopes_api = EnvelopesApi::try_new()?;
-    envelopes_api.send_envelope(open_checkin)?;
+    
+    if let Err(e) = envelopes_api.send_envelope(open_checkin) {
+        log::error!("Failed to send in-progress check-in envelope: {e}");
+        log::info!("Continuing to run program...");
+    }
 
     let (success, code, elapsed) = run_program(args, monitor_slug);
 
@@ -161,7 +165,11 @@ fn execute_checkin(
         monitor_config: None,
     };
 
-    envelopes_api.send_envelope(close_checkin)?;
+    if let Err(e) = envelopes_api.send_envelope(close_checkin) {
+        log::error!("Failed to send final check-in envelope: {e}");
+        log::info!("Continuing to exit with program's exit code...");
+    }
+
     Ok((success, code))
 }
 

--- a/tests/integration/_cases/monitors/monitors-run-server-error-win.trycmd
+++ b/tests/integration/_cases/monitors/monitors-run-server-error-win.trycmd
@@ -1,0 +1,8 @@
+```
+$ sentry-cli monitors run foo-monitor -- cmd.exe /C echo 123
+? success
+[..]ERROR[..]Failed to send in-progress check-in envelope[..]
+123
+[..]ERROR[..]Failed to send final check-in envelope[..]
+
+```

--- a/tests/integration/_cases/monitors/monitors-run-server-error.trycmd
+++ b/tests/integration/_cases/monitors/monitors-run-server-error.trycmd
@@ -1,0 +1,8 @@
+```
+$ sentry-cli monitors run foo-monitor -- echo 123
+? success
+[..]ERROR[..]Failed to send in-progress check-in envelope[..]
+123
+[..]ERROR[..]Failed to send final check-in envelope[..]
+
+```

--- a/tests/integration/monitors/run.rs
+++ b/tests/integration/monitors/run.rs
@@ -12,6 +12,18 @@ fn command_monitors_run() {
 }
 
 #[test]
+fn command_monitors_run_server_error() {
+    let _server =
+        integration::mock_endpoint(EndpointOptions::new("POST", "/api/1337/envelope/", 500));
+
+    #[cfg(not(windows))]
+    integration::register_test("monitors/monitors-run-server-error.trycmd");
+
+    #[cfg(windows)]
+    integration::register_test("monitors/monitors-run-server-error-win.trycmd");
+}
+
+#[test]
 fn command_monitors_run_token_auth() {
     let _server = integration::mock_endpoint(
         EndpointOptions::new("POST", "/api/0/monitors/foo-monitor/checkins/", 200)


### PR DESCRIPTION
Fix a bug where a failure in sending the crons checkin before running the program in the `monitors run` command (e.g. due to a Sentry outage) would cause the program to be prevented from running. Now, we instead log the error and continue running the program.

Also, ensure that a failure in sending the final checkin (after the program has finished) does not cause the program to exit with a different exit code. `sentry-cli monitors run` should propagate the exit code of the program it runs.

Fixes #2169