### PR TITLE
ref(test): Remove redundant line

### DIFF
--- a/tests/integration/debug_files/upload.rs
+++ b/tests/integration/debug_files/upload.rs
@@ -181,11 +181,6 @@ fn ensure_correct_assemble_call() {
         command.env(k, v.as_ref());
     });
 
-    command.env(
-        "SENTRY_AUTH_TOKEN",
-        "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
-    );
-
     let command_result = command.assert();
 
     // First assert the mock was called as expected, then that the command was successful.


### PR DESCRIPTION
This line is redundant, since `env::set_all` already handles setting the auth token.