### PR TITLE
fix(mobile-app): Check server support before upload

### DIFF
--- a/src/commands/mobile_app/upload.rs
+++ b/src/commands/mobile_app/upload.rs
@@ -12,7 +12,7 @@ use symbolic::common::ByteView;
 use zip::write::SimpleFileOptions;
 use zip::{DateTime, ZipWriter};
 
-use crate::api::{Api, AuthenticatedApi};
+use crate::api::{Api, AuthenticatedApi, ChunkUploadCapability};
 use crate::config::Config;
 use crate::utils::args::ArgExt;
 use crate::utils::chunks::{upload_chunks, Chunk, ASSEMBLE_POLL_INTERVAL};
@@ -295,6 +295,13 @@ fn upload_file(
                 is required for mobile app uploads. {SELF_HOSTED_ERROR_HINT}"
             )
         })?;
+
+    if !chunk_upload_options.supports(ChunkUploadCapability::PreprodArtifacts) {
+        bail!(
+            "The Sentry server lacks support for receiving files uploaded \
+            with this command. {SELF_HOSTED_ERROR_HINT}"
+        );
+    }
 
     let progress_style =
         ProgressStyle::default_spinner().template("{spinner} Optimizing bundle for upload...");


### PR DESCRIPTION
Currently, we attempt to upload the mobile-app artifacts, even if we have not confirmed that receiving such artifacts is supported by the server.

Ref https://github.com/getsentry/sentry-cli/pull/2542#discussion_r2166727002