### PR TITLE
fix: Explicitly deprecate `--started` flag

### DIFF
--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -2054,8 +2054,6 @@ pub struct UpdatedRelease {
     pub projects: Option<Vec<String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub url: Option<String>,
-    #[serde(rename = "dateStarted", skip_serializing_if = "Option::is_none")]
-    pub date_started: Option<DateTime<Utc>>,
     #[serde(rename = "dateReleased", skip_serializing_if = "Option::is_none")]
     pub date_released: Option<DateTime<Utc>>,
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/src/commands/releases/finalize.rs
+++ b/src/commands/releases/finalize.rs
@@ -20,9 +20,10 @@ pub fn make_command(command: Command) -> Command {
         .arg(
             Arg::new("started")
                 .long("started")
+                .hide(true)
                 .value_parser(get_timestamp)
                 .value_name("TIMESTAMP")
-                .help("Set the release start date."),
+                .help("[DEPRECATED] This value is ignored."),
         )
         .arg(
             Arg::new("released")
@@ -38,13 +39,19 @@ pub fn execute(matches: &ArgMatches) -> Result<()> {
     let api = Api::current();
     let version = matches.get_one::<String>("version").unwrap();
 
+    if matches.get_one::<DateTime<Utc>>("started").is_some() {
+        log::warn!(
+            "The --started flag is deprecated. Its value is ignored, \
+            and the argument will be completely removed in a future version."
+        );
+    }
+
     api.authenticated()?.update_release(
         &config.get_org(matches)?,
         version,
         &UpdatedRelease {
             projects: config.get_projects(matches).ok(),
             url: matches.get_one::<String>("url").cloned(),
-            date_started: matches.get_one::<DateTime<Utc>>("started").copied(),
             date_released: Some(
                 matches
                     .get_one::<DateTime<Utc>>("released")

--- a/tests/integration/_cases/releases/releases-finalize-dates.trycmd
+++ b/tests/integration/_cases/releases/releases-finalize-dates.trycmd
@@ -1,5 +1,5 @@
 ```
-$ sentry-cli releases finalize wat-release --started 1431648100 --released 1431648000
+$ sentry-cli releases finalize wat-release --released 1431648000
 ? success
 Finalized release wat-release
 

--- a/tests/integration/releases/finalize.rs
+++ b/tests/integration/releases/finalize.rs
@@ -41,7 +41,6 @@ fn release_with_custom_dates() {
             .with_response_file("releases/get-release.json")
             .with_matcher(Matcher::PartialJson(json!({
                 "projects": ["wat-project"],
-                "dateStarted": "2015-05-15T00:01:40Z",
                 "dateReleased": "2015-05-15T00:00:00Z"
             }))),
         )


### PR DESCRIPTION
The Sentry server [already ignores the value passed as `--started`](https://github.com/getsentry/sentry/blob/993bddbb73d9091fb949ad34578c7b28e0e3b8ab/src/sentry/api/endpoints/organization_release_details.py#L415-L534) to the `releases finalize` command. So, the option does not work as expected.

Here, we explicitly mark the parameter as deprecated by logging a warning message stating that the value is ignored. We also stop sending the started date to the server.

Fixes #2481