### PR TITLE
feat(preprod): Show analysis URL after mobile-app upload

### DIFF
--- a/src/api/data_types/chunking/mobile_app.rs
+++ b/src/api/data_types/chunking/mobile_app.rs
@@ -9,7 +9,7 @@ pub struct ChunkedMobileAppRequest<'a> {
     pub checksum: Digest,
     pub chunks: &'a [Digest],
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub git_sha: Option<&'a str>,
+    pub head_sha: Option<&'a str>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub build_configuration: Option<&'a str>,
 }
@@ -20,4 +20,5 @@ pub struct AssembleMobileAppResponse {
     pub state: ChunkedFileState,
     pub missing_chunks: Vec<Digest>,
     pub detail: Option<String>,
+    pub artifact_id: Option<String>,
 }

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -1036,7 +1036,7 @@ impl<'a> AuthenticatedApi<'a> {
         project: &str,
         checksum: Digest,
         chunks: &[Digest],
-        git_sha: Option<&str>,
+        head_sha: Option<&str>,
         build_configuration: Option<&str>,
     ) -> ApiResult<AssembleMobileAppResponse> {
         let url = format!(
@@ -1049,7 +1049,7 @@ impl<'a> AuthenticatedApi<'a> {
             .with_json_body(&ChunkedMobileAppRequest {
                 checksum,
                 chunks,
-                git_sha,
+                head_sha,
                 build_configuration,
             })?
             .send()?

--- a/tests/integration/_cases/mobile_app/mobile_app-upload-apk-all-uploaded.trycmd
+++ b/tests/integration/_cases/mobile_app/mobile_app-upload-apk-all-uploaded.trycmd
@@ -2,8 +2,7 @@
 $ sentry-cli mobile-app upload tests/integration/_fixtures/mobile_app/apk.apk
 ? success
 [..]WARN[..]EXPERIMENTAL: The mobile-app subcommand is experimental. The command is subject to breaking changes and may be removed without notice in any release.
-Nothing to upload, all files are on the server
 Successfully uploaded 1 file to Sentry
-  - tests/integration/_fixtures/mobile_app/apk.apk
+  - tests/integration/_fixtures/mobile_app/apk.apk (http[..]/wat-org/preprod/wat-project/42)
 
 ```

--- a/tests/integration/_cases/mobile_app/mobile_app-upload-apk.trycmd
+++ b/tests/integration/_cases/mobile_app/mobile_app-upload-apk.trycmd
@@ -3,6 +3,6 @@ $ sentry-cli mobile-app upload tests/integration/_fixtures/mobile_app/apk.apk --
 ? success
 [..]WARN[..]EXPERIMENTAL: The mobile-app subcommand is experimental. The command is subject to breaking changes and may be removed without notice in any release.
 Successfully uploaded 1 file to Sentry
-  - tests/integration/_fixtures/mobile_app/apk.apk
+  - tests/integration/_fixtures/mobile_app/apk.apk (http[..]/wat-org/preprod/wat-project/42)
 
 ```

--- a/tests/integration/_cases/mobile_app/mobile_app-upload-ipa.trycmd
+++ b/tests/integration/_cases/mobile_app/mobile_app-upload-ipa.trycmd
@@ -3,6 +3,6 @@ $ sentry-cli mobile-app upload tests/integration/_fixtures/mobile_app/ipa.ipa --
 ? success
 [..]WARN[..]EXPERIMENTAL: The mobile-app subcommand is experimental. The command is subject to breaking changes and may be removed without notice in any release.
 Successfully uploaded 1 file to Sentry
-  - tests/integration/_fixtures/mobile_app/ipa.ipa
+  - tests/integration/_fixtures/mobile_app/ipa.ipa (http[..]/wat-org/preprod/wat-project/some-text-id)
 
 ```

--- a/tests/integration/mobile_app/upload.rs
+++ b/tests/integration/mobile_app/upload.rs
@@ -86,7 +86,7 @@ fn command_mobile_app_upload_apk_all_uploaded() {
                 "POST",
                 "/api/0/projects/wat-org/wat-project/files/preprodartifacts/assemble/",
             )
-            .with_response_body(r#"{"state":"ok","missingChunks":[]}"#),
+            .with_response_body(r#"{"state":"ok","missingChunks":[],"artifactId":"42"}"#),
         )
         .register_trycmd_test("mobile_app/mobile_app-upload-apk-all-uploaded.trycmd")
         .with_default_token();
@@ -159,7 +159,7 @@ fn command_mobile_app_upload_apk_chunked() {
                 "/api/0/projects/wat-org/wat-project/files/preprodartifacts/assemble/",
             )
             .with_header_matcher("content-type", "application/json")
-            .with_matcher(r#"{"checksum":"18e40e6e932d0b622d631e887be454cc2003dbb5","chunks":["18e40e6e932d0b622d631e887be454cc2003dbb5"],"git_sha":"test_sha"}"#)
+            .with_matcher(r#"{"checksum":"18e40e6e932d0b622d631e887be454cc2003dbb5","chunks":["18e40e6e932d0b622d631e887be454cc2003dbb5"],"head_sha":"test_sha"}"#)
             .with_response_fn(move |_| {
                 if is_first_assemble_call.swap(false, Ordering::Relaxed) {
                     r#"{
@@ -169,7 +169,8 @@ fn command_mobile_app_upload_apk_chunked() {
                 } else {
                     r#"{
                         "state": "ok",
-                        "missingChunks": []
+                        "missingChunks": [],
+                        "artifactId": "42"
                     }"#
                 }
                 .into()
@@ -213,7 +214,7 @@ fn command_mobile_app_upload_ipa_chunked() {
                 "/api/0/projects/wat-org/wat-project/files/preprodartifacts/assemble/",
             )
             .with_header_matcher("content-type", "application/json")
-             .with_matcher(r#"{"checksum":"ed9da71e3688261875db21b266da84ffe004a8a4","chunks":["ed9da71e3688261875db21b266da84ffe004a8a4"],"git_sha":"test_sha"}"#)
+             .with_matcher(r#"{"checksum":"ed9da71e3688261875db21b266da84ffe004a8a4","chunks":["ed9da71e3688261875db21b266da84ffe004a8a4"],"head_sha":"test_sha"}"#)
             .with_response_fn(move |_| {
                 if is_first_assemble_call.swap(false, Ordering::Relaxed) {
                     r#"{
@@ -223,7 +224,8 @@ fn command_mobile_app_upload_ipa_chunked() {
                 } else {
                     r#"{
                         "state": "ok",
-                        "missingChunks": []
+                        "missingChunks": [],
+                        "artifactId": "some-text-id"
                     }"#
                 }
                 .into()


### PR DESCRIPTION
Adds output when uploading a mobile app to show the analysis URL:

```
$ sentry-cli mobile-app upload ~/apks/HackerNews.apk
> Preparing for upload completed in 0.229s
Successfully uploaded 1 file to Sentry
  - /Users/chromy/apks/HackerNews.apk https://sentry.my.sentry.io/sentry/preprod/internal/57
```

Also updates the `sentry-cli` logic for recent changes to the upload endpoint:
- `gitSha` renamed to `headSha`
- Endpoint also returns `artifactId`
- We now are not expected to poll till assemble is complete, instead we call assemble twice:
  - First time to find the missing chunks
  - (here we upload all missing chunks)
  - Second time to get the `artfiactId` and trigger an assembly job
This avoids having to wait for the (slow) assembly process to complete prior to the CLI exiting.