### PR TITLE
feat(js): Export `live` option type for `releases.uploadSourceMaps`

### DIFF
--- a/js/index.d.ts
+++ b/js/index.d.ts
@@ -208,7 +208,10 @@ declare module '@sentry/cli' {
 
     proposeVersion(): Promise<string>;
 
-    uploadSourceMaps(release: string, options: SentryCliUploadSourceMapsOptions): Promise<string>;
+    uploadSourceMaps(
+      release: string,
+      options: SentryCliUploadSourceMapsOptions & { live?: boolean | 'rejectOnError' }
+    ): Promise<string>;
 
     listDeploys(release: string): Promise<string>;
 

--- a/js/releases/index.js
+++ b/js/releases/index.js
@@ -149,6 +149,7 @@ class Releases {
    *   ext: ['js', 'map', 'jsbundle', 'bundle'],  // override file extensions to scan for
    *   projects: ['node'],        // provide a list of projects
    *   decompress: false          // decompress gzip files before uploading
+   *   live: undefined            // whether to inherit stdio to display `sentry-cli` output directly.
    * });
    *
    * @param {string} release Unique name of the release.

--- a/js/releases/index.js
+++ b/js/releases/index.js
@@ -149,7 +149,7 @@ class Releases {
    *   ext: ['js', 'map', 'jsbundle', 'bundle'],  // override file extensions to scan for
    *   projects: ['node'],        // provide a list of projects
    *   decompress: false          // decompress gzip files before uploading
-   *   live: undefined            // whether to inherit stdio to display `sentry-cli` output directly.
+   *   live: true                 // whether to inherit stdio to display `sentry-cli` output directly.
    * });
    *
    * @param {string} release Unique name of the release.


### PR DESCRIPTION
While working on #2605, I missed that we also need to add the new `live` option to the manually created *public* type declaration of the `SentryCLI().releases.uploadSourceMaps` method. This PR now adds the `live` option to this method. (feat because although there's no behaviour change, from a user perspective #2605 is only public with this change)

Very good reason to tackle #2617, since it will eliminate this kind of divergence. I gave it a quick try and got results pretty quickly. However, due to our internal typing currently being a lot more lenient than what the type declarations specify, I'd consider unifying the typing a breaking change. The goal is that our exported type declarations come from out internal type definitions BUT to get to this point, we first need to change these internal types to adhere to the currently exported declarations. 
@szokeasaurusrex let me know when you want to tackle v3, then I'll take another look at this.