### PR TITLE
ci(docker): Don't publish to GHCR via Craft

### DIFF
--- a/.craft.yml
+++ b/.craft.yml
@@ -95,15 +95,6 @@ targets:
   - name: sentry-pypi
     internalPypiRepo: getsentry/pypi
   - name: docker
-    id: GHCR (release)
-    source: ghcr.io/getsentry/sentry-cli
-    target: ghcr.io/getsentry/sentry-cli
-  - name: docker
-    id: GHCR (latest)
-    source: ghcr.io/getsentry/sentry-cli
-    target: ghcr.io/getsentry/sentry-cli
-    targetFormat: '{{{target}}}:latest'
-  - name: docker
     id: Docker Hub (release)
     source: ghcr.io/getsentry/sentry-cli
     target: getsentry/sentry-cli


### PR DESCRIPTION
It appears that Craft does not support pushing to GHCR, only to Docker Hub: https://github.com/getsentry/publish/actions/runs/13391431698/job/37399828094