### PR TITLE
meta: Add `CODEOWNERS` file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @szokeasaurusrex


### PR DESCRIPTION
List @szokeasaurusrex as the default `CODEOWNER` for the Sentry CLI repo