### PR TITLE
Add basic file validation to mobile-app upload command

### DIFF
--- a/src/commands/mobile_app/upload.rs
+++ b/src/commands/mobile_app/upload.rs
@@ -1,8 +1,14 @@
+use std::fs::File;
+use std::io::{BufReader, Seek, SeekFrom};
+use std::path::Path;
+
+use anyhow::anyhow;
 use anyhow::Result;
 use clap::ArgAction;
 use clap::{Arg, ArgMatches, Command};
 
 use crate::utils::args::ArgExt;
+use crate::utils::mobile_app::{is_aab_file, is_apk_file, is_xcarchive_directory, is_zip_file};
 
 pub fn make_command(command: Command) -> Command {
     command
@@ -19,8 +25,60 @@ pub fn make_command(command: Command) -> Command {
 }
 
 #[expect(clippy::unnecessary_wraps)]
-pub fn execute(_matches: &ArgMatches) -> Result<()> {
-    eprintln!("Uploading mobile app files to a project is not yet implemented.");
+pub fn execute(matches: &ArgMatches) -> Result<()> {
+    let path_strings = matches.get_many::<String>("paths").unwrap();
 
+    let mut paths: Vec<&Path> = Vec::new();
+    for path_string in path_strings {
+        let path: &Path = path_string.as_ref();
+
+        if !path.exists() {
+            return Err(anyhow!("File does not exist: {}", path.display()));
+        }
+
+        if !path.is_file() {
+            return Err(anyhow!("Path is not a file: {}", path.display()));
+        }
+
+        validate_mobile_app_file(path)?;
+        paths.push(path);
+    }
+
+    for path in paths {
+        println!("Uploading mobile app file: {}", path.display());
+        // TODO: Upload the file to the chunked uploads API
+    }
+
+    eprintln!("Uploading mobile app files to a project is not yet implemented.");
     Ok(())
+}
+
+/// Validate the file is a valid mobile app file
+pub fn validate_mobile_app_file(path: &Path) -> Result<()> {
+    let file = File::open(path)?;
+    let mut reader = BufReader::new(file);
+
+    // Check for APK/AAB (both are ZIP files with specific structure)
+    if is_zip_file(&mut reader)? {
+        reader.seek(SeekFrom::Start(0))?;
+
+        if is_aab_file(&mut reader)? {
+            return Ok(());
+        }
+
+        reader.seek(SeekFrom::Start(0))?;
+        if is_apk_file(&mut reader)? {
+            return Ok(());
+        }
+    }
+
+    // Check for XCArchive (directory structure)
+    if path.is_dir() && is_xcarchive_directory(path)? {
+        return Ok(());
+    }
+
+    Err(anyhow!(
+        "File is not a recognized mobile app format (APK, AAB, or XCArchive): {}",
+        path.display()
+    ))
 }

--- a/src/utils/mobile_app/mod.rs
+++ b/src/utils/mobile_app/mod.rs
@@ -1,0 +1,3 @@
+mod validation;
+
+pub use self::validation::{is_aab_file, is_apk_file, is_xcarchive_directory, is_zip_file};

--- a/src/utils/mobile_app/validation.rs
+++ b/src/utils/mobile_app/validation.rs
@@ -1,0 +1,57 @@
+use std::io::{Read, Seek, SeekFrom};
+use std::path::Path;
+
+use anyhow::Result;
+
+pub fn is_zip_file<R: Read + Seek>(reader: &mut R) -> Result<bool> {
+    let mut magic = [0u8; 4];
+    reader.seek(SeekFrom::Start(0))?;
+
+    if reader.read_exact(&mut magic).is_err() {
+        return Ok(false);
+    }
+
+    // https://en.wikipedia.org/wiki/List_of_file_signatures
+    const ZIP_MAGIC: [u8; 4] = [0x50, 0x4B, 0x03, 0x04];
+    const ZIP_MAGIC_EMPTY: [u8; 4] = [0x50, 0x4B, 0x05, 0x06];
+    const ZIP_MAGIC_SPANNED: [u8; 4] = [0x50, 0x4B, 0x07, 0x08];
+    Ok(magic == ZIP_MAGIC || magic == ZIP_MAGIC_EMPTY || magic == ZIP_MAGIC_SPANNED)
+}
+
+pub fn is_apk_file<R: Read + Seek>(reader: &mut R) -> Result<bool> {
+    reader.seek(SeekFrom::Start(0))?;
+
+    let mut archive = zip::ZipArchive::new(reader)?;
+
+    // APK files must contain AndroidManifest.xml at the root of the zip file
+    let has_manifest = archive.by_name("AndroidManifest.xml").is_ok();
+
+    Ok(has_manifest)
+}
+
+pub fn is_aab_file<R: Read + Seek>(reader: &mut R) -> Result<bool> {
+    reader.seek(SeekFrom::Start(0))?;
+
+    let mut archive = zip::ZipArchive::new(reader)?;
+
+    // AAB files must contain BundleConfig.pb and base/manifest/AndroidManifest.xml
+    let has_bundle_config = archive.by_name("BundleConfig.pb").is_ok();
+    let has_base_manifest = archive.by_name("base/manifest/AndroidManifest.xml").is_ok();
+
+    Ok(has_bundle_config && has_base_manifest)
+}
+
+pub fn is_xcarchive_directory<P: AsRef<Path>>(path: P) -> Result<bool> {
+    let path = path.as_ref();
+
+    // XCArchive should have .xcarchive extension
+    if path.extension().and_then(|s| s.to_str()) != Some("xcarchive") {
+        return Ok(false);
+    }
+
+    // Check for required XCArchive structure
+    let info_plist = path.join("Info.plist");
+    let products_dir = path.join("Products");
+
+    Ok(info_plist.exists() && products_dir.exists() && products_dir.is_dir())
+}

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -15,6 +15,7 @@ pub mod fs;
 pub mod http;
 pub mod logging;
 pub mod metrics;
+pub mod mobile_app;
 pub mod progress;
 pub mod proguard;
 pub mod releases;


### PR DESCRIPTION
Adds basic validation to ensure the paths provided by the `[PATHS]` argument are an APK, AAB (zip) or XCArchive directory. 