### PR TITLE
ref: Reformat `src/commands`

### DIFF
--- a/src/commands/mobile_app/upload.rs
+++ b/src/commands/mobile_app/upload.rs
@@ -1,10 +1,10 @@
 use std::borrow::Cow;
-use std::io::Write;
-use std::path::Path;
 #[cfg(not(windows))]
 use std::fs;
+use std::io::Write;
 #[cfg(not(windows))]
 use std::os::unix::fs::PermissionsExt;
+use std::path::Path;
 
 use anyhow::{anyhow, bail, Context as _, Result};
 use clap::{Arg, ArgAction, ArgMatches, Command};
@@ -256,9 +256,14 @@ fn normalize_directory(path: &Path) -> Result<TempFile> {
         .filter(|entry| entry.path().is_file())
         .map(|entry| {
             let entry_path = entry.into_path();
-            let relative_path = entry_path.strip_prefix(
-                path.parent().ok_or_else(|| anyhow!("Cannot determine parent directory for path: {}", path.display()))?
-            )?.to_owned();
+            let relative_path = entry_path
+                .strip_prefix(path.parent().ok_or_else(|| {
+                    anyhow!(
+                        "Cannot determine parent directory for path: {}",
+                        path.display()
+                    )
+                })?)?
+                .to_owned();
             Ok((entry_path, relative_path))
         })
         .collect::<Result<Vec<_>>>()?

--- a/src/commands/react_native/gradle.rs
+++ b/src/commands/react_native/gradle.rs
@@ -119,9 +119,7 @@ pub fn execute(matches: &ArgMatches) -> Result<()> {
 
     if let Some(version) = version {
         for dist in matches.get_many::<String>("dist").unwrap() {
-            println!(
-                "Uploading sourcemaps for release {version} distribution {dist}"
-            );
+            println!("Uploading sourcemaps for release {version} distribution {dist}");
 
             processor.upload(&UploadContext {
                 org: &org,

--- a/src/commands/send_metric/mod.rs
+++ b/src/commands/send_metric/mod.rs
@@ -38,7 +38,7 @@ This command will validate input parameters and attempt to send a metric to \
 Sentry. Due to network errors and rate limits, the metric is not guaranteed to \
 arrive. Check the debug output for transmission errors by passing --log-level=\
 debug or setting `SENTRY_LOG_LEVEL=debug`."))]
-#[command(hide=true)]
+#[command(hide = true)]
 enum SendMetricSubcommand {
     #[command(about = format!("[DEPRECATED] {INCREMENT_ABOUT}"))]
     #[command(long_about = format!("{DEPRECATION_MESSAGE}{{n}}{{n}}{INCREMENT_ABOUT}"))]


### PR DESCRIPTION
Previously, `cargo fmt` was unable to find these files, so CI could not enforce formatting. Fortunately, seems as though most contributors have been using rust-analyzer locally, so there are only a few formatter violations to fix here.

Prerequisite for #2622
 