### PR TITLE
ci: Add a new option `silentLogs` for cleaner CI/build output

### DIFF
--- a/js/__tests__/helper.test.js
+++ b/js/__tests__/helper.test.js
@@ -195,4 +195,179 @@ describe('SentryCli helper', () => {
       ]);
     });
   });
+
+  describe('silentLogs functionality', () => {
+    let consoleInfoSpy;
+    let consoleErrorSpy;
+
+    beforeEach(() => {
+      consoleInfoSpy = jest.spyOn(console, 'info').mockImplementation();
+      consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation();
+    });
+
+    afterEach(() => {
+      consoleInfoSpy.mockRestore();
+      consoleErrorSpy.mockRestore();
+    });
+
+    test('determineSuccessMessage returns correct message for releases new', () => {
+      const args = ['releases', 'new', 'v1.0.0'];
+      const message = helper.determineSuccessMessage(args);
+      expect(message).toBe('✓ Release v1.0.0 created');
+    });
+
+    test('determineSuccessMessage returns correct message for sourcemaps upload', () => {
+      const args = ['sourcemaps', 'upload'];
+      const message = helper.determineSuccessMessage(args);
+      expect(message).toBe('✓ Source maps uploaded');
+    });
+
+    test('determineSuccessMessage returns null for version check', () => {
+      const args = ['--version'];
+      const message = helper.determineSuccessMessage(args);
+      expect(message).toBe(null);
+    });
+
+    test('determineSuccessMessage handles empty args', () => {
+      const message = helper.determineSuccessMessage([]);
+      expect(message).toBe(null);
+    });
+
+    test('determineSuccessMessage handles null args', () => {
+      const message = helper.determineSuccessMessage(null);
+      expect(message).toBe(null);
+    });
+
+    test('execute with silent=true takes precedence over silentLogs=true', async () => {
+      const result = await helper.execute(['--version'], false, true, true);
+
+      expect(result).toBe('');
+      expect(consoleInfoSpy).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('command type coverage', () => {
+    test('determineSuccessMessage handles supported high-impact commands', () => {
+      const testCases = [
+        { args: ['releases', 'new', 'v1.0.0'], expected: '✓ Release v1.0.0 created' },
+        { args: ['releases', 'finalize', 'v1.0.0'], expected: '✓ Release v1.0.0 finalized' },
+        {
+          args: ['releases', 'files', 'v1.0.0', 'upload-sourcemaps'],
+          expected: '✓ Source maps uploaded to release v1.0.0',
+        },
+        { args: ['sourcemaps', 'upload'], expected: '✓ Source maps uploaded' },
+        { args: ['sourcemaps', 'inject'], expected: '✓ Source maps injected' },
+        { args: ['debug-files', 'upload'], expected: '✓ Debug files uploaded' },
+        { args: ['upload-proguard'], expected: '✓ ProGuard mappings uploaded' },
+        { args: ['upload-dif'], expected: '✓ Debug information files uploaded' },
+        { args: ['upload-dsym'], expected: '✓ dSYM files uploaded' },
+        { args: ['deploys', 'new'], expected: '✓ Deploy created' },
+        { args: ['mobile-app', 'upload'], expected: '✓ Mobile app uploaded' },
+        { args: ['send-event'], expected: '✓ Event sent' },
+        { args: ['send-envelope'], expected: '✓ Envelope sent' },
+        { args: ['send-metric'], expected: '✓ Metric sent' },
+      ];
+
+      testCases.forEach(({ args, expected }) => {
+        const message = helper.determineSuccessMessage(args);
+        expect(message).toBe(expected);
+      });
+    });
+
+    test('determineSuccessMessage returns null for info/list operations and utility commands', () => {
+      const testCases = [
+        ['--help'],
+        ['--version'],
+        ['info'],
+        ['login'],
+        ['organizations', 'list'],
+        ['projects', 'list'],
+        ['issues', 'list'],
+        ['events', 'list'],
+        ['files', 'list'],
+        ['deploys', 'list'],
+        ['monitors', 'list'],
+        ['releases', 'list'],
+        ['releases', 'delete', 'v1.0.0'],
+        ['unknown-command'],
+      ];
+
+      testCases.forEach((args) => {
+        const message = helper.determineSuccessMessage(args);
+        expect(message).toBe(null);
+      });
+    });
+  });
+
+  describe('Promise resolution scenarios', () => {
+    let consoleInfoSpy;
+
+    beforeEach(() => {
+      consoleInfoSpy = jest.spyOn(console, 'info').mockImplementation();
+    });
+
+    afterEach(() => {
+      consoleInfoSpy.mockRestore();
+    });
+
+    test('execute with live=true, silentLogs=true uses stdio piping and resolves with undefined', async () => {
+      const result = await helper.execute(['--version'], true, false, true);
+
+      expect(result).toBeUndefined();
+      expect(consoleInfoSpy).not.toHaveBeenCalled(); // --version doesn't have success message
+    });
+
+    test('execute with live=true, silentLogs=true shows success message for supported commands', async () => {
+      const result = await helper.execute(['sourcemaps', 'upload'], true, false, true);
+
+      expect(result).toBeUndefined();
+      expect(consoleInfoSpy).toHaveBeenCalledWith('✓ Source maps uploaded');
+    });
+
+    test('execute with live=false, silentLogs=true uses callback mode and resolves with empty string', async () => {
+      const result = await helper.execute(['--version'], false, false, true);
+
+      expect(result).toBe('');
+      expect(consoleInfoSpy).not.toHaveBeenCalled();
+    });
+
+    test('execute with live=false, silentLogs=true shows success message and returns empty string', async () => {
+      const result = await helper.execute(['sourcemaps', 'upload'], false, false, true);
+
+      expect(result).toBe('');
+      expect(consoleInfoSpy).toHaveBeenCalledWith('✓ Source maps uploaded');
+    });
+
+    test('execute with normal mode (live=false, silent=false, silentLogs=false) returns actual stdout', async () => {
+      const result = await helper.execute(['--version'], false, false, false);
+
+      expect(result.trim()).toBe('sentry-cli DEV');
+      expect(consoleInfoSpy).not.toHaveBeenCalled();
+    });
+
+    test('execute with silent=true suppresses output and messages', async () => {
+      // Test with live=true - uses stdio piping, resolves with undefined
+      const result1 = await helper.execute(['--version'], true, true, false);
+      expect(result1).toBeUndefined();
+
+      // Test with live=false - uses callback mode, resolves with empty string
+      const result2 = await helper.execute(['--version'], false, true, false);
+      expect(result2).toBe('');
+
+      // Test with silentLogs=true (should be ignored when silent=true)
+      const result3 = await helper.execute(['sourcemaps', 'upload'], false, true, true);
+      expect(result3).toBe('');
+
+      // No success messages should be shown when silent=true
+      expect(consoleInfoSpy).not.toHaveBeenCalled();
+    });
+
+    test('execute with live=true and normal mode uses stdio inherit and resolves with undefined', async () => {
+      const result = await helper.execute(['--version'], true, false, false);
+
+      // Should resolve with undefined (stdio inherit mode)
+      expect(result).toBeUndefined();
+      expect(consoleInfoSpy).not.toHaveBeenCalled();
+    });
+  });
 });

--- a/js/__tests__/helper.test.js
+++ b/js/__tests__/helper.test.js
@@ -196,76 +196,24 @@ describe('SentryCli helper', () => {
     });
   });
 
-  describe('silentLogs functionality', () => {
-    let consoleInfoSpy;
-    let consoleErrorSpy;
-
-    beforeEach(() => {
-      consoleInfoSpy = jest.spyOn(console, 'info').mockImplementation();
-      consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation();
-    });
-
-    afterEach(() => {
-      consoleInfoSpy.mockRestore();
-      consoleErrorSpy.mockRestore();
-    });
-
-    test('determineSuccessMessage returns correct message for releases new', () => {
-      const args = ['releases', 'new', 'v1.0.0'];
-      const message = helper.determineSuccessMessage(args);
-      expect(message).toBe('✓ Release v1.0.0 created');
-    });
-
-    test('determineSuccessMessage returns correct message for sourcemaps upload', () => {
-      const args = ['sourcemaps', 'upload'];
-      const message = helper.determineSuccessMessage(args);
-      expect(message).toBe('✓ Source maps uploaded');
-    });
-
-    test('determineSuccessMessage returns null for version check', () => {
-      const args = ['--version'];
-      const message = helper.determineSuccessMessage(args);
-      expect(message).toBe(null);
-    });
-
-    test('determineSuccessMessage handles empty args', () => {
-      const message = helper.determineSuccessMessage([]);
-      expect(message).toBe(null);
-    });
-
-    test('determineSuccessMessage handles null args', () => {
-      const message = helper.determineSuccessMessage(null);
-      expect(message).toBe(null);
-    });
-
-    test('execute with silent=true takes precedence over silentLogs=true', async () => {
-      const result = await helper.execute(['--version'], false, true, true);
-
-      expect(result).toBe('');
-      expect(consoleInfoSpy).not.toHaveBeenCalled();
-    });
-  });
-
-  describe('command type coverage', () => {
+  describe('determineSuccessMessage type coverage', () => {
     test('determineSuccessMessage handles supported high-impact commands', () => {
       const testCases = [
         { args: ['releases', 'new', 'v1.0.0'], expected: '✓ Release v1.0.0 created' },
         { args: ['releases', 'finalize', 'v1.0.0'], expected: '✓ Release v1.0.0 finalized' },
         {
           args: ['releases', 'files', 'v1.0.0', 'upload-sourcemaps'],
-          expected: '✓ Source maps uploaded to release v1.0.0',
+          expected: '✓ Source maps uploaded',
         },
         { args: ['sourcemaps', 'upload'], expected: '✓ Source maps uploaded' },
         { args: ['sourcemaps', 'inject'], expected: '✓ Source maps injected' },
         { args: ['debug-files', 'upload'], expected: '✓ Debug files uploaded' },
         { args: ['upload-proguard'], expected: '✓ ProGuard mappings uploaded' },
         { args: ['upload-dif'], expected: '✓ Debug information files uploaded' },
-        { args: ['upload-dsym'], expected: '✓ dSYM files uploaded' },
+        { args: ['upload-dsym'], expected: '✓ Debug information files uploaded' },
         { args: ['deploys', 'new'], expected: '✓ Deploy created' },
-        { args: ['mobile-app', 'upload'], expected: '✓ Mobile app uploaded' },
         { args: ['send-event'], expected: '✓ Event sent' },
         { args: ['send-envelope'], expected: '✓ Envelope sent' },
-        { args: ['send-metric'], expected: '✓ Metric sent' },
       ];
 
       testCases.forEach(({ args, expected }) => {
@@ -310,22 +258,29 @@ describe('SentryCli helper', () => {
       consoleInfoSpy.mockRestore();
     });
 
-    test('execute with live=true, silentLogs=true uses stdio piping and resolves with undefined', async () => {
+    test('execute with live=true, silentLogs=true uses stdio piping and resolves with empty string', async () => {
       const result = await helper.execute(['--version'], true, false, true);
 
-      expect(result).toBeUndefined();
+      expect(result).toBe('');
       expect(consoleInfoSpy).not.toHaveBeenCalled(); // --version doesn't have success message
     });
 
     test('execute with live=true, silentLogs=true shows success message for supported commands', async () => {
       const result = await helper.execute(['sourcemaps', 'upload'], true, false, true);
 
-      expect(result).toBeUndefined();
+      expect(result).toBe('');
       expect(consoleInfoSpy).toHaveBeenCalledWith('✓ Source maps uploaded');
     });
 
     test('execute with live=false, silentLogs=true uses callback mode and resolves with empty string', async () => {
       const result = await helper.execute(['--version'], false, false, true);
+
+      expect(result).toBe('');
+      expect(consoleInfoSpy).not.toHaveBeenCalled();
+    });
+
+    test('execute with silent=true takes precedence over silentLogs=true', async () => {
+      const result = await helper.execute(['--version'], false, true, true);
 
       expect(result).toBe('');
       expect(consoleInfoSpy).not.toHaveBeenCalled();
@@ -358,14 +313,12 @@ describe('SentryCli helper', () => {
       const result3 = await helper.execute(['sourcemaps', 'upload'], false, true, true);
       expect(result3).toBe('');
 
-      // No success messages should be shown when silent=true
       expect(consoleInfoSpy).not.toHaveBeenCalled();
     });
 
     test('execute with live=true and normal mode uses stdio inherit and resolves with undefined', async () => {
       const result = await helper.execute(['--version'], true, false, false);
 
-      // Should resolve with undefined (stdio inherit mode)
       expect(result).toBeUndefined();
       expect(consoleInfoSpy).not.toHaveBeenCalled();
     });

--- a/js/helper.js
+++ b/js/helper.js
@@ -427,8 +427,8 @@ function determineSuccessMessage(args) {
         return `✓ Release ${args[2]} created`;
       } else if (args[1] === 'finalize' && args[2]) {
         return `✓ Release ${args[2]} finalized`;
-      } else if (args[1] === 'files' && args[3] === 'upload-sourcemaps' && args[2]) {
-        return `✓ Source maps uploaded to release ${args[2]}`;
+      } else if (args[1] === 'files' && args[3] === 'upload-sourcemaps') {
+        return `✓ Source maps uploaded`;
       }
       break;
 
@@ -450,20 +450,12 @@ function determineSuccessMessage(args) {
       return `✓ ProGuard mappings uploaded`;
 
     case 'upload-dif':
-      return `✓ Debug information files uploaded`;
-
     case 'upload-dsym':
-      return `✓ dSYM files uploaded`;
+      return `✓ Debug information files uploaded`;
 
     case 'deploys':
       if (args[1] === 'new') {
         return `✓ Deploy created`;
-      }
-      break;
-
-    case 'mobile-app':
-      if (args[1] === 'upload') {
-        return `✓ Mobile app uploaded`;
       }
       break;
 
@@ -472,9 +464,6 @@ function determineSuccessMessage(args) {
 
     case 'send-envelope':
       return `✓ Envelope sent`;
-
-    case 'send-metric':
-      return `✓ Metric sent`;
 
     // Don't show success messages for info/list operations - they show their own output
     // Don't show for --version, --help - the output is the success

--- a/js/index.js
+++ b/js/index.js
@@ -34,7 +34,11 @@ class SentryCli {
     if (typeof configFile === 'string') {
       this.configFile = configFile;
     }
-    this.options = options || { silent: false };
+    this.options = {
+      silent: false,
+      silentLogs: false,
+      ...options,
+    };
     this.releases = new Releases({ ...this.options, configFile });
   }
 
@@ -65,7 +69,14 @@ class SentryCli {
    * @returns {Promise.<string>} A promise that resolves to the standard output.
    */
   execute(args, live) {
-    return helper.execute(args, live, this.options.silent, this.configFile, this.options);
+    return helper.execute(
+      args,
+      live,
+      this.options.silent,
+      this.options.silentLogs,
+      this.configFile,
+      this.options
+    );
   }
 }
 

--- a/js/releases/__tests__/index.test.js
+++ b/js/releases/__tests__/index.test.js
@@ -7,14 +7,14 @@ describe('SentryCli releases', () => {
   test('call sentry-cli releases propose-version', () => {
     expect.assertions(1);
     const cli = new SentryCli();
-    return cli.releases.proposeVersion().then(version => expect(version).toBeTruthy());
+    return cli.releases.proposeVersion().then((version) => expect(version).toBeTruthy());
   });
 
   describe('with mock', () => {
     let cli;
     let mockExecute;
     beforeAll(() => {
-      mockExecute = jest.fn(async () => { });
+      mockExecute = jest.fn(async () => {});
       jest.doMock('../../helper', () => ({
         ...jest.requireActual('../../helper'),
         execute: mockExecute,
@@ -33,8 +33,9 @@ describe('SentryCli releases', () => {
           ['releases', 'new', 'my-version'],
           null,
           false,
+          false,
           undefined,
-          { silent: false }
+          { silent: false, silentLogs: false }
         );
       });
       test('with projects', async () => {
@@ -43,8 +44,9 @@ describe('SentryCli releases', () => {
           ['releases', 'new', 'my-version', '-p', 'proj-a', '-p', 'proj-b'],
           null,
           false,
+          false,
           undefined,
-          { silent: false }
+          { silent: false, silentLogs: false }
         );
       });
     });
@@ -63,8 +65,9 @@ describe('SentryCli releases', () => {
           ],
           true,
           false,
+          false,
           undefined,
-          { silent: false }
+          { silent: false, silentLogs: false }
         );
       });
       test('with projects', async () => {
@@ -88,8 +91,9 @@ describe('SentryCli releases', () => {
           ],
           true,
           false,
+          false,
           undefined,
-          { silent: false }
+          { silent: false, silentLogs: false }
         );
       });
 
@@ -100,7 +104,7 @@ describe('SentryCli releases', () => {
         await cli.releases.uploadSourceMaps('my-version', { include: paths });
 
         expect(mockExecute).toHaveBeenCalledTimes(2);
-        paths.forEach(path =>
+        paths.forEach((path) =>
           expect(mockExecute).toHaveBeenCalledWith(
             [
               'sourcemaps',
@@ -113,8 +117,9 @@ describe('SentryCli releases', () => {
             ],
             true,
             false,
+            false,
             undefined,
-            { silent: false }
+            { silent: false, silentLogs: false }
           )
         );
       });
@@ -139,8 +144,9 @@ describe('SentryCli releases', () => {
           ],
           true,
           false,
+          false,
           undefined,
-          { silent: false }
+          { silent: false, silentLogs: false }
         );
 
         expect(mockExecute).toHaveBeenCalledWith(
@@ -155,8 +161,9 @@ describe('SentryCli releases', () => {
           ],
           true,
           false,
+          false,
           undefined,
-          { silent: false }
+          { silent: false, silentLogs: false }
         );
       });
 

--- a/js/releases/__tests__/index.test.js
+++ b/js/releases/__tests__/index.test.js
@@ -14,7 +14,7 @@ describe('SentryCli releases', () => {
     let cli;
     let mockExecute;
     beforeAll(() => {
-      mockExecute = jest.fn(async () => {});
+      mockExecute = jest.fn(async () => { });
       jest.doMock('../../helper', () => ({
         ...jest.requireActual('../../helper'),
         execute: mockExecute,
@@ -181,8 +181,9 @@ describe('SentryCli releases', () => {
           ],
           live,
           false,
+          false,
           undefined,
-          { silent: false }
+          { silent: false, silentLogs: false }
         );
       });
     });

--- a/js/releases/index.js
+++ b/js/releases/index.js
@@ -267,7 +267,14 @@ class Releases {
    * @returns {Promise.<string>} A promise that resolves to the standard output.
    */
   async execute(args, live) {
-    return helper.execute(args, live, this.options.silent, this.configFile, this.options);
+    return helper.execute(
+      args,
+      live,
+      this.options.silent,
+      this.options.silentLogs,
+      this.configFile,
+      this.options
+    );
   }
 }
 


### PR DESCRIPTION
This PR introduces a new silentLogs option that provides a middle ground between full verbose output and complete silence. When enabled, it suppresses verbose command output while still displaying essential feedback like success messages and error information.

```
const cli = new SentryCli('config', { silentLogs: true });
await cli.releases.new('v1.0.0');
// Output: "✓ Release v1.0.0 created"

await cli.sourcemaps.upload();  
// Output: "✓ Source maps uploaded"
```