### PR TITLE
build: Bump and pin Alpine Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ RUN touch src/main.rs && cargo build --release --features managed
 # Copy the compiled binary to a target-independent location so it can be picked up later
 RUN cp target/release/sentry-cli /usr/local/bin/sentry-cli
 
-FROM alpine:3.14
+FROM alpine:3.22.0@sha256:8a1f59ffb675680d47db6337b49d22281a139e9d709335b492be023728e11715
 WORKDIR /work
 RUN apk add --no-cache ca-certificates
 COPY ./docker-entrypoint.sh /


### PR DESCRIPTION
Might as well bump this, since we are already bumping the `rust` image (see #2550). Let's also pin the sha