### PR TITLE
fix(update): Properly handle errors when getting latest CLI version

### DIFF
--- a/src/commands/update.rs
+++ b/src/commands/update.rs
@@ -1,6 +1,6 @@
 use std::env;
 
-use anyhow::{bail, Result};
+use anyhow::{bail, Context, Result};
 use clap::{Arg, ArgAction, ArgMatches, Command};
 
 use crate::utils::update::{assert_updatable, can_update_sentrycli, get_latest_sentrycli_release};
@@ -29,7 +29,8 @@ pub fn execute(matches: &ArgMatches) -> Result<()> {
     assert_updatable()?;
 
     let exe = env::current_exe()?;
-    let update = get_latest_sentrycli_release()?;
+    let update = get_latest_sentrycli_release()
+        .with_context(|| "Error getting latest Sentry CLI version.")?;
     if !update.have_version_info() {
         bail!("Could not get the latest release version.");
     }

--- a/src/utils/update.rs
+++ b/src/utils/update.rs
@@ -115,6 +115,7 @@ impl LastUpdateCheck {
     }
 }
 
+#[derive(Default)]
 pub struct SentryCliUpdateInfo {
     latest_release: Option<SentryCliRelease>,
 }
@@ -176,11 +177,10 @@ impl SentryCliUpdateInfo {
     }
 }
 
-#[expect(clippy::unnecessary_wraps)]
 pub fn get_latest_sentrycli_release() -> Result<SentryCliUpdateInfo> {
     let api = Api::current();
     Ok(SentryCliUpdateInfo {
-        latest_release: api.get_latest_sentrycli_release().unwrap_or_default(),
+        latest_release: api.get_latest_sentrycli_release()?,
     })
 }
 
@@ -224,7 +224,8 @@ fn update_nagger_impl() -> Result<()> {
 
     if check.should_run_check() {
         info!("Running update nagger update check");
-        let ui = get_latest_sentrycli_release()?;
+        // Error getting latest version in update nagger should not crash the CLI
+        let ui = get_latest_sentrycli_release().unwrap_or_default();
         if ui.have_version_info() {
             check.update_for_info(&ui);
             let mut f = fs::File::create(&path)?;


### PR DESCRIPTION
The current code suppresses any API errors that occur when trying to get the latest CLI version. This is probably ideal behavior in the update nagger, but likely not in the `sentry-cli update` command.

This change also fixes a `clippy::unnecessary_wraps` lint.

Ref #2357