### PR TITLE
ref(sourcemaps): Remove `SourceMapReference` struct

### DIFF
--- a/src/utils/sourcemaps.rs
+++ b/src/utils/sourcemaps.rs
@@ -107,42 +107,27 @@ pub fn get_sourcemap_reference_from_headers<'a, I: Iterator<Item = (&'a String, 
     None
 }
 
-fn guess_sourcemap_reference(
-    sourcemaps: &HashSet<String>,
-    min_url: &str,
-) -> Result<SourceMapReference> {
+fn guess_sourcemap_reference(sourcemaps: &HashSet<String>, min_url: &str) -> Result<String> {
     let map_ext = "map";
     let (path, basename, ext) = split_url(min_url);
 
     // foo.min.js -> foo.map
     if sourcemaps.contains(&unsplit_url(path, basename, Some("map"))) {
-        return Ok(SourceMapReference::from_url(unsplit_url(
-            None,
-            basename,
-            Some("map"),
-        )));
+        return Ok(unsplit_url(None, basename, Some("map")));
     }
 
     if let Some(ext) = ext.as_ref() {
         // foo.min.js -> foo.min.js.map
         let new_ext = format!("{ext}.{map_ext}");
         if sourcemaps.contains(&unsplit_url(path, basename, Some(&new_ext))) {
-            return Ok(SourceMapReference::from_url(unsplit_url(
-                None,
-                basename,
-                Some(&new_ext),
-            )));
+            return Ok(unsplit_url(None, basename, Some(&new_ext)));
         }
 
         // foo.min.js -> foo.js.map
         if let Some(rest) = ext.strip_prefix("min.") {
             let new_ext = format!("{rest}.{map_ext}");
             if sourcemaps.contains(&unsplit_url(path, basename, Some(&new_ext))) {
-                return Ok(SourceMapReference::from_url(unsplit_url(
-                    None,
-                    basename,
-                    Some(&new_ext),
-                )));
+                return Ok(unsplit_url(None, basename, Some(&new_ext)));
             }
         }
 
@@ -153,11 +138,7 @@ fn guess_sourcemap_reference(
             parts[parts_len - 1] = map_ext;
             let new_ext = parts.join(".");
             if sourcemaps.contains(&unsplit_url(path, basename, Some(&new_ext))) {
-                return Ok(SourceMapReference::from_url(unsplit_url(
-                    None,
-                    basename,
-                    Some(&new_ext),
-                )));
+                return Ok(unsplit_url(None, basename, Some(&new_ext)));
             }
         }
     }
@@ -165,28 +146,10 @@ fn guess_sourcemap_reference(
     bail!("Could not auto-detect referenced sourcemap for {}", min_url);
 }
 
-/// Container to cary relative computed source map url.
-/// and original url with which the file was added to the processor.
-/// This enable us to look up the source map file based on the original url.
-/// Which can be used for example for debug id referencing.
-pub struct SourceMapReference {
-    url: String,
-    original_url: Option<String>,
-}
-
-impl SourceMapReference {
-    pub fn from_url(url: String) -> Self {
-        SourceMapReference {
-            url,
-            original_url: None,
-        }
-    }
-}
-
 pub struct SourceMapProcessor {
     pending_sources: HashSet<(String, ReleaseFileMatch)>,
     sources: SourceFiles,
-    sourcemap_references: HashMap<String, Option<SourceMapReference>>,
+    sourcemap_references: HashMap<String, Option<String>>,
     debug_ids: HashMap<String, DebugId>,
 }
 
@@ -367,7 +330,7 @@ impl SourceMapProcessor {
             let location =
                 discover_sourcemaps_location(contents).filter(|loc| !is_remote_sourcemap(loc));
             let sourcemap_reference = match location {
-                Some(url) => SourceMapReference::from_url(url.to_string()),
+                Some(url) => url.to_string(),
                 None => match guess_sourcemap_reference(&sourcemaps, &source.url) {
                     Ok(target) => target,
                     Err(err) => {
@@ -515,7 +478,7 @@ impl SourceMapProcessor {
             match guess_sourcemap_reference(&sourcemaps_references, bundle_source_url) {
                 Ok(filename) => {
                     let (path, _, _) = split_url(bundle_source_url);
-                    unsplit_url(path, &filename.url, None)
+                    unsplit_url(path, &filename, None)
                 }
                 Err(_) => {
                     warn!("Sourcemap reference for {} not found!", bundle_source_url);
@@ -690,7 +653,7 @@ impl SourceMapProcessor {
             }
 
             if let Some(Some(sourcemap)) = self.sourcemap_references.get(&source.url) {
-                source.set_sourcemap_reference(sourcemap.url.to_string());
+                source.set_sourcemap_reference(sourcemap.to_string());
             }
         }
     }
@@ -706,10 +669,7 @@ impl SourceMapProcessor {
             }
 
             if let Some(Some(sourcemap_reference)) = self.sourcemap_references.get(&source.url) {
-                let sourcemap_url = &sourcemap_reference
-                    .original_url
-                    .clone()
-                    .unwrap_or(sourcemap_reference.url.clone());
+                let sourcemap_url = sourcemap_reference;
 
                 if !self.debug_ids.contains_key(sourcemap_url) {
                     debug!(
@@ -928,7 +888,7 @@ impl SourceMapProcessor {
                     debug_id
                 }
                 Some(sourcemap) => {
-                    if let Some(encoded) = sourcemap.url.strip_prefix(DATA_PREAMBLE) {
+                    if let Some(encoded) = sourcemap.strip_prefix(DATA_PREAMBLE) {
                         // Case 2: The source file has an embedded sourcemap.
 
                         let Ok(mut decoded) = data_encoding::BASE64.decode(encoded.as_bytes())
@@ -959,14 +919,13 @@ impl SourceMapProcessor {
                         let new_sourcemap_url = format!("{DATA_PREAMBLE}{encoded}");
 
                         inject::replace_sourcemap_url(source_file_contents, &new_sourcemap_url)?;
-                        *sourcemap_url = Some(SourceMapReference::from_url(new_sourcemap_url));
+                        *sourcemap_url = Some(new_sourcemap_url);
 
                         debug_id
                     } else {
                         // Handle external sourcemaps
 
-                        let normalized =
-                            inject::normalize_sourcemap_url(source_url, &sourcemap.url);
+                        let normalized = inject::normalize_sourcemap_url(source_url, sourcemap);
                         let matches = inject::find_matching_paths(&sourcemaps, &normalized);
 
                         let sourcemap_url = match &matches[..] {

--- a/src/utils/sourcemaps.rs
+++ b/src/utils/sourcemaps.rs
@@ -111,17 +111,6 @@ fn guess_sourcemap_reference(
     sourcemaps: &HashSet<String>,
     min_url: &str,
 ) -> Result<SourceMapReference> {
-    // if there is only one sourcemap in total we just assume that's the one.
-    // We just need to make sure that we fix up the reference if we need to
-    // (eg: ~/ -> /).
-    if sourcemaps.len() == 1 {
-        let original_url = sourcemaps.iter().next().unwrap();
-        return Ok(SourceMapReference {
-            url: sourcemap::make_relative_path(min_url, original_url),
-            original_url: Option::from(original_url.to_string()),
-        });
-    }
-
     let map_ext = "map";
     let (path, basename, ext) = split_url(min_url);
 


### PR DESCRIPTION
Following #2447, we no longer ever set the `SourceMapReference` struct's `original_url` field to any `Some(_)` value. This essentially makes the struct unnecessary, since we can just pass the URL values around as `String`s.

Depends on:
  - #2447