### PR TITLE
test(debug-files): Add test for assemble endpoint call

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -180,6 +180,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "assert_cmd"
+version = "2.0.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc1835b7f27878de8525dc71410b5a31cdcc5f230aed5ba5df968e09c201b23d"
+dependencies = [
+ "anstyle",
+ "bstr",
+ "doc-comment",
+ "libc",
+ "predicates 3.1.2",
+ "predicates-core",
+ "predicates-tree",
+ "wait-timeout",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -301,6 +317,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05efc5cfd9110c8416e471df0e96702d58690178e206e61b7173706673c93706"
 dependencies = [
  "memchr",
+ "regex-automata",
  "serde",
 ]
 
@@ -735,6 +752,12 @@ name = "dlv-list"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0688c2a7f92e427f44895cd63841bff7b29f8d7a1648b9e7e07a4a365b2e1257"
+
+[[package]]
+name = "doc-comment"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fea41bba32d969b513997752735605054bc0dfa92b4c56bf1189f2e174be7a10"
 
 [[package]]
 name = "dotenv"
@@ -1967,10 +1990,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "predicates"
+version = "3.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e9086cc7640c29a356d1a29fd134380bee9d8f79a17410aa76e7ad295f42c97"
+dependencies = [
+ "anstyle",
+ "difflib",
+ "predicates-core",
+]
+
+[[package]]
 name = "predicates-core"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b794032607612e7abeb4db69adb4e33590fa6cf1149e95fd7cb00e634b92f174"
+
+[[package]]
+name = "predicates-tree"
+version = "1.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41b740d195ed3166cd147c8047ec98db0e22ec019eb8eeb76d343b795304fb13"
+dependencies = [
+ "predicates-core",
+ "termtree",
+]
 
 [[package]]
 name = "prettytable-rs"
@@ -2420,6 +2464,7 @@ version = "2.38.2"
 dependencies = [
  "anyhow",
  "anylog",
+ "assert_cmd",
  "backoff",
  "backtrace",
  "brotli2",
@@ -2459,7 +2504,7 @@ dependencies = [
  "parking_lot",
  "percent-encoding",
  "plist",
- "predicates",
+ "predicates 2.1.5",
  "prettytable-rs",
  "proguard",
  "r2d2",
@@ -2931,6 +2976,12 @@ dependencies = [
  "rustix",
  "windows-sys 0.48.0",
 ]
+
+[[package]]
+name = "termtree"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3369f5ac52d5eb6ab48c6b4ffdc8efbcad6b89c765749064ba298f2c68a16a76"
 
 [[package]]
 name = "thiserror"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -83,6 +83,7 @@ chrono-tz = "0.8.4"
 secrecy = "0.8.0"
 
 [dev-dependencies]
+assert_cmd = "2.0.11"
 insta = { version = "1.26.0", features = ["redactions", "yaml"] }
 mockito = "0.31.1"
 predicates = "2.1.5"

--- a/tests/integration/debug_files/upload.rs
+++ b/tests/integration/debug_files/upload.rs
@@ -1,4 +1,6 @@
-use crate::integration::{mock_endpoint, register_test, EndpointOptions};
+use assert_cmd::Command;
+
+use crate::integration::{mock_endpoint, register_test, test_utils::env, EndpointOptions};
 
 // I have no idea why this is timing out on Windows.
 // I verified it manually, and this command works just fine. — Kamil
@@ -142,4 +144,51 @@ fn command_debug_files_upload_no_upload() {
         .with_response_file("debug_files/post-difs-assemble.json"),
     );
     register_test("debug_files/debug_files-upload-no-upload.trycmd");
+}
+
+#[test]
+/// This test ensures that the correct initial call to the debug files assemble endpoint is made.
+/// The mock assemble endpoint returns a 200 response simulating the case where all chunks
+/// are already uploaded.
+fn ensure_correct_assemble_call() {
+    let _chunk_upload = mock_endpoint(
+        EndpointOptions::new("GET", "/api/0/organizations/wat-org/chunk-upload/", 200)
+            .with_response_file("debug_files/get-chunk-upload.json"),
+    );
+
+    let assemble = mockito::mock("POST", "/api/0/projects/wat-org/wat-project/files/difs/assemble/")
+        .match_body(r#"{"21b76b717dbbd8c89e42d92b29667ac87aa3c124":{"name":"SrcGenSampleApp.pdb","debug_id":"c02651ae-cd6f-492d-bc33-0b83111e7106-8d8e7c60","chunks":["21b76b717dbbd8c89e42d92b29667ac87aa3c124"]}}"#)
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(r#"{
+                "21b76b717dbbd8c89e42d92b29667ac87aa3c124": {
+                    "state": "ok",
+                    "missingChunks": []
+                }
+            }"#)
+        .create();
+
+    let mut command = Command::cargo_bin("sentry-cli").expect("sentry-cli should be available");
+
+    command.args(
+        "debug-files upload --include-sources tests/integration/_fixtures/SrcGenSampleApp.pdb"
+            .split(' '),
+    );
+
+    env::set_all(|k, v| {
+        command.env(k, v.as_ref());
+    });
+
+    command.env(
+        "SENTRY_AUTH_TOKEN",
+        "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+    );
+
+    let command_result = command.assert();
+
+    // First assert the mock was called as expected, then that the command was successful.
+    // This is because failure with the mock assertion can cause the command to fail, and
+    // the mock assertion failure is likely more interesting in this case.
+    assemble.assert();
+    command_result.success();
 }

--- a/tests/integration/test_utils/env.rs
+++ b/tests/integration/test_utils/env.rs
@@ -23,3 +23,10 @@ pub fn set_auth_token(setter: impl FnOnce(&'static str, Cow<'static, str>)) {
         "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef".into(),
     );
 }
+
+/// Set all environment variables, including the auth token and the environments
+/// set by `set`.
+pub fn set_all(mut setter: impl FnMut(&'static str, Cow<'static, str>)) {
+    set(&mut setter);
+    set_auth_token(setter);
+}


### PR DESCRIPTION
Add an integration test for the `debug-files upload` command, which ensures that given a certain file, the expected initial request to the assemble endpoint is made to the Sentry server. Unlike existing tests, this test primarily does not serve to validate command output, but rather to ensure other behavior (in this case, that a specific HTTP request is made).

Also, add the [`assert_cmd`](https://docs.rs/assert_cmd/latest/assert_cmd/) crate as a dev dependency. The crate provides an interface which allows more fine-grained control over how an individual integration test is run compared with the `trycmd` crate we currently use everywhere. `assert_cmd` will help us write better integration tests for chunk uploading, which not only assert command output, but also ensure that the correct data is sent to the Sentry server (see #2194). We use the crate in this new test.