### PR TITLE
feat: Deprecate `useArtifactBundle` option

### DIFF
--- a/js/index.d.ts
+++ b/js/index.d.ts
@@ -133,7 +133,11 @@ declare module '@sentry/cli' {
      */
     dist?: string;
     /**
-     * Use new Artifact Bundles upload, that enables use of Debug ID for Source Maps discovery.
+     * Force use of new Artifact Bundles upload, that enables use of Debug ID for Source Maps discovery,
+     * even when the Sentry server does not declare support for it.
+     *
+     * @deprecated This option is deprecated and will be removed in the next major version. Sentry CLI
+     *     should always respect what the server says it supports.
      */
     useArtifactBundle?: boolean;
   }


### PR DESCRIPTION
Also, update the documentation to more clearly state what the option even does.

Ref #2347