### PR TITLE
build: Replace `username` with `whoami`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,16 +18,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
-name = "advapi32-sys"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e06588080cb19d0acb6739808aafa5f26bfb2ca015b2b6370028b44cf7cb8a9a"
-dependencies = [
- "winapi 0.2.8",
- "winapi-build",
-]
-
-[[package]]
 name = "aes"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -744,7 +734,7 @@ checksum = "1b1d1d91c932ef41c0f2663aa8b0ca0342d444d842c06914aa0a7e352d0bada6"
 dependencies = [
  "libc",
  "redox_users",
- "winapi 0.3.9",
+ "winapi",
 ]
 
 [[package]]
@@ -755,7 +745,7 @@ checksum = "4ebda144c4fe02d1f7ea1a7d9641b6fc6b580adcfa024ae48797ecdeb6825b4d"
 dependencies = [
  "libc",
  "redox_users",
- "winapi 0.3.9",
+ "winapi",
 ]
 
 [[package]]
@@ -2796,10 +2786,10 @@ dependencies = [
  "thiserror 1.0.61",
  "trycmd",
  "url",
- "username",
  "uuid",
  "walkdir",
  "which",
+ "whoami",
  "windows-sys 0.59.0",
  "zip",
 ]
@@ -3233,7 +3223,7 @@ checksum = "c59df8ac95d96ff9bede18eb7300b0fda5e5d8d90960e76f8e14ae765eedbf1f"
 dependencies = [
  "dirs-next",
  "rustversion",
- "winapi 0.3.9",
+ "winapi",
 ]
 
 [[package]]
@@ -3483,16 +3473,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "username"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92e425df6527f7bc1adc7eb3b829ecaec746fbbc0b05e42133ff84afef3b1a09"
-dependencies = [
- "advapi32-sys",
- "winapi 0.2.8",
-]
-
-[[package]]
 name = "utf16_iter"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3572,6 +3552,12 @@ checksum = "9683f9a5a998d873c0d21fcbe3c083009670149a8fab228644b8bd36b2c48cb3"
 dependencies = [
  "wit-bindgen-rt",
 ]
+
+[[package]]
+name = "wasite"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8dad83b4f25e74f184f64c43b150b91efe7647395b42289f38e50566d82855b"
 
 [[package]]
 name = "wasm-bindgen"
@@ -3656,6 +3642,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "web-sys"
+version = "0.3.77"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33b6dd2ef9186f1f2072e409e99cd22a975331a6b3591b12c764e0e55c60d5d2"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "which"
 version = "4.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3668,10 +3664,15 @@ dependencies = [
 ]
 
 [[package]]
-name = "winapi"
-version = "0.2.8"
+name = "whoami"
+version = "1.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "167dc9d6949a9b857f3451275e911c3f44255842c1f7a76f33c55103a909087a"
+checksum = "372d5b87f58ec45c384ba03563b03544dc5fadc3983e434b286913f5b4a9bb6d"
+dependencies = [
+ "redox_syscall 0.5.2",
+ "wasite",
+ "web-sys",
+]
 
 [[package]]
 name = "winapi"
@@ -3682,12 +3683,6 @@ dependencies = [
  "winapi-i686-pc-windows-gnu",
  "winapi-x86_64-pc-windows-gnu",
 ]
-
-[[package]]
-name = "winapi-build"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d315eee3b34aca4797b2da6b13ed88266e6d612562a0c46390af8299fc699bc"
 
 [[package]]
 name = "winapi-i686-pc-windows-gnu"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -68,10 +68,10 @@ sourcemap = { version = "9.1.2", features = ["ram_bundle"] }
 symbolic = { version = "12.13.3", features = ["debuginfo-serde", "il2cpp"] }
 thiserror = "1.0.38"
 url = "2.3.1"
-username = "0.2.0"
 uuid = { version = "1.3.0", features = ["v4", "serde"] }
 walkdir = "2.3.2"
 which = "4.4.0"
+whoami = "1.5.2"
 zip = "2.4.2"
 data-encoding = "2.3.3"
 magic_string = "0.3.4"

--- a/src/commands/bash_hook.rs
+++ b/src/commands/bash_hook.rs
@@ -10,7 +10,6 @@ use clap::{builder::ArgPredicate, Arg, ArgAction, ArgMatches, Command};
 use lazy_static::lazy_static;
 use regex::Regex;
 use sentry::protocol::{Event, Exception, Frame, Stacktrace, User, Value};
-use username::get_user_name;
 use uuid::Uuid;
 
 use crate::commands::send_event;
@@ -92,7 +91,7 @@ fn send_event(
         environment: config.get_environment().map(Into::into),
         release: release.or(detect_release_name().ok()).map(Into::into),
         sdk: Some(get_sdk_info()),
-        user: get_user_name().ok().map(|n| User {
+        user: whoami::fallible::username().ok().map(|n| User {
             username: Some(n),
             ip_address: Some(Default::default()),
             ..Default::default()

--- a/src/commands/send_event.rs
+++ b/src/commands/send_event.rs
@@ -13,7 +13,6 @@ use sentry::protocol::{Event, Level, LogEntry, User};
 use sentry::types::Uuid;
 use sentry::{apply_defaults, Client, ClientOptions, Envelope};
 use serde_json::Value;
-use username::get_user_name;
 
 use crate::api::envelopes_api::EnvelopesApi;
 use crate::constants::USER_AGENT;
@@ -307,7 +306,7 @@ pub fn execute(matches: &ArgMatches) -> Result<()> {
         user.ip_address.get_or_insert(Default::default());
         event.user = Some(user);
     } else {
-        event.user = get_user_name().ok().map(|n| User {
+        event.user = whoami::fallible::username().ok().map(|n| User {
             username: Some(n),
             ip_address: Some(Default::default()),
             ..Default::default()


### PR DESCRIPTION
`username` is completely unmaintained, and it depends on `winapi`, preventing us from supporting Windows on ARM. Use `whoami` instead to get the curent user.

Ref #1426