### PR TITLE
Add Zip normalization of provided paths before uploading

### DIFF
--- a/src/commands/mobile_app/upload.rs
+++ b/src/commands/mobile_app/upload.rs
@@ -30,7 +30,7 @@ pub fn execute(matches: &ArgMatches) -> Result<()> {
         .get_many::<String>("paths")
         .expect("paths argument is required");
 
-    let mut normalized_zips = Vec::new();
+    let mut normalized_zips = vec![];
     for path_string in path_strings {
         let path: &Path = path_string.as_ref();
 

--- a/src/commands/mobile_app/upload.rs
+++ b/src/commands/mobile_app/upload.rs
@@ -32,7 +32,7 @@ pub fn execute(matches: &ArgMatches) -> Result<()> {
         .expect("paths argument is required");
 
     let mut paths = Vec::new();
-    let mut normalized_zips: Vec<TempFile> = Vec::new();
+    let mut normalized_zips = Vec::new();
     for path_string in path_strings {
         let path: &Path = path_string.as_ref();
 

--- a/src/commands/mobile_app/upload.rs
+++ b/src/commands/mobile_app/upload.rs
@@ -35,7 +35,6 @@ pub fn execute(matches: &ArgMatches) -> Result<()> {
 
     let mut normalized_zips = Vec::new();
     for path_string in path_strings {
-        println!("Processing path: {}", path_string);
         let path: &Path = path_string.as_ref();
 
         if !path.exists() {
@@ -94,7 +93,6 @@ fn validate_is_mobile_app(path: &Path, bytes: &[u8]) -> Result<()> {
 
 // For APK and AAB files, we'll copy them directly into the zip
 fn normalize_file(path: &Path, bytes: &[u8]) -> Result<TempFile> {
-    println!("Normalizing file: {}", path.display());
     let temp_file = TempFile::create()?;
     let mut zip = ZipWriter::new(temp_file.open()?);
 

--- a/src/commands/mobile_app/upload.rs
+++ b/src/commands/mobile_app/upload.rs
@@ -105,7 +105,7 @@ fn normalize_file(path: &Path, bytes: &[u8]) -> Result<TempFile> {
         .with_context(|| format!("Failed to get relative path for {}", path.display()))?;
 
     zip.start_file(file_name, SimpleFileOptions::default())?;
-    zip.write(bytes)?;
+    zip.write_all(bytes)?;
 
     zip.finish()?;
     Ok(temp_file)

--- a/src/commands/mobile_app/upload.rs
+++ b/src/commands/mobile_app/upload.rs
@@ -105,7 +105,7 @@ fn normalize_file(path: &Path, bytes: &[u8]) -> Result<TempFile> {
 
     let file_name = path
         .file_name()
-        .unwrap()
+        .expect("Failed to get file name")
         .to_str()
         .with_context(|| format!("Failed to get relative path for {}", path.display()))?;
 

--- a/src/commands/mobile_app/upload.rs
+++ b/src/commands/mobile_app/upload.rs
@@ -35,6 +35,7 @@ pub fn execute(matches: &ArgMatches) -> Result<()> {
 
     let mut normalized_zips = Vec::new();
     for path_string in path_strings {
+        println!("Processing path: {}", path_string);
         let path: &Path = path_string.as_ref();
 
         if !path.exists() {
@@ -93,6 +94,7 @@ fn validate_is_mobile_app(path: &Path, bytes: &[u8]) -> Result<()> {
 
 // For APK and AAB files, we'll copy them directly into the zip
 fn normalize_file(path: &Path, bytes: &[u8]) -> Result<TempFile> {
+    println!("Normalizing file: {}", path.display());
     let temp_file = TempFile::create()?;
     let mut zip = ZipWriter::new(temp_file.open()?);
 
@@ -103,7 +105,7 @@ fn normalize_file(path: &Path, bytes: &[u8]) -> Result<TempFile> {
         .with_context(|| format!("Failed to get relative path for {}", path.display()))?;
 
     zip.start_file(file_name, SimpleFileOptions::default())?;
-    zip.write_all(bytes)?;
+    zip.write(bytes)?;
 
     zip.finish()?;
     Ok(temp_file)

--- a/src/commands/mobile_app/upload.rs
+++ b/src/commands/mobile_app/upload.rs
@@ -5,8 +5,11 @@ use anyhow::Result;
 use clap::ArgAction;
 use clap::{Arg, ArgMatches, Command};
 use symbolic::common::ByteView;
+use zip::write::SimpleFileOptions;
+use zip::ZipWriter;
 
 use crate::utils::args::ArgExt;
+use crate::utils::fs::TempFile;
 use crate::utils::mobile_app::{is_aab_file, is_apk_file, is_xcarchive_directory, is_zip_file};
 
 pub fn make_command(command: Command) -> Command {
@@ -29,6 +32,7 @@ pub fn execute(matches: &ArgMatches) -> Result<()> {
         .expect("paths argument is required");
 
     let mut paths = Vec::new();
+    let mut normalized_zips: Vec<TempFile> = Vec::new();
     for path_string in path_strings {
         let path: &Path = path_string.as_ref();
 
@@ -37,13 +41,13 @@ pub fn execute(matches: &ArgMatches) -> Result<()> {
         }
 
         validate_is_mobile_app(path)?;
-        paths.push(path);
+        let normalized_zip = normalize_mobile_app(path)?;
+        normalized_zips.push(normalized_zip);
     }
 
-    for path in paths {
-        println!("Uploading mobile app file: {}", path.display());
-        // TODO: Normalize the path to be a zip of the underlying file/dir
-        // TODO: Upload the file to the chunked uploads API
+    for zip in normalized_zips {
+        println!("Created normalized zip at: {}", zip.path().display());
+        // TODO: Upload the normalized zip to the chunked uploads API
     }
 
     eprintln!("Uploading mobile app files to a project is not yet implemented.");
@@ -73,4 +77,46 @@ fn validate_is_mobile_app(path: &Path) -> Result<()> {
         "File is not a recognized mobile app format (APK, AAB, or XCArchive): {}",
         path.display()
     ))
+}
+
+/// Normalizes a mobile app file into a zip file to ensure consistent artifact parsing logic on the backend.
+fn normalize_mobile_app(path: &Path) -> Result<TempFile> {
+    let temp_file = TempFile::create()?;
+    let mut zip = ZipWriter::new(temp_file.open()?);
+
+    if path.is_file() {
+        // For APK and AAB files, we'll copy them directly into the zip
+        let mut file = File::open(path)?;
+        let file_name = path
+            .file_name()
+            .ok_or_else(|| anyhow!("Invalid file name"))?
+            .to_string_lossy();
+
+        zip.start_file(file_name, SimpleFileOptions::default())?;
+        std::io::copy(&mut file, &mut zip)?;
+    } else if path.is_dir() {
+        // For XCArchive directories, we'll zip the entire directory
+        for entry in walkdir::WalkDir::new(path)
+            .follow_links(true)
+            .into_iter()
+            .filter_map(Result::ok)
+        {
+            let entry_path = entry.path();
+            if entry_path.is_file() {
+                let relative_path = entry_path
+                    .strip_prefix(path)
+                    .map_err(|_| anyhow!("Failed to get relative path"))?;
+
+                let mut file = File::open(entry_path)?;
+                zip.start_file(
+                    relative_path.to_string_lossy(),
+                    SimpleFileOptions::default(),
+                )?;
+                std::io::copy(&mut file, &mut zip)?;
+            }
+        }
+    }
+
+    zip.finish()?;
+    Ok(temp_file)
 }

--- a/src/commands/mobile_app/upload.rs
+++ b/src/commands/mobile_app/upload.rs
@@ -74,19 +74,19 @@ pub fn execute(matches: &ArgMatches) -> Result<()> {
     Ok(())
 }
 
-fn validate_is_mobile_app(path: &Path, byte_view: &ByteView) -> Result<()> {
+fn validate_is_mobile_app(path: &Path, bytes: &[u8]) -> Result<()> {
     // Check for XCArchive (directory) first
     if path.is_dir() && is_xcarchive_directory(path) {
         return Ok(());
     }
 
     // Check if the file is a zip file (then AAB or APK)
-    if is_zip_file(byte_view) {
-        if is_aab_file(byte_view)? {
+    if is_zip_file(bytes) {
+        if is_aab_file(bytes)? {
             return Ok(());
         }
 
-        if is_apk_file(byte_view)? {
+        if is_apk_file(bytes)? {
             return Ok(());
         }
     }
@@ -98,7 +98,7 @@ fn validate_is_mobile_app(path: &Path, byte_view: &ByteView) -> Result<()> {
 }
 
 // For APK and AAB files, we'll copy them directly into the zip
-fn normalize_file(path: &Path, byte_view: &ByteView) -> Result<TempFile> {
+fn normalize_file(path: &Path, bytes: &[u8]) -> Result<TempFile> {
     let temp_file = TempFile::create()?;
     let mut zip = ZipWriter::new(temp_file.open()?);
 
@@ -108,7 +108,7 @@ fn normalize_file(path: &Path, byte_view: &ByteView) -> Result<TempFile> {
         .to_str()
         .unwrap_or_else(|| panic!("Failed to get file name for {}", path.display()));
     zip.start_file(file_name, SimpleFileOptions::default())?;
-    zip.write_all(byte_view.as_slice())?;
+    zip.write_all(bytes)?;
 
     zip.finish()?;
     Ok(temp_file)

--- a/src/utils/mobile_app/validation.rs
+++ b/src/utils/mobile_app/validation.rs
@@ -43,20 +43,9 @@ where
 {
     let path = path.as_ref();
 
-    // XCArchive should have Info.plist and a .app file in Products/Applications/
+    // XCArchive should have Info.plist and Products directory
     let info_plist = path.join("Info.plist");
-    let applications_dir = path.join("Products").join("Applications");
-
-    if !info_plist.exists() || !applications_dir.exists() || !applications_dir.is_dir() {
-        return Ok(false);
-    }
-
-    // Check if there's at least one .app file in the Applications directory
-    let has_app_file = std::fs::read_dir(&applications_dir)?
-        .filter_map(|entry| entry.ok())
-        .any(|entry| {
-            entry.path().is_dir() && entry.path().extension().is_some_and(|ext| ext == "app")
-        });
+    let products_dir = path.join("Products");
 
     Ok(has_app_file)
 }

--- a/src/utils/mobile_app/validation.rs
+++ b/src/utils/mobile_app/validation.rs
@@ -43,9 +43,9 @@ where
 {
     let path = path.as_ref();
 
-    // XCArchive should have Info.plist and Products directory
+    // XCArchive should have Info.plist and an app file in Products/Applications/
     let info_plist = path.join("Info.plist");
     let products_dir = path.join("Products");
 
-    Ok(has_app_file)
+    Ok(info_plist.exists() && products_dir.exists() && products_dir.is_dir())
 }

--- a/src/utils/mobile_app/validation.rs
+++ b/src/utils/mobile_app/validation.rs
@@ -43,7 +43,7 @@ where
 {
     let path = path.as_ref();
 
-    // XCArchive should have Info.plist and an app file in Products/Applications/
+    // XCArchive should have Info.plist and a Products/ directory
     let info_plist = path.join("Info.plist");
     let products_dir = path.join("Products");
 

--- a/src/utils/mobile_app/validation.rs
+++ b/src/utils/mobile_app/validation.rs
@@ -37,7 +37,7 @@ pub fn is_aab_file(bytes: &[u8]) -> Result<bool> {
     Ok(has_bundle_config && has_base_manifest)
 }
 
-pub fn is_xcarchive_directory<P>(path: P) -> Result<bool>
+pub fn is_xcarchive_directory<P>(path: P) -> bool
 where
     P: AsRef<Path>,
 {
@@ -47,5 +47,5 @@ where
     let info_plist = path.join("Info.plist");
     let products_dir = path.join("Products");
 
-    Ok(info_plist.exists() && products_dir.exists() && products_dir.is_dir())
+    info_plist.exists() && products_dir.exists() && products_dir.is_dir()
 }


### PR DESCRIPTION
For ease of parsing artifacts on the backend, we'll "normalize" all provided paths to a basic zip file. This ensures that no matter the artifact uploaded (files: APK, AAB, directory: XCArchive), we can process all as a zip file on the backend. This was an optimization done with Emerge that greatly simplified backend artifact handling.

Skipping tests here to be added at a later time when I leverage a full integration test to validate the chunked uploads match the expected zip format.