### PR TITLE
ci: Use `windows-2022`

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -176,7 +176,7 @@ jobs:
       TARGET: ${{ matrix.arch }}-pc-windows-msvc
 
     name: Windows ${{ matrix.arch }}
-    runs-on: windows-2019
+    runs-on: windows-2022
 
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # 4.2.2


### PR DESCRIPTION
`windows-2019` is deprecated