### PR TITLE
feat(dif): Fail `debug-files upload` when file is too big

### DIFF
--- a/tests/integration/_responses/debug_files/get-chunk-upload-small-max-size.json
+++ b/tests/integration/_responses/debug_files/get-chunk-upload-small-max-size.json
@@ -1,0 +1,11 @@
+{
+  "url": "organizations/wat-org/chunk-upload/",
+  "chunkSize": 8388608,
+  "chunksPerRequest": 64,
+  "maxFileSize": 2048,
+  "maxRequestSize": 33554432,
+  "concurrency": 8,
+  "hashAlgorithm": "sha1",
+  "compression": ["gzip"],
+  "accept": ["debug_files", "release_files", "pdbs", "portablepdbs", "sources", "bcsymbolmaps"]
+}

--- a/tests/integration/debug_files/upload.rs
+++ b/tests/integration/debug_files/upload.rs
@@ -731,3 +731,19 @@ fn chunk_upload_multiple_files_small_chunks_only_some() {
         "Uploaded chunks differ from the expected chunks"
     );
 }
+
+#[test]
+fn test_dif_too_big() {
+    TestManager::new()
+        .mock_endpoint(
+            MockEndpointBuilder::new("GET", "/api/0/organizations/wat-org/chunk-upload/")
+                .with_response_file("debug_files/get-chunk-upload-small-max-size.json"),
+        )
+        .assert_cmd(vec![
+            "debug-files",
+            "upload",
+            "tests/integration/_fixtures/SrcGenSampleApp.pdb",
+        ])
+        .with_default_token()
+        .run_and_assert(AssertCommand::Failure);
+}

--- a/tests/integration/test_utils/test_manager.rs
+++ b/tests/integration/test_utils/test_manager.rs
@@ -185,6 +185,8 @@ pub struct AssertCmdTestManager {
 pub enum AssertCommand {
     /// Assert that the command succeeds (i.e. returns a `0` exit code).
     Success,
+    /// Assert that the command fails (i.e. returns a non-zero exit code).
+    Failure,
 }
 
 impl AssertCmdTestManager {
@@ -219,6 +221,7 @@ impl AssertCmdTestManager {
 
         match assert {
             AssertCommand::Success => command_result.success(),
+            AssertCommand::Failure => command_result.failure(),
         };
     }
 


### PR DESCRIPTION
Previously, we only logged an easy-to-miss warning when we had to skip uploading a debug file because it was too big. Now, we instead fail the entire upload loudly, to ensure users do not miss this important information.

Depends on:
  - #2330 
  - #2329 

Resolves #2313