### PR TITLE
ref(tests): Decouple test env vars from trycmd code

### DIFF
--- a/tests/integration/test_utils/env.rs
+++ b/tests/integration/test_utils/env.rs
@@ -1,0 +1,25 @@
+//! Utilities for setting environment variables in integration tests.
+
+use std::borrow::Cow;
+
+/// Set the environment variables, which should be set for all integration tests,
+/// using the provided setter function.
+/// The setter function takes as parameters the environment variable name, and the
+/// value to set it to, in that order.
+pub fn set(mut setter: impl FnMut(&'static str, Cow<'static, str>)) {
+    let dsn = format!("http://test@{}/1337", mockito::server_address()).into();
+
+    setter("SENTRY_INTEGRATION_TEST", "1".into());
+    setter("SENTRY_ORG", "wat-org".into());
+    setter("SENTRY_PROJECT", "wat-project".into());
+    setter("SENTRY_URL", mockito::server_url().into());
+    setter("SENTRY_DSN", dsn);
+}
+
+/// Set the auth token environment variable using the provided setter function.
+pub fn set_auth_token(setter: impl FnOnce(&'static str, Cow<'static, str>)) {
+    setter(
+        "SENTRY_AUTH_TOKEN",
+        "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef".into(),
+    );
+}

--- a/tests/integration/test_utils/mod.rs
+++ b/tests/integration/test_utils/mod.rs
@@ -1,0 +1,3 @@
+//! A collection of utilities for integration tests.
+
+pub mod env;


### PR DESCRIPTION
As a part of #2194, I intend to introduce the [`assert_cmd` crate](https://docs.rs/assert_cmd/latest/assert_cmd/) to have more control over how the assertions for the chunk upload tests are run. This control would be difficult to achieve with `trycmd`.

So, here, I am splitting off the logic for setting environment variables to make it also reusable for `assert_cmd` tests
