### PR TITLE
chore(cursor): Add Rust formatting check to Cursor rules

### DIFF
--- a/.cursor/rules/sentry-cli-project.mdc
+++ b/.cursor/rules/sentry-cli-project.mdc
@@ -65,4 +65,8 @@ Reference: https://develop.sentry.dev/engineering-practices/commit-messages/
 - Test fixtures in `tests/integration/_fixtures/`
 - Cross-platform testing via CI matrix
 
+## Code Formatting
+
+- Always run `cargo fmt --all -- --check` before committing to ensure consistent Rust code formatting
+
 Remember: This is a production tool used by many developers. Changes should be well-tested, backward-compatible, and follow established patterns.


### PR DESCRIPTION
## Summary
- Added `cargo fmt --all -- --check` command to the Cursor rules file
- Ensures consistent Rust code formatting before committing changes
- Helps maintain code quality standards across the project

## Test plan
- [x] Updated `.cursor/rules/sentry-cli-project.mdc` with formatting requirement
- [x] Verified the formatting command syntax is correct

🤖 Generated with [Claude Code](https://claude.ai/code)