### PR TITLE
feat(errors): Print backtrace when `RUST_BACKTRACE=1`

### DIFF
--- a/src/utils/system.rs
+++ b/src/utils/system.rs
@@ -76,10 +76,8 @@ pub fn print_error(err: &Error) {
         clap_err.exit();
     }
 
-    eprintln!("{} {}", style("error:").red(), err);
-    err.chain()
-        .skip(1)
-        .for_each(|cause| eprintln!("  {} {}", style("caused by:").dim(), cause));
+    // Debug style for error includes cause chain and backtrace (if available).
+    eprintln!("{} {:?}", style("error:").red(), err);
 
     if Config::current_opt().map_or(true, |config| {
         config.get_log_level() < log::LevelFilter::Info

--- a/tests/integration/_cases/debug_files/debug_files-bundle-jvm-output-is-file.trycmd
+++ b/tests/integration/_cases/debug_files/debug_files-bundle-jvm-output-is-file.trycmd
@@ -5,7 +5,9 @@ $ sentry-cli debug-files bundle-jvm --output ./file.txt --debug-id D384DC3B-AB2F
 > Bundled 2 files for upload
 > Bundle ID: [..]-[..]-[..]-[..]-[..]
 error: Unable to write source bundle
-  caused by: [..]
+
+Caused by:
+[..]
 
 Add --log-level=[info|debug] or export SENTRY_LOG_LEVEL=[info|debug] to see more output.
 Please attach the full debug log to all bug reports.

--- a/tests/integration/_cases/info/info-no-token-backtrace.trycmd
+++ b/tests/integration/_cases/info/info-no-token-backtrace.trycmd
@@ -1,0 +1,18 @@
+```
+$ RUST_BACKTRACE=1 sentry-cli info
+? failed
+Sentry Server: https://sentry.io
+Default Organization: -
+Default Project: -
+
+Authentication Info:
+  Method: Unauthorized
+error: Auth token is required for this request. Please run `sentry-cli login` and try again!
+
+Stack backtrace:
+...
+
+Add --log-level=[info|debug] or export SENTRY_LOG_LEVEL=[info|debug] to see more output.
+Please attach the full debug log to all bug reports.
+
+```

--- a/tests/integration/_cases/releases/releases-delete-active.trycmd
+++ b/tests/integration/_cases/releases/releases-delete-active.trycmd
@@ -2,7 +2,9 @@
 $ sentry-cli releases delete wat-release
 ? failed
 error: API request failed
-  caused by: sentry reported an error: This release is referenced by active issues and cannot be removed. (http status: 400)
+
+Caused by:
+[..]sentry reported an error: This release is referenced by active issues and cannot be removed. (http status: 400)
 
 Add --log-level=[info|debug] or export SENTRY_LOG_LEVEL=[info|debug] to see more output.
 Please attach the full debug log to all bug reports.

--- a/tests/integration/_cases/send_metric/send_metric-increment-unsuccessful-api-call.trycmd
+++ b/tests/integration/_cases/send_metric/send_metric-increment-unsuccessful-api-call.trycmd
@@ -3,7 +3,9 @@ $ sentry-cli send-metric increment -n testmetric
 ? failed
 [..]
 error: API request failed
-  caused by: sentry reported an error: internal server error (http status: 500)
+
+Caused by:
+[..]sentry reported an error: internal server error (http status: 500)
 
 Add --log-level=[info|debug] or export SENTRY_LOG_LEVEL=[info|debug] to see more output.
 Please attach the full debug log to all bug reports.

--- a/tests/integration/info.rs
+++ b/tests/integration/info.rs
@@ -17,6 +17,15 @@ fn command_info_no_token() {
 }
 
 #[test]
+fn command_info_no_token_backtrace() {
+    // Special case where we don't want any env variables set, so we don't use `register_task` helper.
+    TestCases::new()
+        .env("SENTRY_INTEGRATION_TEST", "1")
+        .env("RUST_BACKTRACE", "1")
+        .case("tests/integration/_cases/info/info-no-token-backtrace.trycmd");
+}
+
+#[test]
 fn command_info_basic() {
     let _server = mock_endpoint(
         EndpointOptions::new("GET", "/api/0/", 200).with_response_file("info/get-info.json"),


### PR DESCRIPTION
The `anyhow` crate we use for error handling adds stack backtraces errors whenever [certain standard environment variables](https://doc.rust-lang.org/std/backtrace/index.html#environment-variables) are set (e.g. when `RUST_BACKTRACE=1`).

Modify our error-printing logic to include these stack backtraces when printing errors that crash Sentry CLI, so that users can add this information to bug reports.

Closes #2187