### PR TITLE
ref(test): Change chunk upload options org

### DIFF
--- a/tests/integration/_responses/debug_files/get-chunk-upload.json
+++ b/tests/integration/_responses/debug_files/get-chunk-upload.json
@@ -1,20 +1,11 @@
 {
-  "url": "organizations/kamil-test/chunk-upload/",
+  "url": "organizations/wat-org/chunk-upload/",
   "chunkSize": 8388608,
   "chunksPerRequest": 64,
   "maxFileSize": 2147483648,
   "maxRequestSize": 33554432,
   "concurrency": 8,
   "hashAlgorithm": "sha1",
-  "compression": [
-    "gzip"
-  ],
-  "accept": [
-    "debug_files",
-    "release_files",
-    "pdbs",
-    "portablepdbs",
-    "sources",
-    "bcsymbolmaps"
-  ]
+  "compression": ["gzip"],
+  "accept": ["debug_files", "release_files", "pdbs", "portablepdbs", "sources", "bcsymbolmaps"]
 }


### PR DESCRIPTION
The mock response we use for the chunk upload options contains `kamil-test` as the org for the chunk uploading URL, when elsewhere in tests, we typically use the `wat-org` org. So, change the URL accordingly.