### PR TITLE
ci: Remove unneeded `-D warnings`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
         run: cargo fmt --all -- --check
 
       - name: Run Clippy
-        run: cargo clippy --workspace --tests -- -D warnings
+        run: cargo clippy --workspace --tests
 
   test:
     strategy:


### PR DESCRIPTION
This explicit `-D warnings` is redundant, since we set the `RUSTFLAGS` environment variable to `-Dwarnings` above.

#2426 tests this change by intentionally introducing a Clippy warnings. As expected, the CI lint action fails.