### PR TITLE
ci: Change lint action to `-D warnings`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
         run: cargo fmt --all -- --check
 
       - name: Run Clippy
-        run: cargo clippy --workspace --tests -- -D clippy::all
+        run: cargo clippy --workspace --tests -- -D warnings
 
   test:
     strategy:


### PR DESCRIPTION
Currently, the lint action specifies `-D clippy::all`. This means that if we enable any additional lints in the code, e.g. by adding `#![warn(clippy::pedantic)]` to the `main` module, these lints will not fail CI. By specifying `-D warnings` instead, any lints we enable as warnings in code will fail CI.