### PR TITLE
ref: Delete unused struct field

### DIFF
--- a/src/utils/auth_token/org_auth_token.rs
+++ b/src/utils/auth_token/org_auth_token.rs
@@ -13,9 +13,7 @@ pub struct OrgAuthToken {
 
 /// Represents the payload data of an org auth token.
 #[derive(Clone, Debug, Deserialize)]
-#[expect(dead_code)] // Otherwise, we get a warning about unused fields
 pub struct AuthTokenPayload {
-    iat: f64,
     pub region_url: String,
     pub org: String,
 


### PR DESCRIPTION
We never use this struct field. It was originally included because auth token payloads include this field, but since we only ever deserialize this payload, `serde` ignores the field if it is not on the struct.

Depends on:
  - #2527