### PR TITLE
ref: Update `main` to indicate it does not return

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -4,6 +4,6 @@ mod config;
 mod constants;
 mod utils;
 
-pub fn main() {
+pub fn main() -> ! {
     commands::main()
 }


### PR DESCRIPTION
Sentry CLI's `main` function calls `commands::main`, which does not return, since it calls `std::process::exit`. Update the function signature to reflect this.

Depends on #2191 