### PR TITLE
chore(ci): Use yarn for node tests instead of npm

### DIFF
--- a/.github/workflows/test_node.yml
+++ b/.github/workflows/test_node.yml
@@ -47,7 +47,7 @@ jobs:
 
       # older node versions need an older nft
       - run: |
-          SENTRYCLI_SKIP_DOWNLOAD=1 yarn install -f --frozen-lockfile
+          SENTRYCLI_SKIP_DOWNLOAD=1 yarn install --ignore-engines --frozen-lockfile
           SENTRYCLI_SKIP_DOWNLOAD=1 yarn add @vercel/nft@0.22.1
         if: matrix.node-version == '10.x' || matrix.node-version == '12.x'
 

--- a/.github/workflows/test_node.yml
+++ b/.github/workflows/test_node.yml
@@ -42,10 +42,10 @@ jobs:
           node-version: ${{ matrix.node-version }}
 
       # We need to skip the fallback download because downloading will fail on release branches because the new version isn't available yet.
-      - run: SENTRYCLI_SKIP_DOWNLOAD=1 npm install
+      - run: SENTRYCLI_SKIP_DOWNLOAD=1 yarn install
 
       # older node versions need an older nft
-      - run: SENTRYCLI_SKIP_DOWNLOAD=1 npm install @vercel/nft@0.22.1
+      - run: SENTRYCLI_SKIP_DOWNLOAD=1 yarn add @vercel/nft@0.22.1
         if: matrix.node-version == '10.x' || matrix.node-version == '12.x'
 
-      - run: npm test
+      - run: yarn test

--- a/.github/workflows/test_node.yml
+++ b/.github/workflows/test_node.yml
@@ -48,7 +48,7 @@ jobs:
       # older node versions need an older nft
       - run: |
           SENTRYCLI_SKIP_DOWNLOAD=1 yarn install --ignore-engines --frozen-lockfile
-          SENTRYCLI_SKIP_DOWNLOAD=1 yarn add @vercel/nft@0.22.1
+          SENTRYCLI_SKIP_DOWNLOAD=1 yarn add @vercel/nft@0.22.1 --ignore-engines
         if: matrix.node-version == '10.x' || matrix.node-version == '12.x'
 
       - run: yarn test

--- a/.github/workflows/test_node.yml
+++ b/.github/workflows/test_node.yml
@@ -20,9 +20,9 @@ jobs:
           node-version-file: package.json
 
       # We need to skip the fallback download because downloading will fail on release branches because the new version isn't available yet.
-      - run: SENTRYCLI_SKIP_DOWNLOAD=1 npm install
+      - run: SENTRYCLI_SKIP_DOWNLOAD=1 yarn install --frozen-lockfile
 
-      - run: npm run check:types
+      - run: yarn check:types
 
   test_node:
     strategy:
@@ -42,10 +42,13 @@ jobs:
           node-version: ${{ matrix.node-version }}
 
       # We need to skip the fallback download because downloading will fail on release branches because the new version isn't available yet.
-      - run: SENTRYCLI_SKIP_DOWNLOAD=1 yarn install
+      - run: SENTRYCLI_SKIP_DOWNLOAD=1 yarn install --frozen-lockfile
+        if: matrix.node-version != '10.x' && matrix.node-version != '12.x'
 
       # older node versions need an older nft
-      - run: SENTRYCLI_SKIP_DOWNLOAD=1 yarn add @vercel/nft@0.22.1
+      - run: |
+          SENTRYCLI_SKIP_DOWNLOAD=1 yarn install -f --frozen-lockfile
+          SENTRYCLI_SKIP_DOWNLOAD=1 yarn add @vercel/nft@0.22.1
         if: matrix.node-version == '10.x' || matrix.node-version == '12.x'
 
       - run: yarn test


### PR DESCRIPTION
builds on top of and should be merged after #2611 

This PR removes usage of `npm` to install dependencies and run tests in the `node_tests.yml` CI workflow. Instead we now use `yarn` like in the rest of the repo.

The reason we seemed to prefer npm over yarn here was that yarn is stricter with the `engines` field and it throws if the older node versions (10 and 12 in our case) don't support a package that needs to be installed. 
Therefore, I added the `--ignore-engines` flags to the install commands for Node 10 and 12. Which, I think is fair. (fwiw, if there was any actual problem, the usage of npm wouldn't have fixed that, it just wouldn't have thrown an error). 

This change now ensures that we use `yarn` for Node tests and type checking, which also means we can use the exact dependencies specified in `yarn.lock`. Previously, since we used npm, it would fetch the dependencies newly since there was no `package-lock.json` file for npm.

I also noticed that we still use `npm pack` in the `build.yml` workflow. This is fine and intentional because `npm pack` has other semantics than `yarn pack`, so I opted to leave this as-is. 