### PR TITLE
ci(docker): Remove invalid argument

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -313,7 +313,7 @@ jobs:
 
       - name: Create multi-architecture image
         run: |
-          docker buildx imagetools create --push -t ghcr.io/${{ github.repository }}:${{ github.sha }} \
+          docker buildx imagetools create -t ghcr.io/${{ github.repository }}:${{ github.sha }} \
             ghcr.io/${{ github.repository }}:${{ github.sha }}-amd64 \
             ghcr.io/${{ github.repository }}:${{ github.sha }}-arm64
 


### PR DESCRIPTION
There is no `--push` argument for `docker buildx imagetools create`. The command should automatically push the new image.