### PR TITLE
ref(utils): Use `usize` in `get_sha1_checksums` signature

### DIFF
--- a/src/utils/dif_upload.rs
+++ b/src/utils/dif_upload.rs
@@ -332,7 +332,7 @@ impl<'data> ChunkedDifMatch<'data> {
     /// Slices the DIF into chunks of `chunk_size` bytes each, and computes SHA1
     /// checksums for every chunk as well as the entire DIF.
     pub fn from(inner: DifMatch<'data>, chunk_size: u64) -> Result<Self> {
-        let (checksum, chunks) = get_sha1_checksums(inner.data(), chunk_size)?;
+        let (checksum, chunks) = get_sha1_checksums(inner.data(), chunk_size as usize)?;
         Ok(ChunkedDifMatch {
             inner: HashedDifMatch { inner, checksum },
             chunks,

--- a/src/utils/file_upload.rs
+++ b/src/utils/file_upload.rs
@@ -412,7 +412,7 @@ fn upload_files_chunked(
     pb.set_style(progress_style);
 
     let view = ByteView::open(archive.path())?;
-    let (checksum, checksums) = get_sha1_checksums(&view, options.chunk_size)?;
+    let (checksum, checksums) = get_sha1_checksums(&view, options.chunk_size as usize)?;
     let mut chunks = view
         .chunks(options.chunk_size as usize)
         .zip(checksums.iter())

--- a/src/utils/fs.rs
+++ b/src/utils/fs.rs
@@ -171,7 +171,7 @@ pub fn get_sha1_checksum<R: Read>(rdr: R) -> Result<Digest> {
 
 /// Returns the SHA1 hash for the entire input, as well as each chunk of it. The
 /// `chunk_size` must be a power of two.
-pub fn get_sha1_checksums(data: &[u8], chunk_size: u64) -> Result<(Digest, Vec<Digest>)> {
+pub fn get_sha1_checksums(data: &[u8], chunk_size: usize) -> Result<(Digest, Vec<Digest>)> {
     if !chunk_size.is_power_of_two() {
         bail!("Chunk size must be a power of two");
     }
@@ -179,7 +179,7 @@ pub fn get_sha1_checksums(data: &[u8], chunk_size: u64) -> Result<(Digest, Vec<D
     let mut total_sha = Sha1::new();
     let mut chunks = Vec::new();
 
-    for chunk in data.chunks(chunk_size as usize) {
+    for chunk in data.chunks(chunk_size) {
         let mut chunk_sha = Sha1::new();
         chunk_sha.update(chunk);
         total_sha.update(chunk);

--- a/src/utils/proguard_upload.rs
+++ b/src/utils/proguard_upload.rs
@@ -38,7 +38,7 @@ impl ChunkedMapping {
         let raw_data = fs::read(mapping)?;
         let file_name = format!("/proguard/{}.txt", mapping.uuid);
 
-        let (hash, chunk_hashes) = get_sha1_checksums(&raw_data, chunk_size)?;
+        let (hash, chunk_hashes) = get_sha1_checksums(&raw_data, chunk_size as usize)?;
         Ok(Self {
             raw_data,
             hash,


### PR DESCRIPTION
Since we convert the argument to usize in the function anyways, it likely makes more sense for this function to explicitly take a usize. In future refactors, we can change the signatures of the functions that take the values to also take `usize`.