### PR TITLE
ref(test): Introduce `assert_cmd` test manager

### DIFF
--- a/tests/integration/mod.rs
+++ b/tests/integration/mod.rs
@@ -31,7 +31,7 @@ use std::io;
 use std::path::Path;
 
 use test_utils::MockEndpointBuilder;
-use test_utils::{env, ChunkOptions, ServerBehavior, TestManager};
+use test_utils::{env, AssertCommand, ChunkOptions, ServerBehavior, TestManager};
 
 pub const UTC_DATE_FORMAT: &str = r"\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}.\d{6,9}Z";
 const VERSION: &str = env!("CARGO_PKG_VERSION");

--- a/tests/integration/test_utils/env.rs
+++ b/tests/integration/test_utils/env.rs
@@ -42,10 +42,3 @@ pub fn set_auth_token(setter: impl FnOnce(&'static str, Cow<'static, str>)) {
         "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef".into(),
     );
 }
-
-/// Set all environment variables, including the auth token and the environments
-/// set by `set`.
-pub fn set_all(server_info: MockServerInfo, mut setter: impl FnMut(&str, Cow<str>)) {
-    set(server_info, &mut setter);
-    set_auth_token(setter);
-}

--- a/tests/integration/test_utils/mod.rs
+++ b/tests/integration/test_utils/mod.rs
@@ -8,6 +8,6 @@ mod test_manager;
 
 pub use mock_common_endpoints::{ChunkOptions, ServerBehavior};
 pub use mock_endpoint_builder::MockEndpointBuilder;
-pub use test_manager::TestManager;
+pub use test_manager::{AssertCommand, TestManager};
 
 use env::MockServerInfo;


### PR DESCRIPTION
This should reduce boilerplate when writing `assert_cmd` tests.