### PR TITLE
fix(logs): Mark `logs` command as beta

### DIFF
--- a/src/commands/logs/mod.rs
+++ b/src/commands/logs/mod.rs
@@ -6,6 +6,9 @@ use anyhow::Result;
 use clap::ArgMatches;
 use clap::{Args, Command, Parser as _, Subcommand};
 
+const BETA_WARNING: &str = "[BETA] The \"logs\" command is in beta. The command is subject \
+    to breaking changes, including removal, in any Sentry CLI release.";
+
 const LIST_ABOUT: &str = "List logs from your organization";
 
 #[derive(Args)]
@@ -15,14 +18,19 @@ pub(super) struct LogsArgs {
 }
 
 #[derive(Subcommand)]
-#[command(about = "Manage logs in Sentry")]
-#[command(long_about = "Manage and query logs in Sentry. \
-    This command provides access to log entries.")]
+#[command(about = "[BETA] Manage logs in Sentry")]
+#[command(long_about = format!(
+    "Manage and query logs in Sentry. \
+    This command provides access to log entries.\n\n\
+    {BETA_WARNING}")
+)]
 enum LogsSubcommand {
-    #[command(about = LIST_ABOUT)]
+    #[command(about = format!("[BETA] {LIST_ABOUT}"))]
     #[command(long_about = format!("{LIST_ABOUT}. \
     Query and filter log entries from your Sentry projects. \
-    Supports filtering by log level and custom queries."))]
+    Supports filtering by log level and custom queries.\n\n\
+    {BETA_WARNING}")
+)]
     List(ListLogsArgs),
 }
 
@@ -34,6 +42,8 @@ pub(super) fn execute(_: &ArgMatches) -> Result<()> {
     let SentryCLICommand::Logs(LogsArgs { subcommand }) = SentryCLI::parse().command else {
         unreachable!("expected logs subcommand");
     };
+
+    eprintln!("{BETA_WARNING}");
 
     match subcommand {
         LogsSubcommand::List(args) => list::execute(args),

--- a/tests/integration/_cases/help/help-windows.trycmd
+++ b/tests/integration/_cases/help/help-windows.trycmd
@@ -17,7 +17,7 @@ Commands:
   info             Print information about the configuration and verify authentication.
   issues           Manage issues in Sentry.
   login            Authenticate with the Sentry server.
-  logs             Manage logs in Sentry
+  logs             [BETA] Manage logs in Sentry
   monitors         Manage cron monitors on Sentry.
   organizations    Manage organizations on Sentry.
   projects         Manage projects on Sentry.

--- a/tests/integration/_cases/help/help.trycmd
+++ b/tests/integration/_cases/help/help.trycmd
@@ -17,7 +17,7 @@ Commands:
   info             Print information about the configuration and verify authentication.
   issues           Manage issues in Sentry.
   login            Authenticate with the Sentry server.
-  logs             Manage logs in Sentry
+  logs             [BETA] Manage logs in Sentry
   monitors         Manage cron monitors on Sentry.
   organizations    Manage organizations on Sentry.
   projects         Manage projects on Sentry.

--- a/tests/integration/_cases/logs/logs-help.trycmd
+++ b/tests/integration/_cases/logs/logs-help.trycmd
@@ -3,10 +3,13 @@ $ sentry-cli logs --help
 ? success
 Manage and query logs in Sentry. This command provides access to log entries.
 
+[BETA] The "logs" command is in beta. The command is subject to breaking changes, including removal,
+in any Sentry CLI release.
+
 Usage: sentry-cli[EXE] logs [OPTIONS] [COMMAND]
 
 Commands:
-  list  List logs from your organization
+  list  [BETA] List logs from your organization
   help  Print this message or the help of the given subcommand(s)
 
 Options:

--- a/tests/integration/_cases/logs/logs-list-help.trycmd
+++ b/tests/integration/_cases/logs/logs-list-help.trycmd
@@ -4,6 +4,9 @@ $ sentry-cli logs list --help
 List logs from your organization. Query and filter log entries from your Sentry projects. Supports
 filtering by log level and custom queries.
 
+[BETA] The "logs" command is in beta. The command is subject to breaking changes, including removal,
+in any Sentry CLI release.
+
 Usage: sentry-cli[EXE] logs list [OPTIONS]
 
 Options:

--- a/tests/integration/_cases/logs/logs-list-no-logs-found.trycmd
+++ b/tests/integration/_cases/logs/logs-list-no-logs-found.trycmd
@@ -1,6 +1,7 @@
 ```
 $ sentry-cli logs list --org wat-org --project 12345
 ? success
+[BETA] The "logs" command is in beta. The command is subject to breaking changes, including removal, in any Sentry CLI release.
 No logs found
 
 ``` 

--- a/tests/integration/_cases/logs/logs-list-with-data.trycmd
+++ b/tests/integration/_cases/logs/logs-list-with-data.trycmd
@@ -1,6 +1,7 @@
 ```
 $ sentry-cli logs list
 ? success
+[BETA] The "logs" command is in beta. The command is subject to breaking changes, including removal, in any Sentry CLI release.
 +------------------+---------------------------+----------+--------------------------+----------------------+
 | Item ID          | Timestamp                 | Severity | Message                  | Trace                |
 +------------------+---------------------------+----------+--------------------------+----------------------+


### PR DESCRIPTION
Sentry's Logs feature is in beta. The commands therefore also should have been explicitly marked as beta.