### PR TITLE
build(docker): Build Docker image on host architecture

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,25 +1,22 @@
-ARG BUILD_ARCH=x86_64
-ARG BUILD_LIBC=musl
-FROM messense/rust-musl-cross:$BUILD_ARCH-$BUILD_LIBC AS sentry-build
+FROM rust:1.84-alpine AS sentry-build
 
-ARG BUILD_ARCH
-ARG BUILD_LIBC
-ENV BUILD_TARGET=$BUILD_ARCH-unknown-linux-$BUILD_LIBC
+# Install build dependencies
+RUN apk add musl-dev perl openssl-dev make
+
 WORKDIR /work
 
 # Build only dependencies to speed up subsequent builds
 COPY Cargo.toml Cargo.lock build.rs ./
 RUN mkdir -p src \
     && echo "fn main() {}" > src/main.rs \
-    && cargo build --release --target=$BUILD_TARGET --locked
+    && cargo build --release --locked
 
 # Add all sources and rebuild the actual sentry-cli
 COPY src src/
-
-RUN touch src/main.rs && cargo build --target=$BUILD_TARGET --release --features managed
+RUN touch src/main.rs && cargo build --release --features managed
 
 # Copy the compiled binary to a target-independent location so it can be picked up later
-RUN cp target/$BUILD_TARGET/release/sentry-cli /usr/local/bin/sentry-cli
+RUN cp target/release/sentry-cli /usr/local/bin/sentry-cli
 
 FROM alpine:3.14
 WORKDIR /work


### PR DESCRIPTION
Instead of using cross-compilation with `rust-musl-cross`, build Sentry CLI Docker container using the official Rust Alpine Docker image. This image will by default build for `musl` Linux (as before) using the architecture of the host system, rather than cross compiling