### PR TITLE
ci: Auto-update GHA with Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+version: 2
+updates:
+  # Updates to GitHub Actions
+  - package-ecosystem: 'github-actions'
+    directory: '/'
+    schedule:
+      interval: 'weekly'


### PR DESCRIPTION
Create a `dependabot.yml` which checks for updates to any GitHub Actions which Sentry CLI uses, and automatically updates them, on a weekly basis.

This configuration is based on [GitHub's example](https://docs.github.com/en/code-security/dependabot/working-with-dependabot/keeping-your-actions-up-to-date-with-dependabot#example-dependabotyml-file-for-github-actions).