### PR TITLE
ref(tests): Simplify `mock_common_upload_endpoints`

### DIFF
--- a/tests/integration/test_utils/mock_common_endpoints.rs
+++ b/tests/integration/test_utils/mock_common_endpoints.rs
@@ -46,8 +46,7 @@ pub fn mock_common_upload_endpoints(
             MockEndpointBuilder::new("POST", "/api/0/projects/wat-org/wat-project/releases/", 208)
                 .with_response_file("releases/get-release.json"),
         )
-        .expect_at_least(release_request_count)
-        .expect_at_most(release_request_count),
+        .expect(release_request_count),
         test_utils::mock_endpoint(
             MockEndpointBuilder::new("GET", "/api/0/organizations/wat-org/chunk-upload/", 200)
                 .with_response_body(chunk_upload_response),


### PR DESCRIPTION
`.expect` is equivalent to calling `.expect_at_most` and `.expect_at_least` with the same value