### PR TITLE
ref(dif): Use `&str` in `DifUpload` struct

### DIFF
--- a/src/commands/debug_files/upload.rs
+++ b/src/commands/debug_files/upload.rs
@@ -226,7 +226,7 @@ pub fn execute(matches: &ArgMatches) -> Result<()> {
     let max_wait = wait_for_secs.map_or(DEFAULT_MAX_WAIT, Duration::from_secs);
 
     // Build generic upload parameters
-    let mut upload = DifUpload::new(org.clone(), project.clone());
+    let mut upload = DifUpload::new(&org, &project);
     upload
         .wait(wait)
         .max_wait(max_wait)


### PR DESCRIPTION
Owned string is not necesary here, and having it will make it harder to convert `DifUpload` into `ChunkOptions`