### PR TITLE
revert: "build: Pin Rust toolchain minor version (#2687)"

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -45,11 +45,11 @@ jobs:
       - name: Checkout Repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # 4.2.2
 
-      - name: Setup Rust Toolchain
-        run: |
-          rustup set profile minimal
-          rustup component add clippy rustfmt
-          rustup target add ${{ matrix.target }}
+      - name: Install Rust Toolchain
+        run: rustup toolchain install stable --profile minimal --component clippy --component rustfmt --no-self-update
+
+      - name: Add Target
+        run: rustup target add ${{ matrix.target }}
 
       - name: Install musl-gcc (Linux only)
         if: matrix.os == 'ubuntu-24.04'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -46,10 +46,8 @@ jobs:
       - name: Checkout Repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # 4.2.2
 
-      - name: Setup Rust Toolchain
-        run: |
-          rustup set profile minimal
-          rustup target add ${{ matrix.target }}
+      - name: Add Target
+        run: rustup target add ${{ matrix.target }}
 
       - name: Install musl-gcc (Linux only)
         if: matrix.os == 'ubuntu-24.04'

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,0 @@
-[toolchain]
-# We pin the minor version to prevent new Clippy lints from breaking CI.
-# But, we still want to pick up new patch versions.
-channel = "1.89"


### PR DESCRIPTION
This reverts commit 1dcc54dc77b95aa5d13a646de2c1f9f4e8d24da5.

Unfortunately, pinning the toolchain causes the release build to fail. Hopefully, we can reintroduce pinning soon, but for now, I would like to unblock release builds.