### PR TITLE
feat(npm): Add support for installing `npm` package on Android

### DIFF
--- a/js/helper.js
+++ b/js/helper.js
@@ -40,7 +40,7 @@ function getDistributionForThisPlatform() {
   let packageName = undefined;
   if (platform === 'darwin') {
     packageName = '@sentry/cli-darwin';
-  } else if (platform === 'linux' || platform === 'freebsd') {
+  } else if (platform === 'linux' || platform === 'freebsd' || platform === 'android') {
     switch (arch) {
       case 'x64':
         packageName = '@sentry/cli-linux-x64';
@@ -79,6 +79,7 @@ function getDistributionForThisPlatform() {
     case 'darwin':
     case 'linux':
     case 'freebsd':
+    case 'android':
       subpath = 'bin/sentry-cli';
       break;
     default:

--- a/npm-binary-distributions/linux-arm/package.json
+++ b/npm-binary-distributions/linux-arm/package.json
@@ -12,7 +12,8 @@
   },
   "os": [
     "linux",
-    "freebsd"
+    "freebsd",
+    "android"
   ],
   "cpu": [
     "arm"

--- a/npm-binary-distributions/linux-arm64/package.json
+++ b/npm-binary-distributions/linux-arm64/package.json
@@ -12,7 +12,8 @@
   },
   "os": [
     "linux",
-    "freebsd"
+    "freebsd",
+    "android"
   ],
   "cpu": [
     "arm64"

--- a/npm-binary-distributions/linux-i686/package.json
+++ b/npm-binary-distributions/linux-i686/package.json
@@ -12,7 +12,8 @@
   },
   "os": [
     "linux",
-    "freebsd"
+    "freebsd",
+    "android"
   ],
   "cpu": [
     "x86",

--- a/npm-binary-distributions/linux-x64/package.json
+++ b/npm-binary-distributions/linux-x64/package.json
@@ -12,7 +12,8 @@
   },
   "os": [
     "linux",
-    "freebsd"
+    "freebsd",
+    "android"
   ],
   "cpu": [
     "x64"

--- a/scripts/install.js
+++ b/scripts/install.js
@@ -81,6 +81,7 @@ function getDownloadUrl(platform, arch) {
       return `${releasesUrl}-Windows-${archString}.exe`;
     case 'linux':
     case 'freebsd':
+    case 'android':
       return `${releasesUrl}-Linux-${archString}`;
     default:
       return null;


### PR DESCRIPTION
Android systems should be able to run the Linux binary. This change enables the Linux binary to be fetched when the `npm` package is installed on an Android system.

Fixes #2288