### PR TITLE
ref(config): Fix `unnecessary_wraps` lint for `set_auth`

### DIFF
--- a/src/commands/login.rs
+++ b/src/commands/login.rs
@@ -21,7 +21,7 @@ pub fn make_command(command: Command) -> Command {
 
 fn update_config(config: &Config, token: AuthToken) -> Result<()> {
     let mut new_cfg = config.clone();
-    new_cfg.set_auth(Auth::Token(token))?;
+    new_cfg.set_auth(Auth::Token(token));
     new_cfg.save()?;
     Ok(())
 }
@@ -69,7 +69,7 @@ pub fn execute(matches: &ArgMatches) -> Result<()> {
         };
 
         let test_cfg = config.make_copy(|cfg| {
-            cfg.set_auth(Auth::Token(token.clone()))?;
+            cfg.set_auth(Auth::Token(token.clone()));
             Ok(())
         })?;
 

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -112,13 +112,13 @@ fn preexecute_hooks() -> Result<bool> {
     }
 }
 
-fn configure_args(config: &mut Config, matches: &ArgMatches) -> Result<()> {
+fn configure_args(config: &mut Config, matches: &ArgMatches) {
     if let Some(api_key) = matches.get_one::<String>("api_key") {
-        config.set_auth(Auth::Key(api_key.to_owned()))?;
+        config.set_auth(Auth::Key(api_key.to_owned()));
     }
 
     if let Some(auth_token) = matches.get_one::<AuthToken>("auth_token") {
-        config.set_auth(Auth::Token(auth_token.to_owned()))?;
+        config.set_auth(Auth::Token(auth_token.to_owned()));
     }
 
     if let Some(url) = matches.get_one::<String>("url") {
@@ -129,8 +129,6 @@ fn configure_args(config: &mut Config, matches: &ArgMatches) -> Result<()> {
         let headers = headers.map(|h| h.to_owned()).collect();
         config.set_headers(headers);
     }
-
-    Ok(())
 }
 
 fn app() -> Command {
@@ -250,7 +248,7 @@ pub fn execute() -> Result<()> {
         set_max_level(log_level);
     }
     let mut config = Config::from_cli_config()?;
-    configure_args(&mut config, &matches)?;
+    configure_args(&mut config, &matches);
     set_quiet_mode(matches.get_flag("quiet"));
 
     if let Some(&log_level) = log_level {

--- a/src/config.rs
+++ b/src/config.rs
@@ -167,8 +167,7 @@ impl Config {
     }
 
     /// Updates the auth info
-    #[expect(clippy::unnecessary_wraps)]
-    pub fn set_auth(&mut self, auth: Auth) -> Result<()> {
+    pub fn set_auth(&mut self, auth: Auth) {
         self.cached_auth = Some(auth);
 
         self.ini.delete_from(Some("auth"), "api_key");
@@ -193,8 +192,6 @@ impl Config {
             }
             None => {}
         }
-
-        Ok(())
     }
 
     /// Returns the base url (without trailing slashes)


### PR DESCRIPTION
Fixing the lint for `set_auth` makes `configure_auth` violate the lint, so we also fix that new violation here.

Ref #2357