### PR TITLE
docs: Explain why lint is disabled

### DIFF
--- a/src/utils/value_parsers.rs
+++ b/src/utils/value_parsers.rs
@@ -10,6 +10,8 @@ pub fn kv_parser(s: &str) -> Result<(String, String)> {
 }
 
 /// Parse an AuthToken, and warn if the format is unrecognized
+// Clap requires parsers to return a Result, hence why this function returns
+// a Result, violating the clippy::unnecessary_wraps lint.
 #[expect(clippy::unnecessary_wraps)]
 pub fn auth_token_parser(s: &str) -> Result<AuthToken, Infallible> {
     let token = AuthToken::from(s);


### PR DESCRIPTION
We need `#[expect(clippy::unnecessary_wraps)]` on this function, add a comment to explain why.