### PR TITLE
ref(send-event): Introduce constant for max breadcrumbs

### DIFF
--- a/src/commands/bash_hook.rs
+++ b/src/commands/bash_hook.rs
@@ -19,6 +19,8 @@ use crate::config::Config;
 use crate::utils::event::{attach_logfile, get_sdk_info};
 use crate::utils::releases::detect_release_name;
 
+const MAX_BREADCRUMBS: usize = 100;
+
 const BASH_SCRIPT: &str = include_str!("../bashsupport.sh");
 lazy_static! {
     static ref FRAME_RE: Regex = Regex::new(r"^(.*?):(.*):(\d+)$").unwrap();
@@ -188,7 +190,7 @@ fn send_event(
         }
     }
 
-    attach_logfile(&mut event, logfile, true)?;
+    attach_logfile(&mut event, logfile, true, MAX_BREADCRUMBS)?;
 
     event.exception.values.push(Exception {
         ty: "BashError".into(),

--- a/src/commands/send_event.rs
+++ b/src/commands/send_event.rs
@@ -20,6 +20,9 @@ use crate::utils::args::{get_timestamp, validate_distribution};
 use crate::utils::event::{attach_logfile, get_sdk_info};
 use crate::utils::releases::detect_release_name;
 
+/// The maximum number of breadcrumbs to attach to an event.
+const MAX_BREADCRUMBS: usize = 100;
+
 pub fn make_command(command: Command) -> Command {
     command.about("Send a manual event to Sentry.")
         .long_about(
@@ -143,7 +146,7 @@ pub fn make_command(command: Command) -> Command {
             Arg::new("logfile")
                 .value_name("PATH")
                 .long("logfile")
-                .help("Send a logfile as breadcrumbs with the event (last 100 records)"),
+                .help(format!("Send a logfile as breadcrumbs with the event (last {MAX_BREADCRUMBS} records)")),
         )
         .arg(
             Arg::new("with_categories")
@@ -322,7 +325,12 @@ pub fn execute(matches: &ArgMatches) -> Result<()> {
     }
 
     if let Some(logfile) = matches.get_one::<String>("logfile") {
-        attach_logfile(&mut event, logfile, matches.get_flag("with_categories"))?;
+        attach_logfile(
+            &mut event,
+            logfile,
+            matches.get_flag("with_categories"),
+            MAX_BREADCRUMBS,
+        )?;
     }
 
     let id = send_raw_event(event)?;

--- a/src/utils/event.rs
+++ b/src/utils/event.rs
@@ -13,7 +13,12 @@ lazy_static! {
 }
 
 /// Attaches all logs from a logfile as breadcrumbs to the given event.
-pub fn attach_logfile(event: &mut Event<'_>, logfile: &str, with_component: bool) -> Result<()> {
+pub fn attach_logfile(
+    event: &mut Event<'_>,
+    logfile: &str,
+    with_component: bool,
+    max_breadcrumbs: usize,
+) -> Result<()> {
     let f = fs::File::open(logfile).context("Could not open logfile")?;
 
     // sentry currently requires timestamps for breadcrumbs at all times.
@@ -46,8 +51,8 @@ pub fn attach_logfile(event: &mut Event<'_>, logfile: &str, with_component: bool
         })
     }
 
-    if event.breadcrumbs.len() > 100 {
-        let skip = event.breadcrumbs.len() - 100;
+    if event.breadcrumbs.len() > max_breadcrumbs {
+        let skip = event.breadcrumbs.len() - max_breadcrumbs;
         event.breadcrumbs.values.drain(..skip);
     }
 


### PR DESCRIPTION
While investigating https://github.com/getsentry/sentry-cli/issues/2709, I noticed the max breadcrumbs limit was hardcoded in multiple locations. This change extracts the value into a constant, so it is easier to change later, if we ever need to.