### PR TITLE
build: Bump MSRV to 1.86

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ build = "build.rs"
 name = "sentry-cli"
 version = "2.46.0"
 edition = "2021"
-rust-version = "1.80"
+rust-version = "1.86"
 
 [dependencies]
 anylog = "0.6.3"

--- a/src/utils/system.rs
+++ b/src/utils/system.rs
@@ -75,9 +75,7 @@ pub fn print_error(err: &Error) {
     // Debug style for error includes cause chain and backtrace (if available).
     eprintln!("{} {:?}", style("error:").red(), err);
 
-    if Config::current_opt().map_or(true, |config| {
-        config.get_log_level() < log::LevelFilter::Info
-    }) {
+    if Config::current_opt().is_none_or(|config| config.get_log_level() < log::LevelFilter::Info) {
         eprintln!();
         eprintln!("{}", style("Add --log-level=[info|debug] or export SENTRY_LOG_LEVEL=[info|debug] to see more output.").dim());
         eprintln!(


### PR DESCRIPTION
This will allow us to use lints which require newer MSRV (such as [`clippy::allow_attributes`](https://rust-lang.github.io/rust-clippy/master/index.html#allow_attributes)).

Also, fix a lint which surfaces after bumping MSRV.