### PR TITLE
fix(proguard): Add leading `/` to uploaded Proguard file name

### DIFF
--- a/src/utils/proguard/mapping.rs
+++ b/src/utils/proguard/mapping.rs
@@ -69,7 +69,7 @@ impl AsRef<[u8]> for ProguardMapping<'_> {
 
 impl Assemblable for ProguardMapping<'_> {
     fn name(&self) -> Cow<str> {
-        format!("proguard/{}.txt", self.uuid).into()
+        format!("/proguard/{}.txt", self.uuid).into()
     }
 
     fn debug_id(&self) -> Option<DebugId> {


### PR DESCRIPTION
The leading `/` is [required](https://github.com/getsentry/sentry/blob/e5a117971a55245eadbc2f525dde11f93f10ef57/src/sentry/models/debugfile.py#L51) for Sentry to identify an uploaded file as a Proguard file.

This bug was initially created in #2296, which has fortunately not been released yet.