### PR TITLE
ref(test): Align `with_reponse_body` parameter to `mockito`

### DIFF
--- a/tests/integration/test_utils/mock_endpoint_builder.rs
+++ b/tests/integration/test_utils/mock_endpoint_builder.rs
@@ -35,9 +35,8 @@ impl MockEndpointBuilder {
     /// Set the response body of the mock endpoint.
     pub fn with_response_body<T>(mut self, body: T) -> Self
     where
-        T: Into<String>,
+        T: AsRef<[u8]> + 'static,
     {
-        let body = body.into();
         self.builder = Box::new(|server| (self.builder)(server).with_body(body));
         self
     }


### PR DESCRIPTION
Change the `body` parameter of `with_response_body` to match the parameter that `mockito` takes. Also, add a `'static` bound because the builder closure can only capture `'static` items