### PR TITLE
build: Bump `rust` docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.84-alpine AS sentry-build
+FROM rust:1.87.0-alpine3.20@sha256:126df0f2a57e675f9306fe180b833982ffb996e90a92a793bb75253cfeed5475 AS sentry-build
 
 # Install build dependencies
 RUN apk add musl-dev perl openssl-dev make


### PR DESCRIPTION
Now that we bumped our MSRV (#2526), we also need to bump the `rust` Docker image we use for building the `sentry-cli` Docker image.

Also, for good measure, let's pin the SHA of the image.