### PR TITLE
fix(sourcemaps): Avoid associating only sourcemap with all minified sources

### DIFF
--- a/tests/integration/_cases/sourcemaps/sourcemaps-upload-file-ram-bundle.trycmd
+++ b/tests/integration/_cases/sourcemaps/sourcemaps-upload-file-ram-bundle.trycmd
@@ -1,7 +1,7 @@
 ```
 $ sentry-cli sourcemaps upload --bundle tests/integration/_fixtures/file-ram-bundle/index.android.bundle --bundle-sourcemap tests/integration/_fixtures/file-ram-bundle/index.android.bundle.packager.map --release=wat-release
 ? success
-> Analyzing 2 sources
+> Analyzing 1 sources
 > Rewriting sources
 > Adding source map references
 > Bundled 14 files for upload

--- a/tests/integration/_cases/sourcemaps/sourcemaps-upload-indexed-ram-bundle.trycmd
+++ b/tests/integration/_cases/sourcemaps/sourcemaps-upload-indexed-ram-bundle.trycmd
@@ -1,7 +1,7 @@
 ```
 $ sentry-cli sourcemaps upload --bundle tests/integration/_fixtures/indexed-ram-bundle/main.jsbundle --bundle-sourcemap tests/integration/_fixtures/indexed-ram-bundle/main.jsbundle.packager.map --release=wat-release
 ? success
-> Analyzing 2 sources
+> Analyzing 1 sources
 > Rewriting sources
 > Adding source map references
 > Bundled 2107 files for upload


### PR DESCRIPTION
Remove the branch from `guess_sourcemap_reference` which handles the case of there only being one sourcemap. If there are multiple minified souces, they would all (erroneously) end up associated with the same single sourcemap.

Also, since code for uploading bundles was relying on this branch (specifically when unpacking bundles), refactor so that we use the sourcemap which is passed to the command directly, rather thna "guessing" it.

Fixes https://github.com/getsentry/sentry-cli/issues/2438
Fixes https://github.com/getsentry/sentry-cli/issues/2503