### PR TITLE
ci: Build for Windows ARM

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -170,7 +170,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        arch: [i686, x86_64]
+        arch: [i686, x86_64, aarch64]
 
     env:
       TARGET: ${{ matrix.arch }}-pc-windows-msvc

--- a/scripts/wheels
+++ b/scripts/wheels
@@ -54,6 +54,11 @@ WHEELS = (
         plat='win_amd64',
         exe='sentry-cli.exe',
     ),
+    Wheel(
+        src='sentry-cli-Windows-aarch64.exe',
+        plat='win_arm64',
+        exe='sentry-cli.exe',
+    ),
 )
 
 


### PR DESCRIPTION
Create a release build for Windows ARM. We still will need to make changes to actually distribute this through all channels (e.g. through `npm` and possibly the install shell script).

Closes #1426