### PR TITLE
ref(chunks): Remove `upload-dif` reference from `poll_assemble`

### DIFF
--- a/src/utils/chunks/upload.rs
+++ b/src/utils/chunks/upload.rs
@@ -201,8 +201,8 @@ where
 
         if chunks_missing {
             anyhow::bail!(
-                "Some uploaded files are now missing on the server. Please retry by running \
-        `sentry-cli upload-dif` again. If this problem persists, please report a bug.",
+                "Some uploaded files are now missing on the server. Please try rerunning \
+                the command. If this problem persists, please report a bug.",
             );
         }
 


### PR DESCRIPTION
We should not mention `upload-dif` in this error message because (1) `upload-dif` is a soft-deprecated hidden alias to `debug-files upload` and (2) `poll_assemble` has now been generalized and could be used with other commands in the future.

For reason (2), this change makes the error message general rather than referring to the `debug-files upload` command.