### PR TITLE
feat: Improve custom panic hook

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2567,7 +2567,6 @@ dependencies = [
  "anylog",
  "assert_cmd",
  "backoff",
- "backtrace",
  "brotli2",
  "bytecount",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,6 @@ rust-version = "1.80"
 anylog = "0.6.3"
 anyhow = { version = "1.0.69", features = ["backtrace"] }
 backoff = "0.4.0"
-backtrace = "0.3.67"
 brotli2 = "0.3.2"
 bytecount = "0.6.3"
 chrono = { version = "0.4.31", features = ["serde"] }

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -15,7 +15,7 @@ use crate::constants::{ARCH, PLATFORM, VERSION};
 use crate::utils::auth_token::{redact_token_from_string, AuthToken};
 use crate::utils::logging::set_quiet_mode;
 use crate::utils::logging::Logger;
-use crate::utils::system::{init_backtrace, load_dotenv, print_error, QuietExit};
+use crate::utils::system::{load_dotenv, print_error, set_panic_hook, QuietExit};
 use crate::utils::update::run_sentrycli_update_nagger;
 use crate::utils::value_parsers::auth_token_parser;
 
@@ -331,7 +331,7 @@ pub fn execute() -> Result<()> {
 }
 
 fn setup() {
-    init_backtrace();
+    set_panic_hook();
 
     // Store the result of loading the dotenv file. We must load the dotenv file
     // before setting the log level, as the log level can be set in the dotenv


### PR DESCRIPTION
This change improves Sentry CLI's panic hook to make panic messages more user-friendly.

The panic message generated by the hook emphasizes that panics are internal errors in the Sentry CLI, and the message directs users to our bug report issue form. The message also always includes a stack backtrace, regardless of whether `RUST_BACKTRACE` is set.

The new panic message looks like the following:

```
🔥 Internal Error in Sentry CLI 🔥

Uh-oh! 😬 Sentry CLI has just crashed due to an internal error. Please open a bug report issue at https://github.com/getsentry/sentry-cli/issues/new?template=BUG_REPORT.yml. 🐞

🔬 Technical Details 🔬

thread 'main' panicked at src/commands/sourcemaps/upload.rs:422:5:
test error

Stack Backtrace:
   0: std::backtrace_rs::backtrace::libunwind::trace
             at /rustc/9fc6b43126469e3858e2fe86cafb4f0fd5068869/library/std/src/../../backtrace/src/backtrace/libunwind.rs:116:5
   1: std::backtrace_rs::backtrace::trace_unsynchronized
             at /rustc/9fc6b43126469e3858e2fe86cafb4f0fd5068869/library/std/src/../../backtrace/src/backtrace/mod.rs:66:5
[... truncated ...]
```

This change also removes the dependency on the `backtrace` crate, and renames the function which sets the panic hook from `init_backtrace` to `set_panic_hook`.