### PR TITLE
fix: warn about missing SENTRY_RELEASE when it's set to empty string

### DIFF
--- a/src/api/data_types/chunking/artifact.rs
+++ b/src/api/data_types/chunking/artifact.rs
@@ -9,7 +9,7 @@ pub struct ChunkedArtifactRequest<'a> {
     pub chunks: &'a [Digest],
     #[serde(skip_serializing_if = "Vec::is_empty")]
     pub projects: Vec<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(skip_serializing_if = "version_is_empty")]
     pub version: Option<&'a str>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub dist: Option<&'a str>,
@@ -21,4 +21,11 @@ pub struct AssembleArtifactsResponse {
     pub state: ChunkedFileState,
     pub missing_chunks: Vec<Digest>,
     pub detail: Option<String>,
+}
+
+fn version_is_empty(version: &Option<&str>) -> bool {
+    match version {
+        Some(v) => v.is_empty(),
+        None => true,
+    }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -363,8 +363,12 @@ impl Config {
         matches
             .get_one::<String>("release")
             .cloned()
-            .or_else(|| env::var("SENTRY_RELEASE").ok())
-            .ok_or_else(|| format_err!("A release slug is required (provide with --release)"))
+            .or_else(|| {
+                env::var("SENTRY_RELEASE")
+                    .ok()
+                    .and_then(|v| if v.is_empty() { None } else { Some(v) })
+            })
+            .ok_or_else(|| format_err!("A release slug is required (provide with --release) or set the SENTRY_RELEASE environment variable"))
     }
 
     // Backward compatibility with `releases files <VERSION>` commands.

--- a/src/config.rs
+++ b/src/config.rs
@@ -368,7 +368,7 @@ impl Config {
                     .ok()
                     .filter(|v| !v.is_empty())
             })
-            .ok_or_else(|| format_err!("A release slug is required (provide with --release) or set the SENTRY_RELEASE environment variable"))
+            .ok_or_else(|| format_err!("A release slug is required (provide with --release or by setting the SENTRY_RELEASE environment variable)"))
     }
 
     // Backward compatibility with `releases files <VERSION>` commands.

--- a/src/config.rs
+++ b/src/config.rs
@@ -366,7 +366,7 @@ impl Config {
             .or_else(|| {
                 env::var("SENTRY_RELEASE")
                     .ok()
-                    .and_then(|v| if v.is_empty() { None } else { Some(v) })
+                    .filter(|v| !v.is_empty())
             })
             .ok_or_else(|| format_err!("A release slug is required (provide with --release) or set the SENTRY_RELEASE environment variable"))
     }

--- a/src/utils/file_upload.rs
+++ b/src/utils/file_upload.rs
@@ -96,7 +96,7 @@ pub struct UploadContext<'a> {
 impl UploadContext<'_> {
     pub fn release(&self) -> Result<&str> {
         self.release
-            .ok_or_else(|| anyhow!("A release slug is required (provide with --release)"))
+            .ok_or_else(|| anyhow!("A release slug is required (provide with --release) or set the SENTRY_RELEASE environment variable"))
     }
 }
 

--- a/src/utils/file_upload.rs
+++ b/src/utils/file_upload.rs
@@ -75,7 +75,7 @@ pub fn initialize_legacy_release_upload(context: &UploadContext) -> Result<()> {
             },
         )?;
     } else {
-        bail!("This version of Sentry does not support artifact bundles. A release slug is required (provide with --release)");
+        bail!("This version of Sentry does not support artifact bundles. A release slug is required (provide with --release or by setting the SENTRY_RELEASE environment variable)");
     }
     Ok(())
 }
@@ -96,7 +96,7 @@ pub struct UploadContext<'a> {
 impl UploadContext<'_> {
     pub fn release(&self) -> Result<&str> {
         self.release
-            .ok_or_else(|| anyhow!("A release slug is required (provide with --release) or set the SENTRY_RELEASE environment variable"))
+            .ok_or_else(|| anyhow!("A release slug is required (provide with --release or by setting the SENTRY_RELEASE environment variable)"))
     }
 }
 


### PR DESCRIPTION
I'm not sure if this covers all instances/paths

closes #2385