### PR TITLE
test: Batch `bash_hook` tests together

### DIFF
--- a/tests/integration/bash_hook.rs
+++ b/tests/integration/bash_hook.rs
@@ -1,26 +1,6 @@
 use crate::integration::register_test;
 
 #[test]
-fn command_bash_hook_help() {
-    register_test("bash_hook/bash_hook-help.trycmd");
-}
-
-#[test]
 fn command_bash_hook() {
-    register_test("bash_hook/bash_hook.trycmd");
-}
-
-#[test]
-fn command_bash_hook_tags() {
-    register_test("bash_hook/bash_hook-tags.trycmd");
-}
-
-#[test]
-fn command_bash_hook_release() {
-    register_test("bash_hook/bash_hook-release.trycmd");
-}
-
-#[test]
-fn command_bash_hook_release_using_environment() {
-    register_test("bash_hook/bash_hook-release-env.trycmd");
+    register_test("bash_hook/*.trycmd");
 }


### PR DESCRIPTION
`trycmd` is [smart enough](https://docs.rs/trycmd/latest/trycmd/#getting-started) to enumerate all of these test cases
