### PR TITLE
feat: Only warn for token org mismatch

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -346,15 +346,14 @@ impl Config {
             (None, Some(cli_org)) => Ok(cli_org),
             (Some(token_org), None) => Ok(token_org.to_string()),
             (Some(token_org), Some(cli_org)) => {
-                if cli_org.is_empty() {
-                    return Ok(token_org.to_owned());
-                }
                 if cli_org != *token_org {
-                    return Err(format_err!(
-                        "Two different org values supplied: `{token_org}` (from token), `{cli_org}`."
-                    ));
+                    log::warn!(
+                        "Using organization `{token_org}` (embedded in token) rather \
+                        than manually-configured organization `{cli_org}`. To use \
+                        `{cli_org}`, please provide an auth token for this organization."
+                    );
                 }
-                Ok(cli_org)
+                Ok(token_org.into())
             }
         }
     }

--- a/tests/integration/_cases/org_tokens/org-mismatch.trycmd
+++ b/tests/integration/_cases/org_tokens/org-mismatch.trycmd
@@ -1,9 +1,7 @@
 ```
 $ sentry-cli --auth-token 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 sourcemaps upload --org otherorg test_path
 ? failed
-error: Two different org values supplied: `sentry` (from token), `otherorg`.
-
-Add --log-level=[info|debug] or export SENTRY_LOG_LEVEL=[info|debug] to see more output.
-Please attach the full debug log to all bug reports.
+[..]WARN[..]Using organization `sentry` (embedded in token) rather than manually-configured organization `otherorg`. To use `otherorg`, please provide an auth token for this organization.
+...
 
 ```


### PR DESCRIPTION
If the manually-configured org differs from the token-embedded org, issue a warning, and use the token-embedded org. Previously, we would error in this case.

Closes #2381