### PR TITLE
feat(mobile-app): Add new VCS params to mobile-app command

### DIFF
--- a/src/api/data_types/chunking/mobile_app.rs
+++ b/src/api/data_types/chunking/mobile_app.rs
@@ -26,7 +26,7 @@ pub struct ChunkedMobileAppRequest<'a> {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub base_ref: Option<&'a str>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub pr_number: Option<&u32>,
+    pub pr_number: Option<&'a u32>,
 }
 
 #[derive(Debug, Deserialize)]

--- a/src/api/data_types/chunking/mobile_app.rs
+++ b/src/api/data_types/chunking/mobile_app.rs
@@ -9,9 +9,24 @@ pub struct ChunkedMobileAppRequest<'a> {
     pub checksum: Digest,
     pub chunks: &'a [Digest],
     #[serde(skip_serializing_if = "Option::is_none")]
+    pub build_configuration: Option<&'a str>,
+    // VCS fields
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub head_sha: Option<&'a str>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub build_configuration: Option<&'a str>,
+    pub base_sha: Option<&'a str>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub provider: Option<&'a str>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub head_repo_name: Option<&'a str>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub base_repo_name: Option<&'a str>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub head_ref: Option<&'a str>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub base_ref: Option<&'a str>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub pr_number: Option<&'a str>,
 }
 
 #[derive(Debug, Deserialize)]

--- a/src/api/data_types/chunking/mobile_app.rs
+++ b/src/api/data_types/chunking/mobile_app.rs
@@ -26,7 +26,7 @@ pub struct ChunkedMobileAppRequest<'a> {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub base_ref: Option<&'a str>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub pr_number: Option<&'a str>,
+    pub pr_number: Option<i32>,
 }
 
 #[derive(Debug, Deserialize)]

--- a/src/api/data_types/chunking/mobile_app.rs
+++ b/src/api/data_types/chunking/mobile_app.rs
@@ -26,7 +26,7 @@ pub struct ChunkedMobileAppRequest<'a> {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub base_ref: Option<&'a str>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub pr_number: Option<i32>,
+    pub pr_number: Option<&u32>,
 }
 
 #[derive(Debug, Deserialize)]

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -1036,8 +1036,15 @@ impl<'a> AuthenticatedApi<'a> {
         project: &str,
         checksum: Digest,
         chunks: &[Digest],
-        head_sha: Option<&str>,
         build_configuration: Option<&str>,
+        head_sha: Option<&str>,
+        base_sha: Option<&str>,
+        provider: Option<&str>,
+        head_repo_name: Option<&str>,
+        base_repo_name: Option<&str>,
+        head_ref: Option<&str>,
+        base_ref: Option<&str>,
+        pr_number: Option<&str>,
     ) -> ApiResult<AssembleMobileAppResponse> {
         let url = format!(
             "/projects/{}/{}/files/preprodartifacts/assemble/",
@@ -1049,8 +1056,15 @@ impl<'a> AuthenticatedApi<'a> {
             .with_json_body(&ChunkedMobileAppRequest {
                 checksum,
                 chunks,
-                head_sha,
                 build_configuration,
+                head_sha,
+                base_sha,
+                provider,
+                head_repo_name,
+                base_repo_name,
+                head_ref,
+                base_ref,
+                pr_number,
             })?
             .send()?
             .convert_rnf(ApiErrorKind::ProjectNotFound)

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -1037,14 +1037,7 @@ impl<'a> AuthenticatedApi<'a> {
         checksum: Digest,
         chunks: &[Digest],
         build_configuration: Option<&str>,
-        head_sha: Option<&str>,
-        base_sha: Option<&str>,
-        provider: Option<&str>,
-        head_repo_name: Option<&str>,
-        base_repo_name: Option<&str>,
-        head_ref: Option<&str>,
-        base_ref: Option<&str>,
-        pr_number: Option<i32>,
+        vcs_info: &VcsInfo<'_>,
     ) -> ApiResult<AssembleMobileAppResponse> {
         let url = format!(
             "/projects/{}/{}/files/preprodartifacts/assemble/",
@@ -1057,14 +1050,14 @@ impl<'a> AuthenticatedApi<'a> {
                 checksum,
                 chunks,
                 build_configuration,
-                head_sha,
-                base_sha,
-                provider,
-                head_repo_name,
-                base_repo_name,
-                head_ref,
-                base_ref,
-                pr_number,
+                head_sha: vcs_info.head_sha,
+                base_sha: vcs_info.base_sha,
+                provider: vcs_info.vcs_provider,
+                head_repo_name: vcs_info.head_repo_name,
+                base_repo_name: vcs_info.base_repo_name,
+                head_ref: vcs_info.head_ref,
+                base_ref: vcs_info.base_ref,
+                pr_number: vcs_info.pr_number,
             })?
             .send()?
             .convert_rnf(ApiErrorKind::ProjectNotFound)
@@ -2530,6 +2523,21 @@ pub struct RegionResponse {
 #[derive(Debug, Deserialize)]
 struct LogsResponse {
     data: Vec<LogEntry>,
+}
+
+/// VCS information for mobile app uploads
+#[derive(Debug)]
+// This is not dead code because it is used in the mobile app upload command
+#[expect(dead_code)]
+pub struct VcsInfo<'a> {
+    pub head_sha: Option<&'a str>,
+    pub base_sha: Option<&'a str>,
+    pub vcs_provider: Option<&'a str>,
+    pub head_repo_name: Option<&'a str>,
+    pub base_repo_name: Option<&'a str>,
+    pub head_ref: Option<&'a str>,
+    pub base_ref: Option<&'a str>,
+    pub pr_number: Option<i32>,
 }
 
 /// Log entry structure from the logs API

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -2526,6 +2526,7 @@ struct LogsResponse {
 }
 
 /// VCS information for mobile app uploads
+#[cfg(feature = "unstable-mobile-app")]
 #[derive(Debug)]
 pub struct VcsInfo<'a> {
     pub head_sha: Option<&'a str>,

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -1044,7 +1044,7 @@ impl<'a> AuthenticatedApi<'a> {
         base_repo_name: Option<&str>,
         head_ref: Option<&str>,
         base_ref: Option<&str>,
-        pr_number: Option<&str>,
+        pr_number: Option<i32>,
     ) -> ApiResult<AssembleMobileAppResponse> {
         let url = format!(
             "/projects/{}/{}/files/preprodartifacts/assemble/",

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -2536,7 +2536,7 @@ pub struct VcsInfo<'a> {
     pub base_repo_name: Option<&'a str>,
     pub head_ref: Option<&'a str>,
     pub base_ref: Option<&'a str>,
-    pub pr_number: Option<&u32>,
+    pub pr_number: Option<&'a u32>,
 }
 
 /// Log entry structure from the logs API

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -2527,8 +2527,6 @@ struct LogsResponse {
 
 /// VCS information for mobile app uploads
 #[derive(Debug)]
-// This is not dead code because it is used in the mobile app upload command
-#[expect(dead_code)]
 pub struct VcsInfo<'a> {
     pub head_sha: Option<&'a str>,
     pub base_sha: Option<&'a str>,

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -2536,7 +2536,7 @@ pub struct VcsInfo<'a> {
     pub base_repo_name: Option<&'a str>,
     pub head_ref: Option<&'a str>,
     pub base_ref: Option<&'a str>,
-    pub pr_number: Option<i32>,
+    pub pr_number: Option<&u32>,
 }
 
 /// Log entry structure from the logs API

--- a/src/commands/mobile_app/upload.rs
+++ b/src/commands/mobile_app/upload.rs
@@ -108,7 +108,7 @@ pub fn execute(matches: &ArgMatches) -> Result<()> {
     let base_repo_name = matches.get_one("base_repo_name").map(String::as_str);
     let head_ref = matches.get_one("head_ref").map(String::as_str);
     let base_ref = matches.get_one("base_ref").map(String::as_str);
-    let pr_number = matches.get_one("pr_number").map(String::as_str);
+    let pr_number = matches.get_one("pr_number").map(String::as_str).and_then(|s| s.parse::<i32>().ok());
 
     let build_configuration = matches.get_one("build_configuration").map(String::as_str);
 
@@ -348,7 +348,7 @@ fn upload_file(
     base_repo_name: Option<&str>,
     head_ref: Option<&str>,
     base_ref: Option<&str>,
-    pr_number: Option<&str>,
+    pr_number: Option<i32>,
 ) -> Result<String> {
     const SELF_HOSTED_ERROR_HINT: &str = "If you are using a self-hosted Sentry server, \
         update to the latest version of Sentry to use the mobile-app upload command.";
@@ -364,7 +364,10 @@ fn upload_file(
         base_repo_name.unwrap_or("unknown"),
         head_ref.unwrap_or("unknown"),
         base_ref.unwrap_or("unknown"),
-        pr_number.unwrap_or("unknown"),
+        pr_number
+            .map(|n| n.to_string())
+            .as_deref()
+            .unwrap_or("unknown"),
         build_configuration.unwrap_or("unknown")
     );
 

--- a/src/commands/mobile_app/upload.rs
+++ b/src/commands/mobile_app/upload.rs
@@ -108,7 +108,10 @@ pub fn execute(matches: &ArgMatches) -> Result<()> {
     let base_repo_name = matches.get_one("base_repo_name").map(String::as_str);
     let head_ref = matches.get_one("head_ref").map(String::as_str);
     let base_ref = matches.get_one("base_ref").map(String::as_str);
-    let pr_number = matches.get_one("pr_number").map(String::as_str).and_then(|s| s.parse::<i32>().ok());
+    let pr_number = matches
+        .get_one("pr_number")
+        .map(String::as_str)
+        .and_then(|s| s.parse::<i32>().ok());
 
     let build_configuration = matches.get_one("build_configuration").map(String::as_str);
 

--- a/src/utils/vcs.rs
+++ b/src/utils/vcs.rs
@@ -399,13 +399,6 @@ pub fn find_head() -> Result<String> {
     Ok(head.id().to_string())
 }
 
-pub fn find_base_sha(repo: &Repository, branch: &str) -> Result<String> {
-    let head = repo.revparse_single(branch)?;
-    Ok(head.id().to_string())
-}
-
-
-
 /// Given commit specs, repos and remote_name this returns a list of head
 /// commits from it.
 pub fn find_heads(

--- a/src/utils/vcs.rs
+++ b/src/utils/vcs.rs
@@ -211,6 +211,7 @@ fn is_matching_url(a: &str, b: &str) -> bool {
     VcsUrl::parse(a) == VcsUrl::parse(b)
 }
 
+// TODO: This is not used anywhere.
 pub fn get_repo_from_remote(repo: &str) -> String {
     let obj = VcsUrl::parse(repo);
     obj.id
@@ -397,6 +398,13 @@ pub fn find_head() -> Result<String> {
     let head = repo.revparse_single("HEAD")?;
     Ok(head.id().to_string())
 }
+
+pub fn find_base_sha(repo: &Repository, branch: &str) -> Result<String> {
+    let head = repo.revparse_single(branch)?;
+    Ok(head.id().to_string())
+}
+
+
 
 /// Given commit specs, repos and remote_name this returns a list of head
 /// commits from it.

--- a/src/utils/vcs.rs
+++ b/src/utils/vcs.rs
@@ -211,7 +211,6 @@ fn is_matching_url(a: &str, b: &str) -> bool {
     VcsUrl::parse(a) == VcsUrl::parse(b)
 }
 
-// TODO: This is not used anywhere.
 pub fn get_repo_from_remote(repo: &str) -> String {
     let obj = VcsUrl::parse(repo);
     obj.id

--- a/tests/integration/_cases/mobile_app/mobile_app-upload-apk.trycmd
+++ b/tests/integration/_cases/mobile_app/mobile_app-upload-apk.trycmd
@@ -1,6 +1,6 @@
 ```
-$ sentry-cli mobile-app upload tests/integration/_fixtures/mobile_app/apk.apk --sha test_sha
-? success
+$ sentry-cli mobile-app upload tests/integration/_fixtures/mobile_app/apk.apk --head-sha test_head_sha
+? 1
 [..]WARN[..]EXPERIMENTAL: The mobile-app subcommand is experimental. The command is subject to breaking changes and may be removed without notice in any release.
 Successfully uploaded 1 file to Sentry
   - tests/integration/_fixtures/mobile_app/apk.apk (http[..]/wat-org/preprod/wat-project/42)

--- a/tests/integration/_cases/mobile_app/mobile_app-upload-apk.trycmd
+++ b/tests/integration/_cases/mobile_app/mobile_app-upload-apk.trycmd
@@ -1,6 +1,6 @@
 ```
 $ sentry-cli mobile-app upload tests/integration/_fixtures/mobile_app/apk.apk --head-sha test_head_sha
-? 1
+? success
 [..]WARN[..]EXPERIMENTAL: The mobile-app subcommand is experimental. The command is subject to breaking changes and may be removed without notice in any release.
 Successfully uploaded 1 file to Sentry
   - tests/integration/_fixtures/mobile_app/apk.apk (http[..]/wat-org/preprod/wat-project/42)

--- a/tests/integration/_cases/mobile_app/mobile_app-upload-help-macos.trycmd
+++ b/tests/integration/_cases/mobile_app/mobile_app-upload-help-macos.trycmd
@@ -19,17 +19,38 @@ Options:
           The project ID or slug.
       --auth-token <AUTH_TOKEN>
           Use the given Sentry auth token.
-      --sha <sha>
-          The git commit sha to use for the upload. If not provided, the current commit sha will be
+      --head-sha <head_sha>
+          The VCS commit sha to use for the upload. If not provided, the current commit sha will be
           used.
-      --build-configuration <build_configuration>
-          The build configuration to use for the upload. If not provided, the current version will
-          be used.
+      --base-sha <base_sha>
+          The VCS commit's base sha to use for the upload. If not provided, the merge-base of the
+          current and remote branch will be used.
       --log-level <LOG_LEVEL>
           Set the log output verbosity. [possible values: trace, debug, info, warn, error]
+      --vcs-provider <vcs_provider>
+          The VCS provider to use for the upload. If not provided, the current provider will be
+          used.
+      --head-repo-name <head_repo_name>
+          The name of the git repository to use for the upload (e.g. organization/repository). If
+          not provided, the current repository will be used.
       --quiet
           Do not print any output while preserving correct exit code. This flag is currently
           implemented only for selected subcommands. [aliases: silent]
+      --base-repo-name <base_repo_name>
+          The name of the git repository to use for the upload (e.g. organization/repository). If
+          not provided, the current repository will be used.
+      --head-ref <head_ref>
+          The reference (branch) to use for the upload. If not provided, the current reference will
+          be used.
+      --base-ref <base_ref>
+          The reference (branch) to use for the upload. If not provided, the current reference will
+          be used.
+      --pr-number <pr_number>
+          The pull request number to use for the upload. If not provided, the current pull request
+          number will be used.
+      --build-configuration <build_configuration>
+          The build configuration to use for the upload. If not provided, the current version will
+          be used.
   -h, --help
           Print help
 

--- a/tests/integration/_cases/mobile_app/mobile_app-upload-help-not-macos.trycmd
+++ b/tests/integration/_cases/mobile_app/mobile_app-upload-help-not-macos.trycmd
@@ -1,12 +1,12 @@
 ```
 $ sentry-cli mobile-app upload --help
-? success
 [EXPERIMENTAL] Upload mobile app files to a project.
 
 Usage: sentry-cli[EXE] mobile-app upload [OPTIONS] <PATH>...
 
 Arguments:
-  <PATH>...  The path to the mobile app files to upload. Supported files include Apk, and Aab.
+  <PATH>...  The path to the mobile app files to upload. Supported files include Apk, Aab,
+             XCArchive, and IPA.
 
 Options:
   -o, --org <ORG>
@@ -18,17 +18,38 @@ Options:
           The project ID or slug.
       --auth-token <AUTH_TOKEN>
           Use the given Sentry auth token.
-      --sha <sha>
-          The git commit sha to use for the upload. If not provided, the current commit sha will be
+      --head-sha <head_sha>
+          The VCS commit sha to use for the upload. If not provided, the current commit sha will be
           used.
-      --build-configuration <build_configuration>
-          The build configuration to use for the upload. If not provided, the current version will
-          be used.
+      --base-sha <base_sha>
+          The VCS commit's base sha to use for the upload. If not provided, the merge-base of the
+          current and remote branch will be used.
       --log-level <LOG_LEVEL>
           Set the log output verbosity. [possible values: trace, debug, info, warn, error]
+      --vcs-provider <vcs_provider>
+          The VCS provider to use for the upload. If not provided, the current provider will be
+          used.
+      --head-repo-name <head_repo_name>
+          The name of the git repository to use for the upload (e.g. organization/repository). If
+          not provided, the current repository will be used.
       --quiet
           Do not print any output while preserving correct exit code. This flag is currently
           implemented only for selected subcommands. [aliases: silent]
+      --base-repo-name <base_repo_name>
+          The name of the git repository to use for the upload (e.g. organization/repository). If
+          not provided, the current repository will be used.
+      --head-ref <head_ref>
+          The reference (branch) to use for the upload. If not provided, the current reference will
+          be used.
+      --base-ref <base_ref>
+          The reference (branch) to use for the upload. If not provided, the current reference will
+          be used.
+      --pr-number <pr_number>
+          The pull request number to use for the upload. If not provided, the current pull request
+          number will be used.
+      --build-configuration <build_configuration>
+          The build configuration to use for the upload. If not provided, the current version will
+          be used.
   -h, --help
           Print help
 

--- a/tests/integration/_cases/mobile_app/mobile_app-upload-help-not-macos.trycmd
+++ b/tests/integration/_cases/mobile_app/mobile_app-upload-help-not-macos.trycmd
@@ -5,8 +5,7 @@ $ sentry-cli mobile-app upload --help
 Usage: sentry-cli[EXE] mobile-app upload [OPTIONS] <PATH>...
 
 Arguments:
-  <PATH>...  The path to the mobile app files to upload. Supported files include Apk, Aab,
-             XCArchive, and IPA.
+  <PATH>...  The path to the mobile app files to upload. Supported files include Apk, and Aab.
 
 Options:
   -o, --org <ORG>

--- a/tests/integration/_cases/mobile_app/mobile_app-upload-ipa.trycmd
+++ b/tests/integration/_cases/mobile_app/mobile_app-upload-ipa.trycmd
@@ -1,5 +1,5 @@
 ```
-$ sentry-cli mobile-app upload tests/integration/_fixtures/mobile_app/ipa.ipa --sha test_sha
+$ sentry-cli mobile-app upload tests/integration/_fixtures/mobile_app/ipa.ipa --head-sha test_head_sha
 ? success
 [..]WARN[..]EXPERIMENTAL: The mobile-app subcommand is experimental. The command is subject to breaking changes and may be removed without notice in any release.
 Successfully uploaded 1 file to Sentry

--- a/tests/integration/mobile_app/upload.rs
+++ b/tests/integration/mobile_app/upload.rs
@@ -159,7 +159,7 @@ fn command_mobile_app_upload_apk_chunked() {
                 "/api/0/projects/wat-org/wat-project/files/preprodartifacts/assemble/",
             )
             .with_header_matcher("content-type", "application/json")
-            .with_matcher(r#"{"checksum":"18e40e6e932d0b622d631e887be454cc2003dbb5","chunks":["18e40e6e932d0b622d631e887be454cc2003dbb5"],"head_sha":"test_sha"}"#)
+            .with_matcher(r#"{"checksum":"18e40e6e932d0b622d631e887be454cc2003dbb5","chunks":["18e40e6e932d0b622d631e887be454cc2003dbb5"],"head_sha":"test_head_sha"}"#)
             .with_response_fn(move |_| {
                 if is_first_assemble_call.swap(false, Ordering::Relaxed) {
                     r#"{
@@ -214,7 +214,7 @@ fn command_mobile_app_upload_ipa_chunked() {
                 "/api/0/projects/wat-org/wat-project/files/preprodartifacts/assemble/",
             )
             .with_header_matcher("content-type", "application/json")
-             .with_matcher(r#"{"checksum":"ed9da71e3688261875db21b266da84ffe004a8a4","chunks":["ed9da71e3688261875db21b266da84ffe004a8a4"],"head_sha":"test_sha"}"#)
+             .with_matcher(r#"{"checksum":"ed9da71e3688261875db21b266da84ffe004a8a4","chunks":["ed9da71e3688261875db21b266da84ffe004a8a4"],"head_sha":"test_head_sha"}"#)
             .with_response_fn(move |_| {
                 if is_first_assemble_call.swap(false, Ordering::Relaxed) {
                     r#"{


### PR DESCRIPTION
Adds new VCS params as args to the `mobile-app` command and passes them to the API (pending https://github.com/getsentry/sentry/pull/97332). Notably removes `sha` in favor of `head_sha`. Given this command is still unreleased and marked experimental, this would usually be a breaking change but I don't believe we need any backwards compatibility here.

We'll implement default value providing for most of these as well in follow ups, as I'd prefer to silo those implementations for easier review && testing.