### PR TITLE
feat: Remove organization and project info log

### DIFF
--- a/src/commands/debug_files/upload.rs
+++ b/src/commands/debug_files/upload.rs
@@ -6,7 +6,6 @@ use anyhow::{bail, format_err, Result};
 use clap::{builder::PossibleValuesParser, Arg, ArgAction, ArgMatches, Command};
 use console::style;
 use itertools::Itertools;
-use log::info;
 use symbolic::common::DebugId;
 use symbolic::debuginfo::FileFormat;
 
@@ -218,11 +217,6 @@ pub fn execute(matches: &ArgMatches) -> Result<()> {
         .get_many::<DebugId>("ids")
         .unwrap_or_default()
         .copied();
-
-    info!(
-        "Issuing a command for Organization: {} Project: {}",
-        org, project
-    );
 
     let wait_for_secs = matches.get_one::<u64>("wait_for").copied();
     let wait = matches.get_flag("wait") || wait_for_secs.is_some();

--- a/src/commands/issues/mute.rs
+++ b/src/commands/issues/mute.rs
@@ -1,6 +1,5 @@
 use anyhow::Result;
 use clap::{ArgMatches, Command};
-use log::info;
 
 use crate::api::{Api, IssueChanges, IssueFilter};
 use crate::config::Config;
@@ -13,14 +12,10 @@ pub fn execute(matches: &ArgMatches) -> Result<()> {
     let config = Config::current();
     let (org, project) = config.get_org_and_project(matches)?;
     let filter = IssueFilter::get_filter_from_matches(matches)?;
-    let mut changes: IssueChanges = Default::default();
-
-    info!(
-        "Issuing a command for Organization: {} Project: {}",
-        org, project
-    );
-
-    changes.new_status = Some("muted".into());
+    let changes = IssueChanges {
+        new_status: Some("muted".into()),
+        ..Default::default()
+    };
 
     if Api::current()
         .authenticated()?

--- a/src/commands/issues/resolve.rs
+++ b/src/commands/issues/resolve.rs
@@ -1,6 +1,5 @@
 use anyhow::Result;
 use clap::{Arg, ArgAction, ArgMatches, Command};
-use log::info;
 
 use crate::api::{Api, IssueChanges, IssueFilter};
 use crate::config::Config;
@@ -20,11 +19,6 @@ pub fn execute(matches: &ArgMatches) -> Result<()> {
     let (org, project) = config.get_org_and_project(matches)?;
     let filter = IssueFilter::get_filter_from_matches(matches)?;
     let mut changes: IssueChanges = Default::default();
-
-    info!(
-        "Issuing a command for Organization: {} Project: {}",
-        org, project
-    );
 
     if matches.get_flag("next_release") {
         changes.new_status = Some("resolvedInNextRelease".into());

--- a/src/commands/issues/unresolve.rs
+++ b/src/commands/issues/unresolve.rs
@@ -1,6 +1,5 @@
 use anyhow::Result;
 use clap::{ArgMatches, Command};
-use log::info;
 
 use crate::api::{Api, IssueChanges, IssueFilter};
 use crate::config::Config;
@@ -13,14 +12,10 @@ pub fn execute(matches: &ArgMatches) -> Result<()> {
     let config = Config::current();
     let (org, project) = config.get_org_and_project(matches)?;
     let filter = IssueFilter::get_filter_from_matches(matches)?;
-    let mut changes: IssueChanges = Default::default();
-
-    info!(
-        "Issuing a command for Organization: {} Project: {}",
-        org, project
-    );
-
-    changes.new_status = Some("unresolved".into());
+    let changes = IssueChanges {
+        new_status: Some("unresolved".into()),
+        ..Default::default()
+    };
 
     if Api::current()
         .authenticated()?

--- a/src/commands/react_native/appcenter.rs
+++ b/src/commands/react_native/appcenter.rs
@@ -7,7 +7,6 @@ use anyhow::{anyhow, Result};
 use clap::{Arg, ArgAction, ArgMatches, Command};
 use console::style;
 use if_chain::if_chain;
-use log::info;
 
 use crate::api::Api;
 use crate::config::Config;
@@ -121,11 +120,6 @@ pub fn execute(matches: &ArgMatches) -> Result<()> {
         .unwrap_or("Staging");
     let api = Api::current();
     let print_release_name = matches.get_flag("print_release_name");
-
-    info!(
-        "Issuing a command for Organization: {} Project: {}",
-        org, project
-    );
 
     if !print_release_name {
         println!(

--- a/src/commands/react_native/gradle.rs
+++ b/src/commands/react_native/gradle.rs
@@ -82,11 +82,6 @@ pub fn execute(matches: &ArgMatches) -> Result<()> {
     );
     let bundle_url = format!("~/{}", bundle_path.file_name().unwrap().to_string_lossy());
 
-    info!(
-        "Issuing a command for Organization: {} Project: {}",
-        org, project
-    );
-
     println!("Processing react-native sourcemaps for Sentry upload.");
     info!("  bundle path: {}", bundle_path.display());
     info!("  sourcemap path: {}", sourcemap_path.display());

--- a/src/commands/react_native/xcode.rs
+++ b/src/commands/react_native/xcode.rs
@@ -170,11 +170,6 @@ pub fn execute(matches: &ArgMatches) -> Result<()> {
     }
     .canonicalize()?;
 
-    info!(
-        "Issuing a command for Organization: {} Project: {}",
-        org, project
-    );
-
     // if we allow fetching and we detect a simulator run, then we need to switch
     // to simulator mode.
     let fetch_url;

--- a/src/commands/upload_proguard.rs
+++ b/src/commands/upload_proguard.rs
@@ -5,7 +5,6 @@ use anyhow::{bail, Error, Result};
 use clap::ArgAction;
 use clap::{Arg, ArgMatches, Command};
 use console::style;
-use log::info;
 use symbolic::common::ByteView;
 use uuid::Uuid;
 
@@ -247,11 +246,6 @@ pub fn execute(matches: &ArgMatches) -> Result<()> {
 
         println!("{} uploading mappings", style(">").dim());
         (org, project) = config.get_org_and_project(matches)?;
-
-        info!(
-            "Issuing a command for Organization: {} Project: {}",
-            org, project
-        );
 
         authenticated_api = api.authenticated()?;
 


### PR DESCRIPTION
These appear to have been originally added in #670; however, we have not adopted these info logs consistently across all of our commands, and we believe they are likely not very useful.

Since some of these commands are going to be modified to accept multiple projects, the info log would anyways need to be reworked if we were to keep it; however, it is simpler just to get rid of the log for now.