### PR TITLE
chore: Pin rust toolchain to latest stable to prevent random CI failures

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -46,7 +46,8 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # 4.2.2
 
       - name: Install Rust Toolchain
-        run: rustup toolchain install stable --profile minimal --component clippy --component rustfmt --no-self-update
+        # Pin to specific version to avoid clippy lint changes in new releases
+        run: rustup toolchain install 1.89.0 --profile minimal --component clippy --component rustfmt --no-self-update
 
       - name: Add Target
         run: rustup target add ${{ matrix.target }}


### PR DESCRIPTION
CI will often times fail when a new stable version of clippy (rust toolchain) is released. This occurred today (https://github.com/getsentry/sentry-cli/pull/2684) and previously (https://github.com/getsentry/sentry-cli/pull/2571), resulting in failures for unrelated PRs which blocked work.

Moving forward, I'd propose we pin to a specific version of the rust toolchain and instead of following with a fix to the lints, we explicitly update the toolchain and fix lints as part of that update. This prevents unnecessary developer frustration needing to wait for fixes to land before CI is fixed.