### PR TITLE
fix(macOS): Fix sentry-cli login failure behind proxy on macOS

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ clap = { version = "4.1.6", default-features = false, features = [
 ] }
 clap_complete = "4.4.3"
 console = "0.15.5"
-curl = { version = "0.4.46", features = ["static-curl", "static-ssl"] }
+curl = { version = "0.4.46" }
 dirs = "4.0.0"
 dotenvy = "0.15.7"
 elementtree = "1.2.3"


### PR DESCRIPTION
## Problem
- `sentry-cli login` fails with "Invalid token: API request failed" on macOS behind proxy
- Works fine on Windows/Linux with same token and network config
- curl command works normally

## Root Cause
Static linking of curl (`static-curl`, `static-ssl`) has compatibility issues with HTTPS CONNECT tunnels on macOS, causing `perform()` to fail after proxy connection is established.

## Solution
- Remove static linking features from curl dependency
- Use system curl library instead
- Revert all temporary macOS-specific hacks

## Testing
- ✅ Login works behind HTTP/HTTPS proxy on macOS
- ✅ No regression on Linux/Windows
- ✅ All other commands work normally

## Related Issue
Closes #[2577]