### PR TITLE
build: Move lint config to `Cargo.toml`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -91,6 +91,11 @@ default = []
 managed = []
 with_crash_reporting = []
 
+[lints.clippy]
+allow-attributes = "warn"
+unnecessary-wraps = "warn"
+unwrap-used = "warn"
+
 [target]
 
 [target."cfg(target_os = \"macos\")"]

--- a/build.rs
+++ b/build.rs
@@ -1,30 +1,33 @@
 use std::env;
+use std::error::Error;
 use std::fs::File;
 use std::io::Write;
 use std::path::Path;
 
-fn main() {
-    let out_dir = env::var("OUT_DIR").unwrap();
+fn main() -> Result<(), Box<dyn Error>> {
+    let out_dir = env::var("OUT_DIR").expect("OUT_DIR is set for build scripts");
     let dest_path = Path::new(&out_dir).join("constants.gen.rs");
-    let mut f = File::create(dest_path).unwrap();
+    let mut f = File::create(dest_path)?;
 
-    let target = env::var("TARGET").unwrap();
+    let target = env::var("TARGET").expect("TARGET is set for build scripts");
     let mut target_bits = target.split('-');
 
     // https://rust-lang.github.io/rfcs/0131-target-specification.html#detailed-design
-    let mut arch = target_bits.next().unwrap();
+    let mut arch = target_bits.next().expect("TARGET triple has an arch");
     let _vendor = target_bits.next();
-    let platform = target_bits.next().unwrap();
+    let platform = target_bits.next().expect("TARGET triple has a platform");
 
     if platform == "darwin" && arch == "aarch64" {
         arch = "arm64"; // enforce Darwin naming conventions
     }
 
-    writeln!(f, "/// The platform identifier").ok();
-    writeln!(f, "pub const PLATFORM: &str = \"{platform}\";").ok();
-    writeln!(f, "/// The CPU architecture identifier").ok();
-    writeln!(f, "pub const ARCH: &str = \"{arch}\";").ok();
-    writeln!(f, "/// The user agent for sentry events").ok();
-    writeln!(f, "pub const USER_AGENT: &str = \"sentry-cli/{arch}\";").ok();
+    writeln!(f, "/// The platform identifier")?;
+    writeln!(f, "pub const PLATFORM: &str = \"{platform}\";")?;
+    writeln!(f, "/// The CPU architecture identifier")?;
+    writeln!(f, "pub const ARCH: &str = \"{arch}\";")?;
+    writeln!(f, "/// The user agent for sentry events")?;
+    writeln!(f, "pub const USER_AGENT: &str = \"sentry-cli/{arch}\";")?;
     println!("cargo:rerun-if-changed=build.rs\n");
+
+    Ok(())
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,7 +1,3 @@
-#![warn(clippy::allow_attributes)]
-#![warn(clippy::unnecessary_wraps)]
-#![warn(clippy::unwrap_used)]
-
 mod api;
 mod commands;
 mod config;

--- a/tests/mod.rs
+++ b/tests/mod.rs
@@ -1,1 +1,3 @@
+#![cfg(test)]
+
 mod integration;


### PR DESCRIPTION
This change also requires some changes to the `tests/` and `build.rs`, since the lints are now active for those as well.