### PR TITLE
ref(proguard): Replace MappingRef with ProguardMapping

### DIFF
--- a/src/utils/proguard/mapping.rs
+++ b/src/utils/proguard/mapping.rs
@@ -1,0 +1,64 @@
+use symbolic::common::ByteView;
+use thiserror::Error;
+use uuid::Uuid;
+
+#[derive(Debug, Error)]
+pub enum ProguardMappingError {
+    #[error("Proguard mapping does not contain line information")]
+    MissingLineInfo,
+}
+
+pub struct ProguardMapping<'a> {
+    bytes: ByteView<'a>,
+    uuid: Uuid,
+}
+
+impl<'a> ProguardMapping<'a> {
+    /// Get the length of the mapping in bytes.
+    pub fn len(&self) -> usize {
+        self.bytes.len()
+    }
+
+    /// Get the UUID of the mapping.
+    pub fn uuid(&self) -> Uuid {
+        self.uuid
+    }
+
+    /// Force the UUID of the mapping to a specific value, rather
+    /// than the UUID which is derived from the proguard crate.
+    pub fn force_uuid(&mut self, uuid: Uuid) {
+        self.uuid = uuid;
+    }
+
+    /// Create a new `ProguardMapping` from a `ByteView`.
+    /// Not public because we want to ensure that the `ByteView` contains line
+    /// information, and this method does not check for that. To create a
+    /// `ProguardMapping` externally, use the `TryFrom<ByteView>` implementation.
+    fn new(bytes: ByteView<'a>, uuid: Uuid) -> Self {
+        Self { bytes, uuid }
+    }
+}
+
+impl<'a> TryFrom<ByteView<'a>> for ProguardMapping<'a> {
+    type Error = ProguardMappingError;
+
+    /// Try to create a `ProguardMapping` from a `ByteView`.
+    /// The method returns an error if the mapping does not contain
+    /// line information.
+    fn try_from(value: ByteView<'a>) -> Result<Self, Self::Error> {
+        let mapping = ::proguard::ProguardMapping::new(&value);
+
+        if !mapping.has_line_info() {
+            return Err(ProguardMappingError::MissingLineInfo);
+        }
+
+        let uuid = mapping.uuid();
+        Ok(ProguardMapping::new(value, uuid))
+    }
+}
+
+impl AsRef<[u8]> for ProguardMapping<'_> {
+    fn as_ref(&self) -> &[u8] {
+        self.bytes.as_ref()
+    }
+}

--- a/src/utils/proguard/mod.rs
+++ b/src/utils/proguard/mod.rs
@@ -1,3 +1,5 @@
+mod mapping;
 mod upload;
 
+pub use self::mapping::ProguardMapping;
 pub use self::upload::chunk_upload;

--- a/tests/integration/_cases/upload_proguard/upload_proguard-no-upload.trycmd
+++ b/tests/integration/_cases/upload_proguard/upload_proguard-no-upload.trycmd
@@ -1,7 +1,7 @@
 ```
 $ sentry-cli upload-proguard tests/integration/_fixtures/proguard.txt --no-upload
 ? success
-warning: proguard mapping 'tests/integration/_fixtures/proguard.txt' was ignored because it does not contain any line information.
+warning: ignoring proguard mapping 'tests/integration/_fixtures/proguard.txt': Proguard mapping does not contain line information
 > compressing mappings
 > skipping upload.
 

--- a/tests/integration/_cases/upload_proguard/upload_proguard.trycmd
+++ b/tests/integration/_cases/upload_proguard/upload_proguard.trycmd
@@ -1,7 +1,7 @@
 ```
 $ sentry-cli upload-proguard tests/integration/_fixtures/proguard.txt
 ? success
-warning: proguard mapping 'tests/integration/_fixtures/proguard.txt' was ignored because it does not contain any line information.
+warning: ignoring proguard mapping 'tests/integration/_fixtures/proguard.txt': Proguard mapping does not contain line information
 > compressing mappings
 > uploading mappings
 > Uploaded a total of 0 new mapping files


### PR DESCRIPTION
The new `ProguardMapping` type directly references the `ByteView` of the Proguard file, rather than simply storing the path to the file. This change will enable us to replace `ChunkedMapping` with `Chunked<ProguardMapping>`.