### PR TITLE
ref: Separate `LegacyUploadContext` for legacy uploads

### DIFF
--- a/src/commands/files/upload.rs
+++ b/src/commands/files/upload.rs
@@ -244,7 +244,7 @@ pub fn execute(matches: &ArgMatches) -> Result<()> {
         if let Some(artifact) = authenticated_api
             .region_specific(context.org)
             .upload_release_file(
-                context,
+                &context.try_into()?,
                 &contents,
                 name,
                 Some(


### PR DESCRIPTION
Legacy (i.e. non-chunked) are distinct from chunked uploads, so it makes sense to have a separate struct to enforce these differences via the type system.

Specifically, legacy uploads must be associated with a release, whereas this is not required for many chunk uploads. Legacy uploads must also be associated with at most one project, whereas chunked uploads can have multiple projects (support for which we will add in the CLI with #2408)