### PR TITLE
ref(chunks): Rename `Named` trait to `Assemblable`

### DIFF
--- a/src/utils/chunks/mod.rs
+++ b/src/utils/chunks/mod.rs
@@ -7,7 +7,7 @@
 
 mod types;
 
-pub use types::{Chunked, MissingObjectsInfo, Named};
+pub use types::{Assemblable, Chunked, MissingObjectsInfo};
 
 use std::sync::Arc;
 use std::time::Duration;

--- a/src/utils/chunks/types.rs
+++ b/src/utils/chunks/types.rs
@@ -12,8 +12,8 @@ use crate::utils::fs;
 /// objects and their missing chunks.
 pub type MissingObjectsInfo<'m, T> = (Vec<&'m Chunked<T>>, Vec<Chunk<'m>>);
 
-/// A trait for objects that have a name.
-pub trait Named {
+/// A trait for objects that can be assembled via the `assemble_difs` endpoint.
+pub trait Assemblable {
     /// Returns the name of the object.
     fn name(&self) -> &str;
 }
@@ -87,9 +87,9 @@ where
     }
 }
 
-impl<T> Named for Chunked<T>
+impl<T> Assemblable for Chunked<T>
 where
-    T: Named,
+    T: Assemblable,
 {
     fn name(&self) -> &str {
         self.object().name()

--- a/src/utils/dif_upload.rs
+++ b/src/utils/dif_upload.rs
@@ -38,7 +38,7 @@ use crate::api::{
 use crate::config::Config;
 use crate::constants::{DEFAULT_MAX_DIF_SIZE, DEFAULT_MAX_WAIT};
 use crate::utils::chunks::{
-    upload_chunks, BatchedSliceExt, Chunk, Chunked, ItemSize, MissingObjectsInfo, Named,
+    upload_chunks, Assemblable, BatchedSliceExt, Chunk, Chunked, ItemSize, MissingObjectsInfo,
     ASSEMBLE_POLL_INTERVAL,
 };
 use crate::utils::dif::ObjectDifFeatures;
@@ -304,7 +304,7 @@ impl Display for DifMatch<'_> {
     }
 }
 
-impl Named for DifMatch<'_> {
+impl Assemblable for DifMatch<'_> {
     /// A DIF's name is its file name.
     fn name(&self) -> &str {
         self.file_name()
@@ -1404,7 +1404,7 @@ fn poll_assemble<T>(
     options: &DifUpload,
 ) -> Result<(Vec<DebugInfoFile>, bool)>
 where
-    T: Display + Named,
+    T: Display + Assemblable,
     Chunked<T>: IntoAssembleRequest,
 {
     let progress_style = ProgressStyle::default_bar().template(


### PR DESCRIPTION
Rename the `Named` trait to `Assemblable`, in preparation for adding another method to get the Debug ID. We will need to be able to get the DebugID anywhere where we prepare a call to the assemble endpoint, and this is also the only place we need to have a name. So, it makes sense to have a single trait for both.