### PR TITLE
ref(utils): Remove `allow(dead_code)` from update utils

### DIFF
--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -284,6 +284,7 @@ impl Api {
 
     /// Convenience method that downloads a file into the given file object
     /// and show a progress bar
+    #[cfg(not(feature = "managed"))]
     pub fn download_with_progress(&self, url: &str, dst: &mut File) -> ApiResult<ApiResponse> {
         self.request(Method::Get, url, None)?
             .follow_location(true)?
@@ -329,12 +330,13 @@ impl Api {
 
         if resp.status() == 200 {
             let info: RegistryRelease = resp.convert()?;
-            for (filename, download_url) in info.file_urls {
+            for (filename, _download_url) in info.file_urls {
                 info!("Found asset {}", filename);
                 if filename == ref_name {
                     return Ok(Some(SentryCliRelease {
                         version: info.version,
-                        download_url,
+                        #[cfg(not(feature = "managed"))]
+                        download_url: _download_url,
                     }));
                 }
             }
@@ -2164,6 +2166,7 @@ struct RegistryRelease {
 /// Information about sentry CLI releases
 pub struct SentryCliRelease {
     pub version: String,
+    #[cfg(not(feature = "managed"))]
     pub download_url: String,
 }
 

--- a/src/utils/fs.rs
+++ b/src/utils/fs.rs
@@ -124,6 +124,7 @@ impl Drop for TempFile {
 }
 
 /// Checks if a path is writable.
+#[cfg(not(feature = "managed"))]
 pub fn is_writable<P: AsRef<Path>>(path: P) -> bool {
     fs::OpenOptions::new()
         .write(true)
@@ -134,6 +135,7 @@ pub fn is_writable<P: AsRef<Path>>(path: P) -> bool {
 
 /// Set the mode of a path to 755 if we're on a Unix machine, otherwise
 /// don't do anything with the given path.
+#[cfg(not(feature = "managed"))]
 pub fn set_executable_mode<P: AsRef<Path>>(path: P) -> Result<()> {
     #[cfg(not(windows))]
     fn exec<P: AsRef<Path>>(path: P) -> io::Result<()> {

--- a/src/utils/progress.rs
+++ b/src/utils/progress.rs
@@ -78,6 +78,7 @@ impl Deref for ProgressBar {
 pub enum ProgressBarMode {
     Disabled,
     Request,
+    #[cfg(not(feature = "managed"))]
     Response,
     Shared((Arc<ProgressBar>, u64, usize, Arc<RwLock<Vec<u64>>>)),
 }
@@ -95,6 +96,12 @@ impl ProgressBarMode {
 
     /// Returns whether a progress bar should be displayed during download.
     pub fn response(&self) -> bool {
-        matches!(*self, ProgressBarMode::Response)
+        #[cfg(not(feature = "managed"))]
+        let rv = matches!(*self, ProgressBarMode::Response);
+
+        #[cfg(feature = "managed")]
+        let rv = false;
+
+        rv
     }
 }

--- a/src/utils/update.rs
+++ b/src/utils/update.rs
@@ -1,12 +1,14 @@
-#![allow(dead_code)] // a ton of functions/fields might be unused based on the `managed` feature
-
+#[cfg(not(feature = "managed"))]
 use std::env;
 use std::fs;
 use std::io;
 use std::io::Write;
+#[cfg(not(feature = "managed"))]
 use std::path::Path;
 
-use anyhow::{bail, format_err, Result};
+#[cfg(not(feature = "managed"))]
+use anyhow::bail;
+use anyhow::{format_err, Result};
 use chrono::{DateTime, Duration, Utc};
 use console::{style, user_attended};
 use if_chain::if_chain;
@@ -17,8 +19,11 @@ use serde::{Deserialize, Serialize};
 use crate::api::{Api, SentryCliRelease};
 use crate::config::Config;
 use crate::constants::{APP_NAME, VERSION};
+#[cfg(not(feature = "managed"))]
 use crate::utils::fs::{is_writable, set_executable_mode};
-use crate::utils::system::{is_homebrew_install, is_npm_install, QuietExit};
+#[cfg(not(feature = "managed"))]
+use crate::utils::system::QuietExit;
+use crate::utils::system::{is_homebrew_install, is_npm_install};
 
 #[cfg(windows)]
 fn rename_exe(exe: &Path, downloaded_path: &Path, elevate: bool) -> Result<()> {
@@ -52,6 +57,7 @@ fn rename_exe(exe: &Path, downloaded_path: &Path, elevate: bool) -> Result<()> {
     Ok(())
 }
 
+#[cfg(not(feature = "managed"))]
 #[cfg(not(windows))]
 fn rename_exe(exe: &Path, downloaded_path: &Path, elevate: bool) -> Result<()> {
     if elevate {
@@ -119,6 +125,7 @@ impl SentryCliUpdateInfo {
         self.latest_release.is_some()
     }
 
+    #[cfg(not(feature = "managed"))]
     pub fn is_latest_version(&self) -> bool {
         self.latest_version() == VERSION
     }
@@ -135,6 +142,7 @@ impl SentryCliUpdateInfo {
         }
     }
 
+    #[cfg(not(feature = "managed"))]
     pub fn download_url(&self) -> Result<&str> {
         if let Some(ref rel) = self.latest_release {
             Ok(rel.download_url.as_str())
@@ -143,6 +151,7 @@ impl SentryCliUpdateInfo {
         }
     }
 
+    #[cfg(not(feature = "managed"))]
     pub fn download(&self) -> Result<()> {
         let exe = env::current_exe()?;
         let elevate = !is_writable(&exe);
@@ -175,10 +184,12 @@ pub fn get_latest_sentrycli_release() -> Result<SentryCliUpdateInfo> {
     })
 }
 
+#[cfg(not(feature = "managed"))]
 pub fn can_update_sentrycli() -> bool {
     !is_homebrew_install() && !is_npm_install()
 }
 
+#[cfg(not(feature = "managed"))]
 pub fn assert_updatable() -> Result<()> {
     if is_homebrew_install() {
         println!("This installation of sentry-cli is managed through homebrew");

--- a/src/utils/update.rs
+++ b/src/utils/update.rs
@@ -57,8 +57,7 @@ fn rename_exe(exe: &Path, downloaded_path: &Path, elevate: bool) -> Result<()> {
     Ok(())
 }
 
-#[cfg(not(feature = "managed"))]
-#[cfg(not(windows))]
+#[cfg(not(any(feature = "managed", windows)))]
 fn rename_exe(exe: &Path, downloaded_path: &Path, elevate: bool) -> Result<()> {
     if elevate {
         println!("Need to sudo to overwrite {}", exe.display());


### PR DESCRIPTION
Instead, mark all code that is not needed for the `managed` build with `cfg(not(feature = "managed"))`.
