### PR TITLE
ref(sourcemaps): Reduce sourcemap upload memory usage

### DIFF
--- a/src/commands/debug_files/bundle_jvm.rs
+++ b/src/commands/debug_files/bundle_jvm.rs
@@ -12,6 +12,7 @@ use std::collections::BTreeMap;
 use std::fs;
 use std::path::PathBuf;
 use std::str::FromStr;
+use std::sync::Arc;
 use symbolic::debuginfo::sourcebundle::SourceFileType;
 
 pub fn make_command(command: Command) -> Command {
@@ -97,7 +98,7 @@ pub fn execute(matches: &ArgMatches) -> Result<()> {
                 SourceFile {
                     url,
                     path: source.path.clone(),
-                    contents: source.contents.clone(),
+                    contents: Arc::new(source.contents.clone()),
                     ty: SourceFileType::Source,
                     headers: BTreeMap::new(),
                     messages: vec![],

--- a/src/commands/files/upload.rs
+++ b/src/commands/files/upload.rs
@@ -3,6 +3,7 @@ use std::ffi::OsStr;
 use std::fs;
 use std::io::Read;
 use std::path::Path;
+use std::sync::Arc;
 use std::time::Duration;
 
 use anyhow::{bail, format_err, Result};
@@ -205,7 +206,7 @@ pub fn execute(matches: &ArgMatches) -> Result<()> {
                     SourceFile {
                         url,
                         path: source.path.clone(),
-                        contents: source.contents.clone(),
+                        contents: Arc::new(source.contents.clone()),
                         ty: SourceFileType::Source,
                         headers: headers.clone(),
                         messages: vec![],

--- a/src/utils/file_upload.rs
+++ b/src/utils/file_upload.rs
@@ -119,7 +119,7 @@ impl fmt::Display for LogLevel {
 pub struct SourceFile {
     pub url: String,
     pub path: PathBuf,
-    pub contents: Vec<u8>,
+    pub contents: Arc<Vec<u8>>,
     pub ty: SourceFileType,
     /// A map of headers attached to the source file.
     ///
@@ -134,7 +134,7 @@ pub struct SourceFile {
 impl SourceFile {
     /// Calculates and returns the SHA1 checksum of the file.
     pub fn checksum(&self) -> Result<Digest> {
-        get_sha1_checksum(&*self.contents)
+        get_sha1_checksum(&**self.contents)
     }
 
     /// Returns the value of the "debug-id" header.
@@ -670,7 +670,9 @@ mod tests {
                 let file = SourceFile {
                     url: format!("~/{name}"),
                     path: format!("tests/integration/_fixtures/{name}").into(),
-                    contents: std::fs::read(format!("tests/integration/_fixtures/{name}")).unwrap(),
+                    contents: std::fs::read(format!("tests/integration/_fixtures/{name}"))
+                        .unwrap()
+                        .into(),
                     ty: SourceFileType::SourceMap,
                     headers: Default::default(),
                     messages: Default::default(),


### PR DESCRIPTION
Prevent an unnecessary copy of all sourcemap files being uploaded from being stored in memory, by using an `Arc` for the `contents` field of `SourceFile`.

Depends on:
  - #2340
  - #2341

Fixes #2342