### PR TITLE
build: Build Docker image in CI and publish to GHCR

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -263,6 +263,34 @@ jobs:
           path: npm-binary-distributions/*/*.tgz
           if-no-files-found: 'error'
 
+  docker:
+    name: Docker Image
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          push: true
+          tags: |
+            ghcr.io/${{ github.repository }}:${{ github.ref_name }}
+          platforms: linux/amd64,linux/aarch64
+
   merge:
     name: Create Release Artifact
     runs-on: ubuntu-24.04


### PR DESCRIPTION
This will cause `sentry-cli:<hash>` to be created and pushed to GHCR in the release build action, which runs on push to branches matching `release/*`. We can add a step to the actual release process which tags these GHCR images with the version number and also publish them to Docker Hub

Ref #1338 