### PR TITLE
ref: Exclude `mobile-app` command from release builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,8 +18,14 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-24.04, macos-14, windows-2022]
+        feature-args: ['', '-Funstable-mobile-app']
+        include:
+          - feature-args: ''
+            feature-suffix: ''
+          - feature-args: '-Funstable-mobile-app'
+            feature-suffix: ', mobile-app'
 
-    name: Lint (${{ matrix.os }})
+    name: Lint (${{ matrix.os }}${{ matrix.feature-suffix }})
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # 4.2.2
@@ -33,7 +39,7 @@ jobs:
         run: cargo fmt --all -- --check
 
       - name: Run Clippy
-        run: cargo clippy --workspace --tests
+        run: cargo clippy --workspace --tests ${{ matrix.feature-args }}
 
   lint:
     needs: lint-each-os
@@ -52,8 +58,14 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-24.04, macos-14, windows-2022]
+        feature-args: ['', '-Funstable-mobile-app']
+        include:
+          - feature-args: ''
+            feature-suffix: ''
+          - feature-args: '-Funstable-mobile-app'
+            feature-suffix: ', mobile-app'
 
-    name: Test (${{ matrix.os }})
+    name: Test (${{ matrix.os }}${{ matrix.feature-suffix }})
     runs-on: ${{ matrix.os }}
 
     steps:
@@ -64,7 +76,7 @@ jobs:
           key: ${{ github.job }}
 
       - name: Run Cargo Tests
-        run: cargo test --all
+        run: cargo test --all ${{ matrix.feature-args }}
 
   test_node:
     strategy:

--- a/.gitignore
+++ b/.gitignore
@@ -11,4 +11,5 @@ yarn-error.log
 /sentry-cli
 /sentry-cli.exe
 
-.vscode/
+.vscode/*
+!.vscode/settings.json

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,4 @@
+{
+    "rust-analyzer.cargo.features": ["unstable-mobile-app"],
+    "rust-analyzer.cargo.noDefaultFeatures": false
+}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ rust-version = "1.86"
 [dependencies]
 anylog = "0.6.3"
 anyhow = { version = "1.0.69", features = ["backtrace"] }
+apple-catalog-parsing = { path = "apple-catalog-parsing", optional = true }
 backoff = "0.4.0"
 brotli2 = "0.3.2"
 bytecount = "0.6.3"
@@ -92,6 +93,10 @@ trycmd = "0.14.11"
 default = []
 managed = []
 with_crash_reporting = []
+
+# Feature flag for the mobile-app command, as it is still under development.
+# CI tests run against this flag, but we don't include it in release builds.
+unstable-mobile-app = ["apple-catalog-parsing"]
 
 [workspace.lints.clippy]
 allow-attributes = "warn"

--- a/src/api/data_types/chunking/mobile_app.rs
+++ b/src/api/data_types/chunking/mobile_app.rs
@@ -1,3 +1,4 @@
+#![cfg(feature = "unstable-mobile-app")]
 use serde::{Deserialize, Serialize};
 use sha1_smol::Digest;
 

--- a/src/api/data_types/chunking/mod.rs
+++ b/src/api/data_types/chunking/mod.rs
@@ -14,5 +14,6 @@ pub use self::compression::ChunkCompression;
 pub use self::dif::{AssembleDifsRequest, AssembleDifsResponse, ChunkedDifRequest};
 pub use self::file_state::ChunkedFileState;
 pub use self::hash_algorithm::ChunkHashAlgorithm;
+#[cfg(feature = "unstable-mobile-app")]
 pub use self::mobile_app::{AssembleMobileAppResponse, ChunkedMobileAppRequest};
 pub use self::upload::{ChunkServerOptions, ChunkUploadCapability};

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -1018,6 +1018,7 @@ impl<'a> AuthenticatedApi<'a> {
             .convert_rnf(ApiErrorKind::ReleaseNotFound)
     }
 
+    #[cfg(feature = "unstable-mobile-app")]
     pub fn assemble_mobile_app(
         &self,
         org: &str,

--- a/src/commands/mobile_app/mod.rs
+++ b/src/commands/mobile_app/mod.rs
@@ -1,3 +1,5 @@
+#![cfg(feature = "unstable-mobile-app")]
+
 use anyhow::Result;
 use clap::{ArgMatches, Command};
 

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -31,6 +31,7 @@ macro_rules! each_subcommand {
         $mac!(info);
         $mac!(issues);
         $mac!(login);
+        #[cfg(feature = "unstable-mobile-app")]
         $mac!(mobile_app);
         $mac!(monitors);
         $mac!(organizations);

--- a/src/utils/mobile_app/mod.rs
+++ b/src/utils/mobile_app/mod.rs
@@ -1,3 +1,5 @@
+#![cfg(feature = "unstable-mobile-app")]
+
 #[cfg(target_os = "macos")]
 mod apple;
 mod validation;

--- a/tests/integration/mobile_app/mod.rs
+++ b/tests/integration/mobile_app/mod.rs
@@ -1,3 +1,5 @@
+#![cfg(feature = "unstable-mobile-app")]
+
 use crate::integration::TestManager;
 
 mod upload;


### PR DESCRIPTION
`sentry-cli mobile-app` is still under development. As a result, it makes sense to exclude it from release builds.

This change enables us to still run lints and tests in CI against the `moblie-app` command, but keeps it out of the release build for now. Once the command is ready, we can get rid of the feature flag.

Note that the `mobile-app` has not been included in a release yet, so this change is non-breaking.