### PR TITLE
feat(proguard): Introduce experimental chunk uploading feature

### DIFF
--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -16,6 +16,7 @@ pub mod http;
 pub mod logging;
 pub mod metrics;
 pub mod progress;
+pub mod proguard_upload;
 pub mod releases;
 pub mod retry;
 pub mod sourcemaps;

--- a/src/utils/proguard_upload.rs
+++ b/src/utils/proguard_upload.rs
@@ -1,0 +1,95 @@
+//! This file contains code for enabling chunk uploads for Proguard mappings.
+//!
+//! This code is intended as a temporary solution to enable chunk uploads for
+//! Proguard mappings, while we work on a more permanent solution, which will
+//! work for all different types of debug files.
+
+use std::fs;
+
+use anyhow::Result;
+use indicatif::ProgressStyle;
+use sha1_smol::Digest;
+
+use super::chunks;
+use super::chunks::Chunk;
+use super::fs::get_sha1_checksums;
+use crate::api::{Api, ChunkUploadOptions, ChunkedDifRequest};
+use crate::commands::upload_proguard::MappingRef;
+
+struct ChunkedMapping {
+    raw_data: Vec<u8>,
+    hash: Digest,
+    chunk_hashes: Vec<Digest>,
+    file_name: String,
+    chunk_size: usize,
+}
+
+impl ChunkedMapping {
+    fn try_from_mapping(mapping: &MappingRef, chunk_size: u64) -> Result<Self> {
+        let raw_data = fs::read(mapping)?;
+        let file_name = format!("/proguard/{}.txt", mapping.uuid);
+
+        let (hash, chunk_hashes) = get_sha1_checksums(&raw_data, chunk_size)?;
+        Ok(Self {
+            raw_data,
+            hash,
+            chunk_hashes,
+            file_name,
+            chunk_size: chunk_size.try_into()?,
+        })
+    }
+
+    fn chunks(&self) -> impl Iterator<Item = Chunk<'_>> {
+        self.raw_data
+            .chunks(self.chunk_size)
+            .zip(self.chunk_hashes.iter())
+            .map(|(chunk, hash)| Chunk((*hash, chunk)))
+    }
+}
+
+impl<'a> From<&'a ChunkedMapping> for ChunkedDifRequest<'a> {
+    fn from(value: &'a ChunkedMapping) -> Self {
+        ChunkedDifRequest {
+            name: &value.file_name,
+            debug_id: None,
+            chunks: &value.chunk_hashes,
+        }
+    }
+}
+
+fn to_assemble(chunked: &ChunkedMapping) -> (Digest, ChunkedDifRequest<'_>) {
+    (chunked.hash, chunked.into())
+}
+
+pub fn chunk_upload(
+    paths: &[MappingRef],
+    chunk_upload_options: &ChunkUploadOptions,
+    org: &str,
+    project: &str,
+) -> Result<()> {
+    let chunked_mappings: Vec<ChunkedMapping> = paths
+        .iter()
+        .map(|path| ChunkedMapping::try_from_mapping(path, chunk_upload_options.chunk_size))
+        .collect::<Result<_>>()?;
+
+    let progress_style = ProgressStyle::default_bar().template(
+        "Uploading Proguard mappings...\
+             \n{wide_bar}  {bytes}/{total_bytes} ({eta})",
+    );
+
+    let chunks = chunked_mappings.iter().flat_map(|mapping| mapping.chunks());
+
+    chunks::upload_chunks(
+        &chunks.collect::<Vec<_>>(),
+        chunk_upload_options,
+        progress_style,
+    )?;
+
+    let assemble_request = chunked_mappings.iter().map(to_assemble).collect();
+
+    Api::current()
+        .authenticated()?
+        .assemble_difs(org, project, &assemble_request)?;
+
+    Ok(())
+}


### PR DESCRIPTION
Introduce an experimental chunk uploading feature for the `sentry-cli upload-proguard` command. The feature can be activated by setting the `SENTRY_EXPERIMENTAL_PROGUARD_CHUNK_UPLOAD` environment variable to `1`. The feature is only activated when users opt in via this environment variable.

The experimental chunk uploading feature is not backwards compatible. We attempt the upload regardless of whether the server supports receiving chunk-uploaded Proguard files. Server-side support will only be available once https://github.com/getsentry/sentry/pull/81131 is released. The goal here was to create something that works, so some optimizations that we use for other chunk uploaded file types (e.g. first checking whether any chunks are present on the server, and only uploading the missing ones), are not implemented for Proguard.

Ref #2196