### PR TITLE
docs: Add cargo fmt reminder to CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -76,3 +76,7 @@ Access the `.cursor/rules/` directory and read rule file contents. Parse the fro
 - **Parse frontmatter carefully** - use the metadata to determine rule applicability
 
 Treat these rules as **mandatory guidance** that you must follow for all code changes and development activities within this project.
+
+# Code Formatting
+
+**ALWAYS** run `cargo fmt` before committing any Rust code changes to ensure consistent formatting across the codebase.


### PR DESCRIPTION
## Summary
Add reminder to always run `cargo fmt` before committing Rust code changes for consistent formatting.

🤖 Generated with [Claude Code](https://claude.ai/code)