### PR TITLE
ref(proguard): Use existing chunked upload logic

### DIFF
--- a/src/commands/upload_proguard.rs
+++ b/src/commands/upload_proguard.rs
@@ -211,7 +211,7 @@ pub fn execute(matches: &ArgMatches) -> Result<()> {
                 })
             })?;
 
-        proguard::chunk_upload(&mappings, &chunk_upload_options, &org, &project)?;
+        proguard::chunk_upload(&mappings, chunk_upload_options, &org, &project)?;
     } else {
         if mappings.is_empty() && matches.get_flag("require_one") {
             println!();

--- a/src/utils/chunks/upload.rs
+++ b/src/utils/chunks/upload.rs
@@ -201,8 +201,8 @@ where
 
         if chunks_missing {
             anyhow::bail!(
-                "Some uploaded files are now missing on the server. Please retry by running \
-        `sentry-cli upload-dif` again. If this problem persists, please report a bug.",
+                "Some uploaded files are now missing on the server. Please try rerunning \
+                the command. If this problem persists, please report a bug.",
             );
         }
 

--- a/src/utils/chunks/upload.rs
+++ b/src/utils/chunks/upload.rs
@@ -1,4 +1,7 @@
-use std::{collections::BTreeMap, fmt::Display, thread, time::Instant};
+use std::collections::BTreeMap;
+use std::fmt::Display;
+use std::thread;
+use std::time::Instant;
 
 use anyhow::Result;
 use indicatif::ProgressStyle;

--- a/src/utils/proguard/mapping.rs
+++ b/src/utils/proguard/mapping.rs
@@ -1,4 +1,5 @@
 use std::borrow::Cow;
+use std::fmt::{Display, Formatter, Result as FmtResult};
 
 use symbolic::common::{ByteView, DebugId};
 use thiserror::Error;
@@ -74,5 +75,11 @@ impl Assemblable for ProguardMapping<'_> {
 
     fn debug_id(&self) -> Option<DebugId> {
         None
+    }
+}
+
+impl Display for ProguardMapping<'_> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
+        write!(f, "{} (Proguard mapping)", self.uuid)
     }
 }


### PR DESCRIPTION
Use the existing chunked upload logic (already used for DIFs) when chunked-uploading Proguard mappings.

Closes #2195, #2196