### PR TITLE
test: Test `logs` help message

### DIFF
--- a/tests/integration/logs.rs
+++ b/tests/integration/logs.rs
@@ -37,3 +37,8 @@ fn command_logs_zero_max_rows() {
 fn command_logs_list_help() {
     TestManager::new().register_trycmd_test("logs/logs-list-help.trycmd");
 }
+
+#[test]
+fn command_logs_help() {
+    TestManager::new().register_trycmd_test("logs/logs-help.trycmd");
+}


### PR DESCRIPTION
We have the `.trycmd` file there already, but we never test it.