### PR TITLE
fix: XCArchive upload on macOS ARM only

### DIFF
--- a/src/commands/mobile_app/upload.rs
+++ b/src/commands/mobile_app/upload.rs
@@ -25,8 +25,10 @@ use crate::utils::fs::get_sha1_checksums;
 use crate::utils::fs::TempDir;
 use crate::utils::fs::TempFile;
 #[cfg(all(target_os = "macos", target_arch = "aarch64"))]
-use crate::utils::mobile_app::{handle_asset_catalogs, ipa_to_xcarchive, is_ipa_file};
-use crate::utils::mobile_app::{is_aab_file, is_apk_file, is_apple_app, is_zip_file};
+use crate::utils::mobile_app::{
+    handle_asset_catalogs, ipa_to_xcarchive, is_apple_app, is_ipa_file,
+};
+use crate::utils::mobile_app::{is_aab_file, is_apk_file, is_zip_file};
 use crate::utils::progress::ProgressBar;
 use crate::utils::vcs;
 
@@ -34,7 +36,8 @@ pub fn make_command(command: Command) -> Command {
     #[cfg(all(target_os = "macos", target_arch = "aarch64"))]
     const HELP_TEXT: &str = "The path to the mobile app files to upload. Supported files include Apk, Aab, XCArchive, and IPA.";
     #[cfg(not(all(target_os = "macos", target_arch = "aarch64")))]
-    const HELP_TEXT: &str = "The path to the mobile app files to upload. Supported files include Apk, Aab, and XCArchive.";
+    const HELP_TEXT: &str =
+        "The path to the mobile app files to upload. Supported files include Apk, and Aab.";
     command
         .about("[EXPERIMENTAL] Upload mobile app files to a project.")
         .org_arg()
@@ -201,6 +204,7 @@ fn handle_file(path: &Path, byteview: &ByteView) -> Result<TempFile> {
 fn validate_is_mobile_app(path: &Path, bytes: &[u8]) -> Result<()> {
     debug!("Validating mobile app format for: {}", path.display());
 
+    #[cfg(all(target_os = "macos", target_arch = "aarch64"))]
     if is_apple_app(path) {
         debug!("Detected XCArchive directory");
         return Ok(());
@@ -234,7 +238,7 @@ fn validate_is_mobile_app(path: &Path, bytes: &[u8]) -> Result<()> {
     #[cfg(all(target_os = "macos", target_arch = "aarch64"))]
     let format_list = "APK, AAB, XCArchive, or IPA";
     #[cfg(not(all(target_os = "macos", target_arch = "aarch64")))]
-    let format_list = "APK, AAB, or XCArchive";
+    let format_list = "APK, or AAB";
 
     Err(anyhow!(
         "File is not a recognized mobile app format ({format_list}): {}",

--- a/src/utils/mobile_app/mod.rs
+++ b/src/utils/mobile_app/mod.rs
@@ -6,6 +6,6 @@ mod validation;
 
 #[cfg(all(target_os = "macos", target_arch = "aarch64"))]
 pub use self::apple::{handle_asset_catalogs, ipa_to_xcarchive};
+pub use self::validation::{is_aab_file, is_apk_file, is_zip_file};
 #[cfg(all(target_os = "macos", target_arch = "aarch64"))]
-pub use self::validation::is_ipa_file;
-pub use self::validation::{is_aab_file, is_apk_file, is_apple_app, is_zip_file};
+pub use self::validation::{is_apple_app, is_ipa_file};

--- a/src/utils/mobile_app/validation.rs
+++ b/src/utils/mobile_app/validation.rs
@@ -1,3 +1,4 @@
+#[cfg(all(target_os = "macos", target_arch = "aarch64"))]
 use std::path::Path;
 
 use anyhow::Result;
@@ -51,6 +52,7 @@ pub fn is_ipa_file(bytes: &[u8]) -> Result<bool> {
     Ok(is_ipa)
 }
 
+#[cfg(all(target_os = "macos", target_arch = "aarch64"))]
 pub fn is_xcarchive_directory<P>(path: P) -> bool
 where
     P: AsRef<Path>,
@@ -65,6 +67,7 @@ where
 }
 
 /// A path is an Apple app if it points to an xarchive directory
+#[cfg(all(target_os = "macos", target_arch = "aarch64"))]
 pub fn is_apple_app(path: &Path) -> bool {
     path.is_dir() && is_xcarchive_directory(path)
 }

--- a/tests/integration/_cases/mobile_app/mobile_app-upload-help-not-macos.trycmd
+++ b/tests/integration/_cases/mobile_app/mobile_app-upload-help-not-macos.trycmd
@@ -6,8 +6,7 @@ $ sentry-cli mobile-app upload --help
 Usage: sentry-cli[EXE] mobile-app upload [OPTIONS] <PATH>...
 
 Arguments:
-  <PATH>...  The path to the mobile app files to upload. Supported files include Apk, Aab, and
-             XCArchive.
+  <PATH>...  The path to the mobile app files to upload. Supported files include Apk, and Aab.
 
 Options:
   -o, --org <ORG>


### PR DESCRIPTION
Updates the mobile app command to make sure apple apps aren't uploaded from non-macos ARM, follow up from https://github.com/getsentry/sentry-cli/pull/2619