### PR TITLE
test: Run `trycmd` tests with `RUST_BACKTRACE=0`

### DIFF
--- a/tests/integration/test_utils/env.rs
+++ b/tests/integration/test_utils/env.rs
@@ -14,6 +14,7 @@ pub fn set(mut setter: impl FnMut(&'static str, Cow<'static, str>)) {
     setter("SENTRY_PROJECT", "wat-project".into());
     setter("SENTRY_URL", mockito::server_url().into());
     setter("SENTRY_DSN", dsn);
+    setter("RUST_BACKTRACE", "0".into());
 }
 
 /// Set the auth token environment variable using the provided setter function.


### PR DESCRIPTION
Some of our `trycmd` tests assume that no backtrace is printed in the test commands output, even when an error is supposed to occur. `RUST_BACKTRACE=0` appears to be set in CI, but this becomes a problem running tests locally, where tests sometimes fail when the local environmnent has `RUST_BACKTRACE=1`.

Note that backtraces are still logged tracing back to the error that caused the test failure. But, if we are testing that a specific command which we expect to fail has a certain output, this change ensures that regardless of the outside environment, we don't get a backtrace _in the test output_, as this could fail the test.
