### PR TITLE
ref(proguard): Use existing chunk uploading logic

### DIFF
--- a/src/api/data_types/chunking/upload/options.rs
+++ b/src/api/data_types/chunking/upload/options.rs
@@ -30,6 +30,16 @@ impl ChunkServerOptions {
     pub fn supports(&self, capability: ChunkUploadCapability) -> bool {
         self.accept.contains(&capability)
     }
+
+    /// Determines whether we need to strip debug_ids from the requests. We need
+    /// to strip the debug_ids whenever the server does not support chunked
+    /// uploading of PDBs, to maintain backwards compatibility.
+    ///
+    /// See: https://github.com/getsentry/sentry-cli/issues/980
+    /// See: https://github.com/getsentry/sentry-cli/issues/1056
+    pub fn should_strip_debug_ids(&self) -> bool {
+        !self.supports(ChunkUploadCapability::DebugFiles)
+    }
 }
 
 fn default_chunk_upload_accept() -> Vec<ChunkUploadCapability> {

--- a/src/commands/upload_proguard.rs
+++ b/src/commands/upload_proguard.rs
@@ -211,7 +211,7 @@ pub fn execute(matches: &ArgMatches) -> Result<()> {
                 })
             })?;
 
-        proguard::chunk_upload(&mappings, &chunk_upload_options, &org, &project)?;
+        proguard::chunk_upload(&mappings, chunk_upload_options, &org, &project)?;
     } else {
         if mappings.is_empty() && matches.get_flag("require_one") {
             println!();

--- a/src/utils/chunks/mod.rs
+++ b/src/utils/chunks/mod.rs
@@ -9,7 +9,7 @@ mod types;
 mod upload;
 
 pub use types::{Assemblable, Chunked, MissingObjectsInfo};
-pub use upload::ChunkOptions;
+pub use upload::{ChunkOptions, GenericChunkOptions};
 
 use std::sync::Arc;
 use std::time::Duration;

--- a/src/utils/proguard/mapping.rs
+++ b/src/utils/proguard/mapping.rs
@@ -1,4 +1,5 @@
 use std::borrow::Cow;
+use std::fmt::{Display, Formatter, Result as FmtResult};
 
 use symbolic::common::{ByteView, DebugId};
 use thiserror::Error;
@@ -74,5 +75,11 @@ impl Assemblable for ProguardMapping<'_> {
 
     fn debug_id(&self) -> Option<DebugId> {
         None
+    }
+}
+
+impl Display for ProguardMapping<'_> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
+        write!(f, "{} (Proguard mapping)", self.uuid)
     }
 }

--- a/src/utils/proguard/upload.rs
+++ b/src/utils/proguard/upload.rs
@@ -4,19 +4,14 @@
 //! Proguard mappings, while we work on a more permanent solution, which will
 //! work for all different types of debug files.
 
-use std::thread;
-use std::time::{Duration, Instant};
+use std::time::Duration;
 
 use anyhow::Result;
-use indicatif::ProgressStyle;
 
-use crate::api::{Api, ChunkServerOptions, ChunkedFileState};
-use crate::utils::chunks;
-use crate::utils::chunks::Chunked;
+use crate::api::ChunkServerOptions;
+use crate::utils::chunks::GenericChunkOptions;
+use crate::utils::chunks::{ChunkOptions, Chunked};
 use crate::utils::proguard::ProguardMapping;
-
-/// How often to poll the server for the status of the assembled mappings.
-const ASSEMBLE_POLL_INTERVAL: Duration = Duration::from_secs(1);
 
 /// How long to wait for the server to assemble the mappings before giving up.
 // 120 seconds was chosen somewhat arbitrarily, but in my testing, assembly
@@ -28,7 +23,7 @@ const ASSEMBLE_POLL_TIMEOUT: Duration = Duration::from_secs(120);
 /// Returns an error if the mappings fail to assemble, or if the timeout is reached.
 pub fn chunk_upload(
     mappings: &[ProguardMapping<'_>],
-    chunk_upload_options: &ChunkServerOptions,
+    chunk_upload_options: ChunkServerOptions,
     org: &str,
     project: &str,
 ) -> Result<()> {
@@ -37,48 +32,14 @@ pub fn chunk_upload(
         .map(|mapping| Chunked::from(mapping, chunk_upload_options.chunk_size as usize))
         .collect::<Result<Vec<_>>>()?;
 
-    let progress_style = ProgressStyle::default_bar().template(
-        "Uploading Proguard mappings...\
-             \n{wide_bar}  {bytes}/{total_bytes} ({eta})",
-    );
+    let mut options = GenericChunkOptions::new(chunk_upload_options, org, project);
+    options.set_max_wait(ASSEMBLE_POLL_TIMEOUT);
 
-    let chunks = chunked_mappings
-        .iter()
-        .flat_map(|mapping| mapping.iter_chunks());
+    let (_, has_processing_errors) = options.upload_chunked_objects(&chunked_mappings)?;
 
-    chunks::upload_chunks(
-        &chunks.collect::<Vec<_>>(),
-        chunk_upload_options,
-        progress_style,
-    )?;
-
-    println!("Waiting for server to assemble uploaded mappings...");
-
-    let assemble_request = chunked_mappings.iter().collect();
-    let start = Instant::now();
-    while Instant::now().duration_since(start) < ASSEMBLE_POLL_TIMEOUT {
-        let all_assembled = Api::current()
-            .authenticated()?
-            .assemble_difs(org, project, &assemble_request)?
-            .values()
-            .map(|response| match response.state {
-                ChunkedFileState::Error => anyhow::bail!("Error: {response:?}"),
-                ChunkedFileState::NotFound => anyhow::bail!("File not found: {response:?}"),
-                ChunkedFileState::Ok | ChunkedFileState::Created | ChunkedFileState::Assembling => {
-                    Ok(response)
-                }
-            })
-            .collect::<Result<Vec<_>>>()?
-            .iter()
-            .all(|response| matches!(response.state, ChunkedFileState::Ok));
-
-        if all_assembled {
-            println!("Server finished assembling mappings.");
-            return Ok(());
-        }
-
-        thread::sleep(ASSEMBLE_POLL_INTERVAL);
+    if has_processing_errors {
+        Err(anyhow::anyhow!("Some symbols did not process correctly"))
+    } else {
+        Ok(())
     }
-
-    anyhow::bail!("Timed out waiting for server to assemble uploaded mappings.")
 }


### PR DESCRIPTION
Use the existing chunk uploading logic, which is also used for debug files, in the Proguard chunk uploading code path