### PR TITLE
fix(js): Stop calling `releases files upload-sourcemaps`

### DIFF
--- a/js/__tests__/helper.test.js
+++ b/js/__tests__/helper.test.js
@@ -48,27 +48,27 @@ describe('SentryCli helper', () => {
 
   describe('`prepare` command', () => {
     test('call prepare command add default ignore', () => {
-      const command = ['releases', 'files', 'release', 'upload-sourcemaps', '/dev/null'];
+      const command = ['sourcemaps', 'upload', '--release', 'release', '/dev/null'];
 
       expect(helper.prepareCommand(command)).toEqual([
-        'releases',
-        'files',
+        'sourcemaps',
+        'upload',
+        '--release',
         'release',
-        'upload-sourcemaps',
         '/dev/null',
       ]);
     });
 
     test('call prepare command with array option', () => {
-      const command = ['releases', 'files', 'release', 'upload-sourcemaps', '/dev/null'];
+      const command = ['sourcemaps', 'upload', '--release', 'release', '/dev/null'];
 
       expect(
         helper.prepareCommand(command, SOURCEMAPS_OPTIONS, { stripPrefix: ['node', 'app'] })
       ).toEqual([
-        'releases',
-        'files',
+        'sourcemaps',
+        'upload',
+        '--release',
         'release',
-        'upload-sourcemaps',
         '/dev/null',
         '--strip-prefix',
         'node',
@@ -83,30 +83,30 @@ describe('SentryCli helper', () => {
     });
 
     test('call prepare command with boolean option', () => {
-      const command = ['releases', 'files', 'release', 'upload-sourcemaps', '/dev/null'];
+      const command = ['sourcemaps', 'upload', '--release', 'release', '/dev/null'];
 
       expect(
         helper.prepareCommand(command, SOURCEMAPS_OPTIONS, { sourceMapReference: false })
       ).toEqual([
-        'releases',
-        'files',
+        'sourcemaps',
+        'upload',
+        '--release',
         'release',
-        'upload-sourcemaps',
         '/dev/null',
         '--no-sourcemap-reference',
       ]);
 
       expect(
         helper.prepareCommand(command, SOURCEMAPS_OPTIONS, { sourceMapReference: true })
-      ).toEqual(['releases', 'files', 'release', 'upload-sourcemaps', '/dev/null']);
+      ).toEqual(['sourcemaps', 'upload', '--release', 'release', '/dev/null']);
 
       expect(
         helper.prepareCommand(command, SOURCEMAPS_OPTIONS, { decompress: true, rewrite: true })
       ).toEqual([
-        'releases',
-        'files',
+        'sourcemaps',
+        'upload',
+        '--release',
         'release',
-        'upload-sourcemaps',
         '/dev/null',
         '--decompress',
         '--rewrite',
@@ -115,10 +115,10 @@ describe('SentryCli helper', () => {
       expect(
         helper.prepareCommand(command, SOURCEMAPS_OPTIONS, { rewrite: false, dedupe: false })
       ).toEqual([
-        'releases',
-        'files',
+        'sourcemaps',
+        'upload',
+        '--release',
         'release',
-        'upload-sourcemaps',
         '/dev/null',
         '--no-rewrite',
         '--no-dedupe',
@@ -126,10 +126,10 @@ describe('SentryCli helper', () => {
 
       // Only `invertedParam` registered for `dedupe` in `uploadSourcemaps`, so it should not add anything for positive boolean.
       expect(helper.prepareCommand(command, SOURCEMAPS_OPTIONS, { dedupe: true })).toEqual([
-        'releases',
-        'files',
+        'sourcemaps',
+        'upload',
+        '--release',
         'release',
-        'upload-sourcemaps',
         '/dev/null',
       ]);
 
@@ -139,23 +139,23 @@ describe('SentryCli helper', () => {
     });
 
     test('call prepare command with string option', () => {
-      const command = ['releases', 'files', 'release', 'upload-sourcemaps', '/dev/null'];
+      const command = ['sourcemaps', 'upload', '--release', 'release', '/dev/null'];
 
       expect(helper.prepareCommand(command, SOURCEMAPS_OPTIONS, { ext: ['js'] })).toEqual([
-        'releases',
-        'files',
+        'sourcemaps',
+        'upload',
+        '--release',
         'release',
-        'upload-sourcemaps',
         '/dev/null',
         '--ext',
         'js',
       ]);
 
       expect(helper.prepareCommand(command, SOURCEMAPS_OPTIONS, { urlPrefix: '~/' })).toEqual([
-        'releases',
-        'files',
+        'sourcemaps',
+        'upload',
+        '--release',
         'release',
-        'upload-sourcemaps',
         '/dev/null',
         '--url-prefix',
         '~/',
@@ -164,20 +164,20 @@ describe('SentryCli helper', () => {
       expect(
         helper.prepareCommand(command, SOURCEMAPS_OPTIONS, { urlSuffix: '?hash=1337' })
       ).toEqual([
-        'releases',
-        'files',
+        'sourcemaps',
+        'upload',
+        '--release',
         'release',
-        'upload-sourcemaps',
         '/dev/null',
         '--url-suffix',
         '?hash=1337',
       ]);
 
       expect(helper.prepareCommand(command, SOURCEMAPS_OPTIONS, { decompress: true })).toEqual([
-        'releases',
-        'files',
+        'sourcemaps',
+        'upload',
+        '--release',
         'release',
-        'upload-sourcemaps',
         '/dev/null',
         '--decompress',
       ]);
@@ -185,10 +185,10 @@ describe('SentryCli helper', () => {
       expect(
         helper.prepareCommand(command, SOURCEMAPS_OPTIONS, { ignoreFile: '/js.ignore' })
       ).toEqual([
-        'releases',
-        'files',
+        'sourcemaps',
+        'upload',
+        '--release',
         'release',
-        'upload-sourcemaps',
         '/dev/null',
         '--ignore-file',
         '/js.ignore',

--- a/js/releases/__tests__/index.test.js
+++ b/js/releases/__tests__/index.test.js
@@ -53,10 +53,10 @@ describe('SentryCli releases', () => {
         await cli.releases.uploadSourceMaps('my-version', { include: ['path'] });
         expect(mockExecute).toHaveBeenCalledWith(
           [
-            'releases',
-            'files',
+            'sourcemaps',
+            'upload',
+            '--release',
             'my-version',
-            'upload-sourcemaps',
             'path',
             '--ignore',
             'node_modules',
@@ -74,14 +74,14 @@ describe('SentryCli releases', () => {
         });
         expect(mockExecute).toHaveBeenCalledWith(
           [
-            'releases',
+            'sourcemaps',
+            'upload',
             '-p',
             'proj-a',
             '-p',
             'proj-b',
-            'files',
+            '--release',
             'my-version',
-            'upload-sourcemaps',
             'path',
             '--ignore',
             'node_modules',
@@ -103,10 +103,10 @@ describe('SentryCli releases', () => {
         paths.forEach(path =>
           expect(mockExecute).toHaveBeenCalledWith(
             [
-              'releases',
-              'files',
+              'sourcemaps',
+              'upload',
+              '--release',
               'my-version',
-              'upload-sourcemaps',
               path,
               '--ignore',
               'node_modules',
@@ -129,10 +129,10 @@ describe('SentryCli releases', () => {
 
         expect(mockExecute).toHaveBeenCalledWith(
           [
-            'releases',
-            'files',
+            'sourcemaps',
+            'upload',
+            '--release',
             'my-version',
-            'upload-sourcemaps',
             'some-path',
             '--ignore',
             'not-me', // note how this has been overridden
@@ -145,10 +145,10 @@ describe('SentryCli releases', () => {
 
         expect(mockExecute).toHaveBeenCalledWith(
           [
-            'releases',
-            'files',
+            'sourcemaps',
+            'upload',
+            '--release',
             'my-version',
-            'upload-sourcemaps',
             'other-path',
             '--ignore',
             'node_modules',
@@ -164,10 +164,10 @@ describe('SentryCli releases', () => {
         await cli.releases.uploadSourceMaps('my-version', { include: ['path'], live });
         expect(mockExecute).toHaveBeenCalledWith(
           [
-            'releases',
-            'files',
+            'sourcemaps',
+            'upload',
+            '--release',
             'my-version',
-            'upload-sourcemaps',
             'path',
             '--ignore',
             'node_modules',

--- a/js/releases/index.js
+++ b/js/releases/index.js
@@ -194,9 +194,9 @@ class Releases {
       }
 
       // args which apply to the entire `include` entry (everything besides the path)
-      const args = ['releases']
+      const args = ['sourcemaps', 'upload']
         .concat(helper.getProjectFlagsFromOptions(options))
-        .concat(['files', release, 'upload-sourcemaps']);
+        .concat(['--release', release]);
 
       return uploadPaths.map((path) =>
         // `execute()` is async and thus we're returning a promise here


### PR DESCRIPTION
Migrate Sentry CLI `releases files upload-sourcemaps` to `sourcemaps upload` to remove deprecated command usage and eliminate deprecation warnings.

Ref #2576

---
<a href="https://cursor.com/background-agent?bcId=bc-55ea9b50-8014-41a5-8652-0c83a3d730a0">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-55ea9b50-8014-41a5-8652-0c83a3d730a0">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

