### PR TITLE
build: Only compile `apple-catalog-parsing` when relevant feature enabled

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -112,7 +112,6 @@ workspace = true
 
 [target."cfg(target_os = \"macos\")".dependencies]
 mac-process-info = "0.2.0"
-apple-catalog-parsing = { path = "apple-catalog-parsing" }
 
 [target."cfg(unix)"]
 


### PR DESCRIPTION
Ref https://github.com/getsentry/sentry-cli/pull/2587#issuecomment-3069752009