### PR TITLE
ref(proguard): Create new `proguard` `utils` submodule

### DIFF
--- a/src/commands/upload_proguard.rs
+++ b/src/commands/upload_proguard.rs
@@ -4,12 +4,12 @@ use std::io;
 use std::path::Path;
 use std::path::PathBuf;
 
+use ::proguard::ProguardMapping;
 use anyhow::{bail, Error, Result};
 use clap::ArgAction;
 use clap::{Arg, ArgMatches, Command};
 use console::style;
 use log::info;
-use proguard::ProguardMapping;
 use symbolic::common::ByteView;
 use uuid::Uuid;
 
@@ -19,7 +19,7 @@ use crate::config::Config;
 use crate::utils::android::dump_proguard_uuids_as_properties;
 use crate::utils::args::ArgExt;
 use crate::utils::fs::TempFile;
-use crate::utils::proguard_upload;
+use crate::utils::proguard;
 use crate::utils::system::QuietExit;
 use crate::utils::ui::{copy_with_progress, make_byte_progress_bar};
 
@@ -230,7 +230,7 @@ pub fn execute(matches: &ArgMatches) -> Result<()> {
                 })
             })?;
 
-        proguard_upload::chunk_upload(&mappings, &chunk_upload_options, &org, &project)?;
+        proguard::chunk_upload(&mappings, &chunk_upload_options, &org, &project)?;
     } else {
         if mappings.is_empty() && matches.get_flag("require_one") {
             println!();

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -16,7 +16,7 @@ pub mod http;
 pub mod logging;
 pub mod metrics;
 pub mod progress;
-pub mod proguard_upload;
+pub mod proguard;
 pub mod releases;
 pub mod retry;
 pub mod sourcemaps;

--- a/src/utils/proguard/mod.rs
+++ b/src/utils/proguard/mod.rs
@@ -1,0 +1,3 @@
+mod upload;
+
+pub use self::upload::chunk_upload;

--- a/src/utils/proguard/upload.rs
+++ b/src/utils/proguard/upload.rs
@@ -11,11 +11,11 @@ use anyhow::Result;
 use indicatif::ProgressStyle;
 use sha1_smol::Digest;
 
-use super::chunks;
-use super::chunks::Chunk;
-use super::fs::get_sha1_checksums;
 use crate::api::{Api, ChunkUploadOptions, ChunkedDifRequest, ChunkedFileState};
 use crate::commands::upload_proguard::MappingRef;
+use crate::utils::chunks;
+use crate::utils::chunks::Chunk;
+use crate::utils::fs::get_sha1_checksums;
 
 /// How often to poll the server for the status of the assembled mappings.
 const ASSEMBLE_POLL_INTERVAL: Duration = Duration::from_secs(1);


### PR DESCRIPTION
Create a new `proguard` submodule in `utils`, and move the `proguard_upload` module into that new module. This change is being made in preparation of adding more proguard-related code to `utils`