### PR TITLE
ci(docker): Release Docker image to GHCR

### DIFF
--- a/.github/workflows/release-ghcr-latest-tag.yml
+++ b/.github/workflows/release-ghcr-latest-tag.yml
@@ -1,0 +1,22 @@
+name: Release GHCR Latest Image
+
+on:
+  release:
+    types: [released]
+
+jobs:
+  release-ghcr-latest-tag:
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Tag latest version
+        run: |
+          docker pull ghcr.io/getsentry/sentry-cli:${{ github.sha }}
+          docker tag ghcr.io/getsentry/sentry-cli:${{ github.sha }} ghcr.io/getsentry/sentry-cli:latest
+          docker push ghcr.io/getsentry/sentry-cli:latest

--- a/.github/workflows/release-ghcr-version-tag.yml
+++ b/.github/workflows/release-ghcr-version-tag.yml
@@ -1,0 +1,22 @@
+name: Release GHCR Versioned Image
+
+on:
+  release:
+    types: [prereleased, released]
+
+jobs:
+  release-ghcr-version-tag:
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Tag release version
+        run: |
+          docker pull ghcr.io/getsentry/sentry-cli:${{ github.sha }}
+          docker tag ghcr.io/getsentry/sentry-cli:${{ github.sha }} ghcr.io/getsentry/sentry-cli:${{ github.ref_name }}
+          docker push ghcr.io/getsentry/sentry-cli:${{ github.ref_name }}


### PR DESCRIPTION
We already build and push our Docker images to GHCR, tagged with commit hash, during the Release Build action. This PR adds two new actions which will tag these images with the version number and with the "latest" once the GitHub release is created. We have two separate actions for each, since we only want to add the "latest" tag for releases, not for preleases, but the version tag should be created for both.

Ref #1503