### PR TITLE
ref(api): Remove unnecessary `collect`

### DIFF
--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -379,11 +379,10 @@ impl Api {
         // Curl stores a raw pointer to the stringified checksum internally. We first
         // transform all checksums to string and keep them in scope until the request
         // has completed. The original iterator is not needed anymore after this.
-        let stringified_chunks: Vec<_> = chunks
+        let stringified_chunks = chunks
             .into_iter()
             .map(T::as_ref)
-            .map(|&(checksum, data)| (checksum.to_string(), data))
-            .collect();
+            .map(|&(checksum, data)| (checksum.to_string(), data));
 
         let mut form = curl::easy::Form::new();
         for (ref checksum, data) in stringified_chunks {


### PR DESCRIPTION
Since we only use the `Vec` created by the `collect` in the loop below, there is no reason for the collect. Removing the collect prevents an unnecessary allocation of the `Vec`, and allows the loop instead to lazily compute the stringified chunks during iteration