### PR TITLE
ref(chunks): Make `ChunkOptions` a `struct`

### DIFF
--- a/src/api/data_types/chunking/upload/options.rs
+++ b/src/api/data_types/chunking/upload/options.rs
@@ -30,6 +30,16 @@ impl ChunkServerOptions {
     pub fn supports(&self, capability: ChunkUploadCapability) -> bool {
         self.accept.contains(&capability)
     }
+
+    /// Determines whether we need to strip debug_ids from the requests. We need
+    /// to strip the debug_ids whenever the server does not support chunked
+    /// uploading of PDBs, to maintain backwards compatibility.
+    ///
+    /// See: https://github.com/getsentry/sentry-cli/issues/980
+    /// See: https://github.com/getsentry/sentry-cli/issues/1056
+    pub fn should_strip_debug_ids(&self) -> bool {
+        !self.supports(ChunkUploadCapability::DebugFiles)
+    }
 }
 
 fn default_chunk_upload_accept() -> Vec<ChunkUploadCapability> {

--- a/src/utils/chunks/upload.rs
+++ b/src/utils/chunks/upload.rs
@@ -1,22 +1,63 @@
-use std::time::Duration;
+use std::{cmp, time::Duration};
 
-/// A trait representing options for chunk uploads.
-pub trait ChunkOptions {
-    /// Determines whether we need to strip debug_ids from the requests.
-    /// When this function returns `true`, the caller is responsible for stripping
-    /// the debug_ids from the requests, to maintain backwards compatibility with
-    /// older Sentry servers.
-    fn should_strip_debug_ids(&self) -> bool;
+use crate::api::ChunkServerOptions;
 
-    /// Returns the organization that we are uploading to.
-    fn org(&self) -> &str;
+/// A struct representing options for chunk uploads.
+pub struct ChunkOptions<'a> {
+    server_options: ChunkServerOptions,
+    org: &'a str,
+    project: &'a str,
 
-    /// Returns the project that we are uploading to.
-    fn project(&self) -> &str;
+    /// The maximum wait time for the upload to complete.
+    /// If set to zero, we do not wait for the upload to complete.
+    /// If the server_options.max_wait is set to a smaller nonzero value,
+    /// we use that value instead.
+    max_wait: Duration,
+}
 
-    /// Returns whether we should wait for assembling to complete.
-    fn should_wait(&self) -> bool;
+impl<'a> ChunkOptions<'a> {
+    pub fn new(server_options: ChunkServerOptions, org: &'a str, project: &'a str) -> Self {
+        Self {
+            server_options,
+            org,
+            project,
+            max_wait: Duration::ZERO,
+        }
+    }
 
-    /// Returns the maximum wait time for the upload to complete.
-    fn max_wait(&self) -> Duration;
+    /// Set the maximum wait time for the assembly to complete.
+    pub fn with_max_wait(mut self, max_wait: Duration) -> Self {
+        self.max_wait = max_wait;
+        self
+    }
+
+    pub fn should_strip_debug_ids(&self) -> bool {
+        self.server_options.should_strip_debug_ids()
+    }
+
+    pub fn org(&self) -> &str {
+        self.org
+    }
+
+    pub fn project(&self) -> &str {
+        self.project
+    }
+
+    pub fn should_wait(&self) -> bool {
+        !self.max_wait().is_zero()
+    }
+
+    pub fn max_wait(&self) -> Duration {
+        // If the server specifies a max wait time (indicated by a nonzero value),
+        // we use the minimum of the user-specified max wait time and the server's
+        // max wait time.
+        match self.server_options.max_wait {
+            0 => self.max_wait,
+            server_max_wait => cmp::min(self.max_wait, Duration::from_secs(server_max_wait)),
+        }
+    }
+
+    pub fn server_options(&self) -> &ChunkServerOptions {
+        &self.server_options
+    }
 }


### PR DESCRIPTION
Previously, `ChunkOptions` was implemented as a trait, but we realized it makes more sense to have it be a struct, instead. Now, as a struct, we also have `ChunkOptions` store the `ChunkServerOptions`, which will eventually allow us to simplify some API's, since we can take `ChunkOptions` only, rather than `DIFUpload` and `ChunkServerOptions` for methods such as `upload_difs_chunked`.