### PR TITLE
build: Pin Rust toolchain minor version

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -45,11 +45,11 @@ jobs:
       - name: Checkout Repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # 4.2.2
 
-      - name: Install Rust Toolchain
-        run: rustup toolchain install stable --profile minimal --component clippy --component rustfmt --no-self-update
-
-      - name: Add Target
-        run: rustup target add ${{ matrix.target }}
+      - name: Setup Rust Toolchain
+        run: |
+          rustup set profile minimal
+          rustup component add clippy rustfmt
+          rustup target add ${{ matrix.target }}
 
       - name: Install musl-gcc (Linux only)
         if: matrix.os == 'ubuntu-24.04'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -46,8 +46,10 @@ jobs:
       - name: Checkout Repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # 4.2.2
 
-      - name: Add Target
-        run: rustup target add ${{ matrix.target }}
+      - name: Setup Rust Toolchain
+        run: |
+          rustup set profile minimal
+          rustup target add ${{ matrix.target }}
 
       - name: Install musl-gcc (Linux only)
         if: matrix.os == 'ubuntu-24.04'

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,4 @@
+[toolchain]
+# We pin the minor version to prevent new Clippy lints from breaking CI.
+# But, we still want to pick up new patch versions.
+channel = "1.89"


### PR DESCRIPTION
Pin to the latest Rust toolchain minor version.

Closes #2686