### PR TITLE
meta(cursor): Add rule to avoid explicit type annotations

### DIFF
--- a/.cursor/rules/rust-development.mdc
+++ b/.cursor/rules/rust-development.mdc
@@ -21,6 +21,12 @@ alwaysApply: false
 - Match existing code style and naming conventions
 - Add appropriate logging using `log` crate patterns
 
+## Type Annotations and Inference
+
+- Prefer compiler type inference across the codebase
+- Do not add explicit type annotations in `let` bindings or turbofish syntax (e.g., `::<T>`) unless required for the code to compile or to disambiguate an API that inference cannot resolve
+- If the code compiles without explicit annotations, omit them
+
 ## Development Commands
 
 ```bash


### PR DESCRIPTION
I have noticed that Cursor often adds type annotations, especially in `let` statements, even when they are not needed. This typically occurs with generics, which sadly cannot be linted by [clippy::redundant_type_annotations](https://rust-lang.github.io/rust-clippy/master/index.html#redundant_type_annotations), so I have instead decided to add a Cursor rule to hopefully prevent this behavior going forward