### PR TITLE
ci(docker): Fix GHCR releases so they are multiarch

### DIFF
--- a/.github/workflows/release-ghcr-latest-tag.yml
+++ b/.github/workflows/release-ghcr-latest-tag.yml
@@ -17,6 +17,6 @@ jobs:
 
       - name: Tag latest version
         run: |
-          docker pull ghcr.io/getsentry/sentry-cli:${{ github.sha }}
-          docker tag ghcr.io/getsentry/sentry-cli:${{ github.sha }} ghcr.io/getsentry/sentry-cli:latest
-          docker push ghcr.io/getsentry/sentry-cli:latest
+          docker buildx imagetools create \
+            -t ghcr.io/getsentry/sentry-cli:latest \
+            ghcr.io/getsentry/sentry-cli:${{ github.sha }}

--- a/.github/workflows/release-ghcr-version-tag.yml
+++ b/.github/workflows/release-ghcr-version-tag.yml
@@ -17,6 +17,6 @@ jobs:
 
       - name: Tag release version
         run: |
-          docker pull ghcr.io/getsentry/sentry-cli:${{ github.sha }}
-          docker tag ghcr.io/getsentry/sentry-cli:${{ github.sha }} ghcr.io/getsentry/sentry-cli:${{ github.ref_name }}
-          docker push ghcr.io/getsentry/sentry-cli:${{ github.ref_name }}
+          docker buildx imagetools create \
+            -t ghcr.io/getsentry/sentry-cli:${{ github.ref_name }} \
+            ghcr.io/getsentry/sentry-cli:${{ github.sha }}


### PR DESCRIPTION
Our current release process for GHCR makes the images tagged with the version number and "latest" only be single-arch images, rather than keeping them as multi-arch images.

This change _should_ fix this behavior.