### PR TITLE
docs: Fix typo "the the" -> "the"

### DIFF
--- a/src/utils/dif_upload/mod.rs
+++ b/src/utils/dif_upload/mod.rs
@@ -243,7 +243,7 @@ impl<'data> DifMatch<'data> {
         //
         // We *might* have to locate the original library in the Xcode
         // distribution, then build a new non-fat dSYM file from it and patch
-        // the the UUID.
+        // the UUID.
         if self.file_name().starts_with("libswift") {
             return false;
         }


### PR DESCRIPTION
Fix a small comment typo.