### PR TITLE
ci: Run codeql-analysis on all PRs

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -15,8 +15,6 @@ on:
   push:
     branches: [master]
   pull_request:
-    # The branches below must be a subset of the branches above
-    branches: [master]
   schedule:
     - cron: '32 17 * * 4'
 


### PR DESCRIPTION
Currently, this action only runs on PRs against master, which is a problem when we have a stack of PRs, which are originally opened against a branch other than `master`, but later are changed to have a base of `master` when the parent branch is merged into `master`.