### PR TITLE
build: Fix clippy `unwrap::used` lint in CI

### DIFF
--- a/clippy.toml
+++ b/clippy.toml
@@ -1,0 +1,1 @@
+allow-unwrap-in-tests = true

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,12 +1,6 @@
 #![warn(clippy::allow_attributes)]
 #![warn(clippy::unnecessary_wraps)]
-#![cfg_attr(
-    not(test),
-    warn(
-        clippy::unwrap_used,
-        reason = "unwrap only allowed in tests. Please return a result, or use expect, instead."
-    )
-)]
+#![warn(clippy::unwrap_used)]
 
 mod api;
 mod commands;


### PR DESCRIPTION
Since we run our clippy lints with `--test` in CI, the `unwrap::used` lint, as currently written, was not triggering (e.g. on the PR #2532, which contains a violation which should have triggered the lint).

This change should make the `unwrap_used` lint active, also in CI, but not for test code, as was originally intended.