### PR TITLE
feat: Mark all `files` subcommands as deprecated.

### DIFF
--- a/src/commands/files/delete.rs
+++ b/src/commands/files/delete.rs
@@ -8,7 +8,8 @@ use crate::config::Config;
 
 pub fn make_command(command: Command) -> Command {
     command
-        .about("Delete a release file.")
+        .about("[DEPRECATED] Delete a release file.")
+        .hide(true)
         // Backward compatibility with `releases files <VERSION>` commands.
         .arg(Arg::new("version").long("version").hide(true))
         .arg(

--- a/src/commands/files/list.rs
+++ b/src/commands/files/list.rs
@@ -6,7 +6,8 @@ use crate::{api::Api, config::Config, utils::formatting::Table};
 
 pub fn make_command(command: Command) -> Command {
     command
-        .about("List all release files.")
+        .about("[DEPRECATED] List all release files.")
+        .hide(true)
         // Backward compatibility with `releases files <VERSION>` commands.
         .arg(Arg::new("version").long("version").hide(true))
 }

--- a/src/commands/files/mod.rs
+++ b/src/commands/files/mod.rs
@@ -1,5 +1,6 @@
 use anyhow::Result;
 use clap::{ArgMatches, Command};
+use console::style;
 
 use crate::utils::args::ArgExt;
 
@@ -25,7 +26,8 @@ pub fn make_command(mut command: Command) -> Command {
     }
 
     command = command
-        .about("Manage release artifacts.")
+        .about("[DEPRECATED] Manage release artifacts.")
+        .hide(true)
         .subcommand_required(true)
         .arg_required_else_help(true)
         .org_arg()
@@ -42,6 +44,9 @@ pub fn make_command(mut command: Command) -> Command {
 }
 
 pub fn execute(matches: &ArgMatches) -> Result<()> {
+    eprintln!("{}", style("⚠ DEPRECATION NOTICE: This functionality will be removed in a future version of `sentry-cli`. \
+        Use the `sourcemaps` command instead.").yellow());
+
     macro_rules! execute_subcommand {
         ($name:ident) => {{
             if let Some(sub_matches) =

--- a/src/commands/files/upload.rs
+++ b/src/commands/files/upload.rs
@@ -24,7 +24,8 @@ use crate::utils::progress::ProgressBarMode;
 
 pub fn make_command(command: Command) -> Command {
     command
-        .about("Upload files for a release.")
+        .about("[DEPRECATED] Upload files for a release.")
+        .hide(true)
         // Backward compatibility with `releases files <VERSION>` commands.
         .arg(Arg::new("version").long("version").hide(true))
         .arg(

--- a/src/commands/sourcemaps/explain.rs
+++ b/src/commands/sourcemaps/explain.rs
@@ -16,7 +16,8 @@ use super::resolve::print_source;
 
 pub fn make_command(command: Command) -> Command {
     command
-        .about("Explain why sourcemaps are not working for a given event.")
+        .about("[DEPRECATED] Explain why sourcemaps are not working for a given event.")
+        .hide(true)
         .alias("why")
         .arg(
             Arg::new("event")

--- a/tests/integration/_cases/help/help-windows.trycmd
+++ b/tests/integration/_cases/help/help-windows.trycmd
@@ -14,7 +14,6 @@ Commands:
   debug-files      Locate, analyze or upload debug information files. [aliases: dif]
   deploys          Manage deployments for Sentry releases.
   events           Manage events on Sentry.
-  files            Manage release artifacts.
   info             Print information about the configuration and verify authentication.
   issues           Manage issues in Sentry.
   login            Authenticate with the Sentry server.

--- a/tests/integration/_cases/help/help.trycmd
+++ b/tests/integration/_cases/help/help.trycmd
@@ -14,7 +14,6 @@ Commands:
   debug-files      Locate, analyze or upload debug information files. [aliases: dif]
   deploys          Manage deployments for Sentry releases.
   events           Manage events on Sentry.
-  files            Manage release artifacts.
   info             Print information about the configuration and verify authentication.
   issues           Manage issues in Sentry.
   login            Authenticate with the Sentry server.

--- a/tests/integration/_cases/releases/releases-files-upload-sourcemaps.trycmd
+++ b/tests/integration/_cases/releases/releases-files-upload-sourcemaps.trycmd
@@ -1,6 +1,7 @@
 ```
 $ sentry-cli releases files wat-release upload-sourcemaps --url-prefix '~/assets' build/assets --rewrite
 ? success
+⚠ DEPRECATION NOTICE: This functionality will be removed in a future version of `sentry-cli`. Use the `sourcemaps` command instead.
 > Rewriting sources
 > Adding source map references
 > Nothing to upload

--- a/tests/integration/_cases/sourcemaps/sourcemaps-explain-help.trycmd
+++ b/tests/integration/_cases/sourcemaps/sourcemaps-explain-help.trycmd
@@ -1,7 +1,7 @@
 ```
 $ sentry-cli sourcemaps explain --help
 ? success
-Explain why sourcemaps are not working for a given event.
+[DEPRECATED] Explain why sourcemaps are not working for a given event.
 
 Usage: sentry-cli[EXE] sourcemaps explain [OPTIONS] <EVENT_ID>
 

--- a/tests/integration/_cases/sourcemaps/sourcemaps-help.trycmd
+++ b/tests/integration/_cases/sourcemaps/sourcemaps-help.trycmd
@@ -6,7 +6,6 @@ Manage sourcemaps for Sentry releases.
 Usage: sentry-cli[EXE] sourcemaps [OPTIONS] <COMMAND>
 
 Commands:
-  explain  Explain why sourcemaps are not working for a given event.
   inject   Fixes up JavaScript source files and sourcemaps with debug ids.
   resolve  Resolve sourcemap for a given line/column position.
   upload   Upload sourcemaps for a release.

--- a/tests/integration/_cases/sourcemaps/sourcemaps-no-subcommand.trycmd
+++ b/tests/integration/_cases/sourcemaps/sourcemaps-no-subcommand.trycmd
@@ -6,7 +6,6 @@ Manage sourcemaps for Sentry releases.
 Usage: sentry-cli[EXE] sourcemaps [OPTIONS] <COMMAND>
 
 Commands:
-  explain  Explain why sourcemaps are not working for a given event.
   inject   Fixes up JavaScript source files and sourcemaps with debug ids.
   resolve  Resolve sourcemap for a given line/column position.
   upload   Upload sourcemaps for a release.


### PR DESCRIPTION
The commands are now hidden from help output (making them less likely to be discovered and used), and they are marked with a deprecation notice.

When invoking the commands, a deprecation notice will be printed as well.

Also the previously deprecated `sourcemaps explain` command (which was replaced by an in-app sourcemaps debugger)  which already prints a deprecation notice is also being marked as hidden to be less discoverable.

Ref #2513