### PR TITLE
ref: Make `Api::with_body` return `Self`

### DIFF
--- a/src/api/envelopes_api.rs
+++ b/src/api/envelopes_api.rs
@@ -33,7 +33,7 @@ impl EnvelopesApi {
         self.api
             .request(Method::Post, url.as_str(), None)?
             .with_header("X-Sentry-Auth", &auth.to_string())?
-            .with_body(body)?
+            .with_body(body)
             .send()?
             .into_result()
     }

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -1718,10 +1718,9 @@ impl ApiRequest {
         Ok(self)
     }
 
-    #[expect(clippy::unnecessary_wraps)]
-    pub fn with_body(mut self, body: Vec<u8>) -> ApiResult<Self> {
+    pub fn with_body(mut self, body: Vec<u8>) -> Self {
         self.body = Some(body);
-        Ok(self)
+        self
     }
 
     /// attaches some form data to the request.


### PR DESCRIPTION
No need for a `Result` here.

Ref #2357