### PR TITLE
ref(test): Make mock builder status default to `200`

### DIFF
--- a/tests/integration/debug_files/upload.rs
+++ b/tests/integration/debug_files/upload.rs
@@ -6,14 +6,13 @@ use crate::integration::{test_utils::env, MockEndpointBuilder, TestManager};
 fn command_debug_files_upload() {
     TestManager::new()
         .mock_endpoint(
-            MockEndpointBuilder::new("GET", "/api/0/organizations/wat-org/chunk-upload/", 200)
+            MockEndpointBuilder::new("GET", "/api/0/organizations/wat-org/chunk-upload/")
                 .with_response_file("debug_files/get-chunk-upload.json"),
         )
         .mock_endpoint(
             MockEndpointBuilder::new(
                 "POST",
                 "/api/0/projects/wat-org/wat-project/files/difs/assemble/",
-                200,
             )
             .with_response_file("debug_files/post-difs-assemble.json"),
         )
@@ -25,14 +24,13 @@ fn command_debug_files_upload() {
 fn command_debug_files_upload_pdb() {
     TestManager::new()
         .mock_endpoint(
-            MockEndpointBuilder::new("GET", "/api/0/organizations/wat-org/chunk-upload/", 200)
+            MockEndpointBuilder::new("GET", "/api/0/organizations/wat-org/chunk-upload/")
                 .with_response_file("debug_files/get-chunk-upload.json"),
         )
         .mock_endpoint(
             MockEndpointBuilder::new(
                 "POST",
                 "/api/0/projects/wat-org/wat-project/files/difs/assemble/",
-                200,
             )
             .with_response_body(
                 r#"{
@@ -52,14 +50,13 @@ fn command_debug_files_upload_pdb() {
 fn command_debug_files_upload_pdb_embedded_sources() {
     TestManager::new()
         .mock_endpoint(
-            MockEndpointBuilder::new("GET", "/api/0/organizations/wat-org/chunk-upload/", 200)
+            MockEndpointBuilder::new("GET", "/api/0/organizations/wat-org/chunk-upload/")
                 .with_response_file("debug_files/get-chunk-upload.json"),
         )
         .mock_endpoint(
             MockEndpointBuilder::new(
                 "POST",
                 "/api/0/projects/wat-org/wat-project/files/difs/assemble/",
-                200,
             )
             .with_response_body(
                 r#"{
@@ -78,14 +75,13 @@ fn command_debug_files_upload_pdb_embedded_sources() {
 fn command_debug_files_upload_dll_embedded_ppdb_with_sources() {
     TestManager::new()
         .mock_endpoint(
-            MockEndpointBuilder::new("GET", "/api/0/organizations/wat-org/chunk-upload/", 200)
+            MockEndpointBuilder::new("GET", "/api/0/organizations/wat-org/chunk-upload/")
                 .with_response_file("debug_files/get-chunk-upload.json"),
         )
         .mock_endpoint(
             MockEndpointBuilder::new(
                 "POST",
                 "/api/0/projects/wat-org/wat-project/files/difs/assemble/",
-                200,
             )
             .with_response_body(
                 r#"{
@@ -106,14 +102,13 @@ fn command_debug_files_upload_dll_embedded_ppdb_with_sources() {
 fn command_debug_files_upload_mixed_embedded_sources() {
     TestManager::new()
         .mock_endpoint(
-            MockEndpointBuilder::new("GET", "/api/0/organizations/wat-org/chunk-upload/", 200)
+            MockEndpointBuilder::new("GET", "/api/0/organizations/wat-org/chunk-upload/")
                 .with_response_file("debug_files/get-chunk-upload.json"),
         )
         .mock_endpoint(
             MockEndpointBuilder::new(
                 "POST",
                 "/api/0/projects/wat-org/wat-project/files/difs/assemble/",
-                200,
             )
             .with_response_body(
                 r#"{
@@ -136,14 +131,13 @@ fn command_debug_files_upload_mixed_embedded_sources() {
 fn command_debug_files_upload_no_upload() {
     TestManager::new()
         .mock_endpoint(
-            MockEndpointBuilder::new("GET", "/api/0/organizations/wat-org/chunk-upload/", 200)
+            MockEndpointBuilder::new("GET", "/api/0/organizations/wat-org/chunk-upload/")
                 .with_response_file("debug_files/get-chunk-upload.json"),
         )
         .mock_endpoint(
             MockEndpointBuilder::new(
                 "POST",
                 "/api/0/projects/wat-org/wat-project/files/difs/assemble/",
-                200,
             )
             .with_response_file("debug_files/post-difs-assemble.json"),
         )
@@ -157,14 +151,13 @@ fn command_debug_files_upload_no_upload() {
 fn ensure_correct_assemble_call() {
     let manager = TestManager::new()
         .mock_endpoint(
-            MockEndpointBuilder::new("GET", "/api/0/organizations/wat-org/chunk-upload/", 200)
+            MockEndpointBuilder::new("GET", "/api/0/organizations/wat-org/chunk-upload/")
                 .with_response_file("debug_files/get-chunk-upload.json"),
         )
         .mock_endpoint(
             MockEndpointBuilder::new(
                 "POST",
                 "/api/0/projects/wat-org/wat-project/files/difs/assemble/",
-                200,
             )
             .with_header_matcher("content-type", "application/json".into())
             .with_response_body(

--- a/tests/integration/deploys/list.rs
+++ b/tests/integration/deploys/list.rs
@@ -7,7 +7,6 @@ fn command_deploys_list() {
             MockEndpointBuilder::new(
                 "GET",
                 "/api/0/organizations/wat-org/releases/wat-release/deploys/",
-                200,
             )
             .with_response_file("deploys/get-deploys.json"),
         )

--- a/tests/integration/deploys/new.rs
+++ b/tests/integration/deploys/new.rs
@@ -10,7 +10,6 @@ fn command_deploys_new() {
             MockEndpointBuilder::new(
                 "POST",
                 "/api/0/organizations/wat-org/releases/wat-release/deploys/",
-                200,
             )
             .with_response_file("deploys/post-deploys.json")
             .with_matcher(Matcher::PartialJson(json!({
@@ -29,7 +28,6 @@ fn command_releases_deploys_new() {
             MockEndpointBuilder::new(
                 "POST",
                 "/api/0/organizations/wat-org/releases/wat-release/deploys/",
-                200,
             )
             .with_response_file("deploys/post-deploys.json")
             .with_matcher(Matcher::PartialJson(json!({

--- a/tests/integration/events.rs
+++ b/tests/integration/events.rs
@@ -6,12 +6,8 @@ fn command_events() {
         // Mock server is used only for the events/events-list-empty.trycmd
         // test. No harm in leaving it here for other tests.
         .mock_endpoint(
-            MockEndpointBuilder::new(
-                "GET",
-                "/api/0/projects/wat-org/wat-project/events/?cursor=",
-                200,
-            )
-            .with_response_body("[]"),
+            MockEndpointBuilder::new("GET", "/api/0/projects/wat-org/wat-project/events/?cursor=")
+                .with_response_body("[]"),
         )
         .register_trycmd_test("events/*.trycmd")
         .with_default_token();

--- a/tests/integration/info.rs
+++ b/tests/integration/info.rs
@@ -28,8 +28,7 @@ fn command_info_no_token_backtrace() {
 fn command_info_basic() {
     TestManager::new()
         .mock_endpoint(
-            MockEndpointBuilder::new("GET", "/api/0/", 200)
-                .with_response_file("info/get-info.json"),
+            MockEndpointBuilder::new("GET", "/api/0/").with_response_file("info/get-info.json"),
         )
         .register_trycmd_test("info/info-basic.trycmd")
         .with_default_token()
@@ -41,8 +40,7 @@ fn command_info_basic() {
 fn command_info_no_defaults() {
     TestManager::new()
         .mock_endpoint(
-            MockEndpointBuilder::new("GET", "/api/0/", 200)
-                .with_response_file("info/get-info.json"),
+            MockEndpointBuilder::new("GET", "/api/0/").with_response_file("info/get-info.json"),
         )
         .register_trycmd_test("info/info-json.trycmd")
         .with_default_token()
@@ -54,8 +52,7 @@ fn command_info_no_defaults() {
 fn command_info_json() {
     TestManager::new()
         .mock_endpoint(
-            MockEndpointBuilder::new("GET", "/api/0/", 200)
-                .with_response_file("info/get-info.json"),
+            MockEndpointBuilder::new("GET", "/api/0/").with_response_file("info/get-info.json"),
         )
         .register_trycmd_test("info/info-basic.trycmd")
         .with_default_token()
@@ -67,8 +64,7 @@ fn command_info_json() {
 fn command_info_json_without_defaults() {
     TestManager::new()
         .mock_endpoint(
-            MockEndpointBuilder::new("GET", "/api/0/", 200)
-                .with_response_file("info/get-info.json"),
+            MockEndpointBuilder::new("GET", "/api/0/").with_response_file("info/get-info.json"),
         )
         .register_trycmd_test("info/info-json-no-defaults.trycmd")
         .env("SENTRY_ORG", "")

--- a/tests/integration/issues/list.rs
+++ b/tests/integration/issues/list.rs
@@ -12,7 +12,6 @@ fn doesnt_fail_with_empty_response() {
             MockEndpointBuilder::new(
                 "GET",
                 "/api/0/projects/wat-org/wat-project/issues/?query=&cursor=",
-                200,
             )
             .with_response_body("[]"),
         )
@@ -27,7 +26,6 @@ fn display_issues() {
             MockEndpointBuilder::new(
                 "GET",
                 "/api/0/projects/wat-org/wat-project/issues/?query=&cursor=",
-                200,
             )
             .with_response_file("issues/get-issues.json"),
         )
@@ -42,7 +40,6 @@ fn display_resolved_issues() {
             MockEndpointBuilder::new(
                 "GET",
                 "/api/0/projects/wat-org/wat-project/issues/?query=is:resolved&cursor=",
-                200,
             )
             .with_response_file("issues/get-resolved-issues.json"),
         )

--- a/tests/integration/monitors.rs
+++ b/tests/integration/monitors.rs
@@ -4,12 +4,12 @@ use crate::integration::{MockEndpointBuilder, TestManager};
 fn command_monitors() {
     let manager = TestManager::new()
         .mock_endpoint(
-            MockEndpointBuilder::new("GET", "/api/0/organizations/wat-org/monitors/?cursor=", 200)
+            MockEndpointBuilder::new("GET", "/api/0/organizations/wat-org/monitors/?cursor=")
                 .with_response_file("monitors/get-monitors.json"),
         )
-        .mock_endpoint(MockEndpointBuilder::new("POST", "/api/1337/envelope/", 200))
+        .mock_endpoint(MockEndpointBuilder::new("POST", "/api/1337/envelope/"))
         .mock_endpoint(
-            MockEndpointBuilder::new("POST", "/api/0/monitors/foo-monitor/checkins/", 200)
+            MockEndpointBuilder::new("POST", "/api/0/monitors/foo-monitor/checkins/")
                 .with_response_file("monitors/post-monitors.json"),
         )
         .register_trycmd_test("monitors/*.trycmd")
@@ -24,11 +24,8 @@ fn command_monitors() {
 
 #[test]
 fn command_monitors_run_server_error() {
-    let manager = TestManager::new().mock_endpoint(MockEndpointBuilder::new(
-        "POST",
-        "/api/1337/envelope/",
-        500,
-    ));
+    let manager = TestManager::new()
+        .mock_endpoint(MockEndpointBuilder::new("POST", "/api/1337/envelope/").with_status(500));
 
     #[cfg(not(windows))]
     manager.register_trycmd_test("monitors/server_error/monitors-run-server-error.trycmd");

--- a/tests/integration/organizations.rs
+++ b/tests/integration/organizations.rs
@@ -16,11 +16,11 @@ fn command_organizations() {
     manager
         // Mocks are for the organizations list command.
         .mock_endpoint(
-            MockEndpointBuilder::new("GET", "/api/0/organizations/?cursor=", 200)
+            MockEndpointBuilder::new("GET", "/api/0/organizations/?cursor=")
                 .with_response_file("organizations/get-organizations.json"),
         )
         .mock_endpoint(
-            MockEndpointBuilder::new("GET", "/api/0/users/me/regions/", 200)
+            MockEndpointBuilder::new("GET", "/api/0/users/me/regions/")
                 .with_response_body(region_response),
         )
         .register_trycmd_test("organizations/*.trycmd")

--- a/tests/integration/projects.rs
+++ b/tests/integration/projects.rs
@@ -5,7 +5,7 @@ fn command_projects_list() {
     TestManager::new()
         // mock for projects list
         .mock_endpoint(
-            MockEndpointBuilder::new("GET", "/api/0/organizations/wat-org/projects/?cursor=", 200)
+            MockEndpointBuilder::new("GET", "/api/0/organizations/wat-org/projects/?cursor=")
                 .with_response_file("projects/get-projects.json"),
         )
         .register_trycmd_test("projects/*.trycmd")

--- a/tests/integration/releases/delete.rs
+++ b/tests/integration/releases/delete.rs
@@ -3,11 +3,13 @@ use crate::integration::{MockEndpointBuilder, TestManager};
 #[test]
 fn successfully_deletes() {
     TestManager::new()
-        .mock_endpoint(MockEndpointBuilder::new(
-            "DELETE",
-            "/api/0/projects/wat-org/wat-project/releases/wat-release/",
-            204,
-        ))
+        .mock_endpoint(
+            MockEndpointBuilder::new(
+                "DELETE",
+                "/api/0/projects/wat-org/wat-project/releases/wat-release/",
+            )
+            .with_status(204),
+        )
         .register_trycmd_test("releases/releases-delete.trycmd")
         .with_default_token();
 }
@@ -15,11 +17,13 @@ fn successfully_deletes() {
 #[test]
 fn allows_for_release_to_start_with_hyphen() {
     TestManager::new()
-        .mock_endpoint(MockEndpointBuilder::new(
-            "DELETE",
-            "/api/0/projects/wat-org/wat-project/releases/-hyphenated-release/",
-            204,
-        ))
+        .mock_endpoint(
+            MockEndpointBuilder::new(
+                "DELETE",
+                "/api/0/projects/wat-org/wat-project/releases/-hyphenated-release/",
+            )
+            .with_status(204),
+        )
         .register_trycmd_test("releases/releases-delete-hyphen.trycmd")
         .with_default_token();
 }
@@ -27,11 +31,13 @@ fn allows_for_release_to_start_with_hyphen() {
 #[test]
 fn informs_about_nonexisting_releases() {
     TestManager::new()
-        .mock_endpoint(MockEndpointBuilder::new(
-            "DELETE",
-            "/api/0/projects/wat-org/wat-project/releases/whoops/",
-            404,
-        ))
+        .mock_endpoint(
+            MockEndpointBuilder::new(
+                "DELETE",
+                "/api/0/projects/wat-org/wat-project/releases/whoops/",
+            )
+            .with_status(404),
+        )
         .register_trycmd_test("releases/releases-delete-nonexisting.trycmd")
         .with_default_token();
 }
@@ -43,8 +49,8 @@ fn doesnt_allow_to_delete_active_releases() {
             MockEndpointBuilder::new(
                 "DELETE",
                 "/api/0/projects/wat-org/wat-project/releases/wat-release/",
-                400,
             )
+            .with_status(400)
             .with_response_file("releases/delete-active-release.json"),
         )
         .register_trycmd_test("releases/releases-delete-active.trycmd")

--- a/tests/integration/releases/finalize.rs
+++ b/tests/integration/releases/finalize.rs
@@ -9,7 +9,6 @@ fn successfully_creates_a_release() {
             MockEndpointBuilder::new(
                 "PUT",
                 "/api/0/projects/wat-org/wat-project/releases/wat-release/",
-                200,
             )
             .with_response_file("releases/get-release.json"),
         )
@@ -24,7 +23,6 @@ fn allows_for_release_to_start_with_hyphen() {
             MockEndpointBuilder::new(
                 "PUT",
                 "/api/0/projects/wat-org/wat-project/releases/-hyphenated-release/",
-                200,
             )
             .with_response_file("releases/get-release.json"),
         )
@@ -39,7 +37,6 @@ fn release_with_custom_dates() {
             MockEndpointBuilder::new(
                 "PUT",
                 "/api/0/projects/wat-org/wat-project/releases/wat-release/",
-                200,
             )
             .with_response_file("releases/get-release.json")
             .with_matcher(Matcher::PartialJson(json!({

--- a/tests/integration/releases/info.rs
+++ b/tests/integration/releases/info.rs
@@ -7,7 +7,6 @@ fn shows_release_details() {
             MockEndpointBuilder::new(
                 "GET",
                 "/api/0/projects/wat-org/wat-project/releases/wat-release/",
-                200,
             )
             .with_response_file("releases/get-release.json"),
         )
@@ -22,7 +21,6 @@ fn shows_release_details_with_projects_and_commits() {
             MockEndpointBuilder::new(
                 "GET",
                 "/api/0/projects/wat-org/wat-project/releases/wat-release/",
-                200,
             )
             .with_response_file("releases/get-release.json"),
         )
@@ -30,7 +28,6 @@ fn shows_release_details_with_projects_and_commits() {
             MockEndpointBuilder::new(
                 "GET",
                 "/api/0/projects/wat-org/wat-project/releases/wat-release/commits/",
-                200,
             )
             .with_response_file("releases/get-release-commits.json"),
         )
@@ -45,7 +42,6 @@ fn doesnt_print_output_with_quiet_flag() {
             MockEndpointBuilder::new(
                 "GET",
                 "/api/0/projects/wat-org/wat-project/releases/wat-release/",
-                200,
             )
             .with_response_file("releases/get-release.json"),
         )
@@ -60,7 +56,6 @@ fn doesnt_print_output_with_silent_flag() {
             MockEndpointBuilder::new(
                 "GET",
                 "/api/0/projects/wat-org/wat-project/releases/wat-release/",
-                200,
             )
             .with_response_file("releases/get-release.json"),
         )
@@ -71,11 +66,13 @@ fn doesnt_print_output_with_silent_flag() {
 #[test]
 fn preserve_valid_exit_code_with_quiet_flag() {
     TestManager::new()
-        .mock_endpoint(MockEndpointBuilder::new(
-            "GET",
-            "/api/0/projects/wat-org/wat-project/releases/unknown-release/",
-            404,
-        ))
+        .mock_endpoint(
+            MockEndpointBuilder::new(
+                "GET",
+                "/api/0/projects/wat-org/wat-project/releases/unknown-release/",
+            )
+            .with_status(404),
+        )
         .register_trycmd_test("releases/releases-info-quiet-failed.trycmd")
         .with_default_token();
 }
@@ -83,11 +80,13 @@ fn preserve_valid_exit_code_with_quiet_flag() {
 #[test]
 fn exits_if_no_release_found() {
     TestManager::new()
-        .mock_endpoint(MockEndpointBuilder::new(
-            "GET",
-            "/api/0/projects/wat-org/wat-project/releases/wat-release/",
-            404,
-        ))
+        .mock_endpoint(
+            MockEndpointBuilder::new(
+                "GET",
+                "/api/0/projects/wat-org/wat-project/releases/wat-release/",
+            )
+            .with_status(404),
+        )
         .register_trycmd_test("releases/releases-info-not-found.trycmd")
         .with_default_token();
 }

--- a/tests/integration/releases/list.rs
+++ b/tests/integration/releases/list.rs
@@ -4,7 +4,7 @@ use crate::integration::{MockEndpointBuilder, TestManager};
 fn displays_releases() {
     TestManager::new()
         .mock_endpoint(
-            MockEndpointBuilder::new("GET", "/api/0/projects/wat-org/wat-project/releases/", 200)
+            MockEndpointBuilder::new("GET", "/api/0/projects/wat-org/wat-project/releases/")
                 .with_response_file("releases/get-releases.json"),
         )
         .register_trycmd_test("releases/releases-list.trycmd")
@@ -15,7 +15,7 @@ fn displays_releases() {
 fn displays_releases_with_projects() {
     TestManager::new()
         .mock_endpoint(
-            MockEndpointBuilder::new("GET", "/api/0/projects/wat-org/wat-project/releases/", 200)
+            MockEndpointBuilder::new("GET", "/api/0/projects/wat-org/wat-project/releases/")
                 .with_response_file("releases/get-releases.json"),
         )
         .register_trycmd_test("releases/releases-list-with-projects.trycmd")
@@ -26,7 +26,7 @@ fn displays_releases_with_projects() {
 fn doesnt_fail_with_empty_response() {
     TestManager::new()
         .mock_endpoint(
-            MockEndpointBuilder::new("GET", "/api/0/projects/wat-org/wat-project/releases/", 200)
+            MockEndpointBuilder::new("GET", "/api/0/projects/wat-org/wat-project/releases/")
                 .with_response_body("[]"),
         )
         .register_trycmd_test("releases/releases-list-empty.trycmd")
@@ -37,7 +37,7 @@ fn doesnt_fail_with_empty_response() {
 fn can_override_org() {
     TestManager::new()
         .mock_endpoint(
-            MockEndpointBuilder::new("GET", "/api/0/projects/whynot/wat-project/releases/", 200)
+            MockEndpointBuilder::new("GET", "/api/0/projects/whynot/wat-project/releases/")
                 .with_response_file("releases/get-releases.json"),
         )
         .register_trycmd_test("releases/releases-list-override-org.trycmd")
@@ -48,7 +48,7 @@ fn can_override_org() {
 fn displays_releases_in_raw_mode() {
     TestManager::new()
         .mock_endpoint(
-            MockEndpointBuilder::new("GET", "/api/0/projects/wat-org/wat-project/releases/", 200)
+            MockEndpointBuilder::new("GET", "/api/0/projects/wat-org/wat-project/releases/")
                 .with_response_file("releases/get-releases.json"),
         )
         .register_trycmd_test("releases/releases-list-raw.trycmd")
@@ -59,7 +59,7 @@ fn displays_releases_in_raw_mode() {
 fn displays_releases_in_raw_mode_with_delimiter() {
     TestManager::new()
         .mock_endpoint(
-            MockEndpointBuilder::new("GET", "/api/0/projects/wat-org/wat-project/releases/", 200)
+            MockEndpointBuilder::new("GET", "/api/0/projects/wat-org/wat-project/releases/")
                 .with_response_file("releases/get-releases.json"),
         )
         .register_trycmd_test("releases/releases-list-raw-delimiter.trycmd")

--- a/tests/integration/releases/new.rs
+++ b/tests/integration/releases/new.rs
@@ -12,7 +12,8 @@ fn command_releases_new_help() {
 fn creates_release() {
     TestManager::new()
         .mock_endpoint(
-            MockEndpointBuilder::new("POST", "/api/0/projects/wat-org/wat-project/releases/", 201)
+            MockEndpointBuilder::new("POST", "/api/0/projects/wat-org/wat-project/releases/")
+                .with_status(201)
                 .with_response_file("releases/get-release.json")
                 .with_matcher(Matcher::PartialJson(json!({
                     "version": "new-release",
@@ -27,7 +28,8 @@ fn creates_release() {
 fn allows_for_release_to_start_with_hyphen() {
     TestManager::new()
         .mock_endpoint(
-            MockEndpointBuilder::new("POST", "/api/0/projects/wat-org/wat-project/releases/", 201)
+            MockEndpointBuilder::new("POST", "/api/0/projects/wat-org/wat-project/releases/")
+                .with_status(201)
                 .with_response_file("releases/get-release.json")
                 .with_matcher(Matcher::PartialJson(json!({
                     "version": "-hyphenated-release",
@@ -42,7 +44,8 @@ fn allows_for_release_to_start_with_hyphen() {
 fn creates_release_with_project() {
     TestManager::new()
         .mock_endpoint(
-            MockEndpointBuilder::new("POST", "/api/0/projects/wat-org/wat-project/releases/", 201)
+            MockEndpointBuilder::new("POST", "/api/0/projects/wat-org/wat-project/releases/")
+                .with_status(201)
                 .with_response_file("releases/get-release.json")
                 .with_matcher(Matcher::PartialJson(json!({
                     "version": "new-release",
@@ -57,7 +60,8 @@ fn creates_release_with_project() {
 fn allows_for_release_with_project_to_start_with_hyphen() {
     TestManager::new()
         .mock_endpoint(
-            MockEndpointBuilder::new("POST", "/api/0/projects/wat-org/wat-project/releases/", 201)
+            MockEndpointBuilder::new("POST", "/api/0/projects/wat-org/wat-project/releases/")
+                .with_status(201)
                 .with_response_file("releases/get-release.json")
                 .with_matcher(Matcher::PartialJson(json!({
                     "version": "-hyphenated-release",
@@ -72,7 +76,8 @@ fn allows_for_release_with_project_to_start_with_hyphen() {
 fn creates_release_even_if_one_already_exists() {
     TestManager::new()
         .mock_endpoint(
-            MockEndpointBuilder::new("POST", "/api/0/projects/wat-org/wat-project/releases/", 208)
+            MockEndpointBuilder::new("POST", "/api/0/projects/wat-org/wat-project/releases/")
+                .with_status(208)
                 .with_response_file("releases/get-release.json")
                 .with_matcher(Matcher::PartialJson(json!({
                     "version": "wat-release",
@@ -87,7 +92,8 @@ fn creates_release_even_if_one_already_exists() {
 fn creates_release_with_custom_url() {
     TestManager::new()
         .mock_endpoint(
-            MockEndpointBuilder::new("POST", "/api/0/projects/wat-org/wat-project/releases/", 208)
+            MockEndpointBuilder::new("POST", "/api/0/projects/wat-org/wat-project/releases/")
+                .with_status(208)
                 .with_response_file("releases/get-release.json")
                 .with_matcher(Matcher::PartialJson(json!({
                     "version": "wat-release",
@@ -103,7 +109,8 @@ fn creates_release_with_custom_url() {
 fn creates_release_which_is_instantly_finalized() {
     TestManager::new()
         .mock_endpoint(
-            MockEndpointBuilder::new("POST", "/api/0/projects/wat-org/wat-project/releases/", 208)
+            MockEndpointBuilder::new("POST", "/api/0/projects/wat-org/wat-project/releases/")
+                .with_status(208)
                 .with_response_file("releases/get-release.json")
                 .with_matcher(Matcher::AllOf(vec![
                     Matcher::PartialJson(json!({

--- a/tests/integration/send_envelope.rs
+++ b/tests/integration/send_envelope.rs
@@ -3,6 +3,6 @@ use crate::integration::{MockEndpointBuilder, TestManager};
 #[test]
 fn command_send_envelope() {
     TestManager::new()
-        .mock_endpoint(MockEndpointBuilder::new("POST", "/api/1337/envelope/", 200))
+        .mock_endpoint(MockEndpointBuilder::new("POST", "/api/1337/envelope/"))
         .register_trycmd_test("send_envelope/*.trycmd");
 }

--- a/tests/integration/send_event.rs
+++ b/tests/integration/send_event.rs
@@ -7,13 +7,13 @@ use crate::integration::{MockEndpointBuilder, TestManager};
 #[test]
 fn command_send_event_not_windows() {
     TestManager::new()
-        .mock_endpoint(MockEndpointBuilder::new("POST", "/api/1337/envelope/", 200))
+        .mock_endpoint(MockEndpointBuilder::new("POST", "/api/1337/envelope/"))
         .register_trycmd_test("send_event/not_windows/*.trycmd");
 }
 
 #[test]
 fn command_send_event() {
     TestManager::new()
-        .mock_endpoint(MockEndpointBuilder::new("POST", "/api/1337/envelope/", 200))
+        .mock_endpoint(MockEndpointBuilder::new("POST", "/api/1337/envelope/"))
         .register_trycmd_test("send_event/*.trycmd");
 }

--- a/tests/integration/send_metric.rs
+++ b/tests/integration/send_metric.rs
@@ -9,7 +9,7 @@ fn envelopes_endpoint_builder() -> MockEndpointBuilder {
             .to_string(),
     );
 
-    MockEndpointBuilder::new("POST", "/api/1337/envelope/", 200)
+    MockEndpointBuilder::new("POST", "/api/1337/envelope/")
         .with_header_matcher("X-Sentry-Auth", expected_auth_header)
 }
 
@@ -41,7 +41,7 @@ fn command_send_metric_increment_no_dsn() {
 #[test]
 fn command_send_metric_increment_unsuccessful_api_call() {
     TestManager::new()
-        .mock_endpoint(MockEndpointBuilder::new("POST", "/api/1337/envelope/", 500))
+        .mock_endpoint(MockEndpointBuilder::new("POST", "/api/1337/envelope/").with_status(500))
         .register_trycmd_test(
             "send_metric/individual_config/send_metric-increment-unsuccessful-api-call.trycmd",
         );

--- a/tests/integration/sourcemaps/explain.rs
+++ b/tests/integration/sourcemaps/explain.rs
@@ -13,11 +13,13 @@ fn command_sourcemaps_explain() {
 #[test]
 fn command_sourcemaps_explain_missing_event() {
     TestManager::new()
-        .mock_endpoint(MockEndpointBuilder::new(
-            "GET",
-            "/api/0/projects/wat-org/wat-project/events/43a57a55cd5a4207ac520c03e1dee1b4/json/",
-            404,
-        ))
+        .mock_endpoint(
+            MockEndpointBuilder::new(
+                "GET",
+                "/api/0/projects/wat-org/wat-project/events/43a57a55cd5a4207ac520c03e1dee1b4/json/",
+            )
+            .with_status(404),
+        )
         .register_trycmd_test("sourcemaps/sourcemaps-explain-missing-event.trycmd")
         .with_default_token();
 }
@@ -29,7 +31,6 @@ fn command_sourcemaps_explain_missing_release() {
             MockEndpointBuilder::new(
                 "GET",
                 "/api/0/projects/wat-org/wat-project/events/43a57a55cd5a4207ac520c03e1dee1b4/json/",
-                200,
             )
             .with_response_file("sourcemaps/get-event-missing-release.json"),
         )
@@ -44,7 +45,6 @@ fn command_sourcemaps_explain_missing_exception() {
             MockEndpointBuilder::new(
                 "GET",
                 "/api/0/projects/wat-org/wat-project/events/43a57a55cd5a4207ac520c03e1dee1b4/json/",
-                200,
             )
             .with_response_file("sourcemaps/get-event-missing-exception.json"),
         )
@@ -59,7 +59,6 @@ fn command_sourcemaps_explain_missing_stacktrace() {
             MockEndpointBuilder::new(
                 "GET",
                 "/api/0/projects/wat-org/wat-project/events/43a57a55cd5a4207ac520c03e1dee1b4/json/",
-                200,
             )
             .with_response_file("sourcemaps/get-event-missing-stacktrace.json"),
         )
@@ -74,7 +73,6 @@ fn command_sourcemaps_explain_frame_no_inapp() {
             MockEndpointBuilder::new(
                 "GET",
                 "/api/0/projects/wat-org/wat-project/events/43a57a55cd5a4207ac520c03e1dee1b4/json/",
-                200,
             )
             .with_response_file("sourcemaps/get-event-frame-no-inapp.json"),
         )
@@ -89,7 +87,6 @@ fn command_sourcemaps_explain_frame_no_abspath() {
             MockEndpointBuilder::new(
                 "GET",
                 "/api/0/projects/wat-org/wat-project/events/43a57a55cd5a4207ac520c03e1dee1b4/json/",
-                200,
             )
             .with_response_file("sourcemaps/get-event-frame-no-abspath.json"),
         )
@@ -104,7 +101,6 @@ fn command_sourcemaps_explain_frame_no_extension() {
             MockEndpointBuilder::new(
                 "GET",
                 "/api/0/projects/wat-org/wat-project/events/43a57a55cd5a4207ac520c03e1dee1b4/json/",
-                200,
             )
             .with_response_file("sourcemaps/get-event-frame-no-extension.json"),
         )
@@ -119,7 +115,6 @@ fn command_sourcemaps_explain_frame_malformed_abspath() {
             MockEndpointBuilder::new(
                 "GET",
                 "/api/0/projects/wat-org/wat-project/events/43a57a55cd5a4207ac520c03e1dee1b4/json/",
-                200,
             )
             .with_response_file("sourcemaps/get-event-frame-malformed-abspath.json"),
         )
@@ -134,7 +129,6 @@ fn command_sourcemaps_explain_already_mapped() {
             MockEndpointBuilder::new(
                 "GET",
                 "/api/0/projects/wat-org/wat-project/events/43a57a55cd5a4207ac520c03e1dee1b4/json/",
-                200,
             )
             .with_response_file("sourcemaps/get-event-already-mapped.json"),
         )
@@ -149,7 +143,6 @@ fn command_sourcemaps_explain_no_artifacts() {
             MockEndpointBuilder::new(
                 "GET",
                 "/api/0/projects/wat-org/wat-project/events/43a57a55cd5a4207ac520c03e1dee1b4/json/",
-                200,
             )
             .with_response_file("sourcemaps/get-event.json"),
         )
@@ -157,7 +150,6 @@ fn command_sourcemaps_explain_no_artifacts() {
             MockEndpointBuilder::new(
                 "GET",
                 "/api/0/projects/wat-org/wat-project/releases/ytho-test/files/?cursor=",
-                200,
             )
             .with_response_file("sourcemaps/get-artifacts-empty.json"),
         )
@@ -172,7 +164,6 @@ fn command_sourcemaps_explain_no_matching_artifact() {
             MockEndpointBuilder::new(
                 "GET",
                 "/api/0/projects/wat-org/wat-project/events/43a57a55cd5a4207ac520c03e1dee1b4/json/",
-                200,
             )
             .with_response_file("sourcemaps/get-event.json"),
         )
@@ -180,7 +171,6 @@ fn command_sourcemaps_explain_no_matching_artifact() {
             MockEndpointBuilder::new(
                 "GET",
                 "/api/0/projects/wat-org/wat-project/releases/ytho-test/files/?cursor=",
-                200,
             )
             .with_response_file("sourcemaps/get-artifacts-no-match.json"),
         )
@@ -195,7 +185,6 @@ fn command_sourcemaps_explain_partial_matching_artifact() {
             MockEndpointBuilder::new(
                 "GET",
                 "/api/0/projects/wat-org/wat-project/events/43a57a55cd5a4207ac520c03e1dee1b4/json/",
-                200,
             )
             .with_response_file("sourcemaps/get-event.json"),
         )
@@ -203,7 +192,6 @@ fn command_sourcemaps_explain_partial_matching_artifact() {
             MockEndpointBuilder::new(
                 "GET",
                 "/api/0/projects/wat-org/wat-project/releases/ytho-test/files/?cursor=",
-                200,
             )
             .with_response_file("sourcemaps/get-artifacts-partial-match.json"),
         )
@@ -218,7 +206,6 @@ fn command_sourcemaps_explain_artifact_dist_mismatch() {
             MockEndpointBuilder::new(
                 "GET",
                 "/api/0/projects/wat-org/wat-project/events/43a57a55cd5a4207ac520c03e1dee1b4/json/",
-                200,
             )
             .with_response_file("sourcemaps/get-event.json"),
         )
@@ -226,7 +213,6 @@ fn command_sourcemaps_explain_artifact_dist_mismatch() {
             MockEndpointBuilder::new(
                 "GET",
                 "/api/0/projects/wat-org/wat-project/releases/ytho-test/files/?cursor=",
-                200,
             )
             .with_response_file("sourcemaps/get-artifacts.json"),
         )
@@ -241,7 +227,6 @@ fn command_sourcemaps_explain_artifact_no_dist() {
             MockEndpointBuilder::new(
                 "GET",
                 "/api/0/projects/wat-org/wat-project/events/43a57a55cd5a4207ac520c03e1dee1b4/json/",
-                200,
             )
             .with_response_file("sourcemaps/get-event.json"),
         )
@@ -249,7 +234,6 @@ fn command_sourcemaps_explain_artifact_no_dist() {
             MockEndpointBuilder::new(
                 "GET",
                 "/api/0/projects/wat-org/wat-project/releases/ytho-test/files/?cursor=",
-                200,
             )
             .with_response_file("sourcemaps/get-artifacts-no-dist.json"),
         )
@@ -264,7 +248,6 @@ fn command_sourcemaps_explain_event_no_dist() {
             MockEndpointBuilder::new(
                 "GET",
                 "/api/0/projects/wat-org/wat-project/events/43a57a55cd5a4207ac520c03e1dee1b4/json/",
-                200,
             )
             .with_response_file("sourcemaps/get-event-missing-dist.json"),
         )
@@ -272,7 +255,6 @@ fn command_sourcemaps_explain_event_no_dist() {
             MockEndpointBuilder::new(
                 "GET",
                 "/api/0/projects/wat-org/wat-project/releases/ytho-test/files/?cursor=",
-                200,
             )
             .with_response_file("sourcemaps/get-artifacts.json"),
         )
@@ -287,7 +269,6 @@ fn command_sourcemaps_explain_detect_from_sourcemap_header() {
             MockEndpointBuilder::new(
                 "GET",
                 "/api/0/projects/wat-org/wat-project/events/43a57a55cd5a4207ac520c03e1dee1b4/json/",
-                200,
             )
             .with_response_file("sourcemaps/get-event-missing-dist.json"),
         )
@@ -295,7 +276,6 @@ fn command_sourcemaps_explain_detect_from_sourcemap_header() {
             MockEndpointBuilder::new(
                 "GET",
                 "/api/0/projects/wat-org/wat-project/releases/ytho-test/files/?cursor=",
-                200,
             )
             .with_response_file("sourcemaps/get-artifacts-no-sourcemap.json"),
         )
@@ -303,7 +283,6 @@ fn command_sourcemaps_explain_detect_from_sourcemap_header() {
             MockEndpointBuilder::new(
                 "GET",
                 "/api/0/projects/wat-org/wat-project/releases/ytho-test/files/6796495645/",
-                200,
             )
             .with_response_file("sourcemaps/get-file-metadata-sourcemap-header.json"),
         )
@@ -318,7 +297,6 @@ fn command_sourcemaps_explain_detect_from_xsourcemap_header() {
             MockEndpointBuilder::new(
                 "GET",
                 "/api/0/projects/wat-org/wat-project/events/43a57a55cd5a4207ac520c03e1dee1b4/json/",
-                200,
             )
             .with_response_file("sourcemaps/get-event-missing-dist.json"),
         )
@@ -326,7 +304,6 @@ fn command_sourcemaps_explain_detect_from_xsourcemap_header() {
             MockEndpointBuilder::new(
                 "GET",
                 "/api/0/projects/wat-org/wat-project/releases/ytho-test/files/?cursor=",
-                200,
             )
             .with_response_file("sourcemaps/get-artifacts-no-sourcemap.json"),
         )
@@ -334,7 +311,6 @@ fn command_sourcemaps_explain_detect_from_xsourcemap_header() {
             MockEndpointBuilder::new(
                 "GET",
                 "/api/0/projects/wat-org/wat-project/releases/ytho-test/files/6796495645/",
-                200,
             )
             .with_response_file("sourcemaps/get-file-metadata-xsourcemap-header.json"),
         )
@@ -349,7 +325,6 @@ fn command_sourcemaps_explain_detect_from_file_content() {
             MockEndpointBuilder::new(
                 "GET",
                 "/api/0/projects/wat-org/wat-project/events/43a57a55cd5a4207ac520c03e1dee1b4/json/",
-                200,
             )
             .with_response_file("sourcemaps/get-event-missing-dist.json"),
         )
@@ -357,7 +332,6 @@ fn command_sourcemaps_explain_detect_from_file_content() {
             MockEndpointBuilder::new(
                 "GET",
                 "/api/0/projects/wat-org/wat-project/releases/ytho-test/files/?cursor=",
-                200,
             )
             .with_response_file("sourcemaps/get-artifacts-no-sourcemap.json"),
         )
@@ -365,7 +339,6 @@ fn command_sourcemaps_explain_detect_from_file_content() {
             MockEndpointBuilder::new(
                 "GET",
                 "/api/0/projects/wat-org/wat-project/releases/ytho-test/files/6796495645/",
-                200,
             )
             .with_response_file("sourcemaps/get-file-metadata-no-headers.json"),
         )
@@ -373,7 +346,6 @@ fn command_sourcemaps_explain_detect_from_file_content() {
             MockEndpointBuilder::new(
                 "GET",
                 "/api/0/projects/wat-org/wat-project/releases/ytho-test/files/6796495645/?download=1",
-                200,
             )
             .with_response_file("sourcemaps/get-file.js"),
         )
@@ -388,7 +360,6 @@ fn command_sourcemaps_explain_print_sourcemap() {
             MockEndpointBuilder::new(
                 "GET",
                 "/api/0/projects/wat-org/wat-project/events/43a57a55cd5a4207ac520c03e1dee1b4/json/",
-                200,
             )
             .with_response_file("sourcemaps/get-event-missing-dist.json"),
         )
@@ -396,7 +367,6 @@ fn command_sourcemaps_explain_print_sourcemap() {
             MockEndpointBuilder::new(
                 "GET",
                 "/api/0/projects/wat-org/wat-project/releases/ytho-test/files/?cursor=",
-                200,
             )
             .with_response_file("sourcemaps/get-artifacts-no-dist.json"),
         )
@@ -404,7 +374,6 @@ fn command_sourcemaps_explain_print_sourcemap() {
             MockEndpointBuilder::new(
                 "GET",
                 "/api/0/projects/wat-org/wat-project/releases/ytho-test/files/6796495645/",
-                200,
             )
             .with_response_file("sourcemaps/get-file-metadata-sourcemap-header.json"),
         )
@@ -412,7 +381,6 @@ fn command_sourcemaps_explain_print_sourcemap() {
             MockEndpointBuilder::new(
                 "GET",
                 "/api/0/projects/wat-org/wat-project/releases/ytho-test/files/6796495646/?download=1",
-                200,
             )
             .with_response_file("sourcemaps/get-file-sourcemap.js.map"),
         )
@@ -427,7 +395,6 @@ fn command_sourcemaps_explain_select_frame() {
             MockEndpointBuilder::new(
                 "GET",
                 "/api/0/projects/wat-org/wat-project/events/43a57a55cd5a4207ac520c03e1dee1b4/json/",
-                200,
             )
             .with_response_file("sourcemaps/get-event-select-frame.json"),
         )
@@ -442,7 +409,6 @@ fn command_sourcemaps_explain_select_frame_out_of_range() {
             MockEndpointBuilder::new(
                 "GET",
                 "/api/0/projects/wat-org/wat-project/events/43a57a55cd5a4207ac520c03e1dee1b4/json/",
-                200,
             )
             .with_response_file("sourcemaps/get-event-select-frame.json"),
         )

--- a/tests/integration/sourcemaps/upload.rs
+++ b/tests/integration/sourcemaps/upload.rs
@@ -18,7 +18,6 @@ fn command_sourcemaps_upload_successfully_upload_file() {
             MockEndpointBuilder::new(
                 "GET",
                 "/api/0/projects/wat-org/wat-project/releases/wat-release/files/?cursor=&checksum=38ed853073df85147960ea3a5bced6170ec389b0",
-                200,
             )
             .with_response_body("[]"),
         )
@@ -35,7 +34,6 @@ fn command_sourcemaps_upload_skip_already_uploaded() {
             MockEndpointBuilder::new(
                 "GET",
                 "/api/0/projects/wat-org/wat-project/releases/wat-release/files/?cursor=&checksum=38ed853073df85147960ea3a5bced6170ec389b0&checksum=f3673e2cea68bcb86bb74254a9efaa381d74929f",
-                200,
             )
             .with_response_body(
                 r#"[{
@@ -95,7 +93,6 @@ fn command_sourcemaps_upload_empty() {
             MockEndpointBuilder::new(
                 "GET",
                 "/api/0/projects/wat-org/wat-project/releases/wat-release/files/?cursor=",
-                200,
             )
             .with_response_body("[]"),
         )

--- a/tests/integration/test_utils/mock_common_endpoints.rs
+++ b/tests/integration/test_utils/mock_common_endpoints.rs
@@ -44,14 +44,15 @@ pub(super) fn common_upload_endpoints(
     );
 
     vec![
-        MockEndpointBuilder::new("POST", "/api/0/projects/wat-org/wat-project/releases/", 208)
+        MockEndpointBuilder::new("POST", "/api/0/projects/wat-org/wat-project/releases/")
+            .with_status(208)
             .with_response_file("releases/get-release.json")
             .expect(release_request_count),
-        MockEndpointBuilder::new("GET", "/api/0/organizations/wat-org/chunk-upload/", 200)
+        MockEndpointBuilder::new("GET", "/api/0/organizations/wat-org/chunk-upload/")
             .with_response_body(chunk_upload_response),
-        MockEndpointBuilder::new("POST", "/api/0/organizations/wat-org/chunk-upload/", 200)
+        MockEndpointBuilder::new("POST", "/api/0/organizations/wat-org/chunk-upload/")
             .with_response_body("[]"),
-        MockEndpointBuilder::new("POST", assemble_endpoint, 200)
+        MockEndpointBuilder::new("POST", assemble_endpoint)
             .with_response_body(format!(
                 r#"{{"state":"created","missingChunks":{}}}"#,
                 serde_json::to_string(&missing_chunks).unwrap()

--- a/tests/integration/test_utils/mock_endpoint_builder.rs
+++ b/tests/integration/test_utils/mock_endpoint_builder.rs
@@ -15,15 +15,21 @@ pub struct MockEndpointBuilder {
 
 impl MockEndpointBuilder {
     /// Create a new endpoint options struct
-    pub fn new(method: &'static str, endpoint: &'static str, status: usize) -> Self {
+    pub fn new(method: &'static str, endpoint: &'static str) -> Self {
         Self {
             builder: Box::new(move |server| {
                 server
                     .mock(method, endpoint)
-                    .with_status(status)
                     .with_header("content-type", "application/json")
             }),
         }
+    }
+
+    /// Set the status code of the mock endpoint.
+    /// The default status code (if this method is not called) is 200.
+    pub fn with_status(mut self, status: usize) -> Self {
+        self.builder = Box::new(move |server| (self.builder)(server).with_status(status));
+        self
     }
 
     /// Set the response body of the mock endpoint.

--- a/tests/integration/upload_proguard.rs
+++ b/tests/integration/upload_proguard.rs
@@ -4,12 +4,8 @@ use crate::integration::{MockEndpointBuilder, TestManager};
 fn command_upload_proguard() {
     TestManager::new()
         .mock_endpoint(
-            MockEndpointBuilder::new(
-                "POST",
-                "/api/0/projects/wat-org/wat-project/files/dsyms/",
-                200,
-            )
-            .with_response_body("[]"),
+            MockEndpointBuilder::new("POST", "/api/0/projects/wat-org/wat-project/files/dsyms/")
+                .with_response_body("[]"),
         )
         .register_trycmd_test("upload_proguard/*.trycmd")
         .with_default_token();


### PR DESCRIPTION
`mockito`'s default mock response status is `200`. Since most of our mocks reply with `200`, let's also use this default in our mocks.