### PR TITLE
meta: Add .sentryclirc to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ dump
 checksums.txt
 yarn-error.log
 
+.sentryclirc
 /sentry-cli
 /sentry-cli.exe
 


### PR DESCRIPTION
In debugging, found this trying to make its way into my commit a few times. Adding to gitignore to reduce some dev churn