### PR TITLE
ref(dif): Put hash in `ChunkedDifRequest`

### DIFF
--- a/src/api/data_types/chunking/dif.rs
+++ b/src/api/data_types/chunking/dif.rs
@@ -14,6 +14,28 @@ pub struct ChunkedDifRequest<'a> {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub debug_id: Option<DebugId>,
     pub chunks: &'a [Digest],
+    #[serde(skip)]
+    hash: Digest,
+}
+
+impl<'a> ChunkedDifRequest<'a> {
+    /// Create a new ChunkedDifRequest with the given name, chunk hashes,
+    /// and total hash for the entire file.
+    pub fn new(name: &'a str, chunks: &'a [Digest], hash: Digest) -> Self {
+        Self {
+            name,
+            chunks,
+            hash,
+            debug_id: None,
+        }
+    }
+
+    /// Set the provided debug_id on the request, or clear it if
+    /// `None` is passed.
+    pub fn with_debug_id(mut self, debug_id: Option<DebugId>) -> Self {
+        self.debug_id = debug_id;
+        self
+    }
 }
 
 #[derive(Debug, Deserialize)]
@@ -25,5 +47,40 @@ pub struct ChunkedDifResponse {
     pub dif: Option<DebugInfoFile>,
 }
 
-pub type AssembleDifsRequest<'a> = HashMap<Digest, ChunkedDifRequest<'a>>;
+#[derive(Debug, Serialize)]
+#[serde(transparent)]
+pub struct AssembleDifsRequest<'a>(HashMap<Digest, ChunkedDifRequest<'a>>);
+
+impl AssembleDifsRequest<'_> {
+    /// Strips the debug_id from all requests in the request. We need
+    /// to strip the debug_ids whenever the server does not support chunked
+    /// uploading of PDBs, to maintain backwards compatibility. The
+    /// calling code is responsible for calling this function when needed.
+    ///
+    /// See: https://github.com/getsentry/sentry-cli/issues/980
+    /// See: https://github.com/getsentry/sentry-cli/issues/1056
+    pub fn strip_debug_ids(&mut self) {
+        for r in self.0.values_mut() {
+            r.debug_id = None;
+        }
+    }
+}
+
+impl<'a, T> FromIterator<T> for AssembleDifsRequest<'a>
+where
+    T: Into<ChunkedDifRequest<'a>>,
+{
+    fn from_iter<I>(iter: I) -> Self
+    where
+        I: IntoIterator<Item = T>,
+    {
+        Self(
+            iter.into_iter()
+                .map(|obj| obj.into())
+                .map(|r| (r.hash, r))
+                .collect(),
+        )
+    }
+}
+
 pub type AssembleDifsResponse = HashMap<Digest, ChunkedDifResponse>;

--- a/src/utils/proguard_upload.rs
+++ b/src/utils/proguard_upload.rs
@@ -58,16 +58,8 @@ impl ChunkedMapping {
 
 impl<'a> From<&'a ChunkedMapping> for ChunkedDifRequest<'a> {
     fn from(value: &'a ChunkedMapping) -> Self {
-        ChunkedDifRequest {
-            name: &value.file_name,
-            debug_id: None,
-            chunks: &value.chunk_hashes,
-        }
+        ChunkedDifRequest::new(&value.file_name, &value.chunk_hashes, value.hash)
     }
-}
-
-fn to_assemble(chunked: &ChunkedMapping) -> (Digest, ChunkedDifRequest<'_>) {
-    (chunked.hash, chunked.into())
 }
 
 /// Uploads a set of Proguard mappings to Sentry.
@@ -99,7 +91,7 @@ pub fn chunk_upload(
 
     println!("Waiting for server to assemble uploaded mappings...");
 
-    let assemble_request = chunked_mappings.iter().map(to_assemble).collect();
+    let assemble_request = chunked_mappings.iter().collect();
     let start = Instant::now();
     while Instant::now().duration_since(start) < ASSEMBLE_POLL_TIMEOUT {
         let all_assembled = Api::current()


### PR DESCRIPTION
Putting the hash in the `ChunkedDifRequest` allows us to avoid needing to transform objects into tuples with a `ChunkedDifRequest` and a hash. With this change, we can greatly simplify the API for creating a `ChunkedDifRequest` and an `AssembleDifRequest`