### PR TITLE
fix: Don't error if invalid value supplied for max retries

### DIFF
--- a/src/api/errors/api_error.rs
+++ b/src/api/errors/api_error.rs
@@ -44,8 +44,6 @@ pub(in crate::api) enum ApiErrorKind {
         "DSN missing. Please set the `SENTRY_DSN` environment variable to your project's DSN."
     )]
     DsnMissing,
-    #[error("Error preparing request")]
-    ErrorPreparingRequest,
 }
 
 impl fmt::Display for ApiError {

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -396,7 +396,7 @@ impl Api {
             .request(Method::Post, url, None)?
             .with_form_data(form)?
             .with_retry(
-                self.config.get_max_retry_count().unwrap(),
+                self.config.get_max_retry_count(),
                 &[
                     http::HTTP_STATUS_502_BAD_GATEWAY,
                     http::HTTP_STATUS_503_SERVICE_UNAVAILABLE,
@@ -968,7 +968,7 @@ impl<'a> AuthenticatedApi<'a> {
         self.request(Method::Post, &url)?
             .with_json_body(request)?
             .with_retry(
-                self.api.config.get_max_retry_count().unwrap(),
+                self.api.config.get_max_retry_count(),
                 &[
                     http::HTTP_STATUS_502_BAD_GATEWAY,
                     http::HTTP_STATUS_503_SERVICE_UNAVAILABLE,
@@ -1001,7 +1001,7 @@ impl<'a> AuthenticatedApi<'a> {
                 dist: None,
             })?
             .with_retry(
-                self.api.config.get_max_retry_count().unwrap(),
+                self.api.config.get_max_retry_count(),
                 &[
                     http::HTTP_STATUS_502_BAD_GATEWAY,
                     http::HTTP_STATUS_503_SERVICE_UNAVAILABLE,
@@ -1032,7 +1032,7 @@ impl<'a> AuthenticatedApi<'a> {
                 dist,
             })?
             .with_retry(
-                self.api.config.get_max_retry_count().unwrap(),
+                self.api.config.get_max_retry_count(),
                 &[
                     http::HTTP_STATUS_502_BAD_GATEWAY,
                     http::HTTP_STATUS_503_SERVICE_UNAVAILABLE,
@@ -1408,12 +1408,7 @@ impl RegionSpecificApi<'_> {
         self.request(Method::Post, &path)?
             .with_form_data(form)?
             .with_retry(
-                self.api.api.config.get_max_retry_count().map_err(|e| {
-                    ApiError::with_source(
-                        ApiErrorKind::ErrorPreparingRequest,
-                        e.context("Could not parse retry count"),
-                    )
-                })?,
+                self.api.api.config.get_max_retry_count(),
                 &[http::HTTP_STATUS_507_INSUFFICIENT_STORAGE],
             )
             .progress_bar_mode(ProgressBarMode::Request)
@@ -1472,7 +1467,7 @@ impl RegionSpecificApi<'_> {
             .request(Method::Post, &path)?
             .with_form_data(form)?
             .with_retry(
-                self.api.api.config.get_max_retry_count().unwrap(),
+                self.api.api.config.get_max_retry_count(),
                 &[
                     http::HTTP_STATUS_502_BAD_GATEWAY,
                     http::HTTP_STATUS_503_SERVICE_UNAVAILABLE,


### PR DESCRIPTION
Currently, if an invalid value is supplied for the maximum retry count, the CLI will panic, if a command which reads this value is called.

Since we can always fall back to a reasonable default, we should probably warn instead of errroring at all when an invalid value is supplied.

This change is done in preparation for #2209, since that change will add retries to all endpoints, increasing the chance of a user encountering a panic if this behavior is left unfixed.