### PR TITLE
ci(docker): Add Craft targets for `docker`

### DIFF
--- a/.craft.yml
+++ b/.craft.yml
@@ -94,6 +94,24 @@ targets:
   - name: pypi
   - name: sentry-pypi
     internalPypiRepo: getsentry/pypi
+  - name: docker
+    id: GHCR (release)
+    source: ghcr.io/getsentry/sentry-cli
+    target: ghcr.io/getsentry/sentry-cli
+  - name: docker
+    id: GHCR (latest)
+    source: ghcr.io/getsentry/sentry-cli
+    target: ghcr.io/getsentry/sentry-cli
+    targetFormat: '{{{target}}}:latest'
+  - name: docker
+    id: Docker Hub (release)
+    source: ghcr.io/getsentry/sentry-cli
+    target: getsentry/sentry-cli
+  - name: docker
+    id: Docker Hub (latest)
+    source: ghcr.io/getsentry/sentry-cli
+    target: getsentry/sentry-cli
+    targetFormat: '{{{target}}}:latest'
 requireNames:
   - /^sentry-cli-Darwin-x86_64$/
   - /^sentry-cli-Darwin-arm64$/


### PR DESCRIPTION
Add four new Craft targets to enable releases to Docker Hub and GHCR. These targets simply copy the multiarch Docker image built during the Release Build action to GHCR and Docker Hub. For both GHCR and Docker Hub, we create an image tagged with the version number and with "latest."

Ref #1338