### PR TITLE
ref(test): Rename `EndpointOptions` to `MockEndpointBuilder`

### DIFF
--- a/tests/integration/debug_files/upload.rs
+++ b/tests/integration/debug_files/upload.rs
@@ -1,15 +1,15 @@
 use assert_cmd::Command;
 
-use crate::integration::{mock_endpoint, register_test, test_utils::env, EndpointOptions};
+use crate::integration::{mock_endpoint, register_test, test_utils::env, MockEndpointBuilder};
 
 #[test]
 fn command_debug_files_upload() {
     let _chunk_upload = mock_endpoint(
-        EndpointOptions::new("GET", "/api/0/organizations/wat-org/chunk-upload/", 200)
+        MockEndpointBuilder::new("GET", "/api/0/organizations/wat-org/chunk-upload/", 200)
             .with_response_file("debug_files/get-chunk-upload.json"),
     );
     let _assemble = mock_endpoint(
-        EndpointOptions::new(
+        MockEndpointBuilder::new(
             "POST",
             "/api/0/projects/wat-org/wat-project/files/difs/assemble/",
             200,
@@ -22,11 +22,11 @@ fn command_debug_files_upload() {
 #[test]
 fn command_debug_files_upload_pdb() {
     let _chunk_upload = mock_endpoint(
-        EndpointOptions::new("GET", "/api/0/organizations/wat-org/chunk-upload/", 200)
+        MockEndpointBuilder::new("GET", "/api/0/organizations/wat-org/chunk-upload/", 200)
             .with_response_file("debug_files/get-chunk-upload.json"),
     );
     let _assemble = mock_endpoint(
-        EndpointOptions::new(
+        MockEndpointBuilder::new(
             "POST",
             "/api/0/projects/wat-org/wat-project/files/difs/assemble/",
             200,
@@ -47,11 +47,11 @@ fn command_debug_files_upload_pdb() {
 #[test]
 fn command_debug_files_upload_pdb_embedded_sources() {
     let _chunk_upload = mock_endpoint(
-        EndpointOptions::new("GET", "/api/0/organizations/wat-org/chunk-upload/", 200)
+        MockEndpointBuilder::new("GET", "/api/0/organizations/wat-org/chunk-upload/", 200)
             .with_response_file("debug_files/get-chunk-upload.json"),
     );
     let _assemble = mock_endpoint(
-        EndpointOptions::new(
+        MockEndpointBuilder::new(
             "POST",
             "/api/0/projects/wat-org/wat-project/files/difs/assemble/",
             200,
@@ -71,11 +71,11 @@ fn command_debug_files_upload_pdb_embedded_sources() {
 #[test]
 fn command_debug_files_upload_dll_embedded_ppdb_with_sources() {
     let _chunk_upload = mock_endpoint(
-        EndpointOptions::new("GET", "/api/0/organizations/wat-org/chunk-upload/", 200)
+        MockEndpointBuilder::new("GET", "/api/0/organizations/wat-org/chunk-upload/", 200)
             .with_response_file("debug_files/get-chunk-upload.json"),
     );
     let _assemble = mock_endpoint(
-        EndpointOptions::new(
+        MockEndpointBuilder::new(
             "POST",
             "/api/0/projects/wat-org/wat-project/files/difs/assemble/",
             200,
@@ -95,11 +95,11 @@ fn command_debug_files_upload_dll_embedded_ppdb_with_sources() {
 #[test]
 fn command_debug_files_upload_mixed_embedded_sources() {
     let _chunk_upload = mock_endpoint(
-        EndpointOptions::new("GET", "/api/0/organizations/wat-org/chunk-upload/", 200)
+        MockEndpointBuilder::new("GET", "/api/0/organizations/wat-org/chunk-upload/", 200)
             .with_response_file("debug_files/get-chunk-upload.json"),
     );
     let _assemble = mock_endpoint(
-        EndpointOptions::new(
+        MockEndpointBuilder::new(
             "POST",
             "/api/0/projects/wat-org/wat-project/files/difs/assemble/",
             200,
@@ -123,11 +123,11 @@ fn command_debug_files_upload_mixed_embedded_sources() {
 #[test]
 fn command_debug_files_upload_no_upload() {
     let _chunk_upload = mock_endpoint(
-        EndpointOptions::new("GET", "/api/0/organizations/wat-org/chunk-upload/", 200)
+        MockEndpointBuilder::new("GET", "/api/0/organizations/wat-org/chunk-upload/", 200)
             .with_response_file("debug_files/get-chunk-upload.json"),
     );
     let _assemble = mock_endpoint(
-        EndpointOptions::new(
+        MockEndpointBuilder::new(
             "POST",
             "/api/0/projects/wat-org/wat-project/files/difs/assemble/",
             200,
@@ -143,7 +143,7 @@ fn command_debug_files_upload_no_upload() {
 /// are already uploaded.
 fn ensure_correct_assemble_call() {
     let _chunk_upload = mock_endpoint(
-        EndpointOptions::new("GET", "/api/0/organizations/wat-org/chunk-upload/", 200)
+        MockEndpointBuilder::new("GET", "/api/0/organizations/wat-org/chunk-upload/", 200)
             .with_response_file("debug_files/get-chunk-upload.json"),
     );
 

--- a/tests/integration/deploys/list.rs
+++ b/tests/integration/deploys/list.rs
@@ -1,9 +1,9 @@
-use crate::integration::{mock_endpoint, register_test, EndpointOptions};
+use crate::integration::{mock_endpoint, register_test, MockEndpointBuilder};
 
 #[test]
 fn command_deploys_list() {
     let _server = mock_endpoint(
-        EndpointOptions::new(
+        MockEndpointBuilder::new(
             "GET",
             "/api/0/organizations/wat-org/releases/wat-release/deploys/",
             200,

--- a/tests/integration/deploys/new.rs
+++ b/tests/integration/deploys/new.rs
@@ -1,12 +1,12 @@
 use mockito::Matcher;
 use serde_json::json;
 
-use crate::integration::{mock_endpoint, register_test, EndpointOptions};
+use crate::integration::{mock_endpoint, register_test, MockEndpointBuilder};
 
 #[test]
 fn command_deploys_new() {
     let _server = mock_endpoint(
-        EndpointOptions::new(
+        MockEndpointBuilder::new(
             "POST",
             "/api/0/organizations/wat-org/releases/wat-release/deploys/",
             200,
@@ -23,7 +23,7 @@ fn command_deploys_new() {
 #[test]
 fn command_releases_deploys_new() {
     let _server = mock_endpoint(
-        EndpointOptions::new(
+        MockEndpointBuilder::new(
             "POST",
             "/api/0/organizations/wat-org/releases/wat-release/deploys/",
             200,

--- a/tests/integration/events.rs
+++ b/tests/integration/events.rs
@@ -1,13 +1,13 @@
 use crate::integration::register_test;
 
-use super::{mock_endpoint, EndpointOptions};
+use super::{mock_endpoint, MockEndpointBuilder};
 
 #[test]
 fn command_events() {
     // Mock server is used only for the events/events-list-empty.trycmd
     // test. No harm in leaving it here for other tests.
     let _server = mock_endpoint(
-        EndpointOptions::new(
+        MockEndpointBuilder::new(
             "GET",
             "/api/0/projects/wat-org/wat-project/events/?cursor=",
             200,

--- a/tests/integration/info.rs
+++ b/tests/integration/info.rs
@@ -1,7 +1,7 @@
 use mockito::server_url;
 use trycmd::TestCases;
 
-use crate::integration::{mock_endpoint, register_test, EndpointOptions};
+use crate::integration::{mock_endpoint, register_test, MockEndpointBuilder};
 
 #[test]
 fn command_info_help() {
@@ -28,7 +28,7 @@ fn command_info_no_token_backtrace() {
 #[test]
 fn command_info_basic() {
     let _server = mock_endpoint(
-        EndpointOptions::new("GET", "/api/0/", 200).with_response_file("info/get-info.json"),
+        MockEndpointBuilder::new("GET", "/api/0/", 200).with_response_file("info/get-info.json"),
     );
     let t = register_test("info/info-basic.trycmd");
     t.insert_var("[SERVER]", server_url()).unwrap();
@@ -37,7 +37,7 @@ fn command_info_basic() {
 #[test]
 fn command_info_no_defaults() {
     let _server = mock_endpoint(
-        EndpointOptions::new("GET", "/api/0/", 200).with_response_file("info/get-info.json"),
+        MockEndpointBuilder::new("GET", "/api/0/", 200).with_response_file("info/get-info.json"),
     );
     let t = register_test("info/info-json.trycmd");
     t.insert_var("[SERVER]", server_url()).unwrap();
@@ -46,7 +46,7 @@ fn command_info_no_defaults() {
 #[test]
 fn command_info_json() {
     let _server = mock_endpoint(
-        EndpointOptions::new("GET", "/api/0/", 200).with_response_file("info/get-info.json"),
+        MockEndpointBuilder::new("GET", "/api/0/", 200).with_response_file("info/get-info.json"),
     );
     let t = register_test("info/info-basic.trycmd");
     t.insert_var("[SERVER]", server_url()).unwrap();
@@ -55,7 +55,7 @@ fn command_info_json() {
 #[test]
 fn command_info_json_without_defaults() {
     let _server = mock_endpoint(
-        EndpointOptions::new("GET", "/api/0/", 200).with_response_file("info/get-info.json"),
+        MockEndpointBuilder::new("GET", "/api/0/", 200).with_response_file("info/get-info.json"),
     );
     let t = register_test("info/info-json-no-defaults.trycmd");
     t.env("SENTRY_ORG", "").env("SENTRY_PROJECT", "");

--- a/tests/integration/issues/list.rs
+++ b/tests/integration/issues/list.rs
@@ -1,4 +1,4 @@
-use crate::integration::{mock_endpoint, register_test, EndpointOptions};
+use crate::integration::{mock_endpoint, register_test, MockEndpointBuilder};
 
 #[test]
 fn command_issues_list_help() {
@@ -8,7 +8,7 @@ fn command_issues_list_help() {
 #[test]
 fn doesnt_fail_with_empty_response() {
     let _server = mock_endpoint(
-        EndpointOptions::new(
+        MockEndpointBuilder::new(
             "GET",
             "/api/0/projects/wat-org/wat-project/issues/?query=&cursor=",
             200,
@@ -21,7 +21,7 @@ fn doesnt_fail_with_empty_response() {
 #[test]
 fn display_issues() {
     let _server = mock_endpoint(
-        EndpointOptions::new(
+        MockEndpointBuilder::new(
             "GET",
             "/api/0/projects/wat-org/wat-project/issues/?query=&cursor=",
             200,
@@ -34,7 +34,7 @@ fn display_issues() {
 #[test]
 fn display_resolved_issues() {
     let _server = mock_endpoint(
-        EndpointOptions::new(
+        MockEndpointBuilder::new(
             "GET",
             "/api/0/projects/wat-org/wat-project/issues/?query=is:resolved&cursor=",
             200,

--- a/tests/integration/mod.rs
+++ b/tests/integration/mod.rs
@@ -34,7 +34,7 @@ use mockito::{self, server_url, Mock};
 use trycmd::TestCases;
 
 use test_utils::env;
-use test_utils::{mock_endpoint, EndpointOptions};
+use test_utils::{mock_endpoint, MockEndpointBuilder};
 
 pub const UTC_DATE_FORMAT: &str = r"\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}.\d{6,9}Z";
 const VERSION: &str = env!("CARGO_PKG_VERSION");
@@ -138,21 +138,21 @@ pub fn mock_common_upload_endpoints(
 
     vec![
         mock_endpoint(
-            EndpointOptions::new("POST", "/api/0/projects/wat-org/wat-project/releases/", 208)
+            MockEndpointBuilder::new("POST", "/api/0/projects/wat-org/wat-project/releases/", 208)
                 .with_response_file("releases/get-release.json"),
         )
         .expect_at_least(release_request_count)
         .expect_at_most(release_request_count),
         mock_endpoint(
-            EndpointOptions::new("GET", "/api/0/organizations/wat-org/chunk-upload/", 200)
+            MockEndpointBuilder::new("GET", "/api/0/organizations/wat-org/chunk-upload/", 200)
                 .with_response_body(chunk_upload_response),
         ),
         mock_endpoint(
-            EndpointOptions::new("POST", "/api/0/organizations/wat-org/chunk-upload/", 200)
+            MockEndpointBuilder::new("POST", "/api/0/organizations/wat-org/chunk-upload/", 200)
                 .with_response_body("[]"),
         ),
         mock_endpoint(
-            EndpointOptions::new("POST", assemble_endpoint, 200).with_response_body(format!(
+            MockEndpointBuilder::new("POST", assemble_endpoint, 200).with_response_body(format!(
                 r#"{{"state":"created","missingChunks":{}}}"#,
                 serde_json::to_string(&missing_chunks).unwrap()
             )),

--- a/tests/integration/monitors.rs
+++ b/tests/integration/monitors.rs
@@ -1,15 +1,15 @@
-use crate::integration::{mock_endpoint, register_test, EndpointOptions};
+use crate::integration::{mock_endpoint, register_test, MockEndpointBuilder};
 
 #[test]
 fn command_monitors() {
     let _list_endpoint = mock_endpoint(
-        EndpointOptions::new("GET", "/api/0/organizations/wat-org/monitors/?cursor=", 200)
+        MockEndpointBuilder::new("GET", "/api/0/organizations/wat-org/monitors/?cursor=", 200)
             .with_response_file("monitors/get-monitors.json"),
     );
     let _envelope_endpoint =
-        mock_endpoint(EndpointOptions::new("POST", "/api/1337/envelope/", 200));
+        mock_endpoint(MockEndpointBuilder::new("POST", "/api/1337/envelope/", 200));
     let _token_endpoint = mock_endpoint(
-        EndpointOptions::new("POST", "/api/0/monitors/foo-monitor/checkins/", 200)
+        MockEndpointBuilder::new("POST", "/api/0/monitors/foo-monitor/checkins/", 200)
             .with_response_file("monitors/post-monitors.json"),
     );
 
@@ -24,7 +24,7 @@ fn command_monitors() {
 
 #[test]
 fn command_monitors_run_server_error() {
-    let _server = mock_endpoint(EndpointOptions::new("POST", "/api/1337/envelope/", 500));
+    let _server = mock_endpoint(MockEndpointBuilder::new("POST", "/api/1337/envelope/", 500));
 
     #[cfg(not(windows))]
     register_test("monitors/server_error/monitors-run-server-error.trycmd");

--- a/tests/integration/organizations.rs
+++ b/tests/integration/organizations.rs
@@ -1,12 +1,12 @@
 use mockito::server_url;
 
-use crate::integration::{mock_endpoint, register_test, EndpointOptions};
+use crate::integration::{mock_endpoint, register_test, MockEndpointBuilder};
 
 #[test]
 fn command_organizations() {
     // Mocks are for the organizations list command.
     let _server = mock_endpoint(
-        EndpointOptions::new("GET", "/api/0/organizations/?cursor=", 200)
+        MockEndpointBuilder::new("GET", "/api/0/organizations/?cursor=", 200)
             .with_response_file("organizations/get-organizations.json"),
     );
 
@@ -21,7 +21,7 @@ fn command_organizations() {
     );
 
     let _mock_regions = mock_endpoint(
-        EndpointOptions::new("GET", "/api/0/users/me/regions/", 200)
+        MockEndpointBuilder::new("GET", "/api/0/users/me/regions/", 200)
             .with_response_body(region_response),
     );
     register_test("organizations/*.trycmd");

--- a/tests/integration/projects.rs
+++ b/tests/integration/projects.rs
@@ -1,10 +1,10 @@
-use crate::integration::{mock_endpoint, register_test, EndpointOptions};
+use crate::integration::{mock_endpoint, register_test, MockEndpointBuilder};
 
 #[test]
 fn command_projects_list() {
     // mock for projects list
     let _server = mock_endpoint(
-        EndpointOptions::new("GET", "/api/0/organizations/wat-org/projects/?cursor=", 200)
+        MockEndpointBuilder::new("GET", "/api/0/organizations/wat-org/projects/?cursor=", 200)
             .with_response_file("projects/get-projects.json"),
     );
     register_test("projects/*.trycmd");

--- a/tests/integration/releases/delete.rs
+++ b/tests/integration/releases/delete.rs
@@ -1,8 +1,8 @@
-use crate::integration::{mock_endpoint, register_test, EndpointOptions};
+use crate::integration::{mock_endpoint, register_test, MockEndpointBuilder};
 
 #[test]
 fn successfully_deletes() {
-    let _server = mock_endpoint(EndpointOptions::new(
+    let _server = mock_endpoint(MockEndpointBuilder::new(
         "DELETE",
         "/api/0/projects/wat-org/wat-project/releases/wat-release/",
         204,
@@ -12,7 +12,7 @@ fn successfully_deletes() {
 
 #[test]
 fn allows_for_release_to_start_with_hyphen() {
-    let _server = mock_endpoint(EndpointOptions::new(
+    let _server = mock_endpoint(MockEndpointBuilder::new(
         "DELETE",
         "/api/0/projects/wat-org/wat-project/releases/-hyphenated-release/",
         204,
@@ -22,7 +22,7 @@ fn allows_for_release_to_start_with_hyphen() {
 
 #[test]
 fn informs_about_nonexisting_releases() {
-    let _server = mock_endpoint(EndpointOptions::new(
+    let _server = mock_endpoint(MockEndpointBuilder::new(
         "DELETE",
         "/api/0/projects/wat-org/wat-project/releases/whoops/",
         404,
@@ -33,7 +33,7 @@ fn informs_about_nonexisting_releases() {
 #[test]
 fn doesnt_allow_to_delete_active_releases() {
     let _server = mock_endpoint(
-        EndpointOptions::new(
+        MockEndpointBuilder::new(
             "DELETE",
             "/api/0/projects/wat-org/wat-project/releases/wat-release/",
             400,

--- a/tests/integration/releases/finalize.rs
+++ b/tests/integration/releases/finalize.rs
@@ -1,11 +1,11 @@
-use crate::integration::{mock_endpoint, register_test, EndpointOptions};
+use crate::integration::{mock_endpoint, register_test, MockEndpointBuilder};
 use mockito::Matcher;
 use serde_json::json;
 
 #[test]
 fn successfully_creates_a_release() {
     let _server = mock_endpoint(
-        EndpointOptions::new(
+        MockEndpointBuilder::new(
             "PUT",
             "/api/0/projects/wat-org/wat-project/releases/wat-release/",
             200,
@@ -18,7 +18,7 @@ fn successfully_creates_a_release() {
 #[test]
 fn allows_for_release_to_start_with_hyphen() {
     let _server = mock_endpoint(
-        EndpointOptions::new(
+        MockEndpointBuilder::new(
             "PUT",
             "/api/0/projects/wat-org/wat-project/releases/-hyphenated-release/",
             200,
@@ -31,7 +31,7 @@ fn allows_for_release_to_start_with_hyphen() {
 #[test]
 fn release_with_custom_dates() {
     let _server = mock_endpoint(
-        EndpointOptions::new(
+        MockEndpointBuilder::new(
             "PUT",
             "/api/0/projects/wat-org/wat-project/releases/wat-release/",
             200,

--- a/tests/integration/releases/info.rs
+++ b/tests/integration/releases/info.rs
@@ -1,9 +1,9 @@
-use crate::integration::{mock_endpoint, register_test, EndpointOptions};
+use crate::integration::{mock_endpoint, register_test, MockEndpointBuilder};
 
 #[test]
 fn shows_release_details() {
     let _server = mock_endpoint(
-        EndpointOptions::new(
+        MockEndpointBuilder::new(
             "GET",
             "/api/0/projects/wat-org/wat-project/releases/wat-release/",
             200,
@@ -16,7 +16,7 @@ fn shows_release_details() {
 #[test]
 fn shows_release_details_with_projects_and_commits() {
     let _server = mock_endpoint(
-        EndpointOptions::new(
+        MockEndpointBuilder::new(
             "GET",
             "/api/0/projects/wat-org/wat-project/releases/wat-release/",
             200,
@@ -24,7 +24,7 @@ fn shows_release_details_with_projects_and_commits() {
         .with_response_file("releases/get-release.json"),
     );
     let _commits = mock_endpoint(
-        EndpointOptions::new(
+        MockEndpointBuilder::new(
             "GET",
             "/api/0/projects/wat-org/wat-project/releases/wat-release/commits/",
             200,
@@ -37,7 +37,7 @@ fn shows_release_details_with_projects_and_commits() {
 #[test]
 fn doesnt_print_output_with_quiet_flag() {
     let _server = mock_endpoint(
-        EndpointOptions::new(
+        MockEndpointBuilder::new(
             "GET",
             "/api/0/projects/wat-org/wat-project/releases/wat-release/",
             200,
@@ -50,7 +50,7 @@ fn doesnt_print_output_with_quiet_flag() {
 #[test]
 fn doesnt_print_output_with_silent_flag() {
     let _server = mock_endpoint(
-        EndpointOptions::new(
+        MockEndpointBuilder::new(
             "GET",
             "/api/0/projects/wat-org/wat-project/releases/wat-release/",
             200,
@@ -62,7 +62,7 @@ fn doesnt_print_output_with_silent_flag() {
 
 #[test]
 fn preserve_valid_exit_code_with_quiet_flag() {
-    let _server = mock_endpoint(EndpointOptions::new(
+    let _server = mock_endpoint(MockEndpointBuilder::new(
         "GET",
         "/api/0/projects/wat-org/wat-project/releases/unknown-release/",
         404,
@@ -72,7 +72,7 @@ fn preserve_valid_exit_code_with_quiet_flag() {
 
 #[test]
 fn exits_if_no_release_found() {
-    let _server = mock_endpoint(EndpointOptions::new(
+    let _server = mock_endpoint(MockEndpointBuilder::new(
         "GET",
         "/api/0/projects/wat-org/wat-project/releases/wat-release/",
         404,

--- a/tests/integration/releases/list.rs
+++ b/tests/integration/releases/list.rs
@@ -1,9 +1,9 @@
-use crate::integration::{mock_endpoint, register_test, EndpointOptions};
+use crate::integration::{mock_endpoint, register_test, MockEndpointBuilder};
 
 #[test]
 fn displays_releases() {
     let _server = mock_endpoint(
-        EndpointOptions::new("GET", "/api/0/projects/wat-org/wat-project/releases/", 200)
+        MockEndpointBuilder::new("GET", "/api/0/projects/wat-org/wat-project/releases/", 200)
             .with_response_file("releases/get-releases.json"),
     );
     register_test("releases/releases-list.trycmd");
@@ -12,7 +12,7 @@ fn displays_releases() {
 #[test]
 fn displays_releases_with_projects() {
     let _server = mock_endpoint(
-        EndpointOptions::new("GET", "/api/0/projects/wat-org/wat-project/releases/", 200)
+        MockEndpointBuilder::new("GET", "/api/0/projects/wat-org/wat-project/releases/", 200)
             .with_response_file("releases/get-releases.json"),
     );
     register_test("releases/releases-list-with-projects.trycmd");
@@ -21,7 +21,7 @@ fn displays_releases_with_projects() {
 #[test]
 fn doesnt_fail_with_empty_response() {
     let _server = mock_endpoint(
-        EndpointOptions::new("GET", "/api/0/projects/wat-org/wat-project/releases/", 200)
+        MockEndpointBuilder::new("GET", "/api/0/projects/wat-org/wat-project/releases/", 200)
             .with_response_body("[]"),
     );
     register_test("releases/releases-list-empty.trycmd");
@@ -30,7 +30,7 @@ fn doesnt_fail_with_empty_response() {
 #[test]
 fn can_override_org() {
     let _server = mock_endpoint(
-        EndpointOptions::new("GET", "/api/0/projects/whynot/wat-project/releases/", 200)
+        MockEndpointBuilder::new("GET", "/api/0/projects/whynot/wat-project/releases/", 200)
             .with_response_file("releases/get-releases.json"),
     );
     register_test("releases/releases-list-override-org.trycmd");
@@ -39,7 +39,7 @@ fn can_override_org() {
 #[test]
 fn displays_releases_in_raw_mode() {
     let _server = mock_endpoint(
-        EndpointOptions::new("GET", "/api/0/projects/wat-org/wat-project/releases/", 200)
+        MockEndpointBuilder::new("GET", "/api/0/projects/wat-org/wat-project/releases/", 200)
             .with_response_file("releases/get-releases.json"),
     );
     register_test("releases/releases-list-raw.trycmd");
@@ -48,7 +48,7 @@ fn displays_releases_in_raw_mode() {
 #[test]
 fn displays_releases_in_raw_mode_with_delimiter() {
     let _server = mock_endpoint(
-        EndpointOptions::new("GET", "/api/0/projects/wat-org/wat-project/releases/", 200)
+        MockEndpointBuilder::new("GET", "/api/0/projects/wat-org/wat-project/releases/", 200)
             .with_response_file("releases/get-releases.json"),
     );
     register_test("releases/releases-list-raw-delimiter.trycmd");

--- a/tests/integration/releases/new.rs
+++ b/tests/integration/releases/new.rs
@@ -1,7 +1,7 @@
 use mockito::Matcher;
 use serde_json::json;
 
-use crate::integration::{mock_endpoint, register_test, EndpointOptions, UTC_DATE_FORMAT};
+use crate::integration::{mock_endpoint, register_test, MockEndpointBuilder, UTC_DATE_FORMAT};
 
 #[test]
 fn command_releases_new_help() {
@@ -11,7 +11,7 @@ fn command_releases_new_help() {
 #[test]
 fn creates_release() {
     let _server = mock_endpoint(
-        EndpointOptions::new("POST", "/api/0/projects/wat-org/wat-project/releases/", 201)
+        MockEndpointBuilder::new("POST", "/api/0/projects/wat-org/wat-project/releases/", 201)
             .with_response_file("releases/get-release.json")
             .with_matcher(Matcher::PartialJson(json!({
                 "version": "new-release",
@@ -24,7 +24,7 @@ fn creates_release() {
 #[test]
 fn allows_for_release_to_start_with_hyphen() {
     let _server = mock_endpoint(
-        EndpointOptions::new("POST", "/api/0/projects/wat-org/wat-project/releases/", 201)
+        MockEndpointBuilder::new("POST", "/api/0/projects/wat-org/wat-project/releases/", 201)
             .with_response_file("releases/get-release.json")
             .with_matcher(Matcher::PartialJson(json!({
                 "version": "-hyphenated-release",
@@ -37,7 +37,7 @@ fn allows_for_release_to_start_with_hyphen() {
 #[test]
 fn creates_release_with_project() {
     let _server = mock_endpoint(
-        EndpointOptions::new("POST", "/api/0/projects/wat-org/wat-project/releases/", 201)
+        MockEndpointBuilder::new("POST", "/api/0/projects/wat-org/wat-project/releases/", 201)
             .with_response_file("releases/get-release.json")
             .with_matcher(Matcher::PartialJson(json!({
                 "version": "new-release",
@@ -50,7 +50,7 @@ fn creates_release_with_project() {
 #[test]
 fn allows_for_release_with_project_to_start_with_hyphen() {
     let _server = mock_endpoint(
-        EndpointOptions::new("POST", "/api/0/projects/wat-org/wat-project/releases/", 201)
+        MockEndpointBuilder::new("POST", "/api/0/projects/wat-org/wat-project/releases/", 201)
             .with_response_file("releases/get-release.json")
             .with_matcher(Matcher::PartialJson(json!({
                 "version": "-hyphenated-release",
@@ -63,7 +63,7 @@ fn allows_for_release_with_project_to_start_with_hyphen() {
 #[test]
 fn creates_release_even_if_one_already_exists() {
     let _server = mock_endpoint(
-        EndpointOptions::new("POST", "/api/0/projects/wat-org/wat-project/releases/", 208)
+        MockEndpointBuilder::new("POST", "/api/0/projects/wat-org/wat-project/releases/", 208)
             .with_response_file("releases/get-release.json")
             .with_matcher(Matcher::PartialJson(json!({
                 "version": "wat-release",
@@ -76,7 +76,7 @@ fn creates_release_even_if_one_already_exists() {
 #[test]
 fn creates_release_with_custom_url() {
     let _server = mock_endpoint(
-        EndpointOptions::new("POST", "/api/0/projects/wat-org/wat-project/releases/", 208)
+        MockEndpointBuilder::new("POST", "/api/0/projects/wat-org/wat-project/releases/", 208)
             .with_response_file("releases/get-release.json")
             .with_matcher(Matcher::PartialJson(json!({
                 "version": "wat-release",
@@ -90,7 +90,7 @@ fn creates_release_with_custom_url() {
 #[test]
 fn creates_release_which_is_instantly_finalized() {
     let _server = mock_endpoint(
-        EndpointOptions::new("POST", "/api/0/projects/wat-org/wat-project/releases/", 208)
+        MockEndpointBuilder::new("POST", "/api/0/projects/wat-org/wat-project/releases/", 208)
             .with_response_file("releases/get-release.json")
             .with_matcher(Matcher::AllOf(vec![
                 Matcher::PartialJson(json!({

--- a/tests/integration/send_envelope.rs
+++ b/tests/integration/send_envelope.rs
@@ -1,10 +1,10 @@
 use crate::integration;
 
-use super::EndpointOptions;
+use super::MockEndpointBuilder;
 
 #[test]
 fn command_send_envelope() {
     let _server =
-        integration::mock_endpoint(EndpointOptions::new("POST", "/api/1337/envelope/", 200));
+        integration::mock_endpoint(MockEndpointBuilder::new("POST", "/api/1337/envelope/", 200));
     integration::register_test("send_envelope/*.trycmd");
 }

--- a/tests/integration/send_event.rs
+++ b/tests/integration/send_event.rs
@@ -1,4 +1,4 @@
-use crate::integration::{self, EndpointOptions};
+use crate::integration::{self, MockEndpointBuilder};
 
 // I have no idea why this is timing out on Windows.
 // I verified it manually, and this command works just fine. — Kamil
@@ -7,13 +7,13 @@ use crate::integration::{self, EndpointOptions};
 #[test]
 fn command_send_event_not_windows() {
     let _server =
-        integration::mock_endpoint(EndpointOptions::new("POST", "/api/1337/envelope/", 200));
+        integration::mock_endpoint(MockEndpointBuilder::new("POST", "/api/1337/envelope/", 200));
     integration::register_test("send_event/not_windows/*.trycmd");
 }
 
 #[test]
 fn command_send_event() {
     let _server =
-        integration::mock_endpoint(EndpointOptions::new("POST", "/api/1337/envelope/", 200));
+        integration::mock_endpoint(MockEndpointBuilder::new("POST", "/api/1337/envelope/", 200));
     integration::register_test("send_event/*.trycmd");
 }

--- a/tests/integration/send_metric.rs
+++ b/tests/integration/send_metric.rs
@@ -1,4 +1,4 @@
-use super::EndpointOptions;
+use super::MockEndpointBuilder;
 use crate::integration;
 use mockito::{Matcher, Mock};
 use trycmd::TestCases;
@@ -9,7 +9,7 @@ fn mock_envelopes_endpoint() -> Mock {
             .to_string(),
     );
     integration::mock_endpoint(
-        EndpointOptions::new("POST", "/api/1337/envelope/", 200)
+        MockEndpointBuilder::new("POST", "/api/1337/envelope/", 200)
             .with_header_matcher("X-Sentry-Auth", expected_auth_header),
     )
 }
@@ -37,7 +37,8 @@ fn command_send_metric_increment_no_dsn() {
 
 #[test]
 fn command_send_metric_increment_unsuccessful_api_call() {
-    let _m = integration::mock_endpoint(EndpointOptions::new("POST", "/api/1337/envelope/", 500));
+    let _m =
+        integration::mock_endpoint(MockEndpointBuilder::new("POST", "/api/1337/envelope/", 500));
     integration::register_test(
         "send_metric/individual_config/send_metric-increment-unsuccessful-api-call.trycmd",
     );

--- a/tests/integration/sourcemaps/explain.rs
+++ b/tests/integration/sourcemaps/explain.rs
@@ -1,4 +1,4 @@
-use crate::integration::{mock_endpoint, register_test, EndpointOptions};
+use crate::integration::{mock_endpoint, register_test, MockEndpointBuilder};
 
 #[test]
 fn command_sourcemaps_explain_help() {
@@ -12,7 +12,7 @@ fn command_sourcemaps_explain() {
 
 #[test]
 fn command_sourcemaps_explain_missing_event() {
-    let _event = mock_endpoint(EndpointOptions::new(
+    let _event = mock_endpoint(MockEndpointBuilder::new(
         "GET",
         "/api/0/projects/wat-org/wat-project/events/43a57a55cd5a4207ac520c03e1dee1b4/json/",
         404,
@@ -23,7 +23,7 @@ fn command_sourcemaps_explain_missing_event() {
 #[test]
 fn command_sourcemaps_explain_missing_release() {
     let _event = mock_endpoint(
-        EndpointOptions::new(
+        MockEndpointBuilder::new(
             "GET",
             "/api/0/projects/wat-org/wat-project/events/43a57a55cd5a4207ac520c03e1dee1b4/json/",
             200,
@@ -36,7 +36,7 @@ fn command_sourcemaps_explain_missing_release() {
 #[test]
 fn command_sourcemaps_explain_missing_exception() {
     let _event = mock_endpoint(
-        EndpointOptions::new(
+        MockEndpointBuilder::new(
             "GET",
             "/api/0/projects/wat-org/wat-project/events/43a57a55cd5a4207ac520c03e1dee1b4/json/",
             200,
@@ -49,7 +49,7 @@ fn command_sourcemaps_explain_missing_exception() {
 #[test]
 fn command_sourcemaps_explain_missing_stacktrace() {
     let _event = mock_endpoint(
-        EndpointOptions::new(
+        MockEndpointBuilder::new(
             "GET",
             "/api/0/projects/wat-org/wat-project/events/43a57a55cd5a4207ac520c03e1dee1b4/json/",
             200,
@@ -62,7 +62,7 @@ fn command_sourcemaps_explain_missing_stacktrace() {
 #[test]
 fn command_sourcemaps_explain_frame_no_inapp() {
     let _event = mock_endpoint(
-        EndpointOptions::new(
+        MockEndpointBuilder::new(
             "GET",
             "/api/0/projects/wat-org/wat-project/events/43a57a55cd5a4207ac520c03e1dee1b4/json/",
             200,
@@ -75,7 +75,7 @@ fn command_sourcemaps_explain_frame_no_inapp() {
 #[test]
 fn command_sourcemaps_explain_frame_no_abspath() {
     let _event = mock_endpoint(
-        EndpointOptions::new(
+        MockEndpointBuilder::new(
             "GET",
             "/api/0/projects/wat-org/wat-project/events/43a57a55cd5a4207ac520c03e1dee1b4/json/",
             200,
@@ -88,7 +88,7 @@ fn command_sourcemaps_explain_frame_no_abspath() {
 #[test]
 fn command_sourcemaps_explain_frame_no_extension() {
     let _event = mock_endpoint(
-        EndpointOptions::new(
+        MockEndpointBuilder::new(
             "GET",
             "/api/0/projects/wat-org/wat-project/events/43a57a55cd5a4207ac520c03e1dee1b4/json/",
             200,
@@ -101,7 +101,7 @@ fn command_sourcemaps_explain_frame_no_extension() {
 #[test]
 fn command_sourcemaps_explain_frame_malformed_abspath() {
     let _event = mock_endpoint(
-        EndpointOptions::new(
+        MockEndpointBuilder::new(
             "GET",
             "/api/0/projects/wat-org/wat-project/events/43a57a55cd5a4207ac520c03e1dee1b4/json/",
             200,
@@ -114,7 +114,7 @@ fn command_sourcemaps_explain_frame_malformed_abspath() {
 #[test]
 fn command_sourcemaps_explain_already_mapped() {
     let _event = mock_endpoint(
-        EndpointOptions::new(
+        MockEndpointBuilder::new(
             "GET",
             "/api/0/projects/wat-org/wat-project/events/43a57a55cd5a4207ac520c03e1dee1b4/json/",
             200,
@@ -127,7 +127,7 @@ fn command_sourcemaps_explain_already_mapped() {
 #[test]
 fn command_sourcemaps_explain_no_artifacts() {
     let _event = mock_endpoint(
-        EndpointOptions::new(
+        MockEndpointBuilder::new(
             "GET",
             "/api/0/projects/wat-org/wat-project/events/43a57a55cd5a4207ac520c03e1dee1b4/json/",
             200,
@@ -135,7 +135,7 @@ fn command_sourcemaps_explain_no_artifacts() {
         .with_response_file("sourcemaps/get-event.json"),
     );
     let _artifacts = mock_endpoint(
-        EndpointOptions::new(
+        MockEndpointBuilder::new(
             "GET",
             "/api/0/projects/wat-org/wat-project/releases/ytho-test/files/?cursor=",
             200,
@@ -148,7 +148,7 @@ fn command_sourcemaps_explain_no_artifacts() {
 #[test]
 fn command_sourcemaps_explain_no_matching_artifact() {
     let _event = mock_endpoint(
-        EndpointOptions::new(
+        MockEndpointBuilder::new(
             "GET",
             "/api/0/projects/wat-org/wat-project/events/43a57a55cd5a4207ac520c03e1dee1b4/json/",
             200,
@@ -156,7 +156,7 @@ fn command_sourcemaps_explain_no_matching_artifact() {
         .with_response_file("sourcemaps/get-event.json"),
     );
     let _artifacts = mock_endpoint(
-        EndpointOptions::new(
+        MockEndpointBuilder::new(
             "GET",
             "/api/0/projects/wat-org/wat-project/releases/ytho-test/files/?cursor=",
             200,
@@ -169,7 +169,7 @@ fn command_sourcemaps_explain_no_matching_artifact() {
 #[test]
 fn command_sourcemaps_explain_partial_matching_artifact() {
     let _event = mock_endpoint(
-        EndpointOptions::new(
+        MockEndpointBuilder::new(
             "GET",
             "/api/0/projects/wat-org/wat-project/events/43a57a55cd5a4207ac520c03e1dee1b4/json/",
             200,
@@ -177,7 +177,7 @@ fn command_sourcemaps_explain_partial_matching_artifact() {
         .with_response_file("sourcemaps/get-event.json"),
     );
     let _artifacts = mock_endpoint(
-        EndpointOptions::new(
+        MockEndpointBuilder::new(
             "GET",
             "/api/0/projects/wat-org/wat-project/releases/ytho-test/files/?cursor=",
             200,
@@ -190,7 +190,7 @@ fn command_sourcemaps_explain_partial_matching_artifact() {
 #[test]
 fn command_sourcemaps_explain_artifact_dist_mismatch() {
     let _event = mock_endpoint(
-        EndpointOptions::new(
+        MockEndpointBuilder::new(
             "GET",
             "/api/0/projects/wat-org/wat-project/events/43a57a55cd5a4207ac520c03e1dee1b4/json/",
             200,
@@ -198,7 +198,7 @@ fn command_sourcemaps_explain_artifact_dist_mismatch() {
         .with_response_file("sourcemaps/get-event.json"),
     );
     let _artifacts = mock_endpoint(
-        EndpointOptions::new(
+        MockEndpointBuilder::new(
             "GET",
             "/api/0/projects/wat-org/wat-project/releases/ytho-test/files/?cursor=",
             200,
@@ -211,7 +211,7 @@ fn command_sourcemaps_explain_artifact_dist_mismatch() {
 #[test]
 fn command_sourcemaps_explain_artifact_no_dist() {
     let _event = mock_endpoint(
-        EndpointOptions::new(
+        MockEndpointBuilder::new(
             "GET",
             "/api/0/projects/wat-org/wat-project/events/43a57a55cd5a4207ac520c03e1dee1b4/json/",
             200,
@@ -219,7 +219,7 @@ fn command_sourcemaps_explain_artifact_no_dist() {
         .with_response_file("sourcemaps/get-event.json"),
     );
     let _artifacts = mock_endpoint(
-        EndpointOptions::new(
+        MockEndpointBuilder::new(
             "GET",
             "/api/0/projects/wat-org/wat-project/releases/ytho-test/files/?cursor=",
             200,
@@ -232,7 +232,7 @@ fn command_sourcemaps_explain_artifact_no_dist() {
 #[test]
 fn command_sourcemaps_explain_event_no_dist() {
     let _event = mock_endpoint(
-        EndpointOptions::new(
+        MockEndpointBuilder::new(
             "GET",
             "/api/0/projects/wat-org/wat-project/events/43a57a55cd5a4207ac520c03e1dee1b4/json/",
             200,
@@ -240,7 +240,7 @@ fn command_sourcemaps_explain_event_no_dist() {
         .with_response_file("sourcemaps/get-event-missing-dist.json"),
     );
     let _artifacts = mock_endpoint(
-        EndpointOptions::new(
+        MockEndpointBuilder::new(
             "GET",
             "/api/0/projects/wat-org/wat-project/releases/ytho-test/files/?cursor=",
             200,
@@ -253,7 +253,7 @@ fn command_sourcemaps_explain_event_no_dist() {
 #[test]
 fn command_sourcemaps_explain_detect_from_sourcemap_header() {
     let _event = mock_endpoint(
-        EndpointOptions::new(
+        MockEndpointBuilder::new(
             "GET",
             "/api/0/projects/wat-org/wat-project/events/43a57a55cd5a4207ac520c03e1dee1b4/json/",
             200,
@@ -261,7 +261,7 @@ fn command_sourcemaps_explain_detect_from_sourcemap_header() {
         .with_response_file("sourcemaps/get-event-missing-dist.json"),
     );
     let _artifacts = mock_endpoint(
-        EndpointOptions::new(
+        MockEndpointBuilder::new(
             "GET",
             "/api/0/projects/wat-org/wat-project/releases/ytho-test/files/?cursor=",
             200,
@@ -269,7 +269,7 @@ fn command_sourcemaps_explain_detect_from_sourcemap_header() {
         .with_response_file("sourcemaps/get-artifacts-no-sourcemap.json"),
     );
     let _file_metadata = mock_endpoint(
-        EndpointOptions::new(
+        MockEndpointBuilder::new(
             "GET",
             "/api/0/projects/wat-org/wat-project/releases/ytho-test/files/6796495645/",
             200,
@@ -283,7 +283,7 @@ fn command_sourcemaps_explain_detect_from_sourcemap_header() {
 #[test]
 fn command_sourcemaps_explain_detect_from_xsourcemap_header() {
     let _event = mock_endpoint(
-        EndpointOptions::new(
+        MockEndpointBuilder::new(
             "GET",
             "/api/0/projects/wat-org/wat-project/events/43a57a55cd5a4207ac520c03e1dee1b4/json/",
             200,
@@ -291,7 +291,7 @@ fn command_sourcemaps_explain_detect_from_xsourcemap_header() {
         .with_response_file("sourcemaps/get-event-missing-dist.json"),
     );
     let _artifacts = mock_endpoint(
-        EndpointOptions::new(
+        MockEndpointBuilder::new(
             "GET",
             "/api/0/projects/wat-org/wat-project/releases/ytho-test/files/?cursor=",
             200,
@@ -299,7 +299,7 @@ fn command_sourcemaps_explain_detect_from_xsourcemap_header() {
         .with_response_file("sourcemaps/get-artifacts-no-sourcemap.json"),
     );
     let _file_metadata = mock_endpoint(
-        EndpointOptions::new(
+        MockEndpointBuilder::new(
             "GET",
             "/api/0/projects/wat-org/wat-project/releases/ytho-test/files/6796495645/",
             200,
@@ -313,7 +313,7 @@ fn command_sourcemaps_explain_detect_from_xsourcemap_header() {
 #[test]
 fn command_sourcemaps_explain_detect_from_file_content() {
     let _event = mock_endpoint(
-        EndpointOptions::new(
+        MockEndpointBuilder::new(
             "GET",
             "/api/0/projects/wat-org/wat-project/events/43a57a55cd5a4207ac520c03e1dee1b4/json/",
             200,
@@ -321,7 +321,7 @@ fn command_sourcemaps_explain_detect_from_file_content() {
         .with_response_file("sourcemaps/get-event-missing-dist.json"),
     );
     let _artifacts = mock_endpoint(
-        EndpointOptions::new(
+        MockEndpointBuilder::new(
             "GET",
             "/api/0/projects/wat-org/wat-project/releases/ytho-test/files/?cursor=",
             200,
@@ -329,7 +329,7 @@ fn command_sourcemaps_explain_detect_from_file_content() {
         .with_response_file("sourcemaps/get-artifacts-no-sourcemap.json"),
     );
     let _file_metadata = mock_endpoint(
-        EndpointOptions::new(
+        MockEndpointBuilder::new(
             "GET",
             "/api/0/projects/wat-org/wat-project/releases/ytho-test/files/6796495645/",
             200,
@@ -337,7 +337,7 @@ fn command_sourcemaps_explain_detect_from_file_content() {
         .with_response_file("sourcemaps/get-file-metadata-no-headers.json"),
     );
     let _file = mock_endpoint(
-        EndpointOptions::new(
+        MockEndpointBuilder::new(
             "GET",
             "/api/0/projects/wat-org/wat-project/releases/ytho-test/files/6796495645/?download=1",
             200,
@@ -351,7 +351,7 @@ fn command_sourcemaps_explain_detect_from_file_content() {
 #[test]
 fn command_sourcemaps_explain_print_sourcemap() {
     let _event = mock_endpoint(
-        EndpointOptions::new(
+        MockEndpointBuilder::new(
             "GET",
             "/api/0/projects/wat-org/wat-project/events/43a57a55cd5a4207ac520c03e1dee1b4/json/",
             200,
@@ -359,7 +359,7 @@ fn command_sourcemaps_explain_print_sourcemap() {
         .with_response_file("sourcemaps/get-event-missing-dist.json"),
     );
     let _artifacts = mock_endpoint(
-        EndpointOptions::new(
+        MockEndpointBuilder::new(
             "GET",
             "/api/0/projects/wat-org/wat-project/releases/ytho-test/files/?cursor=",
             200,
@@ -367,7 +367,7 @@ fn command_sourcemaps_explain_print_sourcemap() {
         .with_response_file("sourcemaps/get-artifacts-no-dist.json"),
     );
     let _file_metadata = mock_endpoint(
-        EndpointOptions::new(
+        MockEndpointBuilder::new(
             "GET",
             "/api/0/projects/wat-org/wat-project/releases/ytho-test/files/6796495645/",
             200,
@@ -375,7 +375,7 @@ fn command_sourcemaps_explain_print_sourcemap() {
         .with_response_file("sourcemaps/get-file-metadata-sourcemap-header.json"),
     );
     let _file = mock_endpoint(
-        EndpointOptions::new(
+        MockEndpointBuilder::new(
             "GET",
             "/api/0/projects/wat-org/wat-project/releases/ytho-test/files/6796495646/?download=1",
             200,
@@ -389,7 +389,7 @@ fn command_sourcemaps_explain_print_sourcemap() {
 #[test]
 fn command_sourcemaps_explain_select_frame() {
     let _event = mock_endpoint(
-        EndpointOptions::new(
+        MockEndpointBuilder::new(
             "GET",
             "/api/0/projects/wat-org/wat-project/events/43a57a55cd5a4207ac520c03e1dee1b4/json/",
             200,
@@ -402,7 +402,7 @@ fn command_sourcemaps_explain_select_frame() {
 #[test]
 fn command_sourcemaps_explain_select_frame_out_of_range() {
     let _event = mock_endpoint(
-        EndpointOptions::new(
+        MockEndpointBuilder::new(
             "GET",
             "/api/0/projects/wat-org/wat-project/events/43a57a55cd5a4207ac520c03e1dee1b4/json/",
             200,

--- a/tests/integration/sourcemaps/upload.rs
+++ b/tests/integration/sourcemaps/upload.rs
@@ -1,6 +1,6 @@
 use crate::integration::{
     assert_endpoints, mock_common_upload_endpoints, mock_endpoint, register_test, ChunkOptions,
-    EndpointOptions, ServerBehavior,
+    MockEndpointBuilder, ServerBehavior,
 };
 
 #[test]
@@ -17,7 +17,7 @@ fn command_sourcemaps_upload() {
 fn command_sourcemaps_upload_successfully_upload_file() {
     let upload_endpoints = mock_common_upload_endpoints(ServerBehavior::Legacy, Default::default());
     let _files = mock_endpoint(
-        EndpointOptions::new(
+        MockEndpointBuilder::new(
             "GET",
             "/api/0/projects/wat-org/wat-project/releases/wat-release/files/?cursor=",
             200,
@@ -33,7 +33,7 @@ fn command_sourcemaps_upload_successfully_upload_file() {
 fn command_sourcemaps_upload_skip_already_uploaded() {
     let upload_endpoints = mock_common_upload_endpoints(ServerBehavior::Legacy, Default::default());
     let _files = mock_endpoint(
-        EndpointOptions::new(
+        MockEndpointBuilder::new(
             "GET",
             "/api/0/projects/wat-org/wat-project/releases/wat-release/files/?cursor=&checksum=38ed853073df85147960ea3a5bced6170ec389b0&checksum=f3673e2cea68bcb86bb74254a9efaa381d74929f",
             200,
@@ -58,7 +58,7 @@ fn command_sourcemaps_upload_skip_already_uploaded() {
 fn command_sourcemaps_upload_no_dedupe() {
     let upload_endpoints = mock_common_upload_endpoints(ServerBehavior::Legacy, Default::default());
     let _files = mock_endpoint(
-        EndpointOptions::new(
+        MockEndpointBuilder::new(
             "GET",
             "/api/0/projects/wat-org/wat-project/releases/wat-release/files/?cursor=",
             200,
@@ -105,7 +105,7 @@ fn command_sourcemaps_upload_empty() {
     let _upload_endpoints =
         mock_common_upload_endpoints(ServerBehavior::Legacy, Default::default());
     let _files = mock_endpoint(
-        EndpointOptions::new(
+        MockEndpointBuilder::new(
             "GET",
             "/api/0/projects/wat-org/wat-project/releases/wat-release/files/?cursor=",
             200,

--- a/tests/integration/test_utils/mocking.rs
+++ b/tests/integration/test_utils/mocking.rs
@@ -1,15 +1,21 @@
 use mockito::{Matcher, Mock};
 
-/// Options for creating a mock endpoint.
-pub struct EndpointOptions {
+/// Builder for a mock endpoint.
+///
+/// This struct allows for configuring a mock endpoint to be constructed in
+/// the `mock_endpoint()` function. Options can be chained together to create
+/// complex mocks.
+///
+/// The mock is only created once `mock_endpoint()` is called with the builder.
+pub struct MockEndpointBuilder {
     /// The mock object we are building.
     mock: Mock,
 }
 
-impl EndpointOptions {
+impl MockEndpointBuilder {
     /// Create a new endpoint options struct
     pub fn new(method: &str, endpoint: &str, status: usize) -> Self {
-        EndpointOptions {
+        Self {
             mock: mockito::mock(method, endpoint)
                 .with_status(status)
                 .with_header("content-type", "application/json"),
@@ -51,6 +57,6 @@ impl EndpointOptions {
 
 /// Build and return a mock endpoint with the provided configuration. The mock is automatically
 /// created and started. It is active until dropped.
-pub fn mock_endpoint(opts: EndpointOptions) -> Mock {
+pub fn mock_endpoint(opts: MockEndpointBuilder) -> Mock {
     opts.mock.create()
 }

--- a/tests/integration/test_utils/mod.rs
+++ b/tests/integration/test_utils/mod.rs
@@ -3,4 +3,4 @@
 pub mod env;
 mod mocking;
 
-pub use mocking::{mock_endpoint, EndpointOptions};
+pub use mocking::{mock_endpoint, MockEndpointBuilder};

--- a/tests/integration/upload_proguard.rs
+++ b/tests/integration/upload_proguard.rs
@@ -1,11 +1,11 @@
 use crate::integration::{
-    mock_endpoint, register_test, register_test_without_token, EndpointOptions,
+    mock_endpoint, register_test, register_test_without_token, MockEndpointBuilder,
 };
 
 #[test]
 fn command_upload_proguard() {
     let _dsyms = mock_endpoint(
-        EndpointOptions::new(
+        MockEndpointBuilder::new(
             "POST",
             "/api/0/projects/wat-org/wat-project/files/dsyms/",
             200,


### PR DESCRIPTION
The new name describes more accurately what the struct now does.