### PR TITLE
test(react_native): Bubble up `target_os`

### DIFF
--- a/tests/integration/mod.rs
+++ b/tests/integration/mod.rs
@@ -11,6 +11,7 @@ mod monitors;
 mod org_tokens;
 mod organizations;
 mod projects;
+#[cfg(target_os = "macos")]
 mod react_native;
 mod releases;
 mod send_envelope;

--- a/tests/integration/react_native/mod.rs
+++ b/tests/integration/react_native/mod.rs
@@ -1,10 +1,8 @@
-#[cfg(target_os = "macos")]
 use crate::integration::register_test;
 
 mod xcode;
 
 #[test]
-#[cfg(target_os = "macos")]
 fn xcode_wrap_call_minimum() {
     register_test("react_native/xcode-wrap-call-minimum.trycmd");
     assert_empty_sourcemap_report("rn-sourcemap-report-minimum.json");
@@ -12,7 +10,6 @@ fn xcode_wrap_call_minimum() {
 }
 
 #[test]
-#[cfg(target_os = "macos")]
 fn xcode_wrap_call_bundle() {
     register_test("react_native/xcode-wrap-call-bundle.trycmd");
     assert_packager_sourcemap_report("rn-sourcemap-report-bundle.json");
@@ -20,7 +17,6 @@ fn xcode_wrap_call_bundle() {
 }
 
 #[test]
-#[cfg(target_os = "macos")]
 fn xcode_wrap_call_custom_bundle() {
     register_test("react_native/xcode-wrap-call-custom-bundle.trycmd");
     assert_packager_sourcemap_report("rn-sourcemap-report-custom-bundle.json");
@@ -28,7 +24,6 @@ fn xcode_wrap_call_custom_bundle() {
 }
 
 #[test]
-#[cfg(target_os = "macos")]
 fn xcode_wrap_call_expo_export() {
     register_test("react_native/xcode-wrap-call-expo-export.trycmd");
     assert_packager_sourcemap_report("rn-sourcemap-report-expo-export.json");
@@ -36,7 +31,6 @@ fn xcode_wrap_call_expo_export() {
 }
 
 #[test]
-#[cfg(target_os = "macos")]
 fn xcode_wrap_call_hermesc() {
     register_test("react_native/xcode-wrap-call-hermesc.trycmd");
     assert_sourcemap_report(
@@ -47,7 +41,6 @@ fn xcode_wrap_call_hermesc() {
 }
 
 #[test]
-#[cfg(target_os = "macos")]
 fn xcode_wrap_call_compose_source_maps() {
     std::fs::copy("tests/integration/_fixtures/react_native/compose-source-maps-sourcemap-report.json.before.test","rn-sourcemap-report-compose-source-maps.json").unwrap();
     register_test("react_native/xcode-wrap-call-compose-source-maps.trycmd");
@@ -59,7 +52,6 @@ fn xcode_wrap_call_compose_source_maps() {
 }
 
 #[test]
-#[cfg(target_os = "macos")]
 fn xcode_wrap_call_compose_source_maps_no_debug_id_copy() {
     std::fs::copy("tests/integration/_fixtures/react_native/compose-source-maps-sourcemap-report.json.before.test","rn-sourcemap-report-compose-source-maps-no-debug-id-copy.json").unwrap();
     register_test("react_native/xcode-wrap-call-compose-source-maps-no-debug-id-copy.trycmd");
@@ -71,7 +63,6 @@ fn xcode_wrap_call_compose_source_maps_no_debug_id_copy() {
 }
 
 #[test]
-#[cfg(target_os = "macos")]
 fn xcode_wrap_call_compose_source_maps_custom() {
     register_test("react_native/xcode-wrap-call-compose-source-maps-custom.trycmd");
     assert_sourcemap_report(
@@ -81,22 +72,18 @@ fn xcode_wrap_call_compose_source_maps_custom() {
     clean_up("rn-sourcemap-report-compose-source-maps-custom.json");
 }
 
-#[cfg(target_os = "macos")]
 fn clean_up(path: &str) {
     std::fs::remove_file(path).unwrap();
 }
 
-#[cfg(target_os = "macos")]
 fn assert_packager_sourcemap_report(actual: &str) {
     assert_sourcemap_report("packager-sourcemap-report.json.expected", actual);
 }
 
-#[cfg(target_os = "macos")]
 fn assert_empty_sourcemap_report(actual: &str) {
     assert_sourcemap_report("empty-sourcemap-report.json.expected", actual);
 }
 
-#[cfg(target_os = "macos")]
 fn assert_sourcemap_report(expected: &str, actual: &str) {
     let actual_code = std::fs::read_to_string(actual).unwrap();
     let expected_code =

--- a/tests/integration/react_native/xcode.rs
+++ b/tests/integration/react_native/xcode.rs
@@ -1,12 +1,8 @@
-#[cfg(target_os = "macos")]
 use crate::integration::register_test;
-#[cfg(target_os = "macos")]
 use crate::integration::{mock_common_upload_endpoints, ChunkOptions, ServerBehavior};
-#[cfg(target_os = "macos")]
 use mockito::Mock;
 
 #[test]
-#[cfg(target_os = "macos")]
 fn xcode_upload_source_maps_missing_plist() {
     let _upload_endpoints =
         mock_common_upload_endpoints(ServerBehavior::Modern, ChunkOptions::default());
@@ -14,7 +10,6 @@ fn xcode_upload_source_maps_missing_plist() {
 }
 
 #[test]
-#[cfg(target_os = "macos")]
 fn xcode_upload_source_maps_release_and_dist_from_env() {
     let upload_endpoints =
         mock_common_upload_endpoints(ServerBehavior::Modern, ChunkOptions::default());
@@ -22,7 +17,6 @@ fn xcode_upload_source_maps_release_and_dist_from_env() {
     assert_endpoints(&upload_endpoints);
 }
 
-#[cfg(target_os = "macos")]
 pub fn assert_endpoints(mocks: &[Mock]) {
     for mock in mocks {
         mock.assert();


### PR DESCRIPTION
We can just mark the entire module as macos-only
