### PR TITLE
ref: Simplify `set_executable_mode`

### DIFF
--- a/src/utils/fs.rs
+++ b/src/utils/fs.rs
@@ -136,21 +136,14 @@ pub fn is_writable<P: AsRef<Path>>(path: P) -> bool {
 /// Set the mode of a path to 755 if we're on a Unix machine, otherwise
 /// don't do anything with the given path.
 #[cfg(not(feature = "managed"))]
+#[cfg(not(windows))]
 pub fn set_executable_mode<P: AsRef<Path>>(path: P) -> Result<()> {
-    #[cfg(not(windows))]
-    fn exec<P: AsRef<Path>>(path: P) -> io::Result<()> {
-        use std::os::unix::fs::PermissionsExt;
-        let mut perm = fs::metadata(&path)?.permissions();
-        perm.set_mode(0o755);
-        fs::set_permissions(&path, perm)
-    }
+    use std::os::unix::fs::PermissionsExt;
 
-    #[cfg(windows)]
-    fn exec<P: AsRef<Path>>(_path: P) -> io::Result<()> {
-        Ok(())
-    }
+    let mut perm = fs::metadata(&path)?.permissions();
+    perm.set_mode(0o755);
+    fs::set_permissions(&path, perm)?;
 
-    exec(path)?;
     Ok(())
 }
 

--- a/src/utils/update.rs
+++ b/src/utils/update.rs
@@ -20,7 +20,10 @@ use crate::api::{Api, SentryCliRelease};
 use crate::config::Config;
 use crate::constants::{APP_NAME, VERSION};
 #[cfg(not(feature = "managed"))]
-use crate::utils::fs::{is_writable, set_executable_mode};
+use crate::utils::fs::is_writable;
+#[cfg(not(windows))]
+#[cfg(not(feature = "managed"))]
+use crate::utils::fs::set_executable_mode;
 #[cfg(not(feature = "managed"))]
 use crate::utils::system::QuietExit;
 use crate::utils::system::{is_homebrew_install, is_npm_install};
@@ -171,6 +174,7 @@ impl SentryCliUpdateInfo {
             }
         };
 
+        #[cfg(not(windows))]
         set_executable_mode(&tmp_path)?;
         rename_exe(&exe, &tmp_path, elevate)?;
         Ok(())


### PR DESCRIPTION
Don't compile the function at all for Windows (this avoids `unnecessary_wraps` lint on Windows). Partially unblocks #2360.