### PR TITLE
Setup initial mobile-app command scaffold

### DIFF
--- a/src/commands/mobile_app/mod.rs
+++ b/src/commands/mobile_app/mod.rs
@@ -21,12 +21,11 @@ pub fn make_command(mut command: Command) -> Command {
     }
 
     command = command
-        .about("(Experimental) Manage mobile apps.")
+        .about("[EXPERIMENTAL] Manage mobile apps.")
         .subcommand_required(true)
         .arg_required_else_help(true)
         .org_arg()
         .project_arg(true)
-        .release_arg()
         // TODO: Remove this when ready for release
         .hide(true);
     each_subcommand!(add_subcommand);

--- a/src/commands/mobile_app/mod.rs
+++ b/src/commands/mobile_app/mod.rs
@@ -1,0 +1,48 @@
+use anyhow::Result;
+use clap::{ArgMatches, Command};
+
+use crate::utils::args::ArgExt;
+
+pub mod upload;
+
+macro_rules! each_subcommand {
+    ($mac:ident) => {
+        $mac!(upload);
+    };
+}
+
+pub fn make_command(mut command: Command) -> Command {
+    macro_rules! add_subcommand {
+        ($name:ident) => {{
+            command = command.subcommand(crate::commands::mobile_app::$name::make_command(
+                Command::new(stringify!($name).replace('_', "-")),
+            ));
+        }};
+    }
+
+    command = command
+        .about("(Experimental) Manage mobile apps.")
+        .subcommand_required(true)
+        .arg_required_else_help(true)
+        .org_arg()
+        .project_arg(true)
+        .release_arg()
+        // TODO: Remove this when ready for release
+        .hide(true);
+    each_subcommand!(add_subcommand);
+    command
+}
+
+pub fn execute(matches: &ArgMatches) -> Result<()> {
+    macro_rules! execute_subcommand {
+        ($name:ident) => {{
+            if let Some(sub_matches) =
+                matches.subcommand_matches(&stringify!($name).replace('_', "-"))
+            {
+                return crate::commands::mobile_app::$name::execute(&sub_matches);
+            }
+        }};
+    }
+    each_subcommand!(execute_subcommand);
+    unreachable!();
+}

--- a/src/commands/mobile_app/upload.rs
+++ b/src/commands/mobile_app/upload.rs
@@ -18,6 +18,7 @@ pub fn make_command(command: Command) -> Command {
         )
 }
 
+#[allow(clippy::unnecessary_wraps)]
 pub fn execute(_matches: &ArgMatches) -> Result<()> {
     println!("Uploading mobile app files to a project is not yet implemented.");
 

--- a/src/commands/mobile_app/upload.rs
+++ b/src/commands/mobile_app/upload.rs
@@ -1,0 +1,25 @@
+use anyhow::Result;
+use clap::ArgAction;
+use clap::{Arg, ArgMatches, Command};
+
+use crate::utils::args::ArgExt;
+
+pub fn make_command(command: Command) -> Command {
+    command
+        .about("Upload mobile app files to a project.")
+        .org_arg()
+        .project_arg(false)
+        .arg(
+            Arg::new("paths")
+                .value_name("PATH")
+                .help("The path to the mobile app files to upload. Supported files include Apk, Aab, XCArchive and XCFramework.")
+                .num_args(1..)
+                .action(ArgAction::Append),
+        )
+}
+
+pub fn execute(_matches: &ArgMatches) -> Result<()> {
+    println!("Uploading mobile app files to a project is not yet implemented.");
+
+    Ok(())
+}

--- a/src/commands/mobile_app/upload.rs
+++ b/src/commands/mobile_app/upload.rs
@@ -12,7 +12,7 @@ pub fn make_command(command: Command) -> Command {
         .arg(
             Arg::new("paths")
                 .value_name("PATH")
-                .help("The path to the mobile app files to upload. Supported files include Apk, Aab, XCArchive and XCFramework.")
+                .help("The path to the mobile app files to upload. Supported files include Apk, Aab or XCArchive.")
                 .num_args(1..)
                 .action(ArgAction::Append),
         )

--- a/src/commands/mobile_app/upload.rs
+++ b/src/commands/mobile_app/upload.rs
@@ -6,7 +6,7 @@ use crate::utils::args::ArgExt;
 
 pub fn make_command(command: Command) -> Command {
     command
-        .about("Upload mobile app files to a project.")
+        .about("[EXPERIMENTAL] Upload mobile app files to a project.")
         .org_arg()
         .project_arg(false)
         .arg(
@@ -18,9 +18,9 @@ pub fn make_command(command: Command) -> Command {
         )
 }
 
-#[allow(clippy::unnecessary_wraps)]
+#[expect(clippy::unnecessary_wraps)]
 pub fn execute(_matches: &ArgMatches) -> Result<()> {
-    println!("Uploading mobile app files to a project is not yet implemented.");
+    eprintln!("Uploading mobile app files to a project is not yet implemented.");
 
     Ok(())
 }

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -31,6 +31,7 @@ macro_rules! each_subcommand {
         $mac!(info);
         $mac!(issues);
         $mac!(login);
+        $mac!(mobile_app);
         $mac!(monitors);
         $mac!(organizations);
         $mac!(projects);

--- a/tests/integration/_cases/mobile_app/mobile_app-help.trycmd
+++ b/tests/integration/_cases/mobile_app/mobile_app-help.trycmd
@@ -1,0 +1,25 @@
+```
+$ sentry-cli mobile-app --help
+? success
+[EXPERIMENTAL] Manage mobile apps.
+
+Usage: sentry-cli mobile-app [OPTIONS] <COMMAND>
+
+Commands:
+  upload  [EXPERIMENTAL] Upload mobile app files to a project.
+  help    Print this message or the help of the given subcommand(s)
+
+Options:
+  -o, --org <ORG>                The organization ID or slug.
+      --header <KEY:VALUE>       Custom headers that should be attached to all requests
+                                 in key:value format.
+  -p, --project <PROJECT>        The project ID or slug.
+      --auth-token <AUTH_TOKEN>  Use the given Sentry auth token.
+      --log-level <LOG_LEVEL>    Set the log output verbosity. [possible values: trace, debug, info,
+                                 warn, error]
+      --quiet                    Do not print any output while preserving correct exit code. This
+                                 flag is currently implemented only for selected subcommands.
+                                 [aliases: silent]
+  -h, --help                     Print help
+
+```

--- a/tests/integration/_cases/mobile_app/mobile_app-help.trycmd
+++ b/tests/integration/_cases/mobile_app/mobile_app-help.trycmd
@@ -3,7 +3,7 @@ $ sentry-cli mobile-app --help
 ? success
 [EXPERIMENTAL] Manage mobile apps.
 
-Usage: sentry-cli mobile-app [OPTIONS] <COMMAND>
+Usage: sentry-cli[EXE] mobile-app [OPTIONS] <COMMAND>
 
 Commands:
   upload  [EXPERIMENTAL] Upload mobile app files to a project.

--- a/tests/integration/_cases/mobile_app/mobile_app-upload-help.trycmd
+++ b/tests/integration/_cases/mobile_app/mobile_app-upload-help.trycmd
@@ -3,7 +3,7 @@ $ sentry-cli mobile-app upload --help
 ? success
 [EXPERIMENTAL] Upload mobile app files to a project.
 
-Usage: sentry-cli mobile-app upload [OPTIONS] [PATH]...
+Usage: sentry-cli[EXE] mobile-app upload [OPTIONS] [PATH]...
 
 Arguments:
   [PATH]...  The path to the mobile app files to upload. Supported files include Apk, Aab or

--- a/tests/integration/_cases/mobile_app/mobile_app-upload-help.trycmd
+++ b/tests/integration/_cases/mobile_app/mobile_app-upload-help.trycmd
@@ -1,0 +1,25 @@
+```
+$ sentry-cli mobile-app upload --help
+? success
+[EXPERIMENTAL] Upload mobile app files to a project.
+
+Usage: sentry-cli mobile-app upload [OPTIONS] [PATH]...
+
+Arguments:
+  [PATH]...  The path to the mobile app files to upload. Supported files include Apk, Aab or
+             XCArchive.
+
+Options:
+  -o, --org <ORG>                The organization ID or slug.
+      --header <KEY:VALUE>       Custom headers that should be attached to all requests
+                                 in key:value format.
+  -p, --project <PROJECT>        The project ID or slug.
+      --auth-token <AUTH_TOKEN>  Use the given Sentry auth token.
+      --log-level <LOG_LEVEL>    Set the log output verbosity. [possible values: trace, debug, info,
+                                 warn, error]
+      --quiet                    Do not print any output while preserving correct exit code. This
+                                 flag is currently implemented only for selected subcommands.
+                                 [aliases: silent]
+  -h, --help                     Print help
+
+```

--- a/tests/integration/mobile_app/mod.rs
+++ b/tests/integration/mobile_app/mod.rs
@@ -1,0 +1,8 @@
+use crate::integration::TestManager;
+
+mod upload;
+
+#[test]
+fn command_mobile_app_help() {
+    TestManager::new().register_trycmd_test("mobile_app/mobile_app-help.trycmd");
+}

--- a/tests/integration/mobile_app/upload.rs
+++ b/tests/integration/mobile_app/upload.rs
@@ -1,0 +1,6 @@
+use crate::integration::TestManager;
+
+#[test]
+fn command_mobile_app_upload_help() {
+    TestManager::new().register_trycmd_test("mobile_app/mobile_app-upload-help.trycmd");
+}

--- a/tests/integration/mod.rs
+++ b/tests/integration/mod.rs
@@ -7,6 +7,7 @@ mod info;
 mod invalid_env;
 mod issues;
 mod login;
+pub mod mobile_app;
 mod monitors;
 mod org_tokens;
 mod organizations;

--- a/tests/integration/mod.rs
+++ b/tests/integration/mod.rs
@@ -7,7 +7,7 @@ mod info;
 mod invalid_env;
 mod issues;
 mod login;
-pub mod mobile_app;
+mod mobile_app;
 mod monitors;
 mod org_tokens;
 mod organizations;


### PR DESCRIPTION
In preparation for adding mobile application upload support to Sentry, this creates the basic scaffolding of a new `mobile-app` command with a single `upload` subcommand. The implementation of this subcommand will come in subsequent PRs.

Currently, the `mobile-app` command is set to hidden to ensure minimal exposure if a release is cut.