### PR TITLE
Revert "chore(ci): Use yarn for node tests instead of npm (#2612)"

### DIFF
--- a/.github/workflows/test_node.yml
+++ b/.github/workflows/test_node.yml
@@ -20,6 +20,8 @@ jobs:
           node-version-file: package.json
 
       # We need to skip the fallback download because downloading will fail on release branches because the new version isn't available yet.
+      # We have to use npm here because yarn fails on the non-existing existing optionalDependency version:
+      # https://github.com/yarnpkg/berry/issues/2425#issuecomment-1627807326
       - run: SENTRYCLI_SKIP_DOWNLOAD=1 npm install
 
       - run: npm run check:types
@@ -42,6 +44,8 @@ jobs:
           node-version: ${{ matrix.node-version }}
 
       # We need to skip the fallback download because downloading will fail on release branches because the new version isn't available yet.
+      # We have to use npm here because yarn fails on the non-existing existing optionalDependency version:
+      # https://github.com/yarnpkg/berry/issues/2425#issuecomment-1627807326
       - run: SENTRYCLI_SKIP_DOWNLOAD=1 npm install
 
       # older node versions need an older nft

--- a/.github/workflows/test_node.yml
+++ b/.github/workflows/test_node.yml
@@ -20,9 +20,9 @@ jobs:
           node-version-file: package.json
 
       # We need to skip the fallback download because downloading will fail on release branches because the new version isn't available yet.
-      - run: SENTRYCLI_SKIP_DOWNLOAD=1 yarn install --frozen-lockfile
+      - run: SENTRYCLI_SKIP_DOWNLOAD=1 npm install
 
-      - run: yarn check:types
+      - run: npm run check:types
 
   test_node:
     strategy:
@@ -42,13 +42,10 @@ jobs:
           node-version: ${{ matrix.node-version }}
 
       # We need to skip the fallback download because downloading will fail on release branches because the new version isn't available yet.
-      - run: SENTRYCLI_SKIP_DOWNLOAD=1 yarn install --frozen-lockfile
-        if: matrix.node-version != '10.x' && matrix.node-version != '12.x'
+      - run: SENTRYCLI_SKIP_DOWNLOAD=1 npm install
 
       # older node versions need an older nft
-      - run: |
-          SENTRYCLI_SKIP_DOWNLOAD=1 yarn install --ignore-engines --frozen-lockfile
-          SENTRYCLI_SKIP_DOWNLOAD=1 yarn add @vercel/nft@0.22.1 --ignore-engines
+      - run: SENTRYCLI_SKIP_DOWNLOAD=1 npm install @vercel/nft@0.22.1
         if: matrix.node-version == '10.x' || matrix.node-version == '12.x'
 
-      - run: yarn test
+      - run: npm test


### PR DESCRIPTION
So it turns out `yarn` handles `optionalDependencies` more strictly than `npm`: Revert "chore(ci): Use yarn for node tests instead of npm (#2612)"

TLDR: We need to revert installing dependencies with `yarn` because in contrast to npm, `yarn` exits the installation of `optionalDependencies` if the version does not exist. We're running into this edge case on our release branch, where we first bump the dependency versions to the next version to be released and then run tests which try to install this new version.

More details in Revert "chore(ci): Use yarn for node tests instead of npm (#2612)"
(this is not a bug but an implementation decision of yarn)