### PR TITLE
ci: Run lint action on all target operating systems

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,9 +13,14 @@ env:
   RUSTFLAGS: -Dwarnings
 
 jobs:
-  lint:
-    name: Lint
-    runs-on: ubuntu-24.04
+  lint-each-os:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-24.04, macos-14, windows-2022]
+
+    name: Lint (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # 4.2.2
 
@@ -29,6 +34,18 @@ jobs:
 
       - name: Run Clippy
         run: cargo clippy --workspace --tests
+
+  lint:
+    needs: lint-each-os
+    runs-on: ubuntu-24.04
+    if: always() # Run even if lint-each-os fails
+    name: Lint
+    steps:
+      - name: Check for lint failures
+        if: contains(needs.lint-each-os.result, 'failure') || contains(needs.lint-each-os.result, 'skipped')
+        run: |
+          echo "Required lint check failed. You need to fix the problem before merging."
+          exit 1
 
   test:
     strategy:

--- a/src/utils/system.rs
+++ b/src/utils/system.rs
@@ -27,19 +27,6 @@ pub fn propagate_exit_status(status: process::ExitStatus) {
     }
 }
 
-#[cfg(not(windows))]
-fn is_homebrew_install_result() -> Result<bool> {
-    let mut exe = env::current_exe()?.canonicalize()?;
-    exe.pop();
-    exe.set_file_name("INSTALL_RECEIPT.json");
-    Ok(exe.is_file())
-}
-
-#[cfg(windows)]
-fn is_homebrew_install_result() -> Result<bool> {
-    Ok(false)
-}
-
 fn is_npm_install_result() -> Result<bool> {
     let mut exe = env::current_exe()?.canonicalize()?;
     exe.set_file_name("package.json");
@@ -48,7 +35,14 @@ fn is_npm_install_result() -> Result<bool> {
 
 /// Checks if we were installed from homebrew
 pub fn is_homebrew_install() -> bool {
-    is_homebrew_install_result().unwrap_or(false)
+    #[cfg(not(windows))]
+    if let Ok(mut exe) = env::current_exe().and_then(|p| p.canonicalize()) {
+        exe.pop();
+        exe.set_file_name("INSTALL_RECEIPT.json");
+        return exe.is_file();
+    }
+
+    false
 }
 
 /// Checks if we were installed via npm


### PR DESCRIPTION
Sentry CLI contains platform-dependent code. Therefore, to ensure we catch all linter errors, we need to run `cargo clippy` against all targets.