### PR TITLE
meta(vscode): Make `rust-analyzer` run Clippy

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,4 +1,5 @@
 {
     "rust-analyzer.cargo.features": ["unstable-mobile-app"],
-    "rust-analyzer.cargo.noDefaultFeatures": false
+    "rust-analyzer.cargo.noDefaultFeatures": false,
+    "rust-analyzer.check.command": "clippy"
 }


### PR DESCRIPTION
Having this setting ensures that any linter warnings (at least, for the developer's system) are displayed in the IDE. I have had it enabled in my user settings for awhile, but we should also ensure it is set in the project settings, so that future Sentry CLI contributors have this setting enabled out of the box.