### PR TITLE
ref: Indicate that `commands::main` does not return

### DIFF
--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -349,7 +349,7 @@ fn setup() {
 }
 
 /// Executes the command line application and exits the process.
-pub fn main() {
+pub fn main() -> ! {
     setup();
 
     let exit_code = match execute() {


### PR DESCRIPTION
`commands::main` does not return because it explicitly calls `std::process::exit`. Update `commands::main`'s function signature to indicate this.