### PR TITLE
ref(test): Broaden `with_header_matcher` types

### DIFF
--- a/tests/integration/debug_files/upload.rs
+++ b/tests/integration/debug_files/upload.rs
@@ -159,7 +159,7 @@ fn ensure_correct_assemble_call() {
                 "POST",
                 "/api/0/projects/wat-org/wat-project/files/difs/assemble/",
             )
-            .with_header_matcher("content-type", "application/json".into())
+            .with_header_matcher("content-type", "application/json")
             .with_response_body(
                 r#"{
                 "21b76b717dbbd8c89e42d92b29667ac87aa3c124": {

--- a/tests/integration/test_utils/mock_endpoint_builder.rs
+++ b/tests/integration/test_utils/mock_endpoint_builder.rs
@@ -1,4 +1,4 @@
-use mockito::{Matcher, Mock, ServerGuard};
+use mockito::{IntoHeaderName, Matcher, Mock, ServerGuard};
 
 /// Builder for a mock endpoint.
 ///
@@ -60,7 +60,13 @@ impl MockEndpointBuilder {
 
     /// Matches a header of the mock endpoint. The header must be present and its value must
     /// match the provided matcher in order for the endpoint to be reached.
-    pub fn with_header_matcher(mut self, key: &'static str, matcher: Matcher) -> Self {
+    pub fn with_header_matcher(
+        mut self,
+        key: impl IntoHeaderName,
+        matcher: impl Into<Matcher>,
+    ) -> Self {
+        let key = key.into_header_name();
+        let matcher = matcher.into();
         self.builder = Box::new(move |server| (self.builder)(server).match_header(key, matcher));
         self
     }


### PR DESCRIPTION
Allow accpting any key that implements `IntoHeaderName` and any matcher taht implements `Into<Matcher>`. This is the same signature as `mockito`'s `match_header` method.