### PR TITLE
Fix: symlinks in normalized upload

### DIFF
--- a/src/commands/build/upload.rs
+++ b/src/commands/build/upload.rs
@@ -570,6 +570,7 @@ fn upload_file(
 mod tests {
     use super::*;
     use std::fs;
+    use std::os::unix::fs::symlink;
     use zip::ZipArchive;
 
     #[test]
@@ -653,10 +654,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg(not(windows))]
     fn test_normalize_directory_preserves_symlinks() -> Result<()> {
-        use std::os::unix::fs::symlink;
-
         let temp_dir = crate::utils::fs::TempDir::create()?;
         let test_dir = temp_dir.path().join("TestApp.xcarchive");
         fs::create_dir_all(test_dir.join("Products"))?;

--- a/src/utils/build/normalize.rs
+++ b/src/utils/build/normalize.rs
@@ -75,6 +75,8 @@ fn add_entries_to_zip(
 }
 
 // For XCArchive directories, we'll zip the entire directory
+// It's important to not change the contents of the directory or the size
+// analysis will be wrong and the code signature will break.
 pub fn normalize_directory(path: &Path, parsed_assets_path: &Path) -> Result<TempFile> {
     debug!("Creating normalized zip for directory: {}", path.display());
 


### PR DESCRIPTION
Sometimes uploads have symlinks in them, we need to preserve the contents of the upload, otherwise the code signature breaks. Additionally, the app size would change if we changed the contents, making our size analysis invalid

Closes [EME-266](https://linear.app/getsentry/issue/EME-266/sentry-cli-not-handling-symlinks-properly-when-zipping)