### PR TITLE
build(windows): Statically link CRT on Windows

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,2 @@
+[target.'cfg(all(windows, target_env = "msvc"))']
+rustflags = ["-C", "target-feature=+crt-static"]

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,5 @@
 target
 .DS_Store
-.cargo
 node_modules
 coverage
 dist


### PR DESCRIPTION
Statically link the CRT on Windows. This eliminates Sentry CLI's dependency on `VCRUNTIME140.dll`, allowing Sentry CLI to be run on a clean install of Windows, without requiring any external dependencies.

Fixes #2193
Closes #2201