### PR TITLE
ref(chunks): Make `ChunkedDifRequest` take `Cow<str>` for `name`

### DIFF
--- a/src/api/data_types/chunking/dif.rs
+++ b/src/api/data_types/chunking/dif.rs
@@ -1,3 +1,4 @@
+use std::borrow::Cow;
 use std::collections::HashMap;
 
 use serde::{Deserialize, Serialize};
@@ -10,7 +11,7 @@ use super::ChunkedFileState;
 
 #[derive(Debug, Serialize)]
 pub struct ChunkedDifRequest<'a> {
-    pub name: &'a str,
+    pub name: Cow<'a, str>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub debug_id: Option<DebugId>,
     pub chunks: &'a [Digest],
@@ -21,7 +22,7 @@ pub struct ChunkedDifRequest<'a> {
 impl<'a> ChunkedDifRequest<'a> {
     /// Create a new ChunkedDifRequest with the given name, chunk hashes,
     /// and total hash for the entire file.
-    pub fn new(name: &'a str, chunks: &'a [Digest], hash: Digest) -> Self {
+    pub fn new(name: Cow<'a, str>, chunks: &'a [Digest], hash: Digest) -> Self {
         Self {
             name,
             chunks,

--- a/src/utils/chunks/types.rs
+++ b/src/utils/chunks/types.rs
@@ -1,5 +1,6 @@
 //! Contains data types used in the chunk upload process.
 
+use std::borrow::Cow;
 use std::fmt::{Display, Formatter, Result as FmtResult};
 
 use anyhow::Result;
@@ -17,7 +18,7 @@ pub type MissingObjectsInfo<'m, T> = (Vec<&'m Chunked<T>>, Vec<Chunk<'m>>);
 /// A trait for objects that can be assembled via the `assemble_difs` endpoint.
 pub trait Assemblable {
     /// Returns the name of the object.
-    fn name(&self) -> &str;
+    fn name(&self) -> Cow<'_, str>;
 
     /// Returns the debug ID of the object.
     /// Types which do not have a debug ID should return `None`.
@@ -97,7 +98,7 @@ impl<T> Assemblable for Chunked<T>
 where
     T: Assemblable,
 {
-    fn name(&self) -> &str {
+    fn name(&self) -> Cow<'_, str> {
         self.object().name()
     }
 

--- a/src/utils/dif_upload.rs
+++ b/src/utils/dif_upload.rs
@@ -1,6 +1,7 @@
 //! Searches, processes and uploads debug information files (DIFs). See
 //! `DifUpload` for more information.
 
+use std::borrow::Cow;
 use std::collections::{BTreeMap, BTreeSet};
 use std::convert::TryInto;
 use std::ffi::{OsStr, OsString};
@@ -306,8 +307,8 @@ impl Display for DifMatch<'_> {
 
 impl Assemblable for DifMatch<'_> {
     /// A DIF's name is its file name.
-    fn name(&self) -> &str {
-        self.file_name()
+    fn name(&self) -> Cow<str> {
+        self.file_name().into()
     }
 
     fn debug_id(&self) -> Option<DebugId> {

--- a/src/utils/proguard/upload.rs
+++ b/src/utils/proguard/upload.rs
@@ -4,6 +4,7 @@
 //! Proguard mappings, while we work on a more permanent solution, which will
 //! work for all different types of debug files.
 
+use std::borrow::Cow;
 use std::thread;
 use std::time::{Duration, Instant};
 
@@ -57,7 +58,7 @@ impl ChunkedMapping {
 
 impl<'a> From<&'a ChunkedMapping> for ChunkedDifRequest<'a> {
     fn from(value: &'a ChunkedMapping) -> Self {
-        ChunkedDifRequest::new(&value.file_name, &value.chunk_hashes, value.hash)
+        ChunkedDifRequest::new(Cow::from(&value.file_name), &value.chunk_hashes, value.hash)
     }
 }
 


### PR DESCRIPTION
Also, update the `Assemblable` trait, so the `name` function returns `Cow<str>`

This refactor will allow `ChunkedDifRequest` to also store owned types for the `name`, making the type more flexible. We will use this ability when implementing `Assemblable` for `ProguardMapping`