### PR TITLE
feat(proguard): Use chunk uploading by default

### DIFF
--- a/src/api/data_types/chunking/upload/capability.rs
+++ b/src/api/data_types/chunking/upload/capability.rs
@@ -33,6 +33,9 @@ pub enum ChunkUploadCapability {
     /// Upload of preprod artifacts
     PreprodArtifacts,
 
+    /// Upload of ProGuard mappings
+    Proguard,
+
     /// Any other unsupported capability (ignored)
     Unknown,
 }
@@ -53,6 +56,7 @@ impl<'de> Deserialize<'de> for ChunkUploadCapability {
             "bcsymbolmaps" => ChunkUploadCapability::BcSymbolmap,
             "il2cpp" => ChunkUploadCapability::Il2Cpp,
             "preprod_artifacts" => ChunkUploadCapability::PreprodArtifacts,
+            "proguard" => ChunkUploadCapability::Proguard,
             _ => ChunkUploadCapability::Unknown,
         })
     }

--- a/tests/integration/_responses/debug_files/get-chunk-upload.json
+++ b/tests/integration/_responses/debug_files/get-chunk-upload.json
@@ -7,5 +7,5 @@
   "concurrency": 8,
   "hashAlgorithm": "sha1",
   "compression": ["gzip"],
-  "accept": ["debug_files", "release_files", "pdbs", "portablepdbs", "sources", "bcsymbolmaps"]
+  "accept": ["debug_files", "release_files", "pdbs", "portablepdbs", "sources", "bcsymbolmaps", "proguard"]
 }

--- a/tests/integration/upload_proguard.rs
+++ b/tests/integration/upload_proguard.rs
@@ -72,7 +72,6 @@ fn chunk_upload_already_there() {
             "tests/integration/_fixtures/upload_proguard/mapping.txt",
         ])
         .with_default_token()
-        .env("SENTRY_EXPERIMENTAL_PROGUARD_CHUNK_UPLOAD", "1")
         .run_and_assert(AssertCommand::Success)
 }
 


### PR DESCRIPTION
Enable chunk uploads for Proguard files. This upload method avoids 502 errors when uploading large Proguard files, and enables interrupted uploads to be resumed.

Closes #2328