### PR TITLE
feat(upload): Allow uncompressed chunk uploads

### DIFF
--- a/src/commands/debug_files/upload.rs
+++ b/src/commands/debug_files/upload.rs
@@ -201,6 +201,13 @@ pub fn make_command(command: Command) -> Command {
                 .action(ArgAction::SetTrue)
                 .help("Compute il2cpp line mappings and upload them along with sources."),
         )
+        .arg(
+            Arg::new("use_compression")
+                .long("no-compression")
+                .action(ArgAction::SetFalse)
+                .help("Don't use the compression specified by the server for chunked uploads.")
+                .hide(true),
+        )
 }
 
 pub fn execute(matches: &ArgMatches) -> Result<()> {
@@ -227,6 +234,7 @@ pub fn execute(matches: &ArgMatches) -> Result<()> {
     let wait_for_secs = matches.get_one::<u64>("wait_for").copied();
     let wait = matches.get_flag("wait") || wait_for_secs.is_some();
     let max_wait = wait_for_secs.map_or(DEFAULT_MAX_WAIT, Duration::from_secs);
+    let use_compression = matches.get_flag("use_compression");
 
     // Build generic upload parameters
     let mut upload = DifUpload::new(&org, &project);
@@ -235,7 +243,8 @@ pub fn execute(matches: &ArgMatches) -> Result<()> {
         .max_wait(max_wait)
         .search_paths(matches.get_many::<String>("paths").unwrap_or_default())
         .allow_zips(!matches.get_flag("no_zips"))
-        .filter_ids(ids);
+        .filter_ids(ids)
+        .use_compression(use_compression);
 
     // Restrict symbol types, if specified by the user
     for ty in matches

--- a/src/commands/files/upload.rs
+++ b/src/commands/files/upload.rs
@@ -121,6 +121,13 @@ pub fn make_command(command: Command) -> Command {
                     extensions must be repeated. Specify once per extension.",
                 ),
         )
+        .arg(
+            Arg::new("use_compression")
+                .long("no-compression")
+                .action(ArgAction::SetFalse)
+                .help("Don't use the compression specified by the server for chunked uploads.")
+                .hide(true),
+        )
 }
 
 pub fn execute(matches: &ArgMatches) -> Result<()> {
@@ -148,6 +155,8 @@ pub fn execute(matches: &ArgMatches) -> Result<()> {
     let wait = matches.get_flag("wait") || wait_for_secs.is_some();
     let max_wait = wait_for_secs.map_or(DEFAULT_MAX_WAIT, Duration::from_secs);
 
+    let use_compression = matches.get_flag("use_compression");
+
     let context = &UploadContext {
         org: &org,
         project: project.as_deref(),
@@ -158,6 +167,7 @@ pub fn execute(matches: &ArgMatches) -> Result<()> {
         max_wait,
         dedupe: false,
         chunk_upload_options: chunk_upload_options.as_ref(),
+        use_compression,
     };
 
     let path = Path::new(matches.get_one::<String>("path").unwrap());

--- a/src/commands/react_native/appcenter.rs
+++ b/src/commands/react_native/appcenter.rs
@@ -106,6 +106,13 @@ pub fn make_command(command: Command) -> Command {
                      but at most for the given number of seconds.",
                 ),
         )
+        .arg(
+            Arg::new("use_compression")
+                .long("no-compression")
+                .action(ArgAction::SetFalse)
+                .help("Don't use the compression specified by the server for chunked uploads.")
+                .hide(true),
+        )
 }
 
 pub fn execute(matches: &ArgMatches) -> Result<()> {
@@ -185,6 +192,7 @@ pub fn execute(matches: &ArgMatches) -> Result<()> {
     let wait_for_secs = matches.get_one::<u64>("wait_for").copied();
     let wait = matches.get_flag("wait") || wait_for_secs.is_some();
     let max_wait = wait_for_secs.map_or(DEFAULT_MAX_WAIT, Duration::from_secs);
+    let use_compression = matches.get_flag("use_compression");
 
     match matches.get_many::<String>("dist") {
         None => {
@@ -203,6 +211,7 @@ pub fn execute(matches: &ArgMatches) -> Result<()> {
                 max_wait,
                 dedupe: false,
                 chunk_upload_options: chunk_upload_options.as_ref(),
+                use_compression,
             })?;
         }
         Some(dists) => {
@@ -222,6 +231,7 @@ pub fn execute(matches: &ArgMatches) -> Result<()> {
                     max_wait,
                     dedupe: false,
                     chunk_upload_options: chunk_upload_options.as_ref(),
+                    use_compression,
                 })?;
             }
         }

--- a/src/commands/react_native/gradle.rs
+++ b/src/commands/react_native/gradle.rs
@@ -66,6 +66,13 @@ pub fn make_command(command: Command) -> Command {
                      but at most for the given number of seconds.",
                 ),
         )
+        .arg(
+            Arg::new("use_compression")
+                .long("no-compression")
+                .action(ArgAction::SetFalse)
+                .help("Don't use the compression specified by the server for chunked uploads.")
+                .hide(true),
+        )
 }
 
 pub fn execute(matches: &ArgMatches) -> Result<()> {
@@ -118,6 +125,7 @@ pub fn execute(matches: &ArgMatches) -> Result<()> {
     let wait_for_secs = matches.get_one::<u64>("wait_for").copied();
     let wait = matches.get_flag("wait") || wait_for_secs.is_some();
     let max_wait = wait_for_secs.map_or(DEFAULT_MAX_WAIT, Duration::from_secs);
+    let use_compression = matches.get_flag("use_compression");
 
     if let Some(version) = version {
         for dist in matches.get_many::<String>("dist").unwrap() {
@@ -136,6 +144,7 @@ pub fn execute(matches: &ArgMatches) -> Result<()> {
                 max_wait,
                 dedupe: false,
                 chunk_upload_options: chunk_upload_options.as_ref(),
+                use_compression,
             })?;
         }
     } else {
@@ -150,6 +159,7 @@ pub fn execute(matches: &ArgMatches) -> Result<()> {
             max_wait,
             dedupe: false,
             chunk_upload_options: chunk_upload_options.as_ref(),
+            use_compression,
         })?;
     }
 

--- a/src/commands/react_native/xcode.rs
+++ b/src/commands/react_native/xcode.rs
@@ -125,6 +125,13 @@ pub fn make_command(command: Command) -> Command {
                 .action(ArgAction::SetTrue)
                 .help("Don't try to automatically read release from Xcode project files."),
         )
+        .arg(
+            Arg::new("use_compression")
+                .long("no-compression")
+                .action(ArgAction::SetFalse)
+                .help("Don't use the compression specified by the server for chunked uploads.")
+                .hide(true),
+        )
 }
 
 fn find_node() -> String {
@@ -341,6 +348,7 @@ pub fn execute(matches: &ArgMatches) -> Result<()> {
     let wait_for_secs = matches.get_one::<u64>("wait_for").copied();
     let wait = matches.get_flag("wait") || wait_for_secs.is_some();
     let max_wait = wait_for_secs.map_or(DEFAULT_MAX_WAIT, std::time::Duration::from_secs);
+    let use_compression = matches.get_flag("use_compression");
 
     if dist_from_env.is_err() && release_from_env.is_err() && matches.get_flag("no_auto_release") {
         processor.upload(&UploadContext {
@@ -353,6 +361,7 @@ pub fn execute(matches: &ArgMatches) -> Result<()> {
             max_wait,
             dedupe: false,
             chunk_upload_options: chunk_upload_options.as_ref(),
+            use_compression,
         })?;
     } else {
         let (dist, release_name) = match (&dist_from_env, &release_from_env) {
@@ -389,6 +398,7 @@ pub fn execute(matches: &ArgMatches) -> Result<()> {
                     max_wait,
                     dedupe: false,
                     chunk_upload_options: chunk_upload_options.as_ref(),
+                    use_compression,
                 })?;
             }
             Some(dists) => {
@@ -403,6 +413,7 @@ pub fn execute(matches: &ArgMatches) -> Result<()> {
                         max_wait,
                         dedupe: false,
                         chunk_upload_options: chunk_upload_options.as_ref(),
+                        use_compression,
                     })?;
                 }
             }

--- a/src/commands/sourcemaps/upload.rs
+++ b/src/commands/sourcemaps/upload.rs
@@ -250,6 +250,13 @@ pub fn make_command(command: Command) -> Command {
                 .short('v')
                 .hide(true),
         )
+        .arg(
+            Arg::new("use_compression")
+                .long("no-compression")
+                .action(ArgAction::SetFalse)
+                .help("Don't use the compression specified by the server for chunked uploads.")
+                .hide(true),
+        )
 }
 
 fn get_prefixes_from_args(matches: &ArgMatches) -> Vec<&str> {
@@ -448,6 +455,7 @@ pub fn execute(matches: &ArgMatches) -> Result<()> {
     let wait_for_secs = matches.get_one::<u64>("wait_for").copied();
     let wait = matches.get_flag("wait") || wait_for_secs.is_some();
     let max_wait = wait_for_secs.map_or(DEFAULT_MAX_WAIT, Duration::from_secs);
+    let use_compression = matches.get_flag("use_compression");
     let upload_context = UploadContext {
         org: &org,
         project: Some(&project),
@@ -458,6 +466,7 @@ pub fn execute(matches: &ArgMatches) -> Result<()> {
         max_wait,
         dedupe: !matches.get_flag("no_dedupe"),
         chunk_upload_options: chunk_upload_options.as_ref(),
+        use_compression,
     };
 
     if matches.get_flag("strict") {

--- a/src/utils/chunks/mod.rs
+++ b/src/utils/chunks/mod.rs
@@ -170,6 +170,7 @@ pub fn upload_chunks(
     chunks: &[Chunk<'_>],
     chunk_options: &ChunkServerOptions,
     progress_style: ProgressStyle,
+    use_compression: bool,
 ) -> Result<()> {
     let total_bytes = chunks.iter().map(|&Chunk((_, data))| data.len()).sum();
 
@@ -183,13 +184,18 @@ pub fn upload_chunks(
     // Select the best available compression mechanism. We assume that every
     // compression algorithm has been implemented for uploading, except `Other`
     // which is used for unknown compression algorithms. In case the server
-    // does not support compression, we fall back to `Uncompressed`.
-    let compression = chunk_options
-        .compression
-        .iter()
-        .max()
-        .cloned()
-        .unwrap_or_default();
+    // does not support compression or `--no-compression` was passed,
+    // we fall back to `Uncompressed`.
+    let compression = if use_compression {
+        chunk_options
+            .compression
+            .iter()
+            .max()
+            .cloned()
+            .unwrap_or_default()
+    } else {
+        Default::default()
+    };
 
     info!("using '{}' compression for chunk upload", compression);
 

--- a/src/utils/chunks/options.rs
+++ b/src/utils/chunks/options.rs
@@ -13,6 +13,7 @@ pub struct ChunkOptions<'a> {
     /// If the server_options.max_wait is set to a smaller nonzero value,
     /// we use that value instead.
     max_wait: Duration,
+    use_compression: bool,
 }
 
 impl<'a> ChunkOptions<'a> {
@@ -22,12 +23,19 @@ impl<'a> ChunkOptions<'a> {
             org,
             project,
             max_wait: Duration::ZERO,
+            use_compression: true,
         }
     }
 
     /// Set the maximum wait time for the assembly to complete.
     pub fn with_max_wait(mut self, max_wait: Duration) -> Self {
         self.max_wait = max_wait;
+        self
+    }
+
+    /// Set whether compression should be used for the upload.
+    pub fn with_use_compression(mut self, use_compression: bool) -> Self {
+        self.use_compression = use_compression;
         self
     }
 
@@ -59,5 +67,9 @@ impl<'a> ChunkOptions<'a> {
 
     pub fn server_options(&self) -> &ChunkServerOptions {
         &self.server_options
+    }
+
+    pub fn use_compression(&self) -> bool {
+        self.use_compression
     }
 }

--- a/src/utils/chunks/upload.rs
+++ b/src/utils/chunks/upload.rs
@@ -1,7 +1,7 @@
+use std::collections::BTreeMap;
 use std::fmt::Display;
 use std::thread;
 use std::time::Instant;
-use std::{collections::BTreeMap, time::Duration};
 
 use anyhow::Result;
 use indicatif::ProgressStyle;

--- a/src/utils/dif_upload/mod.rs
+++ b/src/utils/dif_upload/mod.rs
@@ -1447,6 +1447,7 @@ pub struct DifUpload<'a> {
     wait: bool,
     upload_il2cpp_mappings: bool,
     il2cpp_mappings_allowed: bool,
+    use_compression: bool,
 }
 
 impl<'a> DifUpload<'a> {
@@ -1487,6 +1488,7 @@ impl<'a> DifUpload<'a> {
             wait: false,
             upload_il2cpp_mappings: false,
             il2cpp_mappings_allowed: false,
+            use_compression: true,
         }
     }
 
@@ -1595,6 +1597,14 @@ impl<'a> DifUpload<'a> {
     /// Defaults to `false`.
     pub fn il2cpp_mapping(&mut self, il2cpp_mapping: bool) -> &mut Self {
         self.upload_il2cpp_mappings = il2cpp_mapping;
+        self
+    }
+
+    /// Sets whether compression should be used during chunk uploads.
+    ///
+    /// Defaults to `true`.
+    pub fn use_compression(&mut self, use_compression: bool) -> &mut Self {
+        self.use_compression = use_compression;
         self
     }
 
@@ -1766,7 +1776,8 @@ impl<'a> DifUpload<'a> {
     }
 
     fn into_chunk_options(self, server_options: ChunkServerOptions) -> ChunkOptions<'a> {
-        let options = ChunkOptions::new(server_options, self.org, self.project);
+        let options = ChunkOptions::new(server_options, self.org, self.project)
+            .with_use_compression(self.use_compression);
 
         // Only add wait time if self.wait is true. On DifUpload, max_wait may be
         // set even when self.wait is false; on ChunkOptions, the absence of a

--- a/src/utils/file_upload.rs
+++ b/src/utils/file_upload.rs
@@ -91,6 +91,7 @@ pub struct UploadContext<'a> {
     pub max_wait: Duration,
     pub dedupe: bool,
     pub chunk_upload_options: Option<&'a ChunkServerOptions>,
+    pub use_compression: bool,
 }
 
 impl UploadContext<'_> {
@@ -443,7 +444,7 @@ fn upload_files_chunked(
     };
 
     if !chunks.is_empty() {
-        upload_chunks(&chunks, options, progress_style)?;
+        upload_chunks(&chunks, options, progress_style, context.use_compression)?;
         println!("{} Uploaded files to Sentry", style(">").dim());
     } else {
         println!(
@@ -665,6 +666,7 @@ mod tests {
             max_wait: DEFAULT_MAX_WAIT,
             dedupe: true,
             chunk_upload_options: None,
+            use_compression: true,
         };
 
         let source_files = ["bundle.min.js.map", "vendor.min.js.map"]


### PR DESCRIPTION
Since disabling compression for chunk uploads brought some success in https://github.com/getsentry/team-ingest/issues/683, we add a hidden flag `--no-compression` with that effect to upload commands. Hopefully this will show whether the upload working without compression was a fluke.

ref INGEST-132