### PR TITLE
feat(mobile-app): Add default vcs base_ref parsing for mobile-app subcommand

### DIFF
--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -2525,7 +2525,7 @@ struct LogsResponse {
     data: Vec<LogEntry>,
 }
 
-/// VCS information for mobile app uploads
+/// VCS information for build app uploads
 #[derive(Debug)]
 pub struct VcsInfo<'a> {
     pub head_sha: Option<&'a str>,

--- a/src/commands/build/upload.rs
+++ b/src/commands/build/upload.rs
@@ -112,7 +112,7 @@ pub fn execute(matches: &ArgMatches) -> Result<()> {
         let repo_ref = repo.as_ref();
         let remote_url = repo_ref.and_then(|repo| git_repo_remote_url(repo, &cached_remote).ok());
 
-        let vcs_provider: Option<Cow<'_, str>> = matches
+        let vcs_provider = matches
             .get_one("vcs_provider")
             .map(String::as_str)
             .map(Cow::Borrowed)
@@ -123,7 +123,7 @@ pub fn execute(matches: &ArgMatches) -> Result<()> {
                     .map(Cow::Owned)
             });
 
-        let head_repo_name: Option<Cow<'_, str>> = matches
+        let head_repo_name = matches
             .get_one("head_repo_name")
             .map(String::as_str)
             .map(Cow::Borrowed)
@@ -134,14 +134,14 @@ pub fn execute(matches: &ArgMatches) -> Result<()> {
                     .map(Cow::Owned)
             });
 
-        let head_ref: Option<Cow<'_, str>> = matches
+        let head_ref = matches
             .get_one("head_ref")
             .map(String::as_str)
             .map(Cow::Borrowed)
             .or_else(|| {
                 // Try to get the current ref from the VCS if not provided
                 // Note: git_repo_head_ref will return an error for detached HEAD states,
-                // which .ok() converts to None - this prevents sending "HEAD" as a branch name
+                // which the error handling converts to None - this prevents sending "HEAD" as a branch name
                 // In that case, the user will need to provide a valid branch name.
                 repo_ref
                     .and_then(|r| match git_repo_head_ref(r) {

--- a/src/utils/vcs.rs
+++ b/src/utils/vcs.rs
@@ -232,6 +232,14 @@ pub fn git_repo_remote_url(
         .ok_or_else(|| git2::Error::from_str("No remote URL found"))
 }
 
+#[cfg(feature = "unstable-mobile-app")]
+pub fn git_repo_head_ref(repo: &git2::Repository) -> Result<String, git2::Error> {
+    let head = repo.head()?;
+    head.shorthand()
+        .map(|s| s.to_owned())
+        .ok_or_else(|| git2::Error::from_str("No HEAD reference found"))
+}
+
 fn find_reference_url(repo: &str, repos: &[Repo]) -> Result<Option<String>> {
     let mut non_git = false;
     for configured_repo in repos {

--- a/src/utils/vcs.rs
+++ b/src/utils/vcs.rs
@@ -232,7 +232,6 @@ pub fn git_repo_remote_url(
         .ok_or_else(|| git2::Error::from_str("No remote URL found"))
 }
 
-#[cfg(feature = "unstable-mobile-app")]
 pub fn git_repo_head_ref(repo: &git2::Repository) -> Result<String> {
     let head = repo.head()?;
 
@@ -1215,7 +1214,6 @@ fn test_generate_patch_ignore_missing() {
     });
 }
 
-#[cfg(feature = "unstable-mobile-app")]
 #[test]
 fn test_git_repo_head_ref() {
     let dir = git_initialize_repo();

--- a/src/utils/vcs.rs
+++ b/src/utils/vcs.rs
@@ -233,7 +233,7 @@ pub fn git_repo_remote_url(
 }
 
 #[cfg(feature = "unstable-mobile-app")]
-pub fn git_repo_head_ref(repo: &git2::Repository) -> Result<String, git2::Error> {
+pub fn git_repo_head_ref(repo: &git2::Repository) -> Result<String> {
     let head = repo.head()?;
 
     // Only return a reference name if we're not in a detached HEAD state
@@ -241,11 +241,11 @@ pub fn git_repo_head_ref(repo: &git2::Repository) -> Result<String, git2::Error>
     if head.is_branch() {
         head.shorthand()
             .map(|s| s.to_owned())
-            .ok_or_else(|| git2::Error::from_str("No HEAD reference found"))
+            .ok_or_else(|| anyhow::anyhow!("No HEAD reference found"))
     } else {
         // In detached HEAD state, return an error to indicate no valid branch reference
-        Err(git2::Error::from_str(
-            "HEAD is detached - no branch reference available",
+        Err(anyhow::anyhow!(
+            "HEAD is detached - no branch reference available"
         ))
     }
 }

--- a/src/utils/vcs.rs
+++ b/src/utils/vcs.rs
@@ -1233,5 +1233,8 @@ fn test_git_repo_head_ref() {
 
     let head_ref_result = git_repo_head_ref(&repo);
     assert!(head_ref_result.is_err());
-    assert_eq!(head_ref_result.unwrap_err().to_string(), "HEAD is detached - no branch reference available");
+    assert_eq!(
+        head_ref_result.unwrap_err().to_string(),
+        "HEAD is detached - no branch reference available"
+    );
 }

--- a/src/utils/vcs.rs
+++ b/src/utils/vcs.rs
@@ -1224,7 +1224,7 @@ fn test_git_repo_head_ref() {
 
     // Test on a branch (should succeed)
     let head_ref = git_repo_head_ref(&repo).expect("Should get branch reference");
-    assert_eq!(head_ref, "main"); // or "master" depending on git version
+    assert_eq!(head_ref, "master");
 
     // Test in detached HEAD state (should fail)
     let head_commit = repo.head().unwrap().target().unwrap();

--- a/src/utils/vcs.rs
+++ b/src/utils/vcs.rs
@@ -900,6 +900,14 @@ fn git_initialize_repo() -> TempDir {
         .expect("Failed to wait on `git init`.");
 
     Command::new("git")
+        .args(["branch", "-M", "main"])
+        .current_dir(&dir)
+        .spawn()
+        .expect("Failed to execute `git branch`.")
+        .wait()
+        .expect("Failed to wait on `git branch`.");
+
+    Command::new("git")
         .args(["config", "--local", "user.name", "test"])
         .current_dir(&dir)
         .spawn()
@@ -1224,7 +1232,7 @@ fn test_git_repo_head_ref() {
 
     // Test on a branch (should succeed)
     let head_ref = git_repo_head_ref(&repo).expect("Should get branch reference");
-    assert_eq!(head_ref, "master");
+    assert_eq!(head_ref, "main");
 
     // Test in detached HEAD state (should fail)
     let head_commit = repo.head().unwrap().target().unwrap();

--- a/src/utils/vcs.rs
+++ b/src/utils/vcs.rs
@@ -1233,8 +1233,5 @@ fn test_git_repo_head_ref() {
 
     let head_ref_result = git_repo_head_ref(&repo);
     assert!(head_ref_result.is_err());
-    assert_eq!(
-        head_ref_result.unwrap_err().message(),
-        "HEAD is detached - no branch reference available"
-    );
+    assert_eq!(head_ref_result.unwrap_err().to_string(), "HEAD is detached - no branch reference available");
 }


### PR DESCRIPTION
Adds default handling of `head_ref` (branch name) to the `mobile-app upload` subcommand. This will leverage the `head.shorthand()` value if no value is provided by the user.

Also handles the detached HEAD state with some logging that will require the user to specify using the command arguments.