### PR TITLE
ref: Enable `string-to-string` lint

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -101,6 +101,7 @@ unstable-mobile-app = ["apple-catalog-parsing"]
 [workspace.lints.clippy]
 allow-attributes = "warn"
 str-to-string = "warn"
+string-to-string = "warn"
 unnecessary-wraps = "warn"
 unwrap-used = "warn"
 

--- a/src/commands/debug_files/bundle_jvm.rs
+++ b/src/commands/debug_files/bundle_jvm.rs
@@ -96,7 +96,7 @@ pub fn execute(matches: &ArgMatches) -> Result<()> {
             let local_path_jvm_ext = local_path.with_extension("jvm");
             let url = format!("~/{}", path_as_url(&local_path_jvm_ext));
             (
-                url.to_string(),
+                url.clone(),
                 SourceFile {
                     url,
                     path: source.path.clone(),

--- a/src/commands/files/upload.rs
+++ b/src/commands/files/upload.rs
@@ -205,7 +205,7 @@ pub fn execute(matches: &ArgMatches) -> Result<()> {
                 let url = format!("{}/{}{}", url_prefix, path_as_url(local_path), url_suffix);
 
                 (
-                    url.to_string(),
+                    url.clone(),
                     SourceFile {
                         url,
                         path: source.path.clone(),

--- a/src/commands/send_event.rs
+++ b/src/commands/send_event.rs
@@ -316,7 +316,7 @@ pub fn execute(matches: &ArgMatches) -> Result<()> {
 
     if let Some(fingerprint) = matches.get_many::<String>("fingerprint") {
         event.fingerprint = fingerprint
-            .map(|x| x.to_string().into())
+            .map(|x| x.clone().into())
             .collect::<Vec<_>>()
             .into();
     }

--- a/src/commands/sourcemaps/explain.rs
+++ b/src/commands/sourcemaps/explain.rs
@@ -333,7 +333,7 @@ fn print_mapped_frame(frame: &Frame) {
 fn extract_release(event: &ProcessedEvent) -> Result<String> {
     if let Some(release) = event.release.as_ref() {
         success(format!("Event has release name: {release}"));
-        Ok(release.to_string())
+        Ok(release.clone())
     } else {
         error("Event is missing a release name");
         tip("Configure 'release' option in the SDK.\n  \

--- a/src/config.rs
+++ b/src/config.rs
@@ -194,8 +194,7 @@ impl Config {
                 );
             }
             Some(Auth::Key(ref val)) => {
-                self.ini
-                    .set_to(Some("auth"), "api_key".into(), val.to_string());
+                self.ini.set_to(Some("auth"), "api_key".into(), val.clone());
             }
             None => {}
         }
@@ -351,7 +350,7 @@ impl Config {
                     format_err!("An organization ID or slug is required (provide with --org)")
                 }),
             (None, Some(cli_org)) => Ok(cli_org),
-            (Some(token_org), None) => Ok(token_org.to_string()),
+            (Some(token_org), None) => Ok(token_org.clone()),
             (Some(token_org), Some(cli_org)) => {
                 if cli_org != *token_org {
                     log::warn!(
@@ -381,7 +380,7 @@ impl Config {
     // Backward compatibility with `releases files <VERSION>` commands.
     pub fn get_release_with_legacy_fallback(&self, matches: &ArgMatches) -> Result<String> {
         if let Some(version) = matches.get_one::<String>("version") {
-            Ok(version.to_string())
+            Ok(version.clone())
         } else {
             self.get_release(matches)
         }

--- a/src/utils/sourcemaps.rs
+++ b/src/utils/sourcemaps.rs
@@ -292,7 +292,7 @@ impl SourceMapProcessor {
             .iter()
             .map(|x| x.1)
             .filter(|x| x.ty == SourceFileType::SourceMap)
-            .map(|x| x.url.to_string())
+            .map(|x| x.url.clone())
             .collect();
 
         for source in self.sources.values_mut() {
@@ -325,15 +325,14 @@ impl SourceMapProcessor {
                         source.warn(format!(
                             "could not determine a source map reference ({err})"
                         ));
-                        self.sourcemap_references
-                            .insert(source.url.to_string(), None);
+                        self.sourcemap_references.insert(source.url.clone(), None);
                         continue;
                     }
                 },
             };
 
             self.sourcemap_references
-                .insert(source.url.to_string(), Some(sourcemap_reference));
+                .insert(source.url.clone(), Some(sourcemap_reference));
         }
     }
 
@@ -610,7 +609,7 @@ impl SourceMapProcessor {
             }
 
             if let Some(Some(sourcemap)) = self.sourcemap_references.get(&source.url) {
-                source.set_sourcemap_reference(sourcemap.url.to_string());
+                source.set_sourcemap_reference(sourcemap.url.clone());
             }
         }
     }
@@ -925,7 +924,7 @@ impl SourceMapProcessor {
 
                         let sourcemap_url = match &matches[..] {
                             [] => normalized,
-                            [x] => x.to_string(),
+                            [x] => x.clone(),
                             _ => {
                                 warn!("Ambiguous matches for sourcemap path {normalized}:");
                                 for path in matches {

--- a/src/utils/vcs.rs
+++ b/src/utils/vcs.rs
@@ -424,7 +424,7 @@ pub fn find_heads(
     } else {
         for repo in repos {
             let spec = CommitSpec {
-                repo: repo.name.to_string(),
+                repo: repo.name.clone(),
                 path: None,
                 rev: "HEAD".into(),
                 prev_rev: None,
@@ -433,7 +433,7 @@ pub fn find_heads(
                 find_matching_rev(spec.reference(), &spec, repos, false, remote_name.clone())?
             {
                 rv.push(Ref {
-                    repo: repo.name.to_string(),
+                    repo: repo.name.clone(),
                     rev,
                     prev_rev: None,
                 });


### PR DESCRIPTION
Using `clone` makes it clearer that we are cloning a `String` versus calling `to_string` on a `String.