### PR TITLE
build: Make backtraces useable in release builds

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,2 +1,5 @@
+[build]
+rustflags = ["-C", "force-unwind-tables"] # Make backtraces work.
+
 [target.'cfg(all(windows, target_env = "msvc"))']
 rustflags = ["-C", "target-feature=+crt-static"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -113,7 +113,7 @@ winapi = "0.3.9"
 [profile.release]
 opt-level = "z"
 panic = "abort"
-strip = true      # Strip symbols from the binary.
-codegen-units = 1 # Parallel compilation prevents some optimizations.
+strip = "debuginfo" # Only strip debuginfo (not symbols) to keep backtraces useful.
+codegen-units = 1   # Parallel compilation prevents some optimizations.
 # We do not enable link-time optimizations (lto) because they cause the
 # CLI to timeout when run in Xcode Cloud.


### PR DESCRIPTION
Having `panic = "abort"` and `strip = "symbols"` makes backtraces generated with `RUST_BACKTRACE=1` completely useless in release builds.

By changing these options to `panic = "unwind"` and `strip = "debuginfo"` makes backtraces usable in release builds. This will help us debug issues we are unable to reproduce, since we can ask users to set `RUST_BACKTRACE=1` and provide the logs with this option.

This change does somewhat significantly increase release build binary size (from 7.9 MB to 13.9 MB on my system). This is likely acceptable if it improves our ability to debug problems. If folks complain, we can consider distributing a separate "stripped" binary for users sensitive to large binary size.

Closes #2200