### PR TITLE
ci: Pin Actions runners' OS versions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,7 +25,7 @@ jobs:
             container: aarch64-musl
 
     name: Linux ${{ matrix.arch }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
 
     steps:
       - uses: actions/checkout@v2
@@ -56,7 +56,7 @@ jobs:
             target: aarch64-apple-darwin
 
     name: macOS ${{ matrix.arch }}
-    runs-on: macos-latest
+    runs-on: macos-14
 
     steps:
       - uses: actions/checkout@v2
@@ -86,7 +86,7 @@ jobs:
   macos_universal:
     needs: macos
     name: macOS universal
-    runs-on: macos-latest
+    runs-on: macos-14
 
     steps:
       - uses: actions/download-artifact@v4
@@ -144,7 +144,7 @@ jobs:
 
   node:
     name: NPM Package
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     needs: [linux, macos, macos_universal, windows]
 
     steps:
@@ -176,7 +176,7 @@ jobs:
 
   python-base:
     name: python (base)
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v3
       - uses: actions-rs/toolchain@16499b5e05bf2e26879000db0c1d13f7e13fa3af # pin@v1
@@ -197,7 +197,7 @@ jobs:
 
   python:
     name: python
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     needs: [linux, macos, macos_universal, windows, python-base]
     steps:
       - uses: actions/checkout@v3
@@ -223,7 +223,7 @@ jobs:
 
   npm-distributions:
     name: 'Build NPM distributions'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     needs: [linux, macos, macos_universal, windows]
     steps:
       - uses: actions/checkout@v3
@@ -265,7 +265,7 @@ jobs:
 
   merge:
     name: Create Release Artifact
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     needs: [linux, macos, macos_universal, windows, npm-distributions, node, python]
     steps:
       - uses: actions/upload-artifact/merge@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ env:
 jobs:
   lint:
     name: Lint
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
 
@@ -34,7 +34,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os: [ubuntu-24.04, macos-14, windows-2022]
 
     name: Test (${{ matrix.os }})
     runs-on: ${{ matrix.os }}
@@ -65,7 +65,7 @@ jobs:
         node-version: [10.x, 12.x, 14.x, 16.x, 18.x, 20.x]
 
     name: Test Node ${{ matrix.node-version }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -21,7 +21,7 @@ on:
 jobs:
   analyze:
     name: Analyze
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
 
     strategy:
       fail-fast: false

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,7 @@ on:
         required: false
 jobs:
   release:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     name: 'Release a new version'
     steps:
       - name: Get auth token


### PR DESCRIPTION
Several of our GitHub Actions runners are running on `ubuntu-latest`, `windows-latest`, and `macos-latest`, making the actions vulnerable to breakage when these images are updated. Therefore, we should pin to specific versions of these images.
    
Pinning to `ubuntu-24.04`, `windows-2022`, and `macos-14` because these are currently equivalent to `ubuntu-latest`, `windows-latest`, and `macos-latest`, respectively.