### PR TITLE
feat(js): Expose `rejectOnError` in public `execute` type declarations

### DIFF
--- a/js/index.d.ts
+++ b/js/index.d.ts
@@ -217,7 +217,7 @@ declare module '@sentry/cli' {
 
     newDeploy(release: string, options: SentryCliNewDeployOptions): Promise<string>;
 
-    execute(args: string[], live: boolean): Promise<string>;
+    execute(args: string[], live: boolean | 'rejectOnError'): Promise<string>;
   }
 
   export default class SentryCli {
@@ -237,6 +237,6 @@ declare module '@sentry/cli' {
 
     public static getVersion(): string;
     public static getPath(): string;
-    public execute(args: string[], live: boolean): Promise<string>;
+    public execute(args: string[], live: boolean | 'rejectOnError'): Promise<string>;
   }
 }

--- a/js/index.js
+++ b/js/index.js
@@ -57,7 +57,11 @@ class SentryCli {
   /**
    * See {helper.execute} docs.
    * @param {string[]} args Command line arguments passed to `sentry-cli`.
-   * @param {boolean} live We inherit stdio to display `sentry-cli` output directly.
+   * @param {boolean | 'rejectOnError'} live can be set to:
+   *  - `true` to inherit stdio to display `sentry-cli` output directly.
+   *  - `false` to not inherit stdio and return the output as a string.
+   *  - `'rejectOnError'` to inherit stdio and reject the promise if the command
+   *    exits with a non-zero exit code.
    * @returns {Promise.<string>} A promise that resolves to the standard output.
    */
   execute(args, live) {


### PR DESCRIPTION
Of course I missed more occurances of the `live` mode in type declarations 🤦‍♂️ 
(no urgency this time though)

This PR now adds the new `rejectOnError` to the remaining `.execute` type declarations so that this mode can also be set by library consumers directly calling `.execute` (e.g. `@sentry/react-router` SDK).