### PR TITLE
ref: Disallow using `unwrap`

### DIFF
--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -1,3 +1,5 @@
+#![expect(clippy::unwrap_used, reason = "contains legacy code which uses unwrap")]
+
 //! This module implements the API access to the Sentry API as well
 //! as some other APIs we interact with.  In particular it can talk
 //! to the GitHub API to figure out if there are new releases of the

--- a/src/commands/bash_hook.rs
+++ b/src/commands/bash_hook.rs
@@ -1,3 +1,5 @@
+#![expect(clippy::unwrap_used, reason = "deprecated command")]
+
 use std::cmp::min;
 use std::collections::HashMap;
 use std::env;

--- a/src/commands/debug_files/bundle_jvm.rs
+++ b/src/commands/debug_files/bundle_jvm.rs
@@ -1,3 +1,5 @@
+#![expect(clippy::unwrap_used, reason = "contains legacy code which uses unwrap")]
+
 use crate::api::Api;
 use crate::config::Config;
 use crate::constants::DEFAULT_MAX_WAIT;

--- a/src/commands/debug_files/bundle_sources.rs
+++ b/src/commands/debug_files/bundle_sources.rs
@@ -1,3 +1,5 @@
+#![expect(clippy::unwrap_used, reason = "contains legacy code which uses unwrap")]
+
 use std::fs;
 use std::path::{Path, PathBuf};
 

--- a/src/commands/debug_files/check.rs
+++ b/src/commands/debug_files/check.rs
@@ -1,3 +1,5 @@
+#![expect(clippy::unwrap_used, reason = "contains legacy code which uses unwrap")]
+
 use std::io;
 use std::path::Path;
 

--- a/src/commands/debug_files/find.rs
+++ b/src/commands/debug_files/find.rs
@@ -337,6 +337,7 @@ pub fn execute(matches: &ArgMatches) -> Result<()> {
     // which types should we consider?
     if let Some(t) = matches.get_many::<String>("types") {
         for ty in t {
+            #[expect(clippy::unwrap_used, reason = "legacy code")]
             types.insert(ty.parse().unwrap());
         }
     } else {

--- a/src/commands/debug_files/print_sources.rs
+++ b/src/commands/debug_files/print_sources.rs
@@ -17,6 +17,7 @@ pub fn make_command(command: Command) -> Command {
 }
 
 pub fn execute(matches: &ArgMatches) -> Result<()> {
+    #[expect(clippy::unwrap_used, reason = "legacy code")]
     let path = Path::new(matches.get_one::<String>("path").unwrap());
 
     // which types should we consider?

--- a/src/commands/deploys/list.rs
+++ b/src/commands/deploys/list.rs
@@ -33,6 +33,7 @@ pub fn execute(matches: &ArgMatches) -> Result<()> {
             .add(&deploy.env)
             .add(deploy.name())
             .add(HumanDuration(
+                #[expect(clippy::unwrap_used, reason = "legacy code")]
                 Utc::now().signed_duration_since(deploy.finished.unwrap()),
             ));
     }

--- a/src/commands/deploys/new.rs
+++ b/src/commands/deploys/new.rs
@@ -68,10 +68,13 @@ pub fn execute(matches: &ArgMatches) -> Result<()> {
     let api = Api::current();
     let version = config.get_release_with_legacy_fallback(matches)?;
     let mut deploy = Deploy {
+        #[expect(clippy::unwrap_used, reason = "legacy code")]
         env: matches.get_one::<String>("env").unwrap().into(),
         name: matches.get_one::<String>("name").map(|n| n.into()),
         url: matches.get_one::<String>("url").map(|u| u.into()),
-        projects: matches.get_many::<String>("project").map(|x| x.into_iter().map(|x| x.into()).collect()),
+        projects: matches
+            .get_many::<String>("project")
+            .map(|x| x.into_iter().map(|x| x.into()).collect()),
         ..Default::default()
     };
 
@@ -93,8 +96,7 @@ pub fn execute(matches: &ArgMatches) -> Result<()> {
     let org = config.get_org(matches)?;
     let authenticated_api = api.authenticated()?;
 
-    let created_deploy = authenticated_api
-        .create_deploy(&org, &version, &deploy)?;
+    let created_deploy = authenticated_api.create_deploy(&org, &version, &deploy)?;
 
     println!(
         "Created new deploy {} for '{}'",

--- a/src/commands/events/list.rs
+++ b/src/commands/events/list.rs
@@ -43,6 +43,7 @@ pub fn execute(matches: &ArgMatches) -> Result<()> {
     let config = Config::current();
     let org = config.get_org(matches)?;
     let project = config.get_project(matches)?;
+    #[expect(clippy::unwrap_used, reason = "legacy code")]
     let pages = *matches.get_one("pages").unwrap();
     let api = Api::current();
 

--- a/src/commands/files/upload.rs
+++ b/src/commands/files/upload.rs
@@ -1,3 +1,5 @@
+#![expect(clippy::unwrap_used, reason = "contains legacy code which uses unwrap")]
+
 use std::collections::BTreeMap;
 use std::ffi::OsStr;
 use std::fs;

--- a/src/commands/issues/list.rs
+++ b/src/commands/issues/list.rs
@@ -36,6 +36,7 @@ pub fn execute(matches: &ArgMatches) -> Result<()> {
     let config = Config::current();
     let org = config.get_org(matches)?;
     let project = config.get_project(matches)?;
+    #[expect(clippy::unwrap_used, reason = "legacy code")]
     let pages = *matches.get_one("pages").unwrap();
     let query = matches.get_one::<String>("query").cloned();
     let api = Api::current();

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -331,6 +331,7 @@ fn setup() {
     // we use debug internally but our log handler then rejects to a lower limit.
     // This is okay for our uses but not as efficient.
     set_max_level(LevelFilter::Debug);
+    #[expect(clippy::unwrap_used, reason = "legacy code")]
     set_logger(&Logger).unwrap();
 
     if let Err(e) = load_dotenv_result {

--- a/src/commands/monitors/run.rs
+++ b/src/commands/monitors/run.rs
@@ -1,3 +1,5 @@
+#![expect(clippy::unwrap_used, reason = "contains legacy code which uses unwrap")]
+
 use chrono_tz::Tz;
 use std::process;
 use std::time::{Duration, Instant};

--- a/src/commands/react_native/appcenter.rs
+++ b/src/commands/react_native/appcenter.rs
@@ -1,3 +1,5 @@
+#![expect(clippy::unwrap_used, reason = "deprecated command")]
+
 use std::env;
 use std::ffi::OsStr;
 use std::fs;

--- a/src/commands/react_native/gradle.rs
+++ b/src/commands/react_native/gradle.rs
@@ -1,3 +1,5 @@
+#![expect(clippy::unwrap_used, reason = "contains legacy code which uses unwrap")]
+
 use std::env;
 use std::path::PathBuf;
 use std::time::Duration;

--- a/src/commands/react_native/xcode.rs
+++ b/src/commands/react_native/xcode.rs
@@ -1,3 +1,5 @@
+#![expect(clippy::unwrap_used, reason = "contains legacy code which uses unwrap")]
+
 use std::collections::HashMap;
 use std::env;
 use std::fs;

--- a/src/commands/releases/archive.rs
+++ b/src/commands/releases/archive.rs
@@ -15,6 +15,7 @@ pub fn make_command(command: Command) -> Command {
 pub fn execute(matches: &ArgMatches) -> Result<()> {
     let config = Config::current();
     let api = Api::current();
+    #[expect(clippy::unwrap_used, reason = "legacy code")]
     let version = matches.get_one::<String>("version").unwrap();
 
     let info_rv = api.authenticated()?.update_release(

--- a/src/commands/releases/delete.rs
+++ b/src/commands/releases/delete.rs
@@ -15,6 +15,7 @@ pub fn make_command(command: Command) -> Command {
 pub fn execute(matches: &ArgMatches) -> Result<()> {
     let config = Config::current();
     let api = Api::current();
+    #[expect(clippy::unwrap_used, reason = "legacy code")]
     let version = matches.get_one::<String>("version").unwrap();
     let project = config.get_project(matches).ok();
 

--- a/src/commands/releases/finalize.rs
+++ b/src/commands/releases/finalize.rs
@@ -37,6 +37,7 @@ pub fn make_command(command: Command) -> Command {
 pub fn execute(matches: &ArgMatches) -> Result<()> {
     let config = Config::current();
     let api = Api::current();
+    #[expect(clippy::unwrap_used, reason = "legacy code")]
     let version = matches.get_one::<String>("version").unwrap();
 
     if matches.get_one::<DateTime<Utc>>("started").is_some() {

--- a/src/commands/releases/info.rs
+++ b/src/commands/releases/info.rs
@@ -32,6 +32,7 @@ pub fn make_command(command: Command) -> Command {
 pub fn execute(matches: &ArgMatches) -> Result<()> {
     let api = Api::current();
     let authenticated_api = api.authenticated()?;
+    #[expect(clippy::unwrap_used, reason = "legacy code")]
     let version = matches.get_one::<String>("version").unwrap();
     let config = Config::current();
     let org = config.get_org(matches)?;

--- a/src/commands/releases/new.rs
+++ b/src/commands/releases/new.rs
@@ -30,6 +30,7 @@ pub fn make_command(command: Command) -> Command {
 pub fn execute(matches: &ArgMatches) -> Result<()> {
     let config = Config::current();
     let api = Api::current();
+    #[expect(clippy::unwrap_used, reason = "legacy code")]
     let version = matches.get_one::<String>("version").unwrap();
 
     api.authenticated()?.new_release(

--- a/src/commands/releases/restore.rs
+++ b/src/commands/releases/restore.rs
@@ -15,6 +15,7 @@ pub fn make_command(command: Command) -> Command {
 pub fn execute(matches: &ArgMatches) -> Result<()> {
     let config = Config::current();
     let api = Api::current();
+    #[expect(clippy::unwrap_used, reason = "legacy code")]
     let version = matches.get_one::<String>("version").unwrap();
 
     let info_rv = api.authenticated()?.update_release(

--- a/src/commands/releases/set_commits.rs
+++ b/src/commands/releases/set_commits.rs
@@ -1,3 +1,5 @@
+#![expect(clippy::unwrap_used, reason = "contains legacy code which uses unwrap")]
+
 use anyhow::{bail, Result};
 use clap::{Arg, ArgAction, ArgMatches, Command};
 use lazy_static::lazy_static;

--- a/src/commands/send_envelope.rs
+++ b/src/commands/send_envelope.rs
@@ -1,3 +1,5 @@
+#![expect(clippy::unwrap_used, reason = "contains legacy code which uses unwrap")]
+
 use std::path::PathBuf;
 
 use anyhow::Result;

--- a/src/commands/send_event.rs
+++ b/src/commands/send_event.rs
@@ -175,6 +175,7 @@ pub fn execute(matches: &ArgMatches) -> Result<()> {
     let raw = matches.get_flag("raw");
 
     if let Some(path) = matches.get_one::<String>("path") {
+        #[expect(clippy::unwrap_used, reason = "legacy code")]
         let collected_paths: Vec<PathBuf> = glob_with(path, MatchOptions::new())
             .unwrap()
             .flatten()

--- a/src/commands/sourcemaps/explain.rs
+++ b/src/commands/sourcemaps/explain.rs
@@ -1,3 +1,5 @@
+#![expect(clippy::unwrap_used, reason = "deprecated command")]
+
 use std::io::Read;
 use std::path::Path;
 

--- a/src/commands/sourcemaps/inject.rs
+++ b/src/commands/sourcemaps/inject.rs
@@ -71,6 +71,7 @@ pub fn make_command(command: Command) -> Command {
 pub fn execute(matches: &ArgMatches) -> Result<()> {
     let mut processor = SourceMapProcessor::new();
 
+    #[expect(clippy::unwrap_used, reason = "legacy code")]
     let paths = matches
         .get_many::<String>("paths")
         .unwrap()

--- a/src/commands/sourcemaps/upload.rs
+++ b/src/commands/sourcemaps/upload.rs
@@ -1,3 +1,5 @@
+#![expect(clippy::unwrap_used, reason = "contains legacy code which uses unwrap")]
+
 use std::env;
 use std::path::PathBuf;
 use std::time::Duration;

--- a/src/commands/upload_proguard.rs
+++ b/src/commands/upload_proguard.rs
@@ -267,6 +267,7 @@ pub fn execute(matches: &ArgMatches) -> Result<()> {
 
     // if values are given associate
     if let Some(app_id) = matches.get_one::<String>("app_id") {
+        #[expect(clippy::unwrap_used, reason = "legacy code")]
         let version = matches.get_one::<String>("version").unwrap().to_owned();
         let build: Option<String> = matches.get_one::<String>("version_code").cloned();
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,12 @@
 #![warn(clippy::allow_attributes)]
 #![warn(clippy::unnecessary_wraps)]
+#![cfg_attr(
+    not(test),
+    warn(
+        clippy::unwrap_used,
+        reason = "unwrap only allowed in tests. Please return a result, or use expect, instead."
+    )
+)]
 
 mod api;
 mod commands;

--- a/src/utils/args.rs
+++ b/src/utils/args.rs
@@ -67,6 +67,7 @@ pub fn validate_distribution(v: &str) -> Result<String, String> {
 
 pub fn get_timestamp(value: &str) -> Result<DateTime<Utc>> {
     if let Ok(int) = value.parse::<i64>() {
+        #[expect(clippy::unwrap_used, reason = "legacy code")]
         Ok(Utc.timestamp_opt(int, 0).single().unwrap())
     } else if let Ok(dt) = DateTime::parse_from_rfc3339(value) {
         Ok(dt.with_timezone(&Utc))

--- a/src/utils/auth_token/redacting.rs
+++ b/src/utils/auth_token/redacting.rs
@@ -15,7 +15,7 @@ pub fn redact_token_from_string<'r>(to_redact: &'r str, replacement: &'r str) ->
             static ref AUTH_TOKEN_REGEX: Regex = Regex::new(&format!(
                 "(({ORG_AUTH_TOKEN_PREFIX})|({USER_TOKEN_PREFIX}))\\S+"
             ))
-            .unwrap();
+            .expect("this regex is valid");
         }
 
         AUTH_TOKEN_REGEX.replace_all(to_redact, replacement)

--- a/src/utils/auth_token/user_auth_token.rs
+++ b/src/utils/auth_token/user_auth_token.rs
@@ -16,6 +16,7 @@ impl UserAuthToken {
 
         let bytes = data_encoding::HEXLOWER_PERMISSIVE.decode(secret_portion.as_bytes());
 
+        #[expect(clippy::unwrap_used, reason = "legacy code")]
         if bytes.is_ok() && bytes.unwrap().len() == USER_TOKEN_BYTES {
             Ok(UserAuthToken(auth_string.into()))
         } else {

--- a/src/utils/dif_upload/mod.rs
+++ b/src/utils/dif_upload/mod.rs
@@ -1,3 +1,5 @@
+#![expect(clippy::unwrap_used, reason = "contains legacy code which uses unwrap")]
+
 //! Searches, processes and uploads debug information files (DIFs). See
 //! `DifUpload` for more information.
 

--- a/src/utils/event.rs
+++ b/src/utils/event.rs
@@ -9,7 +9,7 @@ use regex::Regex;
 use sentry::protocol::{Breadcrumb, ClientSdkInfo, Event};
 
 lazy_static! {
-    static ref COMPONENT_RE: Regex = Regex::new(r#"^([^:]+): (.*)$"#).unwrap();
+    static ref COMPONENT_RE: Regex = Regex::new(r#"^([^:]+): (.*)$"#).expect("this regex is valid");
 }
 
 /// Attaches all logs from a logfile as breadcrumbs to the given event.

--- a/src/utils/file_search.rs
+++ b/src/utils/file_search.rs
@@ -141,11 +141,10 @@ impl ReleaseFileSearch {
             }
             pb.set_message(&format!("{}", file.path().display()));
 
-            info!(
-                "found: {} ({} bytes)",
-                file.path().display(),
+            info!("found: {} ({} bytes)", file.path().display(), {
+                #[expect(clippy::unwrap_used, reason = "legacy code")]
                 file.metadata().unwrap().len()
-            );
+            });
 
             let mut f = fs::File::open(file.path())?;
             let mut contents = Vec::new();

--- a/src/utils/file_upload.rs
+++ b/src/utils/file_upload.rs
@@ -759,7 +759,7 @@ fn build_artifact_bundle(
 }
 
 fn url_to_bundle_path(url: &str) -> Result<String> {
-    let base = Url::parse("http://~").unwrap();
+    let base = Url::parse("http://~").expect("this url is valid");
     let url = if let Some(rest) = url.strip_prefix("~/") {
         base.join(rest)?
     } else {

--- a/src/utils/formatting.rs
+++ b/src/utils/formatting.rs
@@ -70,6 +70,7 @@ impl Table {
         if self.title_row.is_none() {
             self.title_row = Some(TableRow::new());
         }
+        #[expect(clippy::unwrap_used, reason = "legacy code")]
         self.title_row.as_mut().unwrap()
     }
 

--- a/src/utils/http.rs
+++ b/src/utils/http.rs
@@ -1,3 +1,5 @@
+#![expect(clippy::unwrap_used, reason = "contains legacy code which uses unwrap")]
+
 use std::collections::HashMap;
 
 use lazy_static::lazy_static;

--- a/src/utils/releases.rs
+++ b/src/utils/releases.rs
@@ -1,3 +1,5 @@
+#![expect(clippy::unwrap_used, reason = "contains legacy code which uses unwrap")]
+
 use std::env;
 use std::ffi::OsStr;
 use std::fs;

--- a/src/utils/sourcemaps.rs
+++ b/src/utils/sourcemaps.rs
@@ -1,3 +1,5 @@
+#![expect(clippy::unwrap_used, reason = "contains legacy code which uses unwrap")]
+
 //! Provides sourcemap validation functionality.
 use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
 use std::io::Write;

--- a/src/utils/system.rs
+++ b/src/utils/system.rs
@@ -52,7 +52,8 @@ pub fn is_npm_install() -> bool {
 /// Expands variables in a string
 pub fn expand_vars<F: Fn(&str) -> String>(s: &str, f: F) -> Cow<'_, str> {
     lazy_static! {
-        static ref VAR_RE: Regex = Regex::new(r"\$(\$|[a-zA-Z0-9_]+|\([^)]+\)|\{[^}]+\})").unwrap();
+        static ref VAR_RE: Regex =
+            Regex::new(r"\$(\$|[a-zA-Z0-9_]+|\([^)]+\)|\{[^}]+\})").expect("this regex is valid");
     }
     VAR_RE.replace_all(s, |caps: &Captures<'_>| {
         let key = &caps[1];

--- a/src/utils/ui.rs
+++ b/src/utils/ui.rs
@@ -41,6 +41,7 @@ pub fn capitalize_string(s: &str) -> String {
     let mut bytes = s.as_bytes().to_vec();
     bytes.make_ascii_lowercase();
     bytes[0] = bytes[0].to_ascii_uppercase();
+    #[expect(clippy::unwrap_used, reason = "legacy code")]
     String::from_utf8(bytes).unwrap()
 }
 

--- a/src/utils/update.rs
+++ b/src/utils/update.rs
@@ -1,3 +1,5 @@
+#![expect(clippy::unwrap_used, reason = "contains legacy code which uses unwrap")]
+
 #[cfg(not(feature = "managed"))]
 use std::env;
 use std::fs;

--- a/src/utils/vcs.rs
+++ b/src/utils/vcs.rs
@@ -1,3 +1,5 @@
+#![expect(clippy::unwrap_used, reason = "contains legacy code which uses unwrap")]
+
 use std::fmt;
 use std::path::PathBuf;
 

--- a/src/utils/xcode.rs
+++ b/src/utils/xcode.rs
@@ -1,3 +1,5 @@
+#![expect(clippy::unwrap_used, reason = "contains legacy code which uses unwrap")]
+
 use std::collections::HashMap;
 use std::env;
 use std::fmt;


### PR DESCRIPTION
Add a lint which disallows using `unwrap`, requiring an error to be returned or `expect` to be used, instead.

Since the codebase uses `unwrap` in many places already, which would be impractical to fix here, this change also suppresses the lint for these existing violations. 

The intention with this change is to 