### PR TITLE
ci: Restructure CI process

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,97 +9,38 @@ on:
 
   pull_request:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 env:
   RUSTFLAGS: -Dwarnings
 
 jobs:
-  lint-each-os:
-    strategy:
-      fail-fast: false
-      matrix:
-        os: [ubuntu-24.04, macos-14, windows-2022]
-        feature-args: ['', '-Funstable-mobile-app']
-        include:
-          - feature-args: ''
-            feature-suffix: ''
-          - feature-args: '-Funstable-mobile-app'
-            feature-suffix: ', mobile-app'
-
-    name: Lint (${{ matrix.os }}${{ matrix.feature-suffix }})
-    runs-on: ${{ matrix.os }}
-    steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # 4.2.2
-
-      - name: Install Rust Toolchain
-        run: rustup toolchain install stable --profile minimal --component clippy --component rustfmt --no-self-update
-
-      - uses: swatinem/rust-cache@98c8021b550208e191a6a3145459bfc9fb29c4c0 # 2.8.0
-
-      - name: Run Rustfmt
-        run: cargo fmt --all -- --check
-
-      - name: Run Clippy
-        run: cargo clippy --workspace --tests ${{ matrix.feature-args }}
-
   lint:
-    needs: lint-each-os
-    runs-on: ubuntu-24.04
-    if: always() # Run even if lint-each-os fails
     name: Lint
-    steps:
-      - name: Check for lint failures
-        if: contains(needs.lint-each-os.result, 'failure') || contains(needs.lint-each-os.result, 'skipped')
-        run: |
-          echo "Required lint check failed. You need to fix the problem before merging."
-          exit 1
+    uses: ./.github/workflows/lint.yml
 
   test:
-    strategy:
-      fail-fast: false
-      matrix:
-        os: [ubuntu-24.04, macos-14, windows-2022]
-        feature-args: ['', '-Funstable-mobile-app']
-        include:
-          - feature-args: ''
-            feature-suffix: ''
-          - feature-args: '-Funstable-mobile-app'
-            feature-suffix: ', mobile-app'
-
-    name: Test (${{ matrix.os }}${{ matrix.feature-suffix }})
-    runs-on: ${{ matrix.os }}
-
-    steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # 4.2.2
-
-      - uses: swatinem/rust-cache@98c8021b550208e191a6a3145459bfc9fb29c4c0 # 2.8.0
-        with:
-          key: ${{ github.job }}
-
-      - name: Run Cargo Tests
-        run: cargo test --all ${{ matrix.feature-args }}
+    name: Test
+    uses: ./.github/workflows/test.yml
 
   test_node:
-    strategy:
-      fail-fast: false
-      matrix:
-        node-version: [10.x, 12.x, 14.x, 16.x, 18.x, 20.x]
+    name: Test Node
+    uses: ./.github/workflows/test_node.yml
 
-    name: Test Node ${{ matrix.node-version }}
+  test_swift:
+    name: Test Swift
+    uses: ./.github/workflows/swift-test.yml
+
+  required:
+    name: Check required jobs
     runs-on: ubuntu-24.04
-
+    needs: [lint, test, test_node, test_swift]
+    if: always()
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # 4.2.2
-
-      - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # 4.4.0
-        with:
-          node-version: ${{ matrix.node-version }}
-
-      # We need to skip the fallback download because downloading will fail on release branches because the new version isn't available yet.
-      - run: SENTRYCLI_SKIP_DOWNLOAD=1 npm install
-
-      # older node versions need an older nft
-      - run: SENTRYCLI_SKIP_DOWNLOAD=1 npm install @vercel/nft@0.22.1
-        if: matrix.node-version == '10.x' || matrix.node-version == '12.x'
-
-      - run: npm test
+      - name: Check for failure
+        if: ${{ needs.lint.result != 'success' || needs.test.result != 'success' || needs.test_node.result != 'success' || needs.test_swift.result != 'success' }}
+        run: |
+          echo "One or more jobs failed"
+          exit 1

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,46 @@
+name: Lint
+
+on:
+  workflow_call:
+    outputs:
+      matrix-result:
+        description: 'Matrix job result'
+        value: ${{ jobs.lint.result }}
+
+env:
+  RUSTFLAGS: -Dwarnings
+
+jobs:
+  lint:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-24.04, macos-14, windows-2022]
+        feature-args: ['', '-Funstable-mobile-app']
+        include:
+          - os: ubuntu-24.04
+            display-os: Linux
+          - os: macos-14
+            display-os: macOS
+          - os: windows-2022
+            display-os: Windows
+          - feature-args: ''
+            feature-suffix: ''
+          - feature-args: '-Funstable-mobile-app'
+            feature-suffix: ' (-Funstable-mobile-app)'
+
+    name: ${{ matrix.display-os }}${{ matrix.feature-suffix }}
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # 4.2.2
+
+      - name: Install Rust Toolchain
+        run: rustup toolchain install stable --profile minimal --component clippy --component rustfmt --no-self-update
+
+      - uses: swatinem/rust-cache@98c8021b550208e191a6a3145459bfc9fb29c4c0 # 2.8.0
+
+      - name: Run Rustfmt
+        run: cargo fmt --all -- --check
+
+      - name: Run Clippy
+        run: cargo clippy --workspace --tests ${{ matrix.feature-args }}

--- a/.github/workflows/swift-test.yml
+++ b/.github/workflows/swift-test.yml
@@ -1,15 +1,15 @@
-name: Swift Test
+name: Test Swift
 
 on:
-  push:
-    branches:
-      - master
-      - release/**
-
-  pull_request:
+  workflow_call:
+    outputs:
+      matrix-result:
+        description: 'Job result'
+        value: ${{ jobs.run-tests.result }}
 
 jobs:
   run-tests:
+    name: Run tests
     runs-on: macos-15
     steps:
       - name: Checkout code

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,43 @@
+name: Test
+
+on:
+  workflow_call:
+    outputs:
+      matrix-result:
+        description: 'Matrix job result'
+        value: ${{ jobs.test.result }}
+
+env:
+  RUSTFLAGS: -Dwarnings
+
+jobs:
+  test:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-24.04, macos-14, windows-2022]
+        feature-args: ['', '-Funstable-mobile-app']
+        include:
+          - os: ubuntu-24.04
+            display-os: Linux
+          - os: macos-14
+            display-os: macOS
+          - os: windows-2022
+            display-os: Windows
+          - feature-args: ''
+            feature-suffix: ''
+          - feature-args: '-Funstable-mobile-app'
+            feature-suffix: ' (-Funstable-mobile-app)'
+
+    name: ${{ matrix.display-os }}${{ matrix.feature-suffix }}
+    runs-on: ${{ matrix.os }}
+
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # 4.2.2
+
+      - uses: swatinem/rust-cache@98c8021b550208e191a6a3145459bfc9fb29c4c0 # 2.8.0
+        with:
+          key: ${{ github.job }}
+
+      - name: Run Cargo Tests
+        run: cargo test --all ${{ matrix.feature-args }}

--- a/.github/workflows/test_node.yml
+++ b/.github/workflows/test_node.yml
@@ -1,0 +1,35 @@
+name: Test Node
+
+on:
+  workflow_call:
+    outputs:
+      matrix-result:
+        description: 'Matrix job result'
+        value: ${{ jobs.test_node.result }}
+
+jobs:
+  test_node:
+    strategy:
+      fail-fast: false
+      matrix:
+        node-version: [10.x, 12.x, 14.x, 16.x, 18.x, 20.x]
+
+    name: Test Node ${{ matrix.node-version }}
+    runs-on: ubuntu-24.04
+
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # 4.2.2
+
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # 4.4.0
+        with:
+          node-version: ${{ matrix.node-version }}
+
+      # We need to skip the fallback download because downloading will fail on release branches because the new version isn't available yet.
+      - run: SENTRYCLI_SKIP_DOWNLOAD=1 npm install
+
+      # older node versions need an older nft
+      - run: SENTRYCLI_SKIP_DOWNLOAD=1 npm install @vercel/nft@0.22.1
+        if: matrix.node-version == '10.x' || matrix.node-version == '12.x'
+
+      - run: npm test


### PR DESCRIPTION
This PR contains several improvements to our CI process which aim to make the CI workflow cleaner and to make it easier to configure required tests in code.

## Restructuring

Before the change:

<img width="1642" height="1161" alt="image" src="https://github.com/user-attachments/assets/4a0b9ddc-ed45-4e21-b4a7-50625ee0e350" />

After the change:
<img width="1642" height="1161" alt="image" src="https://github.com/user-attachments/assets/6d3f37d2-0150-45f3-b8e1-5060180b555b" />

After the change, with some of the groups expanded:
<img width="1642" height="1161" alt="image" src="https://github.com/user-attachments/assets/9727ebcb-d642-4989-882f-15b83e8e44f8" />

As can be observed in the screenshots, this restructuring makes it clearer what all the CI check is doing, when viewing the workflow summary in CI.

The restructure also moves the Swift tests from a separate workflow file into the main `ci.yml` file.

## Functional changes

This PR also adds a "Check required jobs" job, which passes only if all other jobs in `ci.yml` pass. We intend to make this check the only required status from `ci.yml` to make PRs mergeable. 

Making "Check required jobs" required will indirectly make the previously non-required checks required: Test Node, Test Swift, and the `-Funstable-mobile-app` tests. With this change, it is now also possible to configure the required checks in code.

Also, this PR adds an optimization, so that any in progress jobs are cancelled if a new commit is pushed to the branch.

Closes #2509
Closes #2558
Closes #2597 