### PR TITLE
ref(test): Add `TestManager` struct for uniform test setup

### DIFF
--- a/tests/integration/bash_hook.rs
+++ b/tests/integration/bash_hook.rs
@@ -1,6 +1,6 @@
-use crate::integration::register_test;
+use crate::integration::TestManager;
 
 #[test]
 fn command_bash_hook() {
-    register_test("bash_hook/*.trycmd");
+    TestManager::new().register_trycmd_test("bash_hook/*.trycmd");
 }

--- a/tests/integration/debug_files/bundle_jvm.rs
+++ b/tests/integration/debug_files/bundle_jvm.rs
@@ -1,6 +1,4 @@
-use crate::integration::{
-    copy_recursively, mock_common_upload_endpoints, register_test, ServerBehavior,
-};
+use crate::integration::{copy_recursively, ServerBehavior, TestManager};
 use std::fs::{create_dir, remove_dir_all, write};
 
 #[test]
@@ -16,9 +14,13 @@ fn command_bundle_jvm_out_not_found_creates_dir() {
         testcase_cwd_path.join("jvm"),
     )
     .unwrap();
-    let _upload_endpoints =
-        mock_common_upload_endpoints(ServerBehavior::Legacy, Default::default());
-    register_test("debug_files/bundle_jvm/debug_files-bundle-jvm-output-not-found.trycmd");
+
+    TestManager::new()
+        .mock_common_upload_endpoints(ServerBehavior::Legacy, Default::default())
+        .register_trycmd_test(
+            "debug_files/bundle_jvm/debug_files-bundle-jvm-output-not-found.trycmd",
+        )
+        .with_default_token();
 }
 
 #[test]
@@ -31,24 +33,29 @@ fn command_bundle_jvm_fails_out_is_file() {
     }
     copy_recursively("tests/integration/_fixtures/jvm/", testcase_cwd_path).unwrap();
     write(testcase_cwd_path.join("file.txt"), "some file content").unwrap();
-    let _upload_endpoints =
-        mock_common_upload_endpoints(ServerBehavior::Legacy, Default::default());
 
-    register_test("debug_files/bundle_jvm/debug_files-bundle-jvm-output-is-file.trycmd");
+    TestManager::new()
+        .mock_common_upload_endpoints(ServerBehavior::Legacy, Default::default())
+        .register_trycmd_test("debug_files/bundle_jvm/debug_files-bundle-jvm-output-is-file.trycmd")
+        .with_default_token();
 }
 
 #[test]
 fn command_bundle_jvm_fails_input_not_found() {
-    let _upload_endpoints =
-        mock_common_upload_endpoints(ServerBehavior::Legacy, Default::default());
-    register_test("debug_files/bundle_jvm/debug_files-bundle-jvm-input-not-found.trycmd");
+    TestManager::new()
+        .mock_common_upload_endpoints(ServerBehavior::Legacy, Default::default())
+        .register_trycmd_test(
+            "debug_files/bundle_jvm/debug_files-bundle-jvm-input-not-found.trycmd",
+        )
+        .with_default_token();
 }
 
 #[test]
 fn command_bundle_jvm_fails_input_is_file() {
-    let _upload_endpoints =
-        mock_common_upload_endpoints(ServerBehavior::Legacy, Default::default());
-    register_test("debug_files/bundle_jvm/debug_files-bundle-jvm-input-is-file.trycmd");
+    TestManager::new()
+        .mock_common_upload_endpoints(ServerBehavior::Legacy, Default::default())
+        .register_trycmd_test("debug_files/bundle_jvm/debug_files-bundle-jvm-input-is-file.trycmd")
+        .with_default_token();
 }
 
 #[test]
@@ -61,16 +68,19 @@ fn command_bundle_jvm_input_dir_empty() {
     }
     copy_recursively("tests/integration/_fixtures/jvm/", testcase_cwd_path).unwrap();
     create_dir(testcase_cwd_path.join("empty-dir")).unwrap();
-    let _upload_endpoints =
-        mock_common_upload_endpoints(ServerBehavior::Legacy, Default::default());
-    register_test("debug_files/bundle_jvm/debug_files-bundle-jvm-input-dir-empty.trycmd");
+    TestManager::new()
+        .mock_common_upload_endpoints(ServerBehavior::Legacy, Default::default())
+        .register_trycmd_test(
+            "debug_files/bundle_jvm/debug_files-bundle-jvm-input-dir-empty.trycmd",
+        )
+        .with_default_token();
 }
 
 #[test]
 fn command_bundle_jvm_fails_invalid_uuid() {
-    let _upload_endpoints =
-        mock_common_upload_endpoints(ServerBehavior::Legacy, Default::default());
-    register_test("debug_files/bundle_jvm/debug_files-bundle-jvm-invalid-uuid.trycmd");
+    TestManager::new()
+        .mock_common_upload_endpoints(ServerBehavior::Legacy, Default::default())
+        .register_trycmd_test("debug_files/bundle_jvm/debug_files-bundle-jvm-invalid-uuid.trycmd");
 }
 
 #[test]
@@ -81,7 +91,8 @@ fn command_bundle_jvm() {
         remove_dir_all(testcase_cwd_path).unwrap();
     }
     copy_recursively("tests/integration/_fixtures/jvm/", testcase_cwd_path).unwrap();
-    let _upload_endpoints =
-        mock_common_upload_endpoints(ServerBehavior::Legacy, Default::default());
-    register_test("debug_files/bundle_jvm/debug_files-bundle-jvm.trycmd");
+    TestManager::new()
+        .mock_common_upload_endpoints(ServerBehavior::Legacy, Default::default())
+        .register_trycmd_test("debug_files/bundle_jvm/debug_files-bundle-jvm.trycmd")
+        .with_default_token();
 }

--- a/tests/integration/debug_files/mod.rs
+++ b/tests/integration/debug_files/mod.rs
@@ -1,21 +1,21 @@
-use crate::integration::register_test;
+use crate::integration::TestManager;
 
 mod bundle_jvm;
 mod upload;
 
 #[test]
 fn command_debug_files_help() {
-    register_test("debug_files/*.trycmd");
+    TestManager::new().register_trycmd_test("debug_files/*.trycmd");
 }
 
 #[cfg(not(windows))]
 #[test]
 fn command_debug_files_not_windows() {
-    register_test("debug_files/not_windows/*.trycmd");
+    TestManager::new().register_trycmd_test("debug_files/not_windows/*.trycmd");
 }
 
 #[cfg(windows)]
 #[test]
 fn command_debug_files_windows() {
-    register_test("debug_files/windows/*.trycmd");
+    TestManager::new().register_trycmd_test("debug_files/windows/*.trycmd");
 }

--- a/tests/integration/debug_files/upload.rs
+++ b/tests/integration/debug_files/upload.rs
@@ -1,140 +1,153 @@
 use assert_cmd::Command;
 
-use crate::integration::{mock_endpoint, register_test, test_utils::env, MockEndpointBuilder};
+use crate::integration::{test_utils::env, MockEndpointBuilder, TestManager};
 
 #[test]
 fn command_debug_files_upload() {
-    let _chunk_upload = mock_endpoint(
-        MockEndpointBuilder::new("GET", "/api/0/organizations/wat-org/chunk-upload/", 200)
-            .with_response_file("debug_files/get-chunk-upload.json"),
-    );
-    let _assemble = mock_endpoint(
-        MockEndpointBuilder::new(
-            "POST",
-            "/api/0/projects/wat-org/wat-project/files/difs/assemble/",
-            200,
+    TestManager::new()
+        .mock_endpoint(
+            MockEndpointBuilder::new("GET", "/api/0/organizations/wat-org/chunk-upload/", 200)
+                .with_response_file("debug_files/get-chunk-upload.json"),
         )
-        .with_response_file("debug_files/post-difs-assemble.json"),
-    );
-    register_test("debug_files/upload/debug_files-upload.trycmd");
+        .mock_endpoint(
+            MockEndpointBuilder::new(
+                "POST",
+                "/api/0/projects/wat-org/wat-project/files/difs/assemble/",
+                200,
+            )
+            .with_response_file("debug_files/post-difs-assemble.json"),
+        )
+        .register_trycmd_test("debug_files/upload/debug_files-upload.trycmd")
+        .with_default_token();
 }
 
 #[test]
 fn command_debug_files_upload_pdb() {
-    let _chunk_upload = mock_endpoint(
-        MockEndpointBuilder::new("GET", "/api/0/organizations/wat-org/chunk-upload/", 200)
-            .with_response_file("debug_files/get-chunk-upload.json"),
-    );
-    let _assemble = mock_endpoint(
-        MockEndpointBuilder::new(
-            "POST",
-            "/api/0/projects/wat-org/wat-project/files/difs/assemble/",
-            200,
+    TestManager::new()
+        .mock_endpoint(
+            MockEndpointBuilder::new("GET", "/api/0/organizations/wat-org/chunk-upload/", 200)
+                .with_response_file("debug_files/get-chunk-upload.json"),
         )
-        .with_response_body(
-            r#"{
+        .mock_endpoint(
+            MockEndpointBuilder::new(
+                "POST",
+                "/api/0/projects/wat-org/wat-project/files/difs/assemble/",
+                200,
+            )
+            .with_response_body(
+                r#"{
                 "5f81d6becc51980870acc9f6636ab53d26160763": {
                     "state": "ok",
                     "missingChunks": []
                 }
             }"#,
-        ),
-    );
-    register_test("debug_files/upload/debug_files-upload-pdb.trycmd");
-    register_test("debug_files/upload/debug_files-upload-pdb-include-sources.trycmd");
+            ),
+        )
+        .register_trycmd_test("debug_files/upload/debug_files-upload-pdb.trycmd")
+        .register_trycmd_test("debug_files/upload/debug_files-upload-pdb-include-sources.trycmd")
+        .with_default_token();
 }
 
 #[test]
 fn command_debug_files_upload_pdb_embedded_sources() {
-    let _chunk_upload = mock_endpoint(
-        MockEndpointBuilder::new("GET", "/api/0/organizations/wat-org/chunk-upload/", 200)
-            .with_response_file("debug_files/get-chunk-upload.json"),
-    );
-    let _assemble = mock_endpoint(
-        MockEndpointBuilder::new(
-            "POST",
-            "/api/0/projects/wat-org/wat-project/files/difs/assemble/",
-            200,
+    TestManager::new()
+        .mock_endpoint(
+            MockEndpointBuilder::new("GET", "/api/0/organizations/wat-org/chunk-upload/", 200)
+                .with_response_file("debug_files/get-chunk-upload.json"),
         )
-        .with_response_body(
-            r#"{
+        .mock_endpoint(
+            MockEndpointBuilder::new(
+                "POST",
+                "/api/0/projects/wat-org/wat-project/files/difs/assemble/",
+                200,
+            )
+            .with_response_body(
+                r#"{
                 "50dd9456dc89cdbc767337da512bdb36b15db6b2": {
                     "state": "ok",
                     "missingChunks": []
                 }
             }"#,
-        ),
-    );
-    register_test("debug_files/upload/debug_files-upload-pdb-embedded-sources.trycmd");
+            ),
+        )
+        .register_trycmd_test("debug_files/upload/debug_files-upload-pdb-embedded-sources.trycmd")
+        .with_default_token();
 }
 
 #[test]
 fn command_debug_files_upload_dll_embedded_ppdb_with_sources() {
-    let _chunk_upload = mock_endpoint(
-        MockEndpointBuilder::new("GET", "/api/0/organizations/wat-org/chunk-upload/", 200)
-            .with_response_file("debug_files/get-chunk-upload.json"),
-    );
-    let _assemble = mock_endpoint(
-        MockEndpointBuilder::new(
-            "POST",
-            "/api/0/projects/wat-org/wat-project/files/difs/assemble/",
-            200,
+    TestManager::new()
+        .mock_endpoint(
+            MockEndpointBuilder::new("GET", "/api/0/organizations/wat-org/chunk-upload/", 200)
+                .with_response_file("debug_files/get-chunk-upload.json"),
         )
-        .with_response_body(
-            r#"{
+        .mock_endpoint(
+            MockEndpointBuilder::new(
+                "POST",
+                "/api/0/projects/wat-org/wat-project/files/difs/assemble/",
+                200,
+            )
+            .with_response_body(
+                r#"{
                 "fc1c9e58a65bd4eaf973bbb7e7a7cc01bfdaf15e": {
                     "state": "ok",
                     "missingChunks": []
                 }
             }"#,
-        ),
-    );
-    register_test("debug_files/upload/debug_files-upload-dll-embedded-ppdb-with-sources.trycmd");
+            ),
+        )
+        .register_trycmd_test(
+            "debug_files/upload/debug_files-upload-dll-embedded-ppdb-with-sources.trycmd",
+        )
+        .with_default_token();
 }
 
 #[test]
 fn command_debug_files_upload_mixed_embedded_sources() {
-    let _chunk_upload = mock_endpoint(
-        MockEndpointBuilder::new("GET", "/api/0/organizations/wat-org/chunk-upload/", 200)
-            .with_response_file("debug_files/get-chunk-upload.json"),
-    );
-    let _assemble = mock_endpoint(
-        MockEndpointBuilder::new(
-            "POST",
-            "/api/0/projects/wat-org/wat-project/files/difs/assemble/",
-            200,
+    TestManager::new()
+        .mock_endpoint(
+            MockEndpointBuilder::new("GET", "/api/0/organizations/wat-org/chunk-upload/", 200)
+                .with_response_file("debug_files/get-chunk-upload.json"),
         )
-        .with_response_body(
-            r#"{
-                "21b76b717dbbd8c89e42d92b29667ac87aa3c124": {
-                    "state": "ok",
-                    "missingChunks": []
-                }
-            }"#,
-        ),
-    );
-    // TODO this isn't tested properly at the moment, because `indicatif` ProgressBar (at least at the current version)
-    //      swallows debug logs printed while the progress bar is active and the session is not attended.
-    //      See how it's supposed to look like `debug_files-bundle_sources-mixed-embedded-sources.trycmd` and try it out
-    //      after an update of `indicatif` to the latest version (currently it's blocked by some other issues).
-    register_test("debug_files/upload/debug_files-upload-mixed-embedded-sources.trycmd");
+        .mock_endpoint(
+            MockEndpointBuilder::new(
+                "POST",
+                "/api/0/projects/wat-org/wat-project/files/difs/assemble/",
+                200,
+            )
+            .with_response_body(
+                r#"{
+                    "21b76b717dbbd8c89e42d92b29667ac87aa3c124": {
+                        "state": "ok",
+                        "missingChunks": []
+                    }
+                }"#,
+            ),
+        )
+        // TODO this isn't tested properly at the moment, because `indicatif` ProgressBar (at least at the current version)
+        //      swallows debug logs printed while the progress bar is active and the session is not attended.
+        //      See how it's supposed to look like `debug_files-bundle_sources-mixed-embedded-sources.trycmd` and try it out
+        //      after an update of `indicatif` to the latest version (currently it's blocked by some other issues).
+        .register_trycmd_test("debug_files/upload/debug_files-upload-mixed-embedded-sources.trycmd")
+        .with_default_token();
 }
 
 #[test]
 fn command_debug_files_upload_no_upload() {
-    let _chunk_upload = mock_endpoint(
-        MockEndpointBuilder::new("GET", "/api/0/organizations/wat-org/chunk-upload/", 200)
-            .with_response_file("debug_files/get-chunk-upload.json"),
-    );
-    let _assemble = mock_endpoint(
-        MockEndpointBuilder::new(
-            "POST",
-            "/api/0/projects/wat-org/wat-project/files/difs/assemble/",
-            200,
+    TestManager::new()
+        .mock_endpoint(
+            MockEndpointBuilder::new("GET", "/api/0/organizations/wat-org/chunk-upload/", 200)
+                .with_response_file("debug_files/get-chunk-upload.json"),
         )
-        .with_response_file("debug_files/post-difs-assemble.json"),
-    );
-    register_test("debug_files/upload/debug_files-upload-no-upload.trycmd");
+        .mock_endpoint(
+            MockEndpointBuilder::new(
+                "POST",
+                "/api/0/projects/wat-org/wat-project/files/difs/assemble/",
+                200,
+            )
+            .with_response_file("debug_files/post-difs-assemble.json"),
+        )
+        .register_trycmd_test("debug_files/upload/debug_files-upload-no-upload.trycmd");
 }
 
 #[test]
@@ -142,7 +155,7 @@ fn command_debug_files_upload_no_upload() {
 /// The mock assemble endpoint returns a 200 response simulating the case where all chunks
 /// are already uploaded.
 fn ensure_correct_assemble_call() {
-    let _chunk_upload = mock_endpoint(
+    let _manager = TestManager::new().mock_endpoint(
         MockEndpointBuilder::new("GET", "/api/0/organizations/wat-org/chunk-upload/", 200)
             .with_response_file("debug_files/get-chunk-upload.json"),
     );

--- a/tests/integration/deploys/list.rs
+++ b/tests/integration/deploys/list.rs
@@ -1,14 +1,16 @@
-use crate::integration::{mock_endpoint, register_test, MockEndpointBuilder};
+use crate::integration::{MockEndpointBuilder, TestManager};
 
 #[test]
 fn command_deploys_list() {
-    let _server = mock_endpoint(
-        MockEndpointBuilder::new(
-            "GET",
-            "/api/0/organizations/wat-org/releases/wat-release/deploys/",
-            200,
+    TestManager::new()
+        .mock_endpoint(
+            MockEndpointBuilder::new(
+                "GET",
+                "/api/0/organizations/wat-org/releases/wat-release/deploys/",
+                200,
+            )
+            .with_response_file("deploys/get-deploys.json"),
         )
-        .with_response_file("deploys/get-deploys.json"),
-    );
-    register_test("deploys/deploys-list.trycmd");
+        .register_trycmd_test("deploys/deploys-list.trycmd")
+        .with_default_token();
 }

--- a/tests/integration/deploys/mod.rs
+++ b/tests/integration/deploys/mod.rs
@@ -1,14 +1,14 @@
-use crate::integration::register_test;
+use crate::integration::TestManager;
 
 mod list;
 mod new;
 
 #[test]
 fn command_deploys_help() {
-    register_test("deploys/deploys-help.trycmd");
+    TestManager::new().register_trycmd_test("deploys/deploys-help.trycmd");
 }
 
 #[test]
 fn command_deploys_no_subcommand() {
-    register_test("deploys/deploys-no-subcommand.trycmd");
+    TestManager::new().register_trycmd_test("deploys/deploys-no-subcommand.trycmd");
 }

--- a/tests/integration/deploys/new.rs
+++ b/tests/integration/deploys/new.rs
@@ -1,38 +1,42 @@
 use mockito::Matcher;
 use serde_json::json;
 
-use crate::integration::{mock_endpoint, register_test, MockEndpointBuilder};
+use crate::integration::{MockEndpointBuilder, TestManager};
 
 #[test]
 fn command_deploys_new() {
-    let _server = mock_endpoint(
-        MockEndpointBuilder::new(
-            "POST",
-            "/api/0/organizations/wat-org/releases/wat-release/deploys/",
-            200,
+    TestManager::new()
+        .mock_endpoint(
+            MockEndpointBuilder::new(
+                "POST",
+                "/api/0/organizations/wat-org/releases/wat-release/deploys/",
+                200,
+            )
+            .with_response_file("deploys/post-deploys.json")
+            .with_matcher(Matcher::PartialJson(json!({
+                "environment": "production",
+                "name": "custom-deploy",
+            }))),
         )
-        .with_response_file("deploys/post-deploys.json")
-        .with_matcher(Matcher::PartialJson(json!({
-            "environment": "production",
-            "name": "custom-deploy",
-        }))),
-    );
-    register_test("deploys/deploys-new.trycmd");
+        .register_trycmd_test("deploys/deploys-new.trycmd")
+        .with_default_token();
 }
 
 #[test]
 fn command_releases_deploys_new() {
-    let _server = mock_endpoint(
-        MockEndpointBuilder::new(
-            "POST",
-            "/api/0/organizations/wat-org/releases/wat-release/deploys/",
-            200,
+    TestManager::new()
+        .mock_endpoint(
+            MockEndpointBuilder::new(
+                "POST",
+                "/api/0/organizations/wat-org/releases/wat-release/deploys/",
+                200,
+            )
+            .with_response_file("deploys/post-deploys.json")
+            .with_matcher(Matcher::PartialJson(json!({
+                "environment": "production",
+                "name": "custom-deploy",
+            }))),
         )
-        .with_response_file("deploys/post-deploys.json")
-        .with_matcher(Matcher::PartialJson(json!({
-            "environment": "production",
-            "name": "custom-deploy",
-        }))),
-    );
-    register_test("releases/releases-deploys-new.trycmd");
+        .register_trycmd_test("releases/releases-deploys-new.trycmd")
+        .with_default_token();
 }

--- a/tests/integration/events.rs
+++ b/tests/integration/events.rs
@@ -1,19 +1,18 @@
-use crate::integration::register_test;
-
-use super::{mock_endpoint, MockEndpointBuilder};
+use crate::integration::{MockEndpointBuilder, TestManager};
 
 #[test]
 fn command_events() {
-    // Mock server is used only for the events/events-list-empty.trycmd
-    // test. No harm in leaving it here for other tests.
-    let _server = mock_endpoint(
-        MockEndpointBuilder::new(
-            "GET",
-            "/api/0/projects/wat-org/wat-project/events/?cursor=",
-            200,
+    TestManager::new()
+        // Mock server is used only for the events/events-list-empty.trycmd
+        // test. No harm in leaving it here for other tests.
+        .mock_endpoint(
+            MockEndpointBuilder::new(
+                "GET",
+                "/api/0/projects/wat-org/wat-project/events/?cursor=",
+                200,
+            )
+            .with_response_body("[]"),
         )
-        .with_response_body("[]"),
-    );
-
-    register_test("events/*.trycmd");
+        .register_trycmd_test("events/*.trycmd")
+        .with_default_token();
 }

--- a/tests/integration/help.rs
+++ b/tests/integration/help.rs
@@ -1,9 +1,11 @@
-use crate::integration::register_test;
+use crate::integration::TestManager;
 
 #[test]
 fn command_help() {
+    let manager = TestManager::new();
+
     #[cfg(not(windows))]
-    register_test("help/help.trycmd");
+    manager.register_trycmd_test("help/help.trycmd");
     #[cfg(windows)]
-    register_test("help/help-windows.trycmd");
+    manager.register_trycmd_test("help/help-windows.trycmd");
 }

--- a/tests/integration/info.rs
+++ b/tests/integration/info.rs
@@ -1,16 +1,15 @@
-use mockito::server_url;
 use trycmd::TestCases;
 
-use crate::integration::{mock_endpoint, register_test, MockEndpointBuilder};
+use crate::integration::{MockEndpointBuilder, TestManager};
 
 #[test]
 fn command_info_help() {
-    register_test("info/info-help.trycmd");
+    TestManager::new().register_trycmd_test("info/info-help.trycmd");
 }
 
 #[test]
 fn command_info_no_token() {
-    // Special case where we don't want any env variables set, so we don't use `register_task` helper.
+    // Special case where we don't want any env variables set, so we don't use `TestManager`.
     TestCases::new()
         .env("SENTRY_INTEGRATION_TEST", "1")
         .case("tests/integration/_cases/info/info-no-token.trycmd");
@@ -18,7 +17,7 @@ fn command_info_no_token() {
 
 #[test]
 fn command_info_no_token_backtrace() {
-    // Special case where we don't want any env variables set, so we don't use `register_task` helper.
+    // Special case where we don't want any env variables set, so we don't use `TestManager`.
     TestCases::new()
         .env("SENTRY_INTEGRATION_TEST", "1")
         .env("RUST_BACKTRACE", "1")
@@ -27,37 +26,54 @@ fn command_info_no_token_backtrace() {
 
 #[test]
 fn command_info_basic() {
-    let _server = mock_endpoint(
-        MockEndpointBuilder::new("GET", "/api/0/", 200).with_response_file("info/get-info.json"),
-    );
-    let t = register_test("info/info-basic.trycmd");
-    t.insert_var("[SERVER]", server_url()).unwrap();
+    TestManager::new()
+        .mock_endpoint(
+            MockEndpointBuilder::new("GET", "/api/0/", 200)
+                .with_response_file("info/get-info.json"),
+        )
+        .register_trycmd_test("info/info-basic.trycmd")
+        .with_default_token()
+        .with_server_var()
+        .expect("Failed to set server variable");
 }
 
 #[test]
 fn command_info_no_defaults() {
-    let _server = mock_endpoint(
-        MockEndpointBuilder::new("GET", "/api/0/", 200).with_response_file("info/get-info.json"),
-    );
-    let t = register_test("info/info-json.trycmd");
-    t.insert_var("[SERVER]", server_url()).unwrap();
+    TestManager::new()
+        .mock_endpoint(
+            MockEndpointBuilder::new("GET", "/api/0/", 200)
+                .with_response_file("info/get-info.json"),
+        )
+        .register_trycmd_test("info/info-json.trycmd")
+        .with_default_token()
+        .with_server_var()
+        .expect("Failed to set server variable");
 }
 
 #[test]
 fn command_info_json() {
-    let _server = mock_endpoint(
-        MockEndpointBuilder::new("GET", "/api/0/", 200).with_response_file("info/get-info.json"),
-    );
-    let t = register_test("info/info-basic.trycmd");
-    t.insert_var("[SERVER]", server_url()).unwrap();
+    TestManager::new()
+        .mock_endpoint(
+            MockEndpointBuilder::new("GET", "/api/0/", 200)
+                .with_response_file("info/get-info.json"),
+        )
+        .register_trycmd_test("info/info-basic.trycmd")
+        .with_default_token()
+        .with_server_var()
+        .expect("Failed to set server variable");
 }
 
 #[test]
 fn command_info_json_without_defaults() {
-    let _server = mock_endpoint(
-        MockEndpointBuilder::new("GET", "/api/0/", 200).with_response_file("info/get-info.json"),
-    );
-    let t = register_test("info/info-json-no-defaults.trycmd");
-    t.env("SENTRY_ORG", "").env("SENTRY_PROJECT", "");
-    t.insert_var("[SERVER]", server_url()).unwrap();
+    TestManager::new()
+        .mock_endpoint(
+            MockEndpointBuilder::new("GET", "/api/0/", 200)
+                .with_response_file("info/get-info.json"),
+        )
+        .register_trycmd_test("info/info-json-no-defaults.trycmd")
+        .env("SENTRY_ORG", "")
+        .env("SENTRY_PROJECT", "")
+        .with_default_token()
+        .with_server_var()
+        .expect("Failed to set server variable");
 }

--- a/tests/integration/invalid_env.rs
+++ b/tests/integration/invalid_env.rs
@@ -1,6 +1,6 @@
-use super::register_test;
+use crate::integration::TestManager;
 
 #[test]
 fn test_invalid_env() {
-    register_test("invalid_env/invalid-env.trycmd");
+    TestManager::new().register_trycmd_test("invalid_env/invalid-env.trycmd");
 }

--- a/tests/integration/issues/list.rs
+++ b/tests/integration/issues/list.rs
@@ -1,45 +1,51 @@
-use crate::integration::{mock_endpoint, register_test, MockEndpointBuilder};
+use crate::integration::{MockEndpointBuilder, TestManager};
 
 #[test]
 fn command_issues_list_help() {
-    register_test("issues/issues-list-help.trycmd");
+    TestManager::new().register_trycmd_test("issues/issues-list-help.trycmd");
 }
 
 #[test]
 fn doesnt_fail_with_empty_response() {
-    let _server = mock_endpoint(
-        MockEndpointBuilder::new(
-            "GET",
-            "/api/0/projects/wat-org/wat-project/issues/?query=&cursor=",
-            200,
+    TestManager::new()
+        .mock_endpoint(
+            MockEndpointBuilder::new(
+                "GET",
+                "/api/0/projects/wat-org/wat-project/issues/?query=&cursor=",
+                200,
+            )
+            .with_response_body("[]"),
         )
-        .with_response_body("[]"),
-    );
-    register_test("issues/issues-list-empty.trycmd");
+        .register_trycmd_test("issues/issues-list-empty.trycmd")
+        .with_default_token();
 }
 
 #[test]
 fn display_issues() {
-    let _server = mock_endpoint(
-        MockEndpointBuilder::new(
-            "GET",
-            "/api/0/projects/wat-org/wat-project/issues/?query=&cursor=",
-            200,
+    TestManager::new()
+        .mock_endpoint(
+            MockEndpointBuilder::new(
+                "GET",
+                "/api/0/projects/wat-org/wat-project/issues/?query=&cursor=",
+                200,
+            )
+            .with_response_file("issues/get-issues.json"),
         )
-        .with_response_file("issues/get-issues.json"),
-    );
-    register_test("issues/issues-display.trycmd");
+        .register_trycmd_test("issues/issues-display.trycmd")
+        .with_default_token();
 }
 
 #[test]
 fn display_resolved_issues() {
-    let _server = mock_endpoint(
-        MockEndpointBuilder::new(
-            "GET",
-            "/api/0/projects/wat-org/wat-project/issues/?query=is:resolved&cursor=",
-            200,
+    TestManager::new()
+        .mock_endpoint(
+            MockEndpointBuilder::new(
+                "GET",
+                "/api/0/projects/wat-org/wat-project/issues/?query=is:resolved&cursor=",
+                200,
+            )
+            .with_response_file("issues/get-resolved-issues.json"),
         )
-        .with_response_file("issues/get-resolved-issues.json"),
-    );
-    register_test("issues/issues-display-with-query.trycmd");
+        .register_trycmd_test("issues/issues-display-with-query.trycmd")
+        .with_default_token();
 }

--- a/tests/integration/issues/mod.rs
+++ b/tests/integration/issues/mod.rs
@@ -1,8 +1,8 @@
-use crate::integration::register_test;
+use crate::integration::TestManager;
 
 mod list;
 
 #[test]
 fn command_issues_help() {
-    register_test("issues/issues-help.trycmd");
+    TestManager::new().register_trycmd_test("issues/issues-help.trycmd");
 }

--- a/tests/integration/login.rs
+++ b/tests/integration/login.rs
@@ -1,6 +1,6 @@
-use crate::integration::register_test;
+use crate::integration::TestManager;
 
 #[test]
 fn command_login() {
-    register_test("login/*.trycmd");
+    TestManager::new().register_trycmd_test("login/*.trycmd");
 }

--- a/tests/integration/mod.rs
+++ b/tests/integration/mod.rs
@@ -30,37 +30,11 @@ use std::fs;
 use std::io;
 use std::path::Path;
 
-use mockito::{self, Mock};
-use trycmd::TestCases;
-
-use test_utils::env;
-use test_utils::{
-    mock_common_upload_endpoints, mock_endpoint, ChunkOptions, MockEndpointBuilder, ServerBehavior,
-};
+use test_utils::MockEndpointBuilder;
+use test_utils::{env, ChunkOptions, ServerBehavior, TestManager};
 
 pub const UTC_DATE_FORMAT: &str = r"\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}.\d{6,9}Z";
 const VERSION: &str = env!("CARGO_PKG_VERSION");
-
-pub fn register_test_without_token(path: &str) -> TestCases {
-    let test_case = TestCases::new();
-
-    env::set(|k, v| {
-        test_case.env(k, v);
-    });
-
-    test_case.case(format!("tests/integration/_cases/{path}"));
-    test_case.insert_var("[VERSION]", VERSION).unwrap();
-    test_case
-}
-pub fn register_test(path: &str) -> TestCases {
-    let test_case = register_test_without_token(path);
-
-    env::set_auth_token(|k, v| {
-        test_case.env(k, v);
-    });
-
-    test_case
-}
 
 /// Copy files from source to destination recursively.
 pub fn copy_recursively(source: impl AsRef<Path>, destination: impl AsRef<Path>) -> io::Result<()> {
@@ -77,18 +51,12 @@ pub fn copy_recursively(source: impl AsRef<Path>, destination: impl AsRef<Path>)
     Ok(())
 }
 
-pub fn assert_endpoints(mocks: &[Mock]) {
-    for mock in mocks {
-        mock.assert();
-    }
-}
-
 #[test]
 pub fn token_redacted() {
-    register_test("token-redacted.trycmd");
+    TestManager::new().register_trycmd_test("token-redacted.trycmd");
 }
 
 #[test]
 pub fn token_redacted_2() {
-    register_test("token-redacted-2.trycmd");
+    TestManager::new().register_trycmd_test("token-redacted-2.trycmd");
 }

--- a/tests/integration/monitors.rs
+++ b/tests/integration/monitors.rs
@@ -1,34 +1,38 @@
-use crate::integration::{mock_endpoint, register_test, MockEndpointBuilder};
+use crate::integration::{MockEndpointBuilder, TestManager};
 
 #[test]
 fn command_monitors() {
-    let _list_endpoint = mock_endpoint(
-        MockEndpointBuilder::new("GET", "/api/0/organizations/wat-org/monitors/?cursor=", 200)
-            .with_response_file("monitors/get-monitors.json"),
-    );
-    let _envelope_endpoint =
-        mock_endpoint(MockEndpointBuilder::new("POST", "/api/1337/envelope/", 200));
-    let _token_endpoint = mock_endpoint(
-        MockEndpointBuilder::new("POST", "/api/0/monitors/foo-monitor/checkins/", 200)
-            .with_response_file("monitors/post-monitors.json"),
-    );
-
-    let cases = register_test("monitors/*.trycmd");
+    let manager = TestManager::new()
+        .mock_endpoint(
+            MockEndpointBuilder::new("GET", "/api/0/organizations/wat-org/monitors/?cursor=", 200)
+                .with_response_file("monitors/get-monitors.json"),
+        )
+        .mock_endpoint(MockEndpointBuilder::new("POST", "/api/1337/envelope/", 200))
+        .mock_endpoint(
+            MockEndpointBuilder::new("POST", "/api/0/monitors/foo-monitor/checkins/", 200)
+                .with_response_file("monitors/post-monitors.json"),
+        )
+        .register_trycmd_test("monitors/*.trycmd")
+        .with_default_token();
 
     #[cfg(not(windows))]
-    cases.case("tests/integration/_cases/monitors/not_windows/*.trycmd");
+    manager.register_trycmd_test("monitors/not_windows/*.trycmd");
 
     #[cfg(windows)]
-    cases.case("tests/integration/_cases/monitors/windows/*.trycmd");
+    manager.register_trycmd_test("monitors/windows/*.trycmd");
 }
 
 #[test]
 fn command_monitors_run_server_error() {
-    let _server = mock_endpoint(MockEndpointBuilder::new("POST", "/api/1337/envelope/", 500));
+    let manager = TestManager::new().mock_endpoint(MockEndpointBuilder::new(
+        "POST",
+        "/api/1337/envelope/",
+        500,
+    ));
 
     #[cfg(not(windows))]
-    register_test("monitors/server_error/monitors-run-server-error.trycmd");
+    manager.register_trycmd_test("monitors/server_error/monitors-run-server-error.trycmd");
 
     #[cfg(windows)]
-    register_test("monitors/server_error/monitors-run-server-error-win.trycmd");
+    manager.register_trycmd_test("monitors/server_error/monitors-run-server-error-win.trycmd");
 }

--- a/tests/integration/org_tokens.rs
+++ b/tests/integration/org_tokens.rs
@@ -1,6 +1,6 @@
-use crate::integration::register_test;
+use crate::integration::TestManager;
 
 #[test]
 fn org_token() {
-    register_test("org_tokens/*.trycmd");
+    TestManager::new().register_trycmd_test("org_tokens/*.trycmd");
 }

--- a/tests/integration/organizations.rs
+++ b/tests/integration/organizations.rs
@@ -1,15 +1,9 @@
 use mockito::server_url;
 
-use crate::integration::{mock_endpoint, register_test, MockEndpointBuilder};
+use crate::integration::{MockEndpointBuilder, TestManager};
 
 #[test]
 fn command_organizations() {
-    // Mocks are for the organizations list command.
-    let _server = mock_endpoint(
-        MockEndpointBuilder::new("GET", "/api/0/organizations/?cursor=", 200)
-            .with_response_file("organizations/get-organizations.json"),
-    );
-
     let region_response = format!(
         r#"{{
             "regions": [{{
@@ -20,9 +14,16 @@ fn command_organizations() {
         server_url(),
     );
 
-    let _mock_regions = mock_endpoint(
-        MockEndpointBuilder::new("GET", "/api/0/users/me/regions/", 200)
-            .with_response_body(region_response),
-    );
-    register_test("organizations/*.trycmd");
+    TestManager::new()
+        // Mocks are for the organizations list command.
+        .mock_endpoint(
+            MockEndpointBuilder::new("GET", "/api/0/organizations/?cursor=", 200)
+                .with_response_file("organizations/get-organizations.json"),
+        )
+        .mock_endpoint(
+            MockEndpointBuilder::new("GET", "/api/0/users/me/regions/", 200)
+                .with_response_body(region_response),
+        )
+        .register_trycmd_test("organizations/*.trycmd")
+        .with_default_token();
 }

--- a/tests/integration/projects.rs
+++ b/tests/integration/projects.rs
@@ -1,11 +1,13 @@
-use crate::integration::{mock_endpoint, register_test, MockEndpointBuilder};
+use crate::integration::{MockEndpointBuilder, TestManager};
 
 #[test]
 fn command_projects_list() {
-    // mock for projects list
-    let _server = mock_endpoint(
-        MockEndpointBuilder::new("GET", "/api/0/organizations/wat-org/projects/?cursor=", 200)
-            .with_response_file("projects/get-projects.json"),
-    );
-    register_test("projects/*.trycmd");
+    TestManager::new()
+        // mock for projects list
+        .mock_endpoint(
+            MockEndpointBuilder::new("GET", "/api/0/organizations/wat-org/projects/?cursor=", 200)
+                .with_response_file("projects/get-projects.json"),
+        )
+        .register_trycmd_test("projects/*.trycmd")
+        .with_default_token();
 }

--- a/tests/integration/react_native/mod.rs
+++ b/tests/integration/react_native/mod.rs
@@ -1,38 +1,43 @@
-use crate::integration::register_test;
+use crate::integration::TestManager;
 
 mod xcode;
 
 #[test]
 fn xcode_wrap_call_minimum() {
-    register_test("react_native/xcode-wrap-call-minimum.trycmd");
+    TestManager::new().register_trycmd_test("react_native/xcode-wrap-call-minimum.trycmd");
+
     assert_empty_sourcemap_report("rn-sourcemap-report-minimum.json");
     clean_up("rn-sourcemap-report-minimum.json");
 }
 
 #[test]
 fn xcode_wrap_call_bundle() {
-    register_test("react_native/xcode-wrap-call-bundle.trycmd");
+    TestManager::new().register_trycmd_test("react_native/xcode-wrap-call-bundle.trycmd");
+
     assert_packager_sourcemap_report("rn-sourcemap-report-bundle.json");
     clean_up("rn-sourcemap-report-bundle.json");
 }
 
 #[test]
 fn xcode_wrap_call_custom_bundle() {
-    register_test("react_native/xcode-wrap-call-custom-bundle.trycmd");
+    TestManager::new().register_trycmd_test("react_native/xcode-wrap-call-custom-bundle.trycmd");
+
     assert_packager_sourcemap_report("rn-sourcemap-report-custom-bundle.json");
     clean_up("rn-sourcemap-report-custom-bundle.json");
 }
 
 #[test]
 fn xcode_wrap_call_expo_export() {
-    register_test("react_native/xcode-wrap-call-expo-export.trycmd");
+    TestManager::new().register_trycmd_test("react_native/xcode-wrap-call-expo-export.trycmd");
+
     assert_packager_sourcemap_report("rn-sourcemap-report-expo-export.json");
     clean_up("rn-sourcemap-report-expo-export.json");
 }
 
 #[test]
 fn xcode_wrap_call_hermesc() {
-    register_test("react_native/xcode-wrap-call-hermesc.trycmd");
+    TestManager::new().register_trycmd_test("react_native/xcode-wrap-call-hermesc.trycmd");
+
     assert_sourcemap_report(
         "hermesc-sourcemap-report.json.expected",
         "rn-sourcemap-report-hermesc.json",
@@ -43,7 +48,10 @@ fn xcode_wrap_call_hermesc() {
 #[test]
 fn xcode_wrap_call_compose_source_maps() {
     std::fs::copy("tests/integration/_fixtures/react_native/compose-source-maps-sourcemap-report.json.before.test","rn-sourcemap-report-compose-source-maps.json").unwrap();
-    register_test("react_native/xcode-wrap-call-compose-source-maps.trycmd");
+
+    TestManager::new()
+        .register_trycmd_test("react_native/xcode-wrap-call-compose-source-maps.trycmd");
+
     assert_sourcemap_report(
         "compose-source-maps-sourcemap-report.json.expected",
         "rn-sourcemap-report-compose-source-maps.json",
@@ -54,7 +62,11 @@ fn xcode_wrap_call_compose_source_maps() {
 #[test]
 fn xcode_wrap_call_compose_source_maps_no_debug_id_copy() {
     std::fs::copy("tests/integration/_fixtures/react_native/compose-source-maps-sourcemap-report.json.before.test","rn-sourcemap-report-compose-source-maps-no-debug-id-copy.json").unwrap();
-    register_test("react_native/xcode-wrap-call-compose-source-maps-no-debug-id-copy.trycmd");
+
+    TestManager::new().register_trycmd_test(
+        "react_native/xcode-wrap-call-compose-source-maps-no-debug-id-copy.trycmd",
+    );
+
     assert_sourcemap_report(
         "compose-source-maps-sourcemap-report.json.expected",
         "rn-sourcemap-report-compose-source-maps-no-debug-id-copy.json",
@@ -64,7 +76,9 @@ fn xcode_wrap_call_compose_source_maps_no_debug_id_copy() {
 
 #[test]
 fn xcode_wrap_call_compose_source_maps_custom() {
-    register_test("react_native/xcode-wrap-call-compose-source-maps-custom.trycmd");
+    TestManager::new()
+        .register_trycmd_test("react_native/xcode-wrap-call-compose-source-maps-custom.trycmd");
+
     assert_sourcemap_report(
         "compose-source-maps-custom-sourcemap-report.json.expected",
         "rn-sourcemap-report-compose-source-maps-custom.json",

--- a/tests/integration/react_native/xcode.rs
+++ b/tests/integration/react_native/xcode.rs
@@ -1,24 +1,20 @@
-use crate::integration::register_test;
-use crate::integration::{mock_common_upload_endpoints, ChunkOptions, ServerBehavior};
-use mockito::Mock;
+use crate::integration::{ServerBehavior, TestManager};
 
 #[test]
 fn xcode_upload_source_maps_missing_plist() {
-    let _upload_endpoints =
-        mock_common_upload_endpoints(ServerBehavior::Modern, ChunkOptions::default());
-    register_test("react_native/xcode-upload-source-maps-invalid-plist.trycmd");
+    TestManager::new()
+        .mock_common_upload_endpoints(ServerBehavior::Modern, Default::default())
+        .register_trycmd_test("react_native/xcode-upload-source-maps-invalid-plist.trycmd")
+        .with_default_token();
 }
 
 #[test]
 fn xcode_upload_source_maps_release_and_dist_from_env() {
-    let upload_endpoints =
-        mock_common_upload_endpoints(ServerBehavior::Modern, ChunkOptions::default());
-    register_test("react_native/xcode-upload-source-maps-release_and_dist_from_env.trycmd");
-    assert_endpoints(&upload_endpoints);
-}
-
-pub fn assert_endpoints(mocks: &[Mock]) {
-    for mock in mocks {
-        mock.assert();
-    }
+    TestManager::new()
+        .mock_common_upload_endpoints(ServerBehavior::Modern, Default::default())
+        .register_trycmd_test(
+            "react_native/xcode-upload-source-maps-release_and_dist_from_env.trycmd",
+        )
+        .with_default_token()
+        .assert_mock_endpoints();
 }

--- a/tests/integration/releases/delete.rs
+++ b/tests/integration/releases/delete.rs
@@ -1,44 +1,52 @@
-use crate::integration::{mock_endpoint, register_test, MockEndpointBuilder};
+use crate::integration::{MockEndpointBuilder, TestManager};
 
 #[test]
 fn successfully_deletes() {
-    let _server = mock_endpoint(MockEndpointBuilder::new(
-        "DELETE",
-        "/api/0/projects/wat-org/wat-project/releases/wat-release/",
-        204,
-    ));
-    register_test("releases/releases-delete.trycmd");
+    TestManager::new()
+        .mock_endpoint(MockEndpointBuilder::new(
+            "DELETE",
+            "/api/0/projects/wat-org/wat-project/releases/wat-release/",
+            204,
+        ))
+        .register_trycmd_test("releases/releases-delete.trycmd")
+        .with_default_token();
 }
 
 #[test]
 fn allows_for_release_to_start_with_hyphen() {
-    let _server = mock_endpoint(MockEndpointBuilder::new(
-        "DELETE",
-        "/api/0/projects/wat-org/wat-project/releases/-hyphenated-release/",
-        204,
-    ));
-    register_test("releases/releases-delete-hyphen.trycmd");
+    TestManager::new()
+        .mock_endpoint(MockEndpointBuilder::new(
+            "DELETE",
+            "/api/0/projects/wat-org/wat-project/releases/-hyphenated-release/",
+            204,
+        ))
+        .register_trycmd_test("releases/releases-delete-hyphen.trycmd")
+        .with_default_token();
 }
 
 #[test]
 fn informs_about_nonexisting_releases() {
-    let _server = mock_endpoint(MockEndpointBuilder::new(
-        "DELETE",
-        "/api/0/projects/wat-org/wat-project/releases/whoops/",
-        404,
-    ));
-    register_test("releases/releases-delete-nonexisting.trycmd");
+    TestManager::new()
+        .mock_endpoint(MockEndpointBuilder::new(
+            "DELETE",
+            "/api/0/projects/wat-org/wat-project/releases/whoops/",
+            404,
+        ))
+        .register_trycmd_test("releases/releases-delete-nonexisting.trycmd")
+        .with_default_token();
 }
 
 #[test]
 fn doesnt_allow_to_delete_active_releases() {
-    let _server = mock_endpoint(
-        MockEndpointBuilder::new(
-            "DELETE",
-            "/api/0/projects/wat-org/wat-project/releases/wat-release/",
-            400,
+    TestManager::new()
+        .mock_endpoint(
+            MockEndpointBuilder::new(
+                "DELETE",
+                "/api/0/projects/wat-org/wat-project/releases/wat-release/",
+                400,
+            )
+            .with_response_file("releases/delete-active-release.json"),
         )
-        .with_response_file("releases/delete-active-release.json"),
-    );
-    register_test("releases/releases-delete-active.trycmd");
+        .register_trycmd_test("releases/releases-delete-active.trycmd")
+        .with_default_token();
 }

--- a/tests/integration/releases/finalize.rs
+++ b/tests/integration/releases/finalize.rs
@@ -1,47 +1,53 @@
-use crate::integration::{mock_endpoint, register_test, MockEndpointBuilder};
+use crate::integration::{MockEndpointBuilder, TestManager};
 use mockito::Matcher;
 use serde_json::json;
 
 #[test]
 fn successfully_creates_a_release() {
-    let _server = mock_endpoint(
-        MockEndpointBuilder::new(
-            "PUT",
-            "/api/0/projects/wat-org/wat-project/releases/wat-release/",
-            200,
+    TestManager::new()
+        .mock_endpoint(
+            MockEndpointBuilder::new(
+                "PUT",
+                "/api/0/projects/wat-org/wat-project/releases/wat-release/",
+                200,
+            )
+            .with_response_file("releases/get-release.json"),
         )
-        .with_response_file("releases/get-release.json"),
-    );
-    register_test("releases/releases-finalize.trycmd");
+        .register_trycmd_test("releases/releases-finalize.trycmd")
+        .with_default_token();
 }
 
 #[test]
 fn allows_for_release_to_start_with_hyphen() {
-    let _server = mock_endpoint(
-        MockEndpointBuilder::new(
-            "PUT",
-            "/api/0/projects/wat-org/wat-project/releases/-hyphenated-release/",
-            200,
+    TestManager::new()
+        .mock_endpoint(
+            MockEndpointBuilder::new(
+                "PUT",
+                "/api/0/projects/wat-org/wat-project/releases/-hyphenated-release/",
+                200,
+            )
+            .with_response_file("releases/get-release.json"),
         )
-        .with_response_file("releases/get-release.json"),
-    );
-    register_test("releases/releases-finalize-hyphen.trycmd");
+        .register_trycmd_test("releases/releases-finalize-hyphen.trycmd")
+        .with_default_token();
 }
 
 #[test]
 fn release_with_custom_dates() {
-    let _server = mock_endpoint(
-        MockEndpointBuilder::new(
-            "PUT",
-            "/api/0/projects/wat-org/wat-project/releases/wat-release/",
-            200,
+    TestManager::new()
+        .mock_endpoint(
+            MockEndpointBuilder::new(
+                "PUT",
+                "/api/0/projects/wat-org/wat-project/releases/wat-release/",
+                200,
+            )
+            .with_response_file("releases/get-release.json")
+            .with_matcher(Matcher::PartialJson(json!({
+                "projects": ["wat-project"],
+                "dateStarted": "2015-05-15T00:01:40Z",
+                "dateReleased": "2015-05-15T00:00:00Z"
+            }))),
         )
-        .with_response_file("releases/get-release.json")
-        .with_matcher(Matcher::PartialJson(json!({
-            "projects": ["wat-project"],
-            "dateStarted": "2015-05-15T00:01:40Z",
-            "dateReleased": "2015-05-15T00:00:00Z"
-        }))),
-    );
-    register_test("releases/releases-finalize-dates.trycmd");
+        .register_trycmd_test("releases/releases-finalize-dates.trycmd")
+        .with_default_token();
 }

--- a/tests/integration/releases/info.rs
+++ b/tests/integration/releases/info.rs
@@ -1,81 +1,93 @@
-use crate::integration::{mock_endpoint, register_test, MockEndpointBuilder};
+use crate::integration::{MockEndpointBuilder, TestManager};
 
 #[test]
 fn shows_release_details() {
-    let _server = mock_endpoint(
-        MockEndpointBuilder::new(
-            "GET",
-            "/api/0/projects/wat-org/wat-project/releases/wat-release/",
-            200,
+    TestManager::new()
+        .mock_endpoint(
+            MockEndpointBuilder::new(
+                "GET",
+                "/api/0/projects/wat-org/wat-project/releases/wat-release/",
+                200,
+            )
+            .with_response_file("releases/get-release.json"),
         )
-        .with_response_file("releases/get-release.json"),
-    );
-    register_test("releases/releases-info.trycmd");
+        .register_trycmd_test("releases/releases-info.trycmd")
+        .with_default_token();
 }
 
 #[test]
 fn shows_release_details_with_projects_and_commits() {
-    let _server = mock_endpoint(
-        MockEndpointBuilder::new(
-            "GET",
-            "/api/0/projects/wat-org/wat-project/releases/wat-release/",
-            200,
+    TestManager::new()
+        .mock_endpoint(
+            MockEndpointBuilder::new(
+                "GET",
+                "/api/0/projects/wat-org/wat-project/releases/wat-release/",
+                200,
+            )
+            .with_response_file("releases/get-release.json"),
         )
-        .with_response_file("releases/get-release.json"),
-    );
-    let _commits = mock_endpoint(
-        MockEndpointBuilder::new(
-            "GET",
-            "/api/0/projects/wat-org/wat-project/releases/wat-release/commits/",
-            200,
+        .mock_endpoint(
+            MockEndpointBuilder::new(
+                "GET",
+                "/api/0/projects/wat-org/wat-project/releases/wat-release/commits/",
+                200,
+            )
+            .with_response_file("releases/get-release-commits.json"),
         )
-        .with_response_file("releases/get-release-commits.json"),
-    );
-    register_test("releases/releases-info-with-commits-projects.trycmd");
+        .register_trycmd_test("releases/releases-info-with-commits-projects.trycmd")
+        .with_default_token();
 }
 
 #[test]
 fn doesnt_print_output_with_quiet_flag() {
-    let _server = mock_endpoint(
-        MockEndpointBuilder::new(
-            "GET",
-            "/api/0/projects/wat-org/wat-project/releases/wat-release/",
-            200,
+    TestManager::new()
+        .mock_endpoint(
+            MockEndpointBuilder::new(
+                "GET",
+                "/api/0/projects/wat-org/wat-project/releases/wat-release/",
+                200,
+            )
+            .with_response_file("releases/get-release.json"),
         )
-        .with_response_file("releases/get-release.json"),
-    );
-    register_test("releases/releases-info-quiet.trycmd");
+        .register_trycmd_test("releases/releases-info-quiet.trycmd")
+        .with_default_token();
 }
 
 #[test]
 fn doesnt_print_output_with_silent_flag() {
-    let _server = mock_endpoint(
-        MockEndpointBuilder::new(
-            "GET",
-            "/api/0/projects/wat-org/wat-project/releases/wat-release/",
-            200,
+    TestManager::new()
+        .mock_endpoint(
+            MockEndpointBuilder::new(
+                "GET",
+                "/api/0/projects/wat-org/wat-project/releases/wat-release/",
+                200,
+            )
+            .with_response_file("releases/get-release.json"),
         )
-        .with_response_file("releases/get-release.json"),
-    );
-    register_test("releases/releases-info-silent.trycmd");
+        .register_trycmd_test("releases/releases-info-silent.trycmd")
+        .with_default_token();
 }
 
 #[test]
 fn preserve_valid_exit_code_with_quiet_flag() {
-    let _server = mock_endpoint(MockEndpointBuilder::new(
-        "GET",
-        "/api/0/projects/wat-org/wat-project/releases/unknown-release/",
-        404,
-    ));
-    register_test("releases/releases-info-quiet-failed.trycmd");
+    TestManager::new()
+        .mock_endpoint(MockEndpointBuilder::new(
+            "GET",
+            "/api/0/projects/wat-org/wat-project/releases/unknown-release/",
+            404,
+        ))
+        .register_trycmd_test("releases/releases-info-quiet-failed.trycmd")
+        .with_default_token();
 }
 
 #[test]
 fn exits_if_no_release_found() {
-    let _server = mock_endpoint(MockEndpointBuilder::new(
-        "GET",
-        "/api/0/projects/wat-org/wat-project/releases/wat-release/",
-        404,
-    ));
-    register_test("releases/releases-info-not-found.trycmd");
+    TestManager::new()
+        .mock_endpoint(MockEndpointBuilder::new(
+            "GET",
+            "/api/0/projects/wat-org/wat-project/releases/wat-release/",
+            404,
+        ))
+        .register_trycmd_test("releases/releases-info-not-found.trycmd")
+        .with_default_token();
 }

--- a/tests/integration/releases/list.rs
+++ b/tests/integration/releases/list.rs
@@ -1,55 +1,67 @@
-use crate::integration::{mock_endpoint, register_test, MockEndpointBuilder};
+use crate::integration::{MockEndpointBuilder, TestManager};
 
 #[test]
 fn displays_releases() {
-    let _server = mock_endpoint(
-        MockEndpointBuilder::new("GET", "/api/0/projects/wat-org/wat-project/releases/", 200)
-            .with_response_file("releases/get-releases.json"),
-    );
-    register_test("releases/releases-list.trycmd");
+    TestManager::new()
+        .mock_endpoint(
+            MockEndpointBuilder::new("GET", "/api/0/projects/wat-org/wat-project/releases/", 200)
+                .with_response_file("releases/get-releases.json"),
+        )
+        .register_trycmd_test("releases/releases-list.trycmd")
+        .with_default_token();
 }
 
 #[test]
 fn displays_releases_with_projects() {
-    let _server = mock_endpoint(
-        MockEndpointBuilder::new("GET", "/api/0/projects/wat-org/wat-project/releases/", 200)
-            .with_response_file("releases/get-releases.json"),
-    );
-    register_test("releases/releases-list-with-projects.trycmd");
+    TestManager::new()
+        .mock_endpoint(
+            MockEndpointBuilder::new("GET", "/api/0/projects/wat-org/wat-project/releases/", 200)
+                .with_response_file("releases/get-releases.json"),
+        )
+        .register_trycmd_test("releases/releases-list-with-projects.trycmd")
+        .with_default_token();
 }
 
 #[test]
 fn doesnt_fail_with_empty_response() {
-    let _server = mock_endpoint(
-        MockEndpointBuilder::new("GET", "/api/0/projects/wat-org/wat-project/releases/", 200)
-            .with_response_body("[]"),
-    );
-    register_test("releases/releases-list-empty.trycmd");
+    TestManager::new()
+        .mock_endpoint(
+            MockEndpointBuilder::new("GET", "/api/0/projects/wat-org/wat-project/releases/", 200)
+                .with_response_body("[]"),
+        )
+        .register_trycmd_test("releases/releases-list-empty.trycmd")
+        .with_default_token();
 }
 
 #[test]
 fn can_override_org() {
-    let _server = mock_endpoint(
-        MockEndpointBuilder::new("GET", "/api/0/projects/whynot/wat-project/releases/", 200)
-            .with_response_file("releases/get-releases.json"),
-    );
-    register_test("releases/releases-list-override-org.trycmd");
+    TestManager::new()
+        .mock_endpoint(
+            MockEndpointBuilder::new("GET", "/api/0/projects/whynot/wat-project/releases/", 200)
+                .with_response_file("releases/get-releases.json"),
+        )
+        .register_trycmd_test("releases/releases-list-override-org.trycmd")
+        .with_default_token();
 }
 
 #[test]
 fn displays_releases_in_raw_mode() {
-    let _server = mock_endpoint(
-        MockEndpointBuilder::new("GET", "/api/0/projects/wat-org/wat-project/releases/", 200)
-            .with_response_file("releases/get-releases.json"),
-    );
-    register_test("releases/releases-list-raw.trycmd");
+    TestManager::new()
+        .mock_endpoint(
+            MockEndpointBuilder::new("GET", "/api/0/projects/wat-org/wat-project/releases/", 200)
+                .with_response_file("releases/get-releases.json"),
+        )
+        .register_trycmd_test("releases/releases-list-raw.trycmd")
+        .with_default_token();
 }
 
 #[test]
 fn displays_releases_in_raw_mode_with_delimiter() {
-    let _server = mock_endpoint(
-        MockEndpointBuilder::new("GET", "/api/0/projects/wat-org/wat-project/releases/", 200)
-            .with_response_file("releases/get-releases.json"),
-    );
-    register_test("releases/releases-list-raw-delimiter.trycmd");
+    TestManager::new()
+        .mock_endpoint(
+            MockEndpointBuilder::new("GET", "/api/0/projects/wat-org/wat-project/releases/", 200)
+                .with_response_file("releases/get-releases.json"),
+        )
+        .register_trycmd_test("releases/releases-list-raw-delimiter.trycmd")
+        .with_default_token();
 }

--- a/tests/integration/releases/mod.rs
+++ b/tests/integration/releases/mod.rs
@@ -1,4 +1,4 @@
-use crate::integration::register_test;
+use crate::integration::TestManager;
 
 mod delete;
 mod finalize;
@@ -8,10 +8,10 @@ mod new;
 
 #[test]
 fn command_releases_help() {
-    register_test("releases/releases-help.trycmd");
+    TestManager::new().register_trycmd_test("releases/releases-help.trycmd");
 }
 
 #[test]
 fn command_releases_no_subcommand() {
-    register_test("releases/releases-no-subcommand.trycmd");
+    TestManager::new().register_trycmd_test("releases/releases-no-subcommand.trycmd");
 }

--- a/tests/integration/releases/new.rs
+++ b/tests/integration/releases/new.rs
@@ -1,104 +1,118 @@
 use mockito::Matcher;
 use serde_json::json;
 
-use crate::integration::{mock_endpoint, register_test, MockEndpointBuilder, UTC_DATE_FORMAT};
+use crate::integration::{MockEndpointBuilder, TestManager, UTC_DATE_FORMAT};
 
 #[test]
 fn command_releases_new_help() {
-    register_test("releases/releases-new-help.trycmd");
+    TestManager::new().register_trycmd_test("releases/releases-new-help.trycmd");
 }
 
 #[test]
 fn creates_release() {
-    let _server = mock_endpoint(
-        MockEndpointBuilder::new("POST", "/api/0/projects/wat-org/wat-project/releases/", 201)
-            .with_response_file("releases/get-release.json")
-            .with_matcher(Matcher::PartialJson(json!({
-                "version": "new-release",
-                "projects": ["wat-project"],
-            }))),
-    );
-    register_test("releases/releases-new.trycmd");
+    TestManager::new()
+        .mock_endpoint(
+            MockEndpointBuilder::new("POST", "/api/0/projects/wat-org/wat-project/releases/", 201)
+                .with_response_file("releases/get-release.json")
+                .with_matcher(Matcher::PartialJson(json!({
+                    "version": "new-release",
+                    "projects": ["wat-project"],
+                }))),
+        )
+        .register_trycmd_test("releases/releases-new.trycmd")
+        .with_default_token();
 }
 
 #[test]
 fn allows_for_release_to_start_with_hyphen() {
-    let _server = mock_endpoint(
-        MockEndpointBuilder::new("POST", "/api/0/projects/wat-org/wat-project/releases/", 201)
-            .with_response_file("releases/get-release.json")
-            .with_matcher(Matcher::PartialJson(json!({
-                "version": "-hyphenated-release",
-                "projects": ["wat-project"],
-            }))),
-    );
-    register_test("releases/releases-new-hyphen.trycmd");
+    TestManager::new()
+        .mock_endpoint(
+            MockEndpointBuilder::new("POST", "/api/0/projects/wat-org/wat-project/releases/", 201)
+                .with_response_file("releases/get-release.json")
+                .with_matcher(Matcher::PartialJson(json!({
+                    "version": "-hyphenated-release",
+                    "projects": ["wat-project"],
+                }))),
+        )
+        .register_trycmd_test("releases/releases-new-hyphen.trycmd")
+        .with_default_token();
 }
 
 #[test]
 fn creates_release_with_project() {
-    let _server = mock_endpoint(
-        MockEndpointBuilder::new("POST", "/api/0/projects/wat-org/wat-project/releases/", 201)
-            .with_response_file("releases/get-release.json")
-            .with_matcher(Matcher::PartialJson(json!({
-                "version": "new-release",
-                "projects": ["wat-project"],
-            }))),
-    );
-    register_test("releases/releases-new-with-project.trycmd");
+    TestManager::new()
+        .mock_endpoint(
+            MockEndpointBuilder::new("POST", "/api/0/projects/wat-org/wat-project/releases/", 201)
+                .with_response_file("releases/get-release.json")
+                .with_matcher(Matcher::PartialJson(json!({
+                    "version": "new-release",
+                    "projects": ["wat-project"],
+                }))),
+        )
+        .register_trycmd_test("releases/releases-new-with-project.trycmd")
+        .with_default_token();
 }
 
 #[test]
 fn allows_for_release_with_project_to_start_with_hyphen() {
-    let _server = mock_endpoint(
-        MockEndpointBuilder::new("POST", "/api/0/projects/wat-org/wat-project/releases/", 201)
-            .with_response_file("releases/get-release.json")
-            .with_matcher(Matcher::PartialJson(json!({
-                "version": "-hyphenated-release",
-                "projects": ["wat-project"],
-            }))),
-    );
-    register_test("releases/releases-new-with-project-hyphen.trycmd");
+    TestManager::new()
+        .mock_endpoint(
+            MockEndpointBuilder::new("POST", "/api/0/projects/wat-org/wat-project/releases/", 201)
+                .with_response_file("releases/get-release.json")
+                .with_matcher(Matcher::PartialJson(json!({
+                    "version": "-hyphenated-release",
+                    "projects": ["wat-project"],
+                }))),
+        )
+        .register_trycmd_test("releases/releases-new-with-project-hyphen.trycmd")
+        .with_default_token();
 }
 
 #[test]
 fn creates_release_even_if_one_already_exists() {
-    let _server = mock_endpoint(
-        MockEndpointBuilder::new("POST", "/api/0/projects/wat-org/wat-project/releases/", 208)
-            .with_response_file("releases/get-release.json")
-            .with_matcher(Matcher::PartialJson(json!({
-                "version": "wat-release",
-                "projects": ["wat-project"],
-            }))),
-    );
-    register_test("releases/releases-new-existing.trycmd");
+    TestManager::new()
+        .mock_endpoint(
+            MockEndpointBuilder::new("POST", "/api/0/projects/wat-org/wat-project/releases/", 208)
+                .with_response_file("releases/get-release.json")
+                .with_matcher(Matcher::PartialJson(json!({
+                    "version": "wat-release",
+                    "projects": ["wat-project"],
+                }))),
+        )
+        .register_trycmd_test("releases/releases-new-existing.trycmd")
+        .with_default_token();
 }
 
 #[test]
 fn creates_release_with_custom_url() {
-    let _server = mock_endpoint(
-        MockEndpointBuilder::new("POST", "/api/0/projects/wat-org/wat-project/releases/", 208)
-            .with_response_file("releases/get-release.json")
-            .with_matcher(Matcher::PartialJson(json!({
-                "version": "wat-release",
-                "projects": ["wat-project"],
-                "url": "https://oh.rly"
-            }))),
-    );
-    register_test("releases/releases-new-url.trycmd");
+    TestManager::new()
+        .mock_endpoint(
+            MockEndpointBuilder::new("POST", "/api/0/projects/wat-org/wat-project/releases/", 208)
+                .with_response_file("releases/get-release.json")
+                .with_matcher(Matcher::PartialJson(json!({
+                    "version": "wat-release",
+                    "projects": ["wat-project"],
+                    "url": "https://oh.rly"
+                }))),
+        )
+        .register_trycmd_test("releases/releases-new-url.trycmd")
+        .with_default_token();
 }
 
 #[test]
 fn creates_release_which_is_instantly_finalized() {
-    let _server = mock_endpoint(
-        MockEndpointBuilder::new("POST", "/api/0/projects/wat-org/wat-project/releases/", 208)
-            .with_response_file("releases/get-release.json")
-            .with_matcher(Matcher::AllOf(vec![
-                Matcher::PartialJson(json!({
-                    "version": "wat-release",
-                    "projects": ["wat-project"],
-                })),
-                Matcher::Regex(format!(r#""dateReleased":"{UTC_DATE_FORMAT}""#)),
-            ])),
-    );
-    register_test("releases/releases-new-finalize.trycmd");
+    TestManager::new()
+        .mock_endpoint(
+            MockEndpointBuilder::new("POST", "/api/0/projects/wat-org/wat-project/releases/", 208)
+                .with_response_file("releases/get-release.json")
+                .with_matcher(Matcher::AllOf(vec![
+                    Matcher::PartialJson(json!({
+                        "version": "wat-release",
+                        "projects": ["wat-project"],
+                    })),
+                    Matcher::Regex(format!(r#""dateReleased":"{UTC_DATE_FORMAT}""#)),
+                ])),
+        )
+        .register_trycmd_test("releases/releases-new-finalize.trycmd")
+        .with_default_token();
 }

--- a/tests/integration/send_envelope.rs
+++ b/tests/integration/send_envelope.rs
@@ -1,10 +1,8 @@
-use crate::integration;
-
-use super::MockEndpointBuilder;
+use crate::integration::{MockEndpointBuilder, TestManager};
 
 #[test]
 fn command_send_envelope() {
-    let _server =
-        integration::mock_endpoint(MockEndpointBuilder::new("POST", "/api/1337/envelope/", 200));
-    integration::register_test("send_envelope/*.trycmd");
+    TestManager::new()
+        .mock_endpoint(MockEndpointBuilder::new("POST", "/api/1337/envelope/", 200))
+        .register_trycmd_test("send_envelope/*.trycmd");
 }

--- a/tests/integration/send_event.rs
+++ b/tests/integration/send_event.rs
@@ -1,4 +1,4 @@
-use crate::integration::{self, MockEndpointBuilder};
+use crate::integration::{MockEndpointBuilder, TestManager};
 
 // I have no idea why this is timing out on Windows.
 // I verified it manually, and this command works just fine. — Kamil
@@ -6,14 +6,14 @@ use crate::integration::{self, MockEndpointBuilder};
 #[cfg(not(windows))]
 #[test]
 fn command_send_event_not_windows() {
-    let _server =
-        integration::mock_endpoint(MockEndpointBuilder::new("POST", "/api/1337/envelope/", 200));
-    integration::register_test("send_event/not_windows/*.trycmd");
+    TestManager::new()
+        .mock_endpoint(MockEndpointBuilder::new("POST", "/api/1337/envelope/", 200))
+        .register_trycmd_test("send_event/not_windows/*.trycmd");
 }
 
 #[test]
 fn command_send_event() {
-    let _server =
-        integration::mock_endpoint(MockEndpointBuilder::new("POST", "/api/1337/envelope/", 200));
-    integration::register_test("send_event/*.trycmd");
+    TestManager::new()
+        .mock_endpoint(MockEndpointBuilder::new("POST", "/api/1337/envelope/", 200))
+        .register_trycmd_test("send_event/*.trycmd");
 }

--- a/tests/integration/send_metric.rs
+++ b/tests/integration/send_metric.rs
@@ -1,45 +1,48 @@
 use super::MockEndpointBuilder;
-use crate::integration;
-use mockito::{Matcher, Mock};
+use crate::integration::TestManager;
+use mockito::Matcher;
 use trycmd::TestCases;
 
-fn mock_envelopes_endpoint() -> Mock {
+fn envelopes_endpoint_builder() -> MockEndpointBuilder {
     let expected_auth_header = Matcher::Regex(
         r#"^Sentry sentry_key=test, sentry_version=7, sentry_timestamp=\d{10}(\.[0-9]+)?, sentry_client=sentry-cli/.*"#
             .to_string(),
     );
-    integration::mock_endpoint(
-        MockEndpointBuilder::new("POST", "/api/1337/envelope/", 200)
-            .with_header_matcher("X-Sentry-Auth", expected_auth_header),
-    )
+
+    MockEndpointBuilder::new("POST", "/api/1337/envelope/", 200)
+        .with_header_matcher("X-Sentry-Auth", expected_auth_header)
 }
 
 #[test]
 fn command_send_metric() {
-    let _m = mock_envelopes_endpoint();
-    integration::register_test("send_metric/*.trycmd");
+    TestManager::new()
+        .mock_endpoint(envelopes_endpoint_builder())
+        .register_trycmd_test("send_metric/*.trycmd");
 }
 
 #[test]
 fn command_send_metric_release_and_environment() {
-    let _m = mock_envelopes_endpoint();
-    integration::register_test("send_metric/with_release_and_environment/*.trycmd")
+    TestManager::new()
+        .mock_endpoint(envelopes_endpoint_builder())
+        .register_trycmd_test("send_metric/with_release_and_environment/*.trycmd")
         .env("SENTRY_RELEASE", "def_release")
         .env("SENTRY_ENVIRONMENT", "def_env");
 }
 
 #[test]
 fn command_send_metric_increment_no_dsn() {
-    let _m = mock_envelopes_endpoint();
+    let _manager = TestManager::new().mock_endpoint(envelopes_endpoint_builder());
+
+    // Custom test case setup because we don't want the DSN to be set by the manager.
     TestCases::new()
         .case("tests/integration/_cases/send_metric/individual_config/send_metric-increment-no-dsn.trycmd");
 }
 
 #[test]
 fn command_send_metric_increment_unsuccessful_api_call() {
-    let _m =
-        integration::mock_endpoint(MockEndpointBuilder::new("POST", "/api/1337/envelope/", 500));
-    integration::register_test(
-        "send_metric/individual_config/send_metric-increment-unsuccessful-api-call.trycmd",
-    );
+    TestManager::new()
+        .mock_endpoint(MockEndpointBuilder::new("POST", "/api/1337/envelope/", 500))
+        .register_trycmd_test(
+            "send_metric/individual_config/send_metric-increment-unsuccessful-api-call.trycmd",
+        );
 }

--- a/tests/integration/sourcemaps/explain.rs
+++ b/tests/integration/sourcemaps/explain.rs
@@ -1,413 +1,451 @@
-use crate::integration::{mock_endpoint, register_test, MockEndpointBuilder};
+use crate::integration::{MockEndpointBuilder, TestManager};
 
 #[test]
 fn command_sourcemaps_explain_help() {
-    register_test("sourcemaps/sourcemaps-explain-help.trycmd");
+    TestManager::new().register_trycmd_test("sourcemaps/sourcemaps-explain-help.trycmd");
 }
 
 #[test]
 fn command_sourcemaps_explain() {
-    register_test("sourcemaps/sourcemaps-explain.trycmd");
+    TestManager::new().register_trycmd_test("sourcemaps/sourcemaps-explain.trycmd");
 }
 
 #[test]
 fn command_sourcemaps_explain_missing_event() {
-    let _event = mock_endpoint(MockEndpointBuilder::new(
-        "GET",
-        "/api/0/projects/wat-org/wat-project/events/43a57a55cd5a4207ac520c03e1dee1b4/json/",
-        404,
-    ));
-    register_test("sourcemaps/sourcemaps-explain-missing-event.trycmd");
+    TestManager::new()
+        .mock_endpoint(MockEndpointBuilder::new(
+            "GET",
+            "/api/0/projects/wat-org/wat-project/events/43a57a55cd5a4207ac520c03e1dee1b4/json/",
+            404,
+        ))
+        .register_trycmd_test("sourcemaps/sourcemaps-explain-missing-event.trycmd")
+        .with_default_token();
 }
 
 #[test]
 fn command_sourcemaps_explain_missing_release() {
-    let _event = mock_endpoint(
-        MockEndpointBuilder::new(
-            "GET",
-            "/api/0/projects/wat-org/wat-project/events/43a57a55cd5a4207ac520c03e1dee1b4/json/",
-            200,
+    TestManager::new()
+        .mock_endpoint(
+            MockEndpointBuilder::new(
+                "GET",
+                "/api/0/projects/wat-org/wat-project/events/43a57a55cd5a4207ac520c03e1dee1b4/json/",
+                200,
+            )
+            .with_response_file("sourcemaps/get-event-missing-release.json"),
         )
-        .with_response_file("sourcemaps/get-event-missing-release.json"),
-    );
-    register_test("sourcemaps/sourcemaps-explain-missing-release.trycmd");
+        .register_trycmd_test("sourcemaps/sourcemaps-explain-missing-release.trycmd")
+        .with_default_token();
 }
 
 #[test]
 fn command_sourcemaps_explain_missing_exception() {
-    let _event = mock_endpoint(
-        MockEndpointBuilder::new(
-            "GET",
-            "/api/0/projects/wat-org/wat-project/events/43a57a55cd5a4207ac520c03e1dee1b4/json/",
-            200,
+    TestManager::new()
+        .mock_endpoint(
+            MockEndpointBuilder::new(
+                "GET",
+                "/api/0/projects/wat-org/wat-project/events/43a57a55cd5a4207ac520c03e1dee1b4/json/",
+                200,
+            )
+            .with_response_file("sourcemaps/get-event-missing-exception.json"),
         )
-        .with_response_file("sourcemaps/get-event-missing-exception.json"),
-    );
-    register_test("sourcemaps/sourcemaps-explain-missing-exception.trycmd");
+        .register_trycmd_test("sourcemaps/sourcemaps-explain-missing-exception.trycmd")
+        .with_default_token();
 }
 
 #[test]
 fn command_sourcemaps_explain_missing_stacktrace() {
-    let _event = mock_endpoint(
-        MockEndpointBuilder::new(
-            "GET",
-            "/api/0/projects/wat-org/wat-project/events/43a57a55cd5a4207ac520c03e1dee1b4/json/",
-            200,
+    TestManager::new()
+        .mock_endpoint(
+            MockEndpointBuilder::new(
+                "GET",
+                "/api/0/projects/wat-org/wat-project/events/43a57a55cd5a4207ac520c03e1dee1b4/json/",
+                200,
+            )
+            .with_response_file("sourcemaps/get-event-missing-stacktrace.json"),
         )
-        .with_response_file("sourcemaps/get-event-missing-stacktrace.json"),
-    );
-    register_test("sourcemaps/sourcemaps-explain-missing-stacktrace.trycmd");
+        .register_trycmd_test("sourcemaps/sourcemaps-explain-missing-stacktrace.trycmd")
+        .with_default_token();
 }
 
 #[test]
 fn command_sourcemaps_explain_frame_no_inapp() {
-    let _event = mock_endpoint(
-        MockEndpointBuilder::new(
-            "GET",
-            "/api/0/projects/wat-org/wat-project/events/43a57a55cd5a4207ac520c03e1dee1b4/json/",
-            200,
+    TestManager::new()
+        .mock_endpoint(
+            MockEndpointBuilder::new(
+                "GET",
+                "/api/0/projects/wat-org/wat-project/events/43a57a55cd5a4207ac520c03e1dee1b4/json/",
+                200,
+            )
+            .with_response_file("sourcemaps/get-event-frame-no-inapp.json"),
         )
-        .with_response_file("sourcemaps/get-event-frame-no-inapp.json"),
-    );
-    register_test("sourcemaps/sourcemaps-explain-frame-no-inapp.trycmd");
+        .register_trycmd_test("sourcemaps/sourcemaps-explain-frame-no-inapp.trycmd")
+        .with_default_token();
 }
 
 #[test]
 fn command_sourcemaps_explain_frame_no_abspath() {
-    let _event = mock_endpoint(
-        MockEndpointBuilder::new(
-            "GET",
-            "/api/0/projects/wat-org/wat-project/events/43a57a55cd5a4207ac520c03e1dee1b4/json/",
-            200,
+    TestManager::new()
+        .mock_endpoint(
+            MockEndpointBuilder::new(
+                "GET",
+                "/api/0/projects/wat-org/wat-project/events/43a57a55cd5a4207ac520c03e1dee1b4/json/",
+                200,
+            )
+            .with_response_file("sourcemaps/get-event-frame-no-abspath.json"),
         )
-        .with_response_file("sourcemaps/get-event-frame-no-abspath.json"),
-    );
-    register_test("sourcemaps/sourcemaps-explain-frame-no-abspath.trycmd");
+        .register_trycmd_test("sourcemaps/sourcemaps-explain-frame-no-abspath.trycmd")
+        .with_default_token();
 }
 
 #[test]
 fn command_sourcemaps_explain_frame_no_extension() {
-    let _event = mock_endpoint(
-        MockEndpointBuilder::new(
-            "GET",
-            "/api/0/projects/wat-org/wat-project/events/43a57a55cd5a4207ac520c03e1dee1b4/json/",
-            200,
+    TestManager::new()
+        .mock_endpoint(
+            MockEndpointBuilder::new(
+                "GET",
+                "/api/0/projects/wat-org/wat-project/events/43a57a55cd5a4207ac520c03e1dee1b4/json/",
+                200,
+            )
+            .with_response_file("sourcemaps/get-event-frame-no-extension.json"),
         )
-        .with_response_file("sourcemaps/get-event-frame-no-extension.json"),
-    );
-    register_test("sourcemaps/sourcemaps-explain-frame-no-extension.trycmd");
+        .register_trycmd_test("sourcemaps/sourcemaps-explain-frame-no-extension.trycmd")
+        .with_default_token();
 }
 
 #[test]
 fn command_sourcemaps_explain_frame_malformed_abspath() {
-    let _event = mock_endpoint(
-        MockEndpointBuilder::new(
-            "GET",
-            "/api/0/projects/wat-org/wat-project/events/43a57a55cd5a4207ac520c03e1dee1b4/json/",
-            200,
+    TestManager::new()
+        .mock_endpoint(
+            MockEndpointBuilder::new(
+                "GET",
+                "/api/0/projects/wat-org/wat-project/events/43a57a55cd5a4207ac520c03e1dee1b4/json/",
+                200,
+            )
+            .with_response_file("sourcemaps/get-event-frame-malformed-abspath.json"),
         )
-        .with_response_file("sourcemaps/get-event-frame-malformed-abspath.json"),
-    );
-    register_test("sourcemaps/sourcemaps-explain-frame-malformed-abspath.trycmd");
+        .register_trycmd_test("sourcemaps/sourcemaps-explain-frame-malformed-abspath.trycmd")
+        .with_default_token();
 }
 
 #[test]
 fn command_sourcemaps_explain_already_mapped() {
-    let _event = mock_endpoint(
-        MockEndpointBuilder::new(
-            "GET",
-            "/api/0/projects/wat-org/wat-project/events/43a57a55cd5a4207ac520c03e1dee1b4/json/",
-            200,
+    TestManager::new()
+        .mock_endpoint(
+            MockEndpointBuilder::new(
+                "GET",
+                "/api/0/projects/wat-org/wat-project/events/43a57a55cd5a4207ac520c03e1dee1b4/json/",
+                200,
+            )
+            .with_response_file("sourcemaps/get-event-already-mapped.json"),
         )
-        .with_response_file("sourcemaps/get-event-already-mapped.json"),
-    );
-    register_test("sourcemaps/sourcemaps-explain-already-mapped.trycmd");
+        .register_trycmd_test("sourcemaps/sourcemaps-explain-already-mapped.trycmd")
+        .with_default_token();
 }
 
 #[test]
 fn command_sourcemaps_explain_no_artifacts() {
-    let _event = mock_endpoint(
-        MockEndpointBuilder::new(
-            "GET",
-            "/api/0/projects/wat-org/wat-project/events/43a57a55cd5a4207ac520c03e1dee1b4/json/",
-            200,
+    TestManager::new()
+        .mock_endpoint(
+            MockEndpointBuilder::new(
+                "GET",
+                "/api/0/projects/wat-org/wat-project/events/43a57a55cd5a4207ac520c03e1dee1b4/json/",
+                200,
+            )
+            .with_response_file("sourcemaps/get-event.json"),
         )
-        .with_response_file("sourcemaps/get-event.json"),
-    );
-    let _artifacts = mock_endpoint(
-        MockEndpointBuilder::new(
-            "GET",
-            "/api/0/projects/wat-org/wat-project/releases/ytho-test/files/?cursor=",
-            200,
+        .mock_endpoint(
+            MockEndpointBuilder::new(
+                "GET",
+                "/api/0/projects/wat-org/wat-project/releases/ytho-test/files/?cursor=",
+                200,
+            )
+            .with_response_file("sourcemaps/get-artifacts-empty.json"),
         )
-        .with_response_file("sourcemaps/get-artifacts-empty.json"),
-    );
-    register_test("sourcemaps/sourcemaps-explain-no-artifacts.trycmd");
+        .register_trycmd_test("sourcemaps/sourcemaps-explain-no-artifacts.trycmd")
+        .with_default_token();
 }
 
 #[test]
 fn command_sourcemaps_explain_no_matching_artifact() {
-    let _event = mock_endpoint(
-        MockEndpointBuilder::new(
-            "GET",
-            "/api/0/projects/wat-org/wat-project/events/43a57a55cd5a4207ac520c03e1dee1b4/json/",
-            200,
+    TestManager::new()
+        .mock_endpoint(
+            MockEndpointBuilder::new(
+                "GET",
+                "/api/0/projects/wat-org/wat-project/events/43a57a55cd5a4207ac520c03e1dee1b4/json/",
+                200,
+            )
+            .with_response_file("sourcemaps/get-event.json"),
         )
-        .with_response_file("sourcemaps/get-event.json"),
-    );
-    let _artifacts = mock_endpoint(
-        MockEndpointBuilder::new(
-            "GET",
-            "/api/0/projects/wat-org/wat-project/releases/ytho-test/files/?cursor=",
-            200,
+        .mock_endpoint(
+            MockEndpointBuilder::new(
+                "GET",
+                "/api/0/projects/wat-org/wat-project/releases/ytho-test/files/?cursor=",
+                200,
+            )
+            .with_response_file("sourcemaps/get-artifacts-no-match.json"),
         )
-        .with_response_file("sourcemaps/get-artifacts-no-match.json"),
-    );
-    register_test("sourcemaps/sourcemaps-explain-no-matching-artifact.trycmd");
+        .register_trycmd_test("sourcemaps/sourcemaps-explain-no-matching-artifact.trycmd")
+        .with_default_token();
 }
 
 #[test]
 fn command_sourcemaps_explain_partial_matching_artifact() {
-    let _event = mock_endpoint(
-        MockEndpointBuilder::new(
-            "GET",
-            "/api/0/projects/wat-org/wat-project/events/43a57a55cd5a4207ac520c03e1dee1b4/json/",
-            200,
+    TestManager::new()
+        .mock_endpoint(
+            MockEndpointBuilder::new(
+                "GET",
+                "/api/0/projects/wat-org/wat-project/events/43a57a55cd5a4207ac520c03e1dee1b4/json/",
+                200,
+            )
+            .with_response_file("sourcemaps/get-event.json"),
         )
-        .with_response_file("sourcemaps/get-event.json"),
-    );
-    let _artifacts = mock_endpoint(
-        MockEndpointBuilder::new(
-            "GET",
-            "/api/0/projects/wat-org/wat-project/releases/ytho-test/files/?cursor=",
-            200,
+        .mock_endpoint(
+            MockEndpointBuilder::new(
+                "GET",
+                "/api/0/projects/wat-org/wat-project/releases/ytho-test/files/?cursor=",
+                200,
+            )
+            .with_response_file("sourcemaps/get-artifacts-partial-match.json"),
         )
-        .with_response_file("sourcemaps/get-artifacts-partial-match.json"),
-    );
-    register_test("sourcemaps/sourcemaps-explain-partial-matching-artifact.trycmd");
+        .register_trycmd_test("sourcemaps/sourcemaps-explain-partial-matching-artifact.trycmd")
+        .with_default_token();
 }
 
 #[test]
 fn command_sourcemaps_explain_artifact_dist_mismatch() {
-    let _event = mock_endpoint(
-        MockEndpointBuilder::new(
-            "GET",
-            "/api/0/projects/wat-org/wat-project/events/43a57a55cd5a4207ac520c03e1dee1b4/json/",
-            200,
+    TestManager::new()
+        .mock_endpoint(
+            MockEndpointBuilder::new(
+                "GET",
+                "/api/0/projects/wat-org/wat-project/events/43a57a55cd5a4207ac520c03e1dee1b4/json/",
+                200,
+            )
+            .with_response_file("sourcemaps/get-event.json"),
         )
-        .with_response_file("sourcemaps/get-event.json"),
-    );
-    let _artifacts = mock_endpoint(
-        MockEndpointBuilder::new(
-            "GET",
-            "/api/0/projects/wat-org/wat-project/releases/ytho-test/files/?cursor=",
-            200,
+        .mock_endpoint(
+            MockEndpointBuilder::new(
+                "GET",
+                "/api/0/projects/wat-org/wat-project/releases/ytho-test/files/?cursor=",
+                200,
+            )
+            .with_response_file("sourcemaps/get-artifacts.json"),
         )
-        .with_response_file("sourcemaps/get-artifacts.json"),
-    );
-    register_test("sourcemaps/sourcemaps-explain-artifact-dist-mismatch.trycmd");
+        .register_trycmd_test("sourcemaps/sourcemaps-explain-artifact-dist-mismatch.trycmd")
+        .with_default_token();
 }
 
 #[test]
 fn command_sourcemaps_explain_artifact_no_dist() {
-    let _event = mock_endpoint(
-        MockEndpointBuilder::new(
-            "GET",
-            "/api/0/projects/wat-org/wat-project/events/43a57a55cd5a4207ac520c03e1dee1b4/json/",
-            200,
+    TestManager::new()
+        .mock_endpoint(
+            MockEndpointBuilder::new(
+                "GET",
+                "/api/0/projects/wat-org/wat-project/events/43a57a55cd5a4207ac520c03e1dee1b4/json/",
+                200,
+            )
+            .with_response_file("sourcemaps/get-event.json"),
         )
-        .with_response_file("sourcemaps/get-event.json"),
-    );
-    let _artifacts = mock_endpoint(
-        MockEndpointBuilder::new(
-            "GET",
-            "/api/0/projects/wat-org/wat-project/releases/ytho-test/files/?cursor=",
-            200,
+        .mock_endpoint(
+            MockEndpointBuilder::new(
+                "GET",
+                "/api/0/projects/wat-org/wat-project/releases/ytho-test/files/?cursor=",
+                200,
+            )
+            .with_response_file("sourcemaps/get-artifacts-no-dist.json"),
         )
-        .with_response_file("sourcemaps/get-artifacts-no-dist.json"),
-    );
-    register_test("sourcemaps/sourcemaps-explain-artifact-no-dist.trycmd");
+        .register_trycmd_test("sourcemaps/sourcemaps-explain-artifact-no-dist.trycmd")
+        .with_default_token();
 }
 
 #[test]
 fn command_sourcemaps_explain_event_no_dist() {
-    let _event = mock_endpoint(
-        MockEndpointBuilder::new(
-            "GET",
-            "/api/0/projects/wat-org/wat-project/events/43a57a55cd5a4207ac520c03e1dee1b4/json/",
-            200,
+    TestManager::new()
+        .mock_endpoint(
+            MockEndpointBuilder::new(
+                "GET",
+                "/api/0/projects/wat-org/wat-project/events/43a57a55cd5a4207ac520c03e1dee1b4/json/",
+                200,
+            )
+            .with_response_file("sourcemaps/get-event-missing-dist.json"),
         )
-        .with_response_file("sourcemaps/get-event-missing-dist.json"),
-    );
-    let _artifacts = mock_endpoint(
-        MockEndpointBuilder::new(
-            "GET",
-            "/api/0/projects/wat-org/wat-project/releases/ytho-test/files/?cursor=",
-            200,
+        .mock_endpoint(
+            MockEndpointBuilder::new(
+                "GET",
+                "/api/0/projects/wat-org/wat-project/releases/ytho-test/files/?cursor=",
+                200,
+            )
+            .with_response_file("sourcemaps/get-artifacts.json"),
         )
-        .with_response_file("sourcemaps/get-artifacts.json"),
-    );
-    register_test("sourcemaps/sourcemaps-explain-event-no-dist.trycmd");
+        .register_trycmd_test("sourcemaps/sourcemaps-explain-event-no-dist.trycmd")
+        .with_default_token();
 }
 
 #[test]
 fn command_sourcemaps_explain_detect_from_sourcemap_header() {
-    let _event = mock_endpoint(
-        MockEndpointBuilder::new(
-            "GET",
-            "/api/0/projects/wat-org/wat-project/events/43a57a55cd5a4207ac520c03e1dee1b4/json/",
-            200,
+    TestManager::new()
+        .mock_endpoint(
+            MockEndpointBuilder::new(
+                "GET",
+                "/api/0/projects/wat-org/wat-project/events/43a57a55cd5a4207ac520c03e1dee1b4/json/",
+                200,
+            )
+            .with_response_file("sourcemaps/get-event-missing-dist.json"),
         )
-        .with_response_file("sourcemaps/get-event-missing-dist.json"),
-    );
-    let _artifacts = mock_endpoint(
-        MockEndpointBuilder::new(
-            "GET",
-            "/api/0/projects/wat-org/wat-project/releases/ytho-test/files/?cursor=",
-            200,
+        .mock_endpoint(
+            MockEndpointBuilder::new(
+                "GET",
+                "/api/0/projects/wat-org/wat-project/releases/ytho-test/files/?cursor=",
+                200,
+            )
+            .with_response_file("sourcemaps/get-artifacts-no-sourcemap.json"),
         )
-        .with_response_file("sourcemaps/get-artifacts-no-sourcemap.json"),
-    );
-    let _file_metadata = mock_endpoint(
-        MockEndpointBuilder::new(
-            "GET",
-            "/api/0/projects/wat-org/wat-project/releases/ytho-test/files/6796495645/",
-            200,
+        .mock_endpoint(
+            MockEndpointBuilder::new(
+                "GET",
+                "/api/0/projects/wat-org/wat-project/releases/ytho-test/files/6796495645/",
+                200,
+            )
+            .with_response_file("sourcemaps/get-file-metadata-sourcemap-header.json"),
         )
-        .with_response_file("sourcemaps/get-file-metadata-sourcemap-header.json"),
-    );
-
-    register_test("sourcemaps/sourcemaps-explain-detect-from-sourcemap-header.trycmd");
+        .register_trycmd_test("sourcemaps/sourcemaps-explain-detect-from-sourcemap-header.trycmd")
+        .with_default_token();
 }
 
 #[test]
 fn command_sourcemaps_explain_detect_from_xsourcemap_header() {
-    let _event = mock_endpoint(
-        MockEndpointBuilder::new(
-            "GET",
-            "/api/0/projects/wat-org/wat-project/events/43a57a55cd5a4207ac520c03e1dee1b4/json/",
-            200,
+    TestManager::new()
+        .mock_endpoint(
+            MockEndpointBuilder::new(
+                "GET",
+                "/api/0/projects/wat-org/wat-project/events/43a57a55cd5a4207ac520c03e1dee1b4/json/",
+                200,
+            )
+            .with_response_file("sourcemaps/get-event-missing-dist.json"),
         )
-        .with_response_file("sourcemaps/get-event-missing-dist.json"),
-    );
-    let _artifacts = mock_endpoint(
-        MockEndpointBuilder::new(
-            "GET",
-            "/api/0/projects/wat-org/wat-project/releases/ytho-test/files/?cursor=",
-            200,
+        .mock_endpoint(
+            MockEndpointBuilder::new(
+                "GET",
+                "/api/0/projects/wat-org/wat-project/releases/ytho-test/files/?cursor=",
+                200,
+            )
+            .with_response_file("sourcemaps/get-artifacts-no-sourcemap.json"),
         )
-        .with_response_file("sourcemaps/get-artifacts-no-sourcemap.json"),
-    );
-    let _file_metadata = mock_endpoint(
-        MockEndpointBuilder::new(
-            "GET",
-            "/api/0/projects/wat-org/wat-project/releases/ytho-test/files/6796495645/",
-            200,
+        .mock_endpoint(
+            MockEndpointBuilder::new(
+                "GET",
+                "/api/0/projects/wat-org/wat-project/releases/ytho-test/files/6796495645/",
+                200,
+            )
+            .with_response_file("sourcemaps/get-file-metadata-xsourcemap-header.json"),
         )
-        .with_response_file("sourcemaps/get-file-metadata-xsourcemap-header.json"),
-    );
-
-    register_test("sourcemaps/sourcemaps-explain-detect-from-xsourcemap-header.trycmd");
+        .register_trycmd_test("sourcemaps/sourcemaps-explain-detect-from-xsourcemap-header.trycmd")
+        .with_default_token();
 }
 
 #[test]
 fn command_sourcemaps_explain_detect_from_file_content() {
-    let _event = mock_endpoint(
-        MockEndpointBuilder::new(
-            "GET",
-            "/api/0/projects/wat-org/wat-project/events/43a57a55cd5a4207ac520c03e1dee1b4/json/",
-            200,
+    TestManager::new()
+        .mock_endpoint(
+            MockEndpointBuilder::new(
+                "GET",
+                "/api/0/projects/wat-org/wat-project/events/43a57a55cd5a4207ac520c03e1dee1b4/json/",
+                200,
+            )
+            .with_response_file("sourcemaps/get-event-missing-dist.json"),
         )
-        .with_response_file("sourcemaps/get-event-missing-dist.json"),
-    );
-    let _artifacts = mock_endpoint(
-        MockEndpointBuilder::new(
-            "GET",
-            "/api/0/projects/wat-org/wat-project/releases/ytho-test/files/?cursor=",
-            200,
+        .mock_endpoint(
+            MockEndpointBuilder::new(
+                "GET",
+                "/api/0/projects/wat-org/wat-project/releases/ytho-test/files/?cursor=",
+                200,
+            )
+            .with_response_file("sourcemaps/get-artifacts-no-sourcemap.json"),
         )
-        .with_response_file("sourcemaps/get-artifacts-no-sourcemap.json"),
-    );
-    let _file_metadata = mock_endpoint(
-        MockEndpointBuilder::new(
-            "GET",
-            "/api/0/projects/wat-org/wat-project/releases/ytho-test/files/6796495645/",
-            200,
+        .mock_endpoint(
+            MockEndpointBuilder::new(
+                "GET",
+                "/api/0/projects/wat-org/wat-project/releases/ytho-test/files/6796495645/",
+                200,
+            )
+            .with_response_file("sourcemaps/get-file-metadata-no-headers.json"),
         )
-        .with_response_file("sourcemaps/get-file-metadata-no-headers.json"),
-    );
-    let _file = mock_endpoint(
-        MockEndpointBuilder::new(
-            "GET",
-            "/api/0/projects/wat-org/wat-project/releases/ytho-test/files/6796495645/?download=1",
-            200,
+        .mock_endpoint(
+            MockEndpointBuilder::new(
+                "GET",
+                "/api/0/projects/wat-org/wat-project/releases/ytho-test/files/6796495645/?download=1",
+                200,
+            )
+            .with_response_file("sourcemaps/get-file.js"),
         )
-        .with_response_file("sourcemaps/get-file.js"),
-    );
-
-    register_test("sourcemaps/sourcemaps-explain-detect-from-file-content.trycmd");
+        .register_trycmd_test("sourcemaps/sourcemaps-explain-detect-from-file-content.trycmd")
+        .with_default_token();
 }
 
 #[test]
 fn command_sourcemaps_explain_print_sourcemap() {
-    let _event = mock_endpoint(
-        MockEndpointBuilder::new(
-            "GET",
-            "/api/0/projects/wat-org/wat-project/events/43a57a55cd5a4207ac520c03e1dee1b4/json/",
-            200,
+    TestManager::new()
+        .mock_endpoint(
+            MockEndpointBuilder::new(
+                "GET",
+                "/api/0/projects/wat-org/wat-project/events/43a57a55cd5a4207ac520c03e1dee1b4/json/",
+                200,
+            )
+            .with_response_file("sourcemaps/get-event-missing-dist.json"),
         )
-        .with_response_file("sourcemaps/get-event-missing-dist.json"),
-    );
-    let _artifacts = mock_endpoint(
-        MockEndpointBuilder::new(
-            "GET",
-            "/api/0/projects/wat-org/wat-project/releases/ytho-test/files/?cursor=",
-            200,
+        .mock_endpoint(
+            MockEndpointBuilder::new(
+                "GET",
+                "/api/0/projects/wat-org/wat-project/releases/ytho-test/files/?cursor=",
+                200,
+            )
+            .with_response_file("sourcemaps/get-artifacts-no-dist.json"),
         )
-        .with_response_file("sourcemaps/get-artifacts-no-dist.json"),
-    );
-    let _file_metadata = mock_endpoint(
-        MockEndpointBuilder::new(
-            "GET",
-            "/api/0/projects/wat-org/wat-project/releases/ytho-test/files/6796495645/",
-            200,
+        .mock_endpoint(
+            MockEndpointBuilder::new(
+                "GET",
+                "/api/0/projects/wat-org/wat-project/releases/ytho-test/files/6796495645/",
+                200,
+            )
+            .with_response_file("sourcemaps/get-file-metadata-sourcemap-header.json"),
         )
-        .with_response_file("sourcemaps/get-file-metadata-sourcemap-header.json"),
-    );
-    let _file = mock_endpoint(
-        MockEndpointBuilder::new(
-            "GET",
-            "/api/0/projects/wat-org/wat-project/releases/ytho-test/files/6796495646/?download=1",
-            200,
+        .mock_endpoint(
+            MockEndpointBuilder::new(
+                "GET",
+                "/api/0/projects/wat-org/wat-project/releases/ytho-test/files/6796495646/?download=1",
+                200,
+            )
+            .with_response_file("sourcemaps/get-file-sourcemap.js.map"),
         )
-        .with_response_file("sourcemaps/get-file-sourcemap.js.map"),
-    );
-
-    register_test("sourcemaps/sourcemaps-explain-print-sourcemap.trycmd");
+        .register_trycmd_test("sourcemaps/sourcemaps-explain-print-sourcemap.trycmd")
+        .with_default_token();
 }
 
 #[test]
 fn command_sourcemaps_explain_select_frame() {
-    let _event = mock_endpoint(
-        MockEndpointBuilder::new(
-            "GET",
-            "/api/0/projects/wat-org/wat-project/events/43a57a55cd5a4207ac520c03e1dee1b4/json/",
-            200,
+    TestManager::new()
+        .mock_endpoint(
+            MockEndpointBuilder::new(
+                "GET",
+                "/api/0/projects/wat-org/wat-project/events/43a57a55cd5a4207ac520c03e1dee1b4/json/",
+                200,
+            )
+            .with_response_file("sourcemaps/get-event-select-frame.json"),
         )
-        .with_response_file("sourcemaps/get-event-select-frame.json"),
-    );
-    register_test("sourcemaps/sourcemaps-explain-select-frame.trycmd");
+        .register_trycmd_test("sourcemaps/sourcemaps-explain-select-frame.trycmd")
+        .with_default_token();
 }
 
 #[test]
 fn command_sourcemaps_explain_select_frame_out_of_range() {
-    let _event = mock_endpoint(
-        MockEndpointBuilder::new(
-            "GET",
-            "/api/0/projects/wat-org/wat-project/events/43a57a55cd5a4207ac520c03e1dee1b4/json/",
-            200,
+    TestManager::new()
+        .mock_endpoint(
+            MockEndpointBuilder::new(
+                "GET",
+                "/api/0/projects/wat-org/wat-project/events/43a57a55cd5a4207ac520c03e1dee1b4/json/",
+                200,
+            )
+            .with_response_file("sourcemaps/get-event-select-frame.json"),
         )
-        .with_response_file("sourcemaps/get-event-select-frame.json"),
-    );
-    register_test("sourcemaps/sourcemaps-explain-select-frame-out-of-range.trycmd");
+        .register_trycmd_test("sourcemaps/sourcemaps-explain-select-frame-out-of-range.trycmd")
+        .with_default_token();
 }

--- a/tests/integration/sourcemaps/inject.rs
+++ b/tests/integration/sourcemaps/inject.rs
@@ -1,10 +1,10 @@
 use std::fs::{self, remove_dir_all};
 
-use crate::integration::{copy_recursively, register_test};
+use crate::integration::{copy_recursively, TestManager};
 
 #[test]
 fn command_sourcemaps_inject_help() {
-    register_test("sourcemaps/sourcemaps-inject-help.trycmd");
+    TestManager::new().register_trycmd_test("sourcemaps/sourcemaps-inject-help.trycmd");
 }
 
 #[test]
@@ -15,7 +15,7 @@ fn command_sourcemaps_inject_output() {
     }
     copy_recursively("tests/integration/_fixtures/inject/", testcase_cwd_path).unwrap();
 
-    register_test("sourcemaps/sourcemaps-inject.trycmd");
+    TestManager::new().register_trycmd_test("sourcemaps/sourcemaps-inject.trycmd");
 }
 
 #[test]
@@ -30,7 +30,7 @@ fn command_sourcemaps_inject_output_nomappings() {
     )
     .unwrap();
 
-    register_test("sourcemaps/sourcemaps-inject-nomappings.trycmd");
+    TestManager::new().register_trycmd_test("sourcemaps/sourcemaps-inject-nomappings.trycmd");
 }
 
 #[test]
@@ -41,7 +41,7 @@ fn command_sourcemaps_inject_output_nofiles() {
     }
     fs::create_dir_all(std::path::Path::new(testcase_cwd_path).join("nonexisting")).unwrap();
 
-    register_test("sourcemaps/sourcemaps-inject-nofiles.trycmd");
+    TestManager::new().register_trycmd_test("sourcemaps/sourcemaps-inject-nofiles.trycmd");
 }
 
 #[test]
@@ -58,7 +58,7 @@ fn command_sourcemaps_inject_output_embedded() {
     )
     .unwrap();
 
-    register_test("sourcemaps/sourcemaps-inject-embedded.trycmd");
+    TestManager::new().register_trycmd_test("sourcemaps/sourcemaps-inject-embedded.trycmd");
 }
 
 #[test]
@@ -73,7 +73,7 @@ fn command_sourcemaps_inject_output_split() {
     )
     .unwrap();
 
-    register_test("sourcemaps/sourcemaps-inject-split.trycmd");
+    TestManager::new().register_trycmd_test("sourcemaps/sourcemaps-inject-split.trycmd");
 }
 
 #[test]
@@ -89,7 +89,7 @@ fn command_sourcemaps_inject_output_split_ambiguous() {
     )
     .unwrap();
 
-    register_test("sourcemaps/sourcemaps-inject-split-ambiguous.trycmd");
+    TestManager::new().register_trycmd_test("sourcemaps/sourcemaps-inject-split-ambiguous.trycmd");
 }
 
 #[test]
@@ -104,7 +104,7 @@ fn command_sourcemaps_inject_bundlers() {
     )
     .unwrap();
 
-    register_test("sourcemaps/sourcemaps-inject-bundlers.trycmd");
+    TestManager::new().register_trycmd_test("sourcemaps/sourcemaps-inject-bundlers.trycmd");
 
     // IIFE tests
     for bundler in ["esbuild", "rollup", "rspack", "vite", "webpack"] {
@@ -160,7 +160,7 @@ fn command_sourcemaps_inject_not_compiled() {
     )
     .unwrap();
 
-    register_test("sourcemaps/sourcemaps-inject-not-compiled.trycmd");
+    TestManager::new().register_trycmd_test("sourcemaps/sourcemaps-inject-not-compiled.trycmd");
 
     let file_contents = fs::read_to_string(format!("{testcase_cwd_path}not-compiled.js")).unwrap();
     assert!(file_contents.contains("//# debugId="));
@@ -168,5 +168,6 @@ fn command_sourcemaps_inject_not_compiled() {
 
 #[test]
 fn command_sourcemaps_inject_complex_extension() {
-    register_test("sourcemaps/sourcemaps-inject-complex-extension.trycmd");
+    TestManager::new()
+        .register_trycmd_test("sourcemaps/sourcemaps-inject-complex-extension.trycmd");
 }

--- a/tests/integration/sourcemaps/mod.rs
+++ b/tests/integration/sourcemaps/mod.rs
@@ -1,4 +1,4 @@
-use crate::integration::register_test;
+use crate::integration::TestManager;
 
 mod explain;
 mod inject;
@@ -7,10 +7,10 @@ mod upload;
 
 #[test]
 fn command_sourcemaps_help() {
-    register_test("sourcemaps/sourcemaps-help.trycmd");
+    TestManager::new().register_trycmd_test("sourcemaps/sourcemaps-help.trycmd");
 }
 
 #[test]
 fn command_sourcemaps_no_subcommand() {
-    register_test("sourcemaps/sourcemaps-no-subcommand.trycmd");
+    TestManager::new().register_trycmd_test("sourcemaps/sourcemaps-no-subcommand.trycmd");
 }

--- a/tests/integration/sourcemaps/resolve.rs
+++ b/tests/integration/sourcemaps/resolve.rs
@@ -1,11 +1,11 @@
-use crate::integration::register_test;
+use crate::integration::TestManager;
 
 #[test]
 fn command_sourcemaps_resolve_help() {
-    register_test("sourcemaps/sourcemaps-resolve-help.trycmd");
+    TestManager::new().register_trycmd_test("sourcemaps/sourcemaps-resolve-help.trycmd");
 }
 
 #[test]
 fn command_sourcemaps_resolve() {
-    register_test("sourcemaps/sourcemaps-resolve.trycmd");
+    TestManager::new().register_trycmd_test("sourcemaps/sourcemaps-resolve.trycmd");
 }

--- a/tests/integration/sourcemaps/upload.rs
+++ b/tests/integration/sourcemaps/upload.rs
@@ -1,186 +1,188 @@
-use crate::integration::{
-    assert_endpoints, mock_common_upload_endpoints, mock_endpoint, register_test, ChunkOptions,
-    MockEndpointBuilder, ServerBehavior,
-};
+use crate::integration::{ChunkOptions, MockEndpointBuilder, ServerBehavior, TestManager};
 
 #[test]
 fn command_sourcemaps_upload_help() {
-    register_test("sourcemaps/sourcemaps-upload-help.trycmd");
+    TestManager::new().register_trycmd_test("sourcemaps/sourcemaps-upload-help.trycmd");
 }
 
 #[test]
 fn command_sourcemaps_upload() {
-    register_test("sourcemaps/sourcemaps-upload.trycmd");
+    TestManager::new().register_trycmd_test("sourcemaps/sourcemaps-upload.trycmd");
 }
 
 #[test]
 fn command_sourcemaps_upload_successfully_upload_file() {
-    let upload_endpoints = mock_common_upload_endpoints(ServerBehavior::Legacy, Default::default());
-    let _files = mock_endpoint(
-        MockEndpointBuilder::new(
-            "GET",
-            "/api/0/projects/wat-org/wat-project/releases/wat-release/files/?cursor=",
-            200,
+    TestManager::new()
+        .mock_common_upload_endpoints(ServerBehavior::Legacy, Default::default())
+        .mock_endpoint(
+            MockEndpointBuilder::new(
+                "GET",
+                "/api/0/projects/wat-org/wat-project/releases/wat-release/files/?cursor=&checksum=38ed853073df85147960ea3a5bced6170ec389b0",
+                200,
+            )
+            .with_response_body("[]"),
         )
-        .with_response_body("[]"),
-    );
-
-    register_test("sourcemaps/sourcemaps-upload-successfully-upload-file.trycmd");
-    assert_endpoints(&upload_endpoints);
+        .register_trycmd_test("sourcemaps/sourcemaps-upload-successfully-upload-file.trycmd")
+        .with_default_token()
+        .assert_mock_endpoints();
 }
 
 #[test]
 fn command_sourcemaps_upload_skip_already_uploaded() {
-    let upload_endpoints = mock_common_upload_endpoints(ServerBehavior::Legacy, Default::default());
-    let _files = mock_endpoint(
-        MockEndpointBuilder::new(
-            "GET",
-            "/api/0/projects/wat-org/wat-project/releases/wat-release/files/?cursor=&checksum=38ed853073df85147960ea3a5bced6170ec389b0&checksum=f3673e2cea68bcb86bb74254a9efaa381d74929f",
-            200,
+    TestManager::new()
+        .mock_common_upload_endpoints(ServerBehavior::Legacy, Default::default())
+        .mock_endpoint(
+            MockEndpointBuilder::new(
+                "GET",
+                "/api/0/projects/wat-org/wat-project/releases/wat-release/files/?cursor=&checksum=38ed853073df85147960ea3a5bced6170ec389b0&checksum=f3673e2cea68bcb86bb74254a9efaa381d74929f",
+                200,
+            )
+            .with_response_body(
+                r#"[{
+                    "id": "1337",
+                    "name": "~/vendor.min.js.map",
+                    "headers": {},
+                    "size": 1522,
+                    "sha1": "f3673e2cea68bcb86bb74254a9efaa381d74929f",
+                    "dateCreated": "2022-05-12T11:08:01.496220Z"
+                }]"#,
+            ),
         )
-        .with_response_body(
-            r#"[{
-                "id": "1337",
-                "name": "~/vendor.min.js.map",
-                "headers": {},
-                "size": 1522,
-                "sha1": "f3673e2cea68bcb86bb74254a9efaa381d74929f",
-                "dateCreated": "2022-05-12T11:08:01.496220Z"
-            }]"#,
-        ),
-    );
-
-    register_test("sourcemaps/sourcemaps-upload-skip-already-uploaded.trycmd");
-    assert_endpoints(&upload_endpoints);
+        .register_trycmd_test("sourcemaps/sourcemaps-upload-skip-already-uploaded.trycmd")
+        .with_default_token()
+        .assert_mock_endpoints();
 }
 
 #[test]
 fn command_sourcemaps_upload_no_dedupe() {
-    let upload_endpoints = mock_common_upload_endpoints(ServerBehavior::Legacy, Default::default());
-    let _files = mock_endpoint(
-        MockEndpointBuilder::new(
-            "GET",
-            "/api/0/projects/wat-org/wat-project/releases/wat-release/files/?cursor=",
-            200,
-        )
-        .with_response_body(
-            r#"[{
-                "id": "1337",
-                "name": "~/vendor.min.js.map",
-                "headers": {},
-                "size": 1522,
-                "sha1": "f3673e2cea68bcb86bb74254a9efaa381d74929f",
-                "dateCreated": "2022-05-12T11:08:01.496220Z"
-            }]"#,
-        ),
-    );
-
-    register_test("sourcemaps/sourcemaps-upload-no-dedupe.trycmd");
-    assert_endpoints(&upload_endpoints);
+    TestManager::new()
+        .mock_common_upload_endpoints(ServerBehavior::Legacy, Default::default())
+        .register_trycmd_test("sourcemaps/sourcemaps-upload-no-dedupe.trycmd")
+        .with_default_token()
+        .assert_mock_endpoints();
 }
 
 #[test]
 fn command_sourcemaps_upload_modern() {
-    let upload_endpoints = mock_common_upload_endpoints(ServerBehavior::Modern, Default::default());
-    register_test("sourcemaps/sourcemaps-upload-modern.trycmd");
-    assert_endpoints(&upload_endpoints);
+    TestManager::new()
+        .mock_common_upload_endpoints(ServerBehavior::Modern, Default::default())
+        .register_trycmd_test("sourcemaps/sourcemaps-upload-modern.trycmd")
+        .with_default_token()
+        .assert_mock_endpoints();
 }
 
 #[test]
 fn command_sourcemaps_upload_modern_v2() {
-    let upload_endpoints = mock_common_upload_endpoints(
-        ServerBehavior::ModernV2,
-        ChunkOptions {
-            missing_chunks: vec!["ec8450a9db19805703a27a2545c18b7b27ba0d7d".to_string()],
-            // Set the chunk size so the bundle will be split into two chunks
-            chunk_size: 512,
-        },
-    );
-    register_test("sourcemaps/sourcemaps-upload-modern.trycmd");
-    assert_endpoints(&upload_endpoints);
+    TestManager::new()
+        .mock_common_upload_endpoints(
+            ServerBehavior::ModernV2,
+            ChunkOptions {
+                missing_chunks: vec!["ec8450a9db19805703a27a2545c18b7b27ba0d7d".to_string()],
+                // Set the chunk size so the bundle will be split into two chunks
+                chunk_size: 512,
+            },
+        )
+        .register_trycmd_test("sourcemaps/sourcemaps-upload-modern.trycmd")
+        .with_default_token()
+        .assert_mock_endpoints();
 }
 
 #[test]
 fn command_sourcemaps_upload_empty() {
-    let _upload_endpoints =
-        mock_common_upload_endpoints(ServerBehavior::Legacy, Default::default());
-    let _files = mock_endpoint(
-        MockEndpointBuilder::new(
-            "GET",
-            "/api/0/projects/wat-org/wat-project/releases/wat-release/files/?cursor=",
-            200,
+    TestManager::new()
+        .mock_common_upload_endpoints(ServerBehavior::Legacy, Default::default())
+        .mock_endpoint(
+            MockEndpointBuilder::new(
+                "GET",
+                "/api/0/projects/wat-org/wat-project/releases/wat-release/files/?cursor=",
+                200,
+            )
+            .with_response_body("[]"),
         )
-        .with_response_body("[]"),
-    );
-    register_test("releases/releases-files-upload-sourcemaps.trycmd");
+        .register_trycmd_test("releases/releases-files-upload-sourcemaps.trycmd")
+        .with_default_token();
 }
 
 #[test]
 fn command_sourcemaps_upload_some_debugids() {
-    let upload_endpoints = mock_common_upload_endpoints(ServerBehavior::Modern, Default::default());
-    register_test("sourcemaps/sourcemaps-upload-some-debugids.trycmd");
-    assert_endpoints(&upload_endpoints);
+    TestManager::new()
+        .mock_common_upload_endpoints(ServerBehavior::Modern, Default::default())
+        .register_trycmd_test("sourcemaps/sourcemaps-upload-some-debugids.trycmd")
+        .with_default_token()
+        .assert_mock_endpoints();
 }
 
 #[test]
 fn command_sourcemaps_upload_some_debugids_v2() {
-    let upload_endpoints = mock_common_upload_endpoints(
-        ServerBehavior::ModernV2,
-        ChunkOptions {
-            missing_chunks: vec!["ff16e0ac593a74b454cc34814f6249f45a1a2dfe".to_string()],
-            chunk_size: 524288,
-        },
-    );
-    register_test("sourcemaps/sourcemaps-upload-some-debugids.trycmd");
-    assert_endpoints(&upload_endpoints);
+    TestManager::new()
+        .mock_common_upload_endpoints(
+            ServerBehavior::ModernV2,
+            ChunkOptions {
+                missing_chunks: vec!["ff16e0ac593a74b454cc34814f6249f45a1a2dfe".to_string()],
+                chunk_size: 524288,
+            },
+        )
+        .register_trycmd_test("sourcemaps/sourcemaps-upload-some-debugids.trycmd")
+        .with_default_token()
+        .assert_mock_endpoints();
 }
 
 /// Tests that debug IDs can be found under the "debugId" field in sourcemaps.
 #[test]
 fn command_sourcemaps_upload_debugid_alias() {
-    let upload_endpoints = mock_common_upload_endpoints(ServerBehavior::Modern, Default::default());
-    register_test("sourcemaps/sourcemaps-upload-debugid-alias.trycmd");
-    assert_endpoints(&upload_endpoints);
+    TestManager::new()
+        .mock_common_upload_endpoints(ServerBehavior::Modern, Default::default())
+        .register_trycmd_test("sourcemaps/sourcemaps-upload-debugid-alias.trycmd")
+        .with_default_token()
+        .assert_mock_endpoints();
 }
 
 #[test]
 fn command_sourcemaps_upload_no_debugids() {
-    let _upload_endpoints =
-        mock_common_upload_endpoints(ServerBehavior::Modern, Default::default());
-    register_test("sourcemaps/sourcemaps-upload-no-debugids.trycmd");
+    TestManager::new()
+        .mock_common_upload_endpoints(ServerBehavior::Modern, Default::default())
+        .register_trycmd_test("sourcemaps/sourcemaps-upload-no-debugids.trycmd")
+        .with_default_token();
 }
 
 #[test]
 fn command_sourcemaps_upload_file_ram_bundle() {
-    let _upload_endpoints =
-        mock_common_upload_endpoints(ServerBehavior::Modern, Default::default());
-    register_test("sourcemaps/sourcemaps-upload-file-ram-bundle.trycmd");
+    TestManager::new()
+        .mock_common_upload_endpoints(ServerBehavior::Modern, Default::default())
+        .register_trycmd_test("sourcemaps/sourcemaps-upload-file-ram-bundle.trycmd")
+        .with_default_token();
 }
 
 #[test]
 fn command_sourcemaps_upload_indexed_ram_bundle() {
-    let _upload_endpoints =
-        mock_common_upload_endpoints(ServerBehavior::Modern, Default::default());
-    register_test("sourcemaps/sourcemaps-upload-indexed-ram-bundle.trycmd");
+    TestManager::new()
+        .mock_common_upload_endpoints(ServerBehavior::Modern, Default::default())
+        .register_trycmd_test("sourcemaps/sourcemaps-upload-indexed-ram-bundle.trycmd")
+        .with_default_token();
 }
 
 #[test]
 fn command_sourcemaps_upload_hermes_bundle_with_referencing_debug_id() {
-    let _upload_endpoints =
-        mock_common_upload_endpoints(ServerBehavior::Modern, Default::default());
-    register_test("sourcemaps/sourcemaps-upload-file-hermes-bundle-reference-debug-id.trycmd");
+    TestManager::new()
+        .mock_common_upload_endpoints(ServerBehavior::Modern, Default::default())
+        .register_trycmd_test(
+            "sourcemaps/sourcemaps-upload-file-hermes-bundle-reference-debug-id.trycmd",
+        )
+        .with_default_token();
 }
 
 #[test]
 fn command_sourcemaps_upload_cjs_mjs() {
-    let _upload_endpoints =
-        mock_common_upload_endpoints(ServerBehavior::Modern, Default::default());
-    register_test("sourcemaps/sourcemaps-upload-cjs-mjs.trycmd");
+    TestManager::new()
+        .mock_common_upload_endpoints(ServerBehavior::Modern, Default::default())
+        .register_trycmd_test("sourcemaps/sourcemaps-upload-cjs-mjs.trycmd")
+        .with_default_token();
 }
 
 #[test]
 fn command_sourcemaps_upload_complex_extension() {
-    let _upload_endpoints =
-        mock_common_upload_endpoints(ServerBehavior::Modern, Default::default());
-    register_test("sourcemaps/sourcemaps-upload-complex-extension.trycmd");
+    TestManager::new()
+        .mock_common_upload_endpoints(ServerBehavior::Modern, Default::default())
+        .register_trycmd_test("sourcemaps/sourcemaps-upload-complex-extension.trycmd")
+        .with_default_token();
 }

--- a/tests/integration/test_utils/mock_common_endpoints.rs
+++ b/tests/integration/test_utils/mock_common_endpoints.rs
@@ -1,19 +1,8 @@
-use mockito::Mock;
-
 use crate::integration::test_utils::MockEndpointBuilder;
-
-pub fn mock_common_upload_endpoints(
-    behavior: ServerBehavior,
-    chunk_options: ChunkOptions,
-) -> Vec<Mock> {
-    common_upload_endpoints(behavior, chunk_options)
-        .map(super::mock_endpoint)
-        .collect()
-}
 
 /// Returns an iterator over builders for the common upload endpoints.
 /// These can be used to generate mocks for the upload endpoints.
-fn common_upload_endpoints(
+pub(super) fn common_upload_endpoints(
     behavior: ServerBehavior,
     chunk_options: ChunkOptions,
 ) -> impl Iterator<Item = MockEndpointBuilder> {

--- a/tests/integration/test_utils/mock_endpoint_builder.rs
+++ b/tests/integration/test_utils/mock_endpoint_builder.rs
@@ -69,10 +69,9 @@ impl MockEndpointBuilder {
         self.mock = self.mock.expect(hits);
         self
     }
-}
 
-/// Build and return a mock endpoint with the provided configuration. The mock is automatically
-/// created and started. It is active until dropped.
-pub fn mock_endpoint(opts: MockEndpointBuilder) -> Mock {
-    opts.mock.create()
+    /// Create and return the mock endpoint.
+    pub(super) fn create(self) -> Mock {
+        self.mock.create()
+    }
 }

--- a/tests/integration/test_utils/mod.rs
+++ b/tests/integration/test_utils/mod.rs
@@ -3,6 +3,8 @@
 pub mod env;
 mod mock_common_endpoints;
 mod mock_endpoint_builder;
+mod test_manager;
 
-pub use mock_common_endpoints::{mock_common_upload_endpoints, ChunkOptions, ServerBehavior};
-pub use mock_endpoint_builder::{mock_endpoint, MockEndpointBuilder};
+pub use mock_common_endpoints::{ChunkOptions, ServerBehavior};
+pub use mock_endpoint_builder::MockEndpointBuilder;
+pub use test_manager::TestManager;

--- a/tests/integration/test_utils/test_manager.rs
+++ b/tests/integration/test_utils/test_manager.rs
@@ -1,0 +1,138 @@
+use std::fmt::Display;
+
+use mockito::Mock;
+use thiserror::Error;
+use trycmd::TestCases;
+
+use crate::integration::{env, MockEndpointBuilder, VERSION};
+
+use super::{mock_common_endpoints, ChunkOptions, ServerBehavior};
+
+#[derive(Error, Debug)]
+pub enum Error {
+    #[error("Failed to insert server variable")]
+    InsertServerVar(#[from] trycmd::Error),
+}
+
+pub type Result<T> = std::result::Result<T, Error>;
+
+/// Helper struct for managing integration tests.
+/// Allows for mocking endpoints and registering different types of tests.
+pub struct TestManager {
+    mocks: Vec<Mock>,
+}
+
+impl TestManager {
+    /// Create a new `TestManager`.
+    /// The test manager has no mocked endpoints by default.
+    pub fn new() -> Self {
+        Self { mocks: vec![] }
+    }
+
+    /// Create a mock endpoint on the mockito test server with the given options.
+    /// Returns the updated `TestManager` with the new mock endpoint.
+    pub fn mock_endpoint(mut self, opts: MockEndpointBuilder) -> Self {
+        self.mocks.push(opts.create());
+        self
+    }
+
+    /// Mock the common upload endpoints.
+    pub fn mock_common_upload_endpoints(
+        self,
+        behavior: ServerBehavior,
+        chunk_options: ChunkOptions,
+    ) -> Self {
+        mock_common_endpoints::common_upload_endpoints(behavior, chunk_options)
+            .fold(self, |manager, builder| manager.mock_endpoint(builder))
+    }
+
+    /// Assert that all mocks have been called the correct number of times.
+    ///
+    /// This method consumes the `TestManager`, thereby also stopping the mocks from being
+    /// served, since after asserting the mocks, they should not be needed anymore.
+    pub fn assert_mock_endpoints(self) {
+        for mock in self.mocks {
+            mock.assert();
+        }
+    }
+
+    /// Register a trycmd test.
+    /// The test is run when the returned `TrycmdTestManager` is dropped.
+    /// Further configuration can be done with the `TrycmdTestManager`.
+    pub fn register_trycmd_test(self, path: impl Display) -> TrycmdTestManager {
+        TrycmdTestManager::new(self, path)
+    }
+}
+
+/// Helper struct for managing trycmd tests.
+/// The tests are run when the `TrycmdTestManager` is dropped.
+pub struct TrycmdTestManager {
+    // The ordering of the fields is important here, since we need to
+    // ensure that `manager` is dropped AFTER `test_case`.
+    //
+    // This is because the mock server is only alive until `manager`
+    // is dropped, and the mock server is required for the test case
+    // to run.  Trycmd tests run when the `TestCases` are dropped, so
+    // we must ensure that `manager` is dropped after `test_case`.
+    //
+    // The Rust language specifies that fields are dropped in the order
+    // of their declaration (https://doc.rust-lang.org/reference/destructors.html).
+    //
+    // So, `test_case` MUST be declared BEFORE `manager`.
+    test_case: TestCases,
+    manager: TestManager,
+}
+
+impl TrycmdTestManager {
+    /// Set a custom environment variable for the test.
+    pub fn env(self, key: impl Into<String>, value: impl Into<String>) -> Self {
+        self.test_case.env(key, value);
+        self
+    }
+
+    /// Register an additional trycmd test case on this test manager.
+    /// The path is relative to `tests/integration/_cases/`.
+    pub fn register_trycmd_test(self, path: impl Display) -> Self {
+        self.test_case
+            .case(format!("tests/integration/_cases/{path}"));
+        self
+    }
+
+    /// Set the auth token environment variable to a fake value.
+    /// This may be needed when running a Sentry CLI command that checks that
+    /// an auth token is set. No token is set by default.
+    pub fn with_default_token(self) -> Self {
+        env::set_auth_token(|k, v| {
+            self.test_case.env(k, v);
+        });
+
+        self
+    }
+
+    /// Insert the server variable into the test case.
+    pub fn with_server_var(self) -> Result<Self> {
+        self.test_case
+            .insert_var("[SERVER]", mockito::server_url())?;
+        Ok(self)
+    }
+
+    /// Assert that all mocks have been called the correct number of times.
+    ///
+    /// This method also runs the trycmd tests, and consumes the manager.
+    pub fn assert_mock_endpoints(self) {
+        self.test_case.run();
+        self.manager.assert_mock_endpoints();
+    }
+
+    fn new(manager: TestManager, path: impl Display) -> Self {
+        let test_case = TestCases::new();
+
+        env::set(|k, v| {
+            test_case.env(k, v);
+        });
+
+        test_case.insert_var("[VERSION]", VERSION).unwrap();
+
+        Self { manager, test_case }.register_trycmd_test(path)
+    }
+}

--- a/tests/integration/token_validation.rs
+++ b/tests/integration/token_validation.rs
@@ -1,6 +1,6 @@
-use crate::integration::register_test;
+use crate::integration::TestManager;
 
 #[test]
 fn test_warn_invalid_auth_token() {
-    register_test("token_validation/*.trycmd");
+    TestManager::new().register_trycmd_test("token_validation/*.trycmd");
 }

--- a/tests/integration/uninstall.rs
+++ b/tests/integration/uninstall.rs
@@ -1,14 +1,14 @@
-use crate::integration::register_test;
+use crate::integration::TestManager;
 
 #[test]
 fn command_uninstall_help() {
-    register_test("uninstall/uninstall-help.trycmd");
+    TestManager::new().register_trycmd_test("uninstall/uninstall-help.trycmd");
 }
 
 #[test]
 fn command_uninstall() {
     #[cfg(not(windows))]
-    register_test("uninstall/uninstall.trycmd");
+    TestManager::new().register_trycmd_test("uninstall/uninstall.trycmd");
     #[cfg(windows)]
-    register_test("uninstall/uninstall-windows.trycmd");
+    TestManager::new().register_trycmd_test("uninstall/uninstall-windows.trycmd");
 }

--- a/tests/integration/update.rs
+++ b/tests/integration/update.rs
@@ -1,6 +1,6 @@
-use crate::integration::register_test;
+use crate::integration::TestManager;
 
 #[test]
 fn command_update() {
-    register_test("update/*.trycmd");
+    TestManager::new().register_trycmd_test("update/*.trycmd");
 }

--- a/tests/integration/upload_dif.rs
+++ b/tests/integration/upload_dif.rs
@@ -1,5 +1,5 @@
 #[cfg(not(windows))]
-use crate::integration::register_test;
+use crate::integration::TestManager;
 
 // I have no idea why this is timing out on Windows.
 // I verified it manually, and this command works just fine. — Kamil
@@ -7,5 +7,5 @@ use crate::integration::register_test;
 #[cfg(not(windows))]
 #[test]
 fn command_upload_dif_help() {
-    register_test("upload_dif/upload_dif-help.trycmd");
+    TestManager::new().register_trycmd_test("upload_dif/upload_dif-help.trycmd");
 }

--- a/tests/integration/upload_dsym.rs
+++ b/tests/integration/upload_dsym.rs
@@ -1,5 +1,5 @@
 #[cfg(not(windows))]
-use crate::integration::register_test;
+use crate::integration::TestManager;
 
 // I have no idea why this is timing out on Windows.
 // I verified it manually, and this command works just fine. — Kamil
@@ -7,5 +7,5 @@ use crate::integration::register_test;
 #[cfg(not(windows))]
 #[test]
 fn command_upload_dsym_help() {
-    register_test("upload_dsym/upload_dsym-help.trycmd");
+    TestManager::new().register_trycmd_test("upload_dsym/upload_dsym-help.trycmd");
 }

--- a/tests/integration/upload_proguard.rs
+++ b/tests/integration/upload_proguard.rs
@@ -1,21 +1,21 @@
-use crate::integration::{
-    mock_endpoint, register_test, register_test_without_token, MockEndpointBuilder,
-};
+use crate::integration::{MockEndpointBuilder, TestManager};
 
 #[test]
 fn command_upload_proguard() {
-    let _dsyms = mock_endpoint(
-        MockEndpointBuilder::new(
-            "POST",
-            "/api/0/projects/wat-org/wat-project/files/dsyms/",
-            200,
+    TestManager::new()
+        .mock_endpoint(
+            MockEndpointBuilder::new(
+                "POST",
+                "/api/0/projects/wat-org/wat-project/files/dsyms/",
+                200,
+            )
+            .with_response_body("[]"),
         )
-        .with_response_body("[]"),
-    );
-    register_test("upload_proguard/*.trycmd");
+        .register_trycmd_test("upload_proguard/*.trycmd")
+        .with_default_token();
 }
 
 #[test]
 fn command_upload_proguard_no_upload_no_auth_token() {
-    register_test_without_token("upload_proguard/upload_proguard-no-upload.trycmd");
+    TestManager::new().register_trycmd_test("upload_proguard/upload_proguard-no-upload.trycmd");
 }


### PR DESCRIPTION
Add `TestManager` to manage setting up Mocks and Trycmd tests. The `TestManager`'s API makes it easier to achieve uniform setup of our integration tests. This will also make bumping to new Mockito (see #2223) easier, since the new Mockito API will require manually setting up a mock server which needs to stay alive for the duration of the test. Having a TestManager will abstract away the management of this server, so the calling code does not need to worry about this.

All tests have been migrated to the new `TestManager` API with this change, as we are also removing the old API. For the most part, all tests should be verifying the same things as they were before this change. However, there are two intentional behavior changes to the tests with the new API:

  - In the old API, the default `register_test` function injected the `SENTRY_AUTH_TOKEN` environment variable. To run a test without an auth token, there was a separate `register_test_without_token` function which did not inject this environment variable. The new API's default `register_trycmd_test` function does not inject the `SENTRY_AUTH_TOKEN` environment variable. To get the environment variable, you need to call `with_default_token` method on the `TrycmdTestManager`. This change adds the `with_default_token` call only to those tests which would fail without the `SENTRY_AUTH_TOKEN` environment variable, meaning that several tests where the token was previously present no longer have it, since they apparently don't need the token.
  - In some of our tests (particularly sourcemap uploads), we used to assert only the mocks generated by `common_upload_endpoints`, even when other mocks were also present. Now, the `TestManager` exposes an `assert_mock_endpoints` function which asserts all the mock endpoints on the manager. This change required a change to some of the additional mocks. One mock's path was made more specific (since it was called with a more specific path), and another mock was deleted since it was never called.