### PR TITLE
ci(npm): Release Windows ARM build to `npm`

### DIFF
--- a/.craft.yml
+++ b/.craft.yml
@@ -34,6 +34,9 @@ targets:
   - name: npm
     id: '@sentry/cli-win32-x64'
     includeNames: /^sentry-cli-win32-x64-\d.*\.tgz$/
+  - name: npm
+    id: '@sentry/cli-win32-arm64'
+    includeNames: /^sentry-cli-win32-arm64-\d.*\.tgz$/
 
   # Main Sentry CLI package
   - name: npm
@@ -113,5 +116,6 @@ requireNames:
   - /^sentry-cli-Linux-aarch64$/
   - /^sentry-cli-Windows-i686.exe$/
   - /^sentry-cli-Windows-x86_64.exe$/
+  - /^sentry-cli-Windows-aarch64.exe$/
   - /^sentry_cli-.*.tar.gz$/
   - /^sentry_cli-.*.whl$/

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -300,6 +300,7 @@ jobs:
           mv binary-artifacts/sentry-cli-Linux-x86_64 npm-binary-distributions/linux-x64/bin/sentry-cli
           mv binary-artifacts/sentry-cli-Windows-i686.exe npm-binary-distributions/win32-i686/bin/sentry-cli.exe
           mv binary-artifacts/sentry-cli-Windows-x86_64.exe npm-binary-distributions/win32-x64/bin/sentry-cli.exe
+          mv binary-artifacts/sentry-cli-Windows-aarch64.exe npm-binary-distributions/win32-arm64/bin/sentry-cli.exe
       - name: Remove binary placeholders
         run: rm -rf npm-binary-distributions/*/bin/.gitkeep
       - name: Make Linux binaries executable

--- a/js/helper.js
+++ b/js/helper.js
@@ -13,6 +13,7 @@ const BINARY_DISTRIBUTIONS = [
   { packageName: '@sentry/cli-linux-arm', subpath: 'bin/sentry-cli' },
   { packageName: '@sentry/cli-win32-x64', subpath: 'bin/sentry-cli.exe' },
   { packageName: '@sentry/cli-win32-i686', subpath: 'bin/sentry-cli.exe' },
+  { packageName: '@sentry/cli-win32-arm64', subpath: 'bin/sentry-cli.exe' },
 ];
 
 /**
@@ -58,13 +59,14 @@ function getDistributionForThisPlatform() {
   } else if (platform === 'win32') {
     switch (arch) {
       case 'x64':
-      // Windows arm64 can run x64 binaries
-      case 'arm64':
         packageName = '@sentry/cli-win32-x64';
         break;
       case 'x86':
       case 'ia32':
         packageName = '@sentry/cli-win32-i686';
+        break;
+      case 'arm64':
+        packageName = '@sentry/cli-win32-arm64';
         break;
     }
   }

--- a/npm-binary-distributions/win32-arm64/README.md
+++ b/npm-binary-distributions/win32-arm64/README.md
@@ -1,0 +1,11 @@
+<p align="center">
+  <a href="https://sentry.io/?utm_source=github&utm_medium=logo" target="_blank">
+    <img src="https://sentry-brand.storage.googleapis.com/sentry-wordmark-dark-280x84.png" alt="Sentry" width="280" height="84">
+  </a>
+</p>
+
+# Sentry CLI Windows ARM64 Binary
+
+This package contains the Sentry CLI binary for Windows ARM64.
+
+See https://github.com/getsentry/sentry-cli for more information.

--- a/npm-binary-distributions/win32-arm64/package.json
+++ b/npm-binary-distributions/win32-arm64/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "@sentry/cli-win32-arm64",
+  "version": "2.42.4",
+  "description": "The windows arm64 distribution of the Sentry CLI binary.",
+  "repository": "https://github.com/getsentry/sentry-cli",
+  "license": "BSD-3-Clause",
+  "publishConfig": {
+    "access": "public"
+  },
+  "engines": {
+    "node": ">=10"
+  },
+  "os": [
+    "win32"
+  ],
+  "cpu": [
+    "arm64"
+  ]
+}

--- a/package.json
+++ b/package.json
@@ -36,7 +36,8 @@
     "@sentry/cli-linux-i686": "2.42.4",
     "@sentry/cli-linux-x64": "2.42.4",
     "@sentry/cli-win32-i686": "2.42.4",
-    "@sentry/cli-win32-x64": "2.42.4"
+    "@sentry/cli-win32-x64": "2.42.4",
+    "@sentry/cli-win32-arm64": "2.42.4"
   },
   "scripts": {
     "postinstall": "node ./scripts/install.js",

--- a/scripts/install.js
+++ b/scripts/install.js
@@ -78,10 +78,6 @@ function getDownloadUrl(platform, arch) {
     case 'darwin':
       return `${releasesUrl}-Darwin-universal`;
     case 'win32':
-      // Windows arm machines can run x64 binaries
-      if (arch === 'arm64') {
-        archString = 'x86_64';
-      }
       return `${releasesUrl}-Windows-${archString}.exe`;
     case 'linux':
     case 'freebsd':


### PR DESCRIPTION
Allows Windows on ARM users installing Sentry CLI from `npm` to use the native build, added in #2429