### PR TITLE
test(monitors): pass empty options to grep

### DIFF
--- a/tests/integration/_cases/monitors/monitors-run-osenv.trycmd
+++ b/tests/integration/_cases/monitors/monitors-run-osenv.trycmd
@@ -1,5 +1,5 @@
 ```
-$ sentry-cli monitors run foo-monitor -- sh -c 'env | sort | grep -E "SENTRY_MONITOR_SLUG"'
+$ sentry-cli monitors run foo-monitor -- sh -c 'env | sort | GREP_OPTIONS="" grep -E "SENTRY_MONITOR_SLUG"'
 ? success
 SENTRY_MONITOR_SLUG=foo-monitor
 


### PR DESCRIPTION
I was trying to run the test suite locally and this particular test was failing because I override GREP_OPTIONS in my profile.

The test would fail as the actual output would include the shell escape characters used to display colors in the terminal which are not expected by the test.

This fixes that.
By the way this is the only place where grep is used so we only need to update it here.