### PR TITLE
test: Make tests pass with custom `--target`

### DIFF
--- a/tests/integration/_cases/bash_hook/bash_hook-release-env.trycmd
+++ b/tests/integration/_cases/bash_hook/bash_hook-release-env.trycmd
@@ -37,7 +37,7 @@ _sentry_err_trap() {
   echo "@exit_code:${_exit_code}" >> "$_SENTRY_TRACEBACK_FILE"
 
   : >> "$_SENTRY_LOG_FILE"
-  export SENTRY_LAST_EVENT=$([CWD]/target/debug/sentry-cli[EXE] bash-hook --send-event --traceback "$_SENTRY_TRACEBACK_FILE" --release "0.2.0" --log "$_SENTRY_LOG_FILE" )
+  export SENTRY_LAST_EVENT=$([..] bash-hook --send-event --traceback "$_SENTRY_TRACEBACK_FILE" --release "0.2.0" --log "$_SENTRY_LOG_FILE" )
   rm -f "$_SENTRY_TRACEBACK_FILE" "$_SENTRY_LOG_FILE"
 }
 

--- a/tests/integration/_cases/bash_hook/bash_hook-release.trycmd
+++ b/tests/integration/_cases/bash_hook/bash_hook-release.trycmd
@@ -37,7 +37,7 @@ _sentry_err_trap() {
   echo "@exit_code:${_exit_code}" >> "$_SENTRY_TRACEBACK_FILE"
 
   : >> "$_SENTRY_LOG_FILE"
-  export SENTRY_LAST_EVENT=$([CWD]/target/debug/sentry-cli[EXE] bash-hook --send-event --traceback "$_SENTRY_TRACEBACK_FILE" --release "0.1.0" --log "$_SENTRY_LOG_FILE" )
+  export SENTRY_LAST_EVENT=$([..] bash-hook --send-event --traceback "$_SENTRY_TRACEBACK_FILE" --release "0.1.0" --log "$_SENTRY_LOG_FILE" )
   rm -f "$_SENTRY_TRACEBACK_FILE" "$_SENTRY_LOG_FILE"
 }
 

--- a/tests/integration/_cases/bash_hook/bash_hook-tags.trycmd
+++ b/tests/integration/_cases/bash_hook/bash_hook-tags.trycmd
@@ -37,7 +37,7 @@ _sentry_err_trap() {
   echo "@exit_code:${_exit_code}" >> "$_SENTRY_TRACEBACK_FILE"
 
   : >> "$_SENTRY_LOG_FILE"
-  export SENTRY_LAST_EVENT=$([CWD]/target/debug/sentry-cli[EXE] bash-hook --send-event --traceback "$_SENTRY_TRACEBACK_FILE" --tag "example:value" --tag "example2:value2" --log "$_SENTRY_LOG_FILE" )
+  export SENTRY_LAST_EVENT=$([..] bash-hook --send-event --traceback "$_SENTRY_TRACEBACK_FILE" --tag "example:value" --tag "example2:value2" --log "$_SENTRY_LOG_FILE" )
   rm -f "$_SENTRY_TRACEBACK_FILE" "$_SENTRY_LOG_FILE"
 }
 

--- a/tests/integration/_cases/bash_hook/bash_hook.trycmd
+++ b/tests/integration/_cases/bash_hook/bash_hook.trycmd
@@ -37,7 +37,7 @@ _sentry_err_trap() {
   echo "@exit_code:${_exit_code}" >> "$_SENTRY_TRACEBACK_FILE"
 
   : >> "$_SENTRY_LOG_FILE"
-  export SENTRY_LAST_EVENT=$([CWD]/target/debug/sentry-cli[EXE] bash-hook --send-event --traceback "$_SENTRY_TRACEBACK_FILE" --log "$_SENTRY_LOG_FILE" )
+  export SENTRY_LAST_EVENT=$([..] bash-hook --send-event --traceback "$_SENTRY_TRACEBACK_FILE" --log "$_SENTRY_LOG_FILE" )
   rm -f "$_SENTRY_TRACEBACK_FILE" "$_SENTRY_LOG_FILE"
 }
 

--- a/tests/integration/_cases/debug_files/debug_files-bundle_sources-mixed-embedded-sources.trycmd
+++ b/tests/integration/_cases/debug_files/debug_files-bundle_sources-mixed-embedded-sources.trycmd
@@ -3,7 +3,7 @@ $ sentry-cli --log-level=debug debug-files bundle-sources tests/integration/_fix
 ? success
   INFO    [..] Loaded config from [CWD]/.sentryclirc
   DEBUG   [..] sentry-cli version: [VERSION], platform: [..], architecture: [..]
-  INFO    [..] sentry-cli was invoked with the following command line: "[CWD]/target/debug/sentry-cli[EXE]" "--log-level=debug" "debug-files" "bundle-sources" "tests/integration/_fixtures/SrcGenSampleApp.pdb"
+  INFO    [..] sentry-cli was invoked with the following command line: "[..]" "--log-level=debug" "debug-files" "bundle-sources" "tests/integration/_fixtures/SrcGenSampleApp.pdb"
   DEBUG   [..] Trying to add source file: /Users/matt/Code/temp/SrcGenSampleApp/SrcGenSampleApp/Program.cs
   DEBUG   [..] Trying to add source file: /Users/matt/Code/temp/SrcGenSampleApp/SrcGenSampleApp/obj/Release/net6.0/SrcGenSampleApp.GlobalUsings.g.cs
   DEBUG   [..] Trying to add source file: /Users/matt/Code/temp/SrcGenSampleApp/SrcGenSampleApp/obj/Release/net6.0/.NETCoreApp,Version=v6.0.AssemblyAttributes.cs

--- a/tests/integration/_cases/send_envelope/send_envelope-file-log.trycmd
+++ b/tests/integration/_cases/send_envelope/send_envelope-file-log.trycmd
@@ -3,7 +3,7 @@ $ sentry-cli send-envelope tests/integration/_fixtures/envelope.dat --log-level=
 ? success
   INFO    [..] Loaded config from [CWD]/.sentryclirc
   DEBUG   [..] sentry-cli version: [VERSION], platform: [..], architecture: [..]
-  INFO    [..] sentry-cli was invoked with the following command line: "[CWD]/target/debug/sentry-cli[EXE]" "send-envelope" "tests/integration/_fixtures/envelope.dat" "--log-level=debug"
+  INFO    [..] sentry-cli was invoked with the following command line: "[..]" "send-envelope" "tests/integration/_fixtures/envelope.dat" "--log-level=debug"
   DEBUG   [..] Sending envelope:
 {"event_id":"22d00b3f-d1b1-4b5d-8d20-49d138cd8a9c"}
 {"type":"event","length":74}

--- a/tests/integration/_cases/send_event/not_windows/send_event-raw.trycmd
+++ b/tests/integration/_cases/send_event/not_windows/send_event-raw.trycmd
@@ -15,7 +15,7 @@ $ sentry-cli send-event --log-level=debug
 ? success
   INFO    [..] Loaded config from [CWD]/.sentryclirc
   DEBUG   [..] sentry-cli version: [VERSION], platform: [..], architecture: [..]
-  INFO    [..] sentry-cli was invoked with the following command line: "[CWD]/target/debug/sentry-cli[EXE]" "send-event" "--log-level=debug" "--level" "debug" "--timestamp" "1649335000929" "--release" "my-release" "--dist" "my-dist" "--env" "production" "--message" "hello" "--platform" "prod" "--tag" "hello:there" "--extra" "hello:there" "--user" "id:42" "--fingerprint" "custom-fingerprint" "--no-environ"
+  INFO    [..] sentry-cli was invoked with the following command line: "[..]" "send-event" "--log-level=debug" "--level" "debug" "--timestamp" "1649335000929" "--release" "my-release" "--dist" "my-dist" "--env" "production" "--message" "hello" "--platform" "prod" "--tag" "hello:there" "--extra" "hello:there" "--user" "id:42" "--fingerprint" "custom-fingerprint" "--no-environ"
   DEBUG   [..] Sending envelope:
 {"event_id":"[..]"}
 {"type":"event","length":[..]}

--- a/tests/integration/_cases/uninstall/uninstall-windows.trycmd
+++ b/tests/integration/_cases/uninstall/uninstall-windows.trycmd
@@ -3,6 +3,6 @@ $ sentry-cli uninstall
 ? failed
 Cannot uninstall on Windows :(
 
-Delete this file yourself: [CWD]/target/debug/sentry-cli[EXE]
+Delete this file yourself: [..]
 
 ```


### PR DESCRIPTION
Currently, some tests fail because they assert `target/debug/sentry-cli` as the path to the binary. This fails when running `cargo test` with a custom `--target`.
    
Instead, let's stop asserting the path to the binary.