### PR TITLE
ref: Enable `clippy::unnecessary_wraps` lint

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
         run: cargo fmt --all -- --check
 
       - name: Run Clippy
-        run: cargo clippy --workspace --tests -- -D clippy::all
+        run: cargo clippy --workspace --tests -- -D warnings
 
   test:
     strategy:

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -1718,6 +1718,7 @@ impl ApiRequest {
         Ok(self)
     }
 
+    #[expect(clippy::unnecessary_wraps)]
     pub fn with_body(mut self, body: Vec<u8>) -> ApiResult<Self> {
         self.body = Some(body);
         Ok(self)
@@ -1739,11 +1740,13 @@ impl ApiRequest {
     }
 
     /// enables a progress bar.
+    #[expect(clippy::unnecessary_wraps)]
     pub fn progress_bar_mode(mut self, mode: ProgressBarMode) -> ApiResult<Self> {
         self.progress_bar_mode = mode;
         Ok(self)
     }
 
+    #[expect(clippy::unnecessary_wraps)]
     pub fn with_retry(
         mut self,
         max_retries: u32,

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -103,6 +103,9 @@ fn preexecute_hooks() -> Result<bool> {
         Ok(false)
     }
 
+    // This function needs to return Result<bool> to remain compatible with the
+    // macOS implementation.
+    #[expect(clippy::unnecessary_wraps)]
     #[cfg(not(target_os = "macos"))]
     fn sentry_react_native_xcode_wrap() -> Result<bool> {
         Ok(false)

--- a/src/commands/sourcemaps/resolve.rs
+++ b/src/commands/sourcemaps/resolve.rs
@@ -33,6 +33,7 @@ pub fn make_command(command: Command) -> Command {
 }
 
 /// Returns the zero indexed position from matches
+#[expect(clippy::unnecessary_wraps)]
 fn lookup_pos(matches: &ArgMatches) -> Option<(u32, u32)> {
     Some((
         matches.get_one::<u32>("line").map_or(0, |x| x - 1),

--- a/src/config.rs
+++ b/src/config.rs
@@ -58,6 +58,7 @@ impl Config {
     }
 
     /// Creates Config based on provided config file.
+    #[expect(clippy::unnecessary_wraps)]
     pub fn from_file(filename: PathBuf, ini: Ini) -> Result<Config> {
         let auth = get_default_auth(&ini);
         let token_embedded_data = match auth {
@@ -167,6 +168,7 @@ impl Config {
     }
 
     /// Updates the auth info
+    #[expect(clippy::unnecessary_wraps)]
     pub fn set_auth(&mut self, auth: Auth) -> Result<()> {
         self.cached_auth = Some(auth);
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,5 @@
+#![warn(clippy::unnecessary_wraps)]
+
 mod api;
 mod commands;
 mod config;

--- a/src/utils/sourcemaps.rs
+++ b/src/utils/sourcemaps.rs
@@ -254,6 +254,7 @@ impl SourceMapProcessor {
     }
 
     /// Adds a new file for processing.
+    #[expect(clippy::unnecessary_wraps)]
     pub fn add(&mut self, url: &str, file: ReleaseFileMatch) -> Result<()> {
         self.pending_sources.insert((url.to_string(), file));
         Ok(())
@@ -691,6 +692,7 @@ impl SourceMapProcessor {
     }
 
     /// Adds sourcemap references to all minified files
+    #[expect(clippy::unnecessary_wraps)]
     pub fn add_sourcemap_references(&mut self) -> Result<()> {
         self.flush_pending_sources();
         self.collect_sourcemap_references();
@@ -710,6 +712,7 @@ impl SourceMapProcessor {
 
     /// Adds debug id to the source file headers from the linked source map.
     /// This is used for files we can't read debug ids from (e.g. Hermes bytecode bundles).
+    #[expect(clippy::unnecessary_wraps)]
     pub fn add_debug_id_references(&mut self) -> Result<()> {
         self.flush_pending_sources();
 

--- a/src/utils/update.rs
+++ b/src/utils/update.rs
@@ -176,6 +176,7 @@ impl SentryCliUpdateInfo {
     }
 }
 
+#[expect(clippy::unnecessary_wraps)]
 pub fn get_latest_sentrycli_release() -> Result<SentryCliUpdateInfo> {
     let api = Api::current();
     Ok(SentryCliUpdateInfo {

--- a/src/utils/value_parsers.rs
+++ b/src/utils/value_parsers.rs
@@ -10,6 +10,7 @@ pub fn kv_parser(s: &str) -> Result<(String, String)> {
 }
 
 /// Parse an AuthToken, and warn if the format is unrecognized
+#[expect(clippy::unnecessary_wraps)]
 pub fn auth_token_parser(s: &str) -> Result<AuthToken, Infallible> {
     let token = AuthToken::from(s);
     if !token.format_recognized() {


### PR DESCRIPTION
However, since fixing each existing violation would require changes to how each function is called, we hold off on fixing the violations in this PR. Instead, we `expect` the current violations individually. Future PRs will fix the existing violations.

Ref #2357