### PR TITLE
build(macos): Allow compiling without Xcode

### DIFF
--- a/apple-catalog-parsing/build.rs
+++ b/apple-catalog-parsing/build.rs
@@ -27,6 +27,12 @@ fn main() {
     // sandbox already. Nested sandboxes are not allowed on Darwin.
     println!("cargo:rerun-if-env-changed={SWIFT_DISABLE_SANDBOX}");
 
+    // Add necessary libraries to the linker search path. Without this line, compiling fails
+    // on systems without Xcode installed (xcode-select is still required).
+    println!(
+        "cargo:rustc-link-search=native=/Library/Developer/CommandLineTools/usr/lib/swift/macosx"
+    );
+
     let out_dir = env::var("OUT_DIR").expect("OUT_DIR is set for build scripts");
 
     // Compile Swift code


### PR DESCRIPTION
When the Xcode app is not installed, compiling `apple-catalog-parsing` fails due to linker errors. The problem can be fixed by expanding the linker search path.

Fixes #2732