### PR TITLE
build: Replace `dotenv` with `dotenvy`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -769,10 +769,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fea41bba32d969b513997752735605054bc0dfa92b4c56bf1189f2e174be7a10"
 
 [[package]]
-name = "dotenv"
-version = "0.15.0"
+name = "dotenvy"
+version = "0.15.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77c90badedccf4105eca100756a0b1289e191f6fcbdadd3cee1d2f614f97da8f"
+checksum = "1aaf95b3e5c8f23aa320147307562d361db0ae0d51242340f558153b4eb2439b"
 
 [[package]]
 name = "dunce"
@@ -2578,7 +2578,7 @@ dependencies = [
  "curl",
  "data-encoding",
  "dirs",
- "dotenv",
+ "dotenvy",
  "elementtree",
  "flate2",
  "git2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ clap_complete = "4.4.3"
 console = "0.15.5"
 curl = { version = "0.4.46", features = ["static-curl", "static-ssl"] }
 dirs = "4.0.0"
-dotenv = "0.15.0"
+dotenvy = "0.15.7"
 elementtree = "1.2.3"
 flate2 = { version = "1.0.25", default-features = false, features = [
   "rust_backend",

--- a/src/utils/system.rs
+++ b/src/utils/system.rs
@@ -5,7 +5,7 @@ use std::process;
 
 use anyhow::{Error, Result};
 use console::style;
-use dotenv::Result as DotenvResult;
+use dotenvy::Result as DotenvResult;
 use lazy_static::lazy_static;
 use regex::{Captures, Regex};
 
@@ -139,8 +139,8 @@ pub fn load_dotenv() -> DotenvResult<()> {
     }
 
     match env::var("SENTRY_DOTENV_PATH") {
-        Ok(path) => dotenv::from_path(path),
-        Err(_) => dotenv::dotenv().map(|_| ()),
+        Ok(path) => dotenvy::from_path(path),
+        Err(_) => dotenvy::dotenv().map(|_| ()),
     }
     .map_or_else(
         |error| {


### PR DESCRIPTION
Replace the unmaintained crate `dotenv` with the maintained fork `dotenvy`.

Fixes #2350