### PR TITLE
feat(sourcemaps): Multi-project sourcemaps upload

### DIFF
--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -1445,6 +1445,7 @@ impl RegionSpecificApi<'_> {
                 PathArg(context.release())
             )
         };
+
         let mut form = curl::easy::Form::new();
 
         let filename = Path::new(name)

--- a/src/commands/debug_files/bundle_jvm.rs
+++ b/src/commands/debug_files/bundle_jvm.rs
@@ -57,7 +57,7 @@ pub fn execute(matches: &ArgMatches) -> Result<()> {
 
     let context = &UploadContext {
         org: &org,
-        project: project.as_deref(),
+        projects: &project.into_iter().collect::<Vec<_>>(),
         release: None,
         dist: None,
         note: None,

--- a/src/commands/files/upload.rs
+++ b/src/commands/files/upload.rs
@@ -150,7 +150,7 @@ pub fn execute(matches: &ArgMatches) -> Result<()> {
 
     let context = &UploadContext {
         org: &org,
-        project: project.as_deref(),
+        projects: &project.into_iter().collect::<Vec<_>>(),
         release: Some(&release),
         dist,
         note: None,

--- a/src/commands/react_native/appcenter.rs
+++ b/src/commands/react_native/appcenter.rs
@@ -111,7 +111,8 @@ pub fn execute(matches: &ArgMatches) -> Result<()> {
     let config = Config::current();
     let here = env::current_dir()?;
     let here_str: &str = &here.to_string_lossy();
-    let (org, project) = config.get_org_and_project(matches)?;
+    let org = config.get_org(matches)?;
+    let projects = config.get_projects(matches)?;
     let app = matches.get_one::<String>("app_name").unwrap();
     let platform = matches.get_one::<String>("platform").unwrap();
     let deployment = matches
@@ -189,7 +190,7 @@ pub fn execute(matches: &ArgMatches) -> Result<()> {
 
             processor.upload(&UploadContext {
                 org: &org,
-                project: Some(&project),
+                projects: &projects,
                 release: Some(&release),
                 dist: None,
                 note: None,
@@ -208,7 +209,7 @@ pub fn execute(matches: &ArgMatches) -> Result<()> {
 
                 processor.upload(&UploadContext {
                     org: &org,
-                    project: Some(&project),
+                    projects: &projects,
                     release: Some(&release),
                     dist: Some(dist),
                     note: None,

--- a/src/commands/react_native/gradle.rs
+++ b/src/commands/react_native/gradle.rs
@@ -70,7 +70,8 @@ pub fn make_command(command: Command) -> Command {
 
 pub fn execute(matches: &ArgMatches) -> Result<()> {
     let config = Config::current();
-    let (org, project) = config.get_org_and_project(matches)?;
+    let org = config.get_org(matches)?;
+    let projects = config.get_projects(matches)?;
     let api = Api::current();
     let base = env::current_dir()?;
 
@@ -123,7 +124,7 @@ pub fn execute(matches: &ArgMatches) -> Result<()> {
 
             processor.upload(&UploadContext {
                 org: &org,
-                project: Some(&project),
+                projects: &projects,
                 release: Some(version),
                 dist: Some(dist),
                 note: None,
@@ -137,7 +138,7 @@ pub fn execute(matches: &ArgMatches) -> Result<()> {
         // Debug Id Upload
         processor.upload(&UploadContext {
             org: &org,
-            project: Some(&project),
+            projects: &projects,
             release: None,
             dist: None,
             note: None,

--- a/src/commands/react_native/xcode.rs
+++ b/src/commands/react_native/xcode.rs
@@ -340,7 +340,7 @@ pub fn execute(matches: &ArgMatches) -> Result<()> {
     if dist_from_env.is_err() && release_from_env.is_err() && matches.get_flag("no_auto_release") {
         processor.upload(&UploadContext {
             org: &org,
-            project: Some(&project),
+            projects: &[project],
             release: None,
             dist: None,
             note: None,
@@ -376,7 +376,7 @@ pub fn execute(matches: &ArgMatches) -> Result<()> {
             None => {
                 processor.upload(&UploadContext {
                     org: &org,
-                    project: Some(&project),
+                    projects: &[project],
                     release: release_name.as_deref(),
                     dist: dist.as_deref(),
                     note: None,
@@ -387,10 +387,11 @@ pub fn execute(matches: &ArgMatches) -> Result<()> {
                 })?;
             }
             Some(dists) => {
+                let projects = &[project];
                 for dist in dists {
                     processor.upload(&UploadContext {
                         org: &org,
-                        project: Some(&project),
+                        projects,
                         release: release_name.as_deref(),
                         dist: Some(dist),
                         note: None,

--- a/src/commands/sourcemaps/upload.rs
+++ b/src/commands/sourcemaps/upload.rs
@@ -421,7 +421,8 @@ fn process_sources_from_paths(
 pub fn execute(matches: &ArgMatches) -> Result<()> {
     let config = Config::current();
     let version = config.get_release_with_legacy_fallback(matches).ok();
-    let (org, project) = config.get_org_and_project(matches)?;
+    let org = config.get_org(matches)?;
+    let projects = config.get_projects(matches)?;
     let api = Api::current();
     let mut processor = SourceMapProcessor::new();
     let mut chunk_upload_options = api.authenticated()?.get_chunk_upload_options(&org)?;
@@ -450,7 +451,7 @@ pub fn execute(matches: &ArgMatches) -> Result<()> {
     let max_wait = wait_for_secs.map_or(DEFAULT_MAX_WAIT, Duration::from_secs);
     let upload_context = UploadContext {
         org: &org,
-        project: Some(&project),
+        projects: &projects,
         release: version.as_deref(),
         dist: matches.get_one::<String>("dist").map(String::as_str),
         note: matches.get_one::<String>("note").map(String::as_str),

--- a/tests/integration/_cases/react_native/xcode-upload-source-maps-release_and_dist_from_env.trycmd
+++ b/tests/integration/_cases/react_native/xcode-upload-source-maps-release_and_dist_from_env.trycmd
@@ -15,7 +15,7 @@ Processing react-native sourcemaps for Sentry upload.
 > Uploaded files to Sentry
 > File upload complete (processing pending on server)
 > Organization: wat-org
-> Project: wat-project
+> Projects: wat-project
 > Release: test-release
 > Dist: test-dist
 > Upload type: artifact bundle

--- a/tests/integration/_cases/sourcemaps/sourcemaps-upload-debugid-alias.trycmd
+++ b/tests/integration/_cases/sourcemaps/sourcemaps-upload-debugid-alias.trycmd
@@ -10,7 +10,7 @@ $ sentry-cli sourcemaps upload tests/integration/_fixtures/upload_debugid_alias
 > Uploaded files to Sentry
 > File upload complete (processing pending on server)
 > Organization: wat-org
-> Project: wat-project
+> Projects: wat-project
 > Release: None
 > Dist: None
 > Upload type: artifact bundle

--- a/tests/integration/_cases/sourcemaps/sourcemaps-upload-file-hermes-bundle-reference-debug-id.trycmd
+++ b/tests/integration/_cases/sourcemaps/sourcemaps-upload-file-hermes-bundle-reference-debug-id.trycmd
@@ -10,7 +10,7 @@ $ sentry-cli sourcemaps upload --bundle tests/integration/_fixtures/file-hermes-
 > Uploaded files to Sentry
 > File upload complete (processing pending on server)
 > Organization: wat-org
-> Project: wat-project
+> Projects: wat-project
 > Release: None
 > Dist: None
 > Upload type: artifact bundle

--- a/tests/integration/_cases/sourcemaps/sourcemaps-upload-file-ram-bundle.trycmd
+++ b/tests/integration/_cases/sourcemaps/sourcemaps-upload-file-ram-bundle.trycmd
@@ -9,7 +9,7 @@ $ sentry-cli sourcemaps upload --bundle tests/integration/_fixtures/file-ram-bun
 > Uploaded files to Sentry
 > File upload complete (processing pending on server)
 > Organization: wat-org
-> Project: wat-project
+> Projects: wat-project
 > Release: wat-release
 > Dist: None
 > Upload type: artifact bundle

--- a/tests/integration/_cases/sourcemaps/sourcemaps-upload-indexed-ram-bundle.trycmd
+++ b/tests/integration/_cases/sourcemaps/sourcemaps-upload-indexed-ram-bundle.trycmd
@@ -9,7 +9,7 @@ $ sentry-cli sourcemaps upload --bundle tests/integration/_fixtures/indexed-ram-
 > Uploaded files to Sentry
 > File upload complete (processing pending on server)
 > Organization: wat-org
-> Project: wat-project
+> Projects: wat-project
 > Release: wat-release
 > Dist: None
 > Upload type: artifact bundle

--- a/tests/integration/_cases/sourcemaps/sourcemaps-upload-modern.trycmd
+++ b/tests/integration/_cases/sourcemaps/sourcemaps-upload-modern.trycmd
@@ -11,7 +11,7 @@ $ sentry-cli sourcemaps upload tests/integration/_fixtures/bundle.min.js.map tes
 > Uploaded files to Sentry
 > File upload complete (processing pending on server)
 > Organization: wat-org
-> Project: wat-project
+> Projects: wat-project
 > Release: None
 > Dist: None
 > Upload type: artifact bundle

--- a/tests/integration/_cases/sourcemaps/sourcemaps-upload-no-dedupe.trycmd
+++ b/tests/integration/_cases/sourcemaps/sourcemaps-upload-no-dedupe.trycmd
@@ -11,7 +11,7 @@ $ sentry-cli sourcemaps upload tests/integration/_fixtures/bundle.min.js.map tes
 > Uploaded files to Sentry
 > File upload complete (processing pending on server)
 > Organization: wat-org
-> Project: wat-project
+> Projects: wat-project
 > Release: wat-release
 > Dist: None
 > Upload type: release bundle

--- a/tests/integration/_cases/sourcemaps/sourcemaps-upload-skip-already-uploaded.trycmd
+++ b/tests/integration/_cases/sourcemaps/sourcemaps-upload-skip-already-uploaded.trycmd
@@ -11,7 +11,7 @@ $ sentry-cli sourcemaps upload tests/integration/_fixtures/bundle.min.js.map tes
 > Uploaded files to Sentry
 > File upload complete (processing pending on server)
 > Organization: wat-org
-> Project: wat-project
+> Projects: wat-project
 > Release: wat-release
 > Dist: None
 > Upload type: release bundle

--- a/tests/integration/_cases/sourcemaps/sourcemaps-upload-some-debugids.trycmd
+++ b/tests/integration/_cases/sourcemaps/sourcemaps-upload-some-debugids.trycmd
@@ -18,7 +18,7 @@ $ sentry-cli sourcemaps upload tests/integration/_fixtures/upload_some_debugids
 > Uploaded files to Sentry
 > File upload complete (processing pending on server)
 > Organization: wat-org
-> Project: wat-project
+> Projects: wat-project
 > Release: None
 > Dist: None
 > Upload type: artifact bundle

--- a/tests/integration/_cases/sourcemaps/sourcemaps-upload-successfully-upload-file.trycmd
+++ b/tests/integration/_cases/sourcemaps/sourcemaps-upload-successfully-upload-file.trycmd
@@ -10,7 +10,7 @@ $ sentry-cli sourcemaps upload tests/integration/_fixtures/bundle.min.js.map --r
 > Uploaded files to Sentry
 > File upload complete (processing pending on server)
 > Organization: wat-org
-> Project: wat-project
+> Projects: wat-project
 > Release: wat-release
 > Dist: None
 > Upload type: release bundle


### PR DESCRIPTION
It is now possible to upload sourcemaps to multiple projects at once, by passing the `-p`/`--project` flag multiple times to the `sentry-cli sourcemaps upload` command. Previously, it was possible to specify multiple projects via this flag, but all but the first project were ignored.

Multi-project sourcemaps uploads only work for Sentry servers which support chunked uploads – since this feature was added quite some time ago, we expect most self-hosted Sentry instances will support this. Older versions of Sentry continue to only support single-project uploads, but now, instead of silently ignoring all but the first project, an error is returned.

Closes #2408