### PR TITLE
ci(docker): Fix caching

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -296,8 +296,8 @@ jobs:
           push: true
           platforms: linux/${{ matrix.platform }}
           tags: ghcr.io/${{ github.repository }}:${{ github.sha }}-${{ matrix.platform }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          cache-from: type=gha,scope=${{ matrix.platform }}
+          cache-to: type=gha,mode=max,scope=${{ matrix.platform }}
 
   multiarch-docker:
     name: Create Multi-Architecture Docker Image


### PR DESCRIPTION
Because we are building two different Docker containers (one for each platform), we need separate caches for each one, otherwise both builds use the same cache, resulting in them overwriting each other. By setting a [separate scope for each,](https://docs.docker.com/build/cache/backends/gha/#scope)
 the caches will be separate and not overwrite each other.