### PR TITLE
feat(api): Improve API error messages

### DIFF
--- a/src/api/errors/api_error.rs
+++ b/src/api/errors/api_error.rs
@@ -48,7 +48,25 @@ pub(in crate::api) enum ApiErrorKind {
 
 impl fmt::Display for ApiError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        fmt::Display::fmt(&self.inner, f)
+        match &self.inner {
+            ApiErrorKind::RequestFailed => write!(
+                f,
+                "{}, due to {}",
+                self.inner,
+                self.source.as_ref().map_or_else(
+                    || "an unknown error".to_owned(),
+                    |source| format!("the following error: {source}")
+                )
+            )?,
+            _ => {
+                write!(f, "{}", self.inner)?;
+                if let Some(source) = &self.source {
+                    write!(f, " This error was caused by: {source}")?;
+                }
+            }
+        }
+
+        Ok(())
     }
 }
 


### PR DESCRIPTION
Include the source of the error in `Display` output (when present), and also improve how we display generic `RequestFailed` error messages.

For example, prior to this change, if calling `sentry-cli login` with an invalid token, one would receive the following error message:

```
Invalid token: API request failed
```

After the change, the error message is:

```
Invalid token: API request failed, due to the following error: sentry reported an error: Invalid token (http status: 401)
```

This change should help debug #2577, as in that issue, `sentry-cli` is failing due to a strange generic `RequestFailed` API error.