### PR TITLE
build: Update `memmap2`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1635,9 +1635,9 @@ checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
 
 [[package]]
 name = "memmap2"
-version = "0.9.4"
+version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe751422e4a8caa417e13c3ea66452215d7d63e19e604f4980461212f3ae1322"
+checksum = "fd3f7eed9d3848f8b98834af67102b720745c4ec028fcd0aa0239277e7de374f"
 dependencies = [
  "libc",
 ]


### PR DESCRIPTION
Recently, `cargo build` started failing on my local system, with an error related to `memmap2`. Upgrading the dependency to the latest version fixes the problem.

Depends on:
  - #2341