### PR TITLE
ref: Simplify `--log-level` parsing

### DIFF
--- a/tests/integration/_cases/send_envelope/send_envelope-help.trycmd
+++ b/tests/integration/_cases/send_envelope/send_envelope-help.trycmd
@@ -25,9 +25,7 @@ Options:
           Use the given Sentry auth token.
 
       --log-level <LOG_LEVEL>
-          Set the log output verbosity.
-          
-          [possible values: trace, debug, info, warn, error]
+          Set the log output verbosity. [possible values: trace, debug, info, warn, error]
 
       --quiet
           Do not print any output while preserving correct exit code. This flag is currently

--- a/tests/integration/_cases/send_event/send_event-help.trycmd
+++ b/tests/integration/_cases/send_event/send_event-help.trycmd
@@ -38,9 +38,7 @@ Options:
           Set the distribution.
 
       --log-level <LOG_LEVEL>
-          Set the log output verbosity.
-          
-          [possible values: trace, debug, info, warn, error]
+          Set the log output verbosity. [possible values: trace, debug, info, warn, error]
 
   -E, --env <ENVIRONMENT>
           Send with a specific environment.

--- a/tests/integration/_cases/send_metric/send_metric-distribution-help.trycmd
+++ b/tests/integration/_cases/send_metric/send_metric-distribution-help.trycmd
@@ -31,9 +31,7 @@ Options:
           Metric value, any finite 64 bit float.
 
       --log-level <LOG_LEVEL>
-          Set the log output verbosity.
-          
-          [possible values: trace, debug, info, warn, error]
+          Set the log output verbosity. [possible values: trace, debug, info, warn, error]
 
       --quiet
           Do not print any output while preserving correct exit code. This flag is currently

--- a/tests/integration/_cases/send_metric/send_metric-gauge-help.trycmd
+++ b/tests/integration/_cases/send_metric/send_metric-gauge-help.trycmd
@@ -31,9 +31,7 @@ Options:
           Metric value, any finite 64 bit float.
 
       --log-level <LOG_LEVEL>
-          Set the log output verbosity.
-[..]
-          [possible values: trace, debug, info, warn, error]
+          Set the log output verbosity. [possible values: trace, debug, info, warn, error]
 
       --quiet
           Do not print any output while preserving correct exit code. This flag is currently

--- a/tests/integration/_cases/send_metric/send_metric-help.trycmd
+++ b/tests/integration/_cases/send_metric/send_metric-help.trycmd
@@ -29,9 +29,7 @@ Options:
           Use the given Sentry auth token.
 
       --log-level <LOG_LEVEL>
-          Set the log output verbosity.
-          
-          [possible values: trace, debug, info, warn, error]
+          Set the log output verbosity. [possible values: trace, debug, info, warn, error]
 
       --quiet
           Do not print any output while preserving correct exit code. This flag is currently

--- a/tests/integration/_cases/send_metric/send_metric-increment-help.trycmd
+++ b/tests/integration/_cases/send_metric/send_metric-increment-help.trycmd
@@ -33,9 +33,7 @@ Options:
           [default: 1]
 
       --log-level <LOG_LEVEL>
-          Set the log output verbosity.
-[..]
-          [possible values: trace, debug, info, warn, error]
+          Set the log output verbosity. [possible values: trace, debug, info, warn, error]
 
       --quiet
           Do not print any output while preserving correct exit code. This flag is currently

--- a/tests/integration/_cases/send_metric/send_metric-set-help.trycmd
+++ b/tests/integration/_cases/send_metric/send_metric-set-help.trycmd
@@ -32,9 +32,7 @@ Options:
           count will not increase.
 
       --log-level <LOG_LEVEL>
-          Set the log output verbosity.
-[..]
-          [possible values: trace, debug, info, warn, error]
+          Set the log output verbosity. [possible values: trace, debug, info, warn, error]
 
       --quiet
           Do not print any output while preserving correct exit code. This flag is currently

--- a/tests/integration/_cases/sourcemaps/sourcemaps-inject-help.trycmd
+++ b/tests/integration/_cases/sourcemaps/sourcemaps-inject-help.trycmd
@@ -46,9 +46,7 @@ Options:
           Don't modify files on disk.
 
       --log-level <LOG_LEVEL>
-          Set the log output verbosity.
-          
-          [possible values: trace, debug, info, warn, error]
+          Set the log output verbosity. [possible values: trace, debug, info, warn, error]
 
       --quiet
           Do not print any output while preserving correct exit code. This flag is currently


### PR DESCRIPTION
We don't need custom logic to parse the log level, `clap` can do this.