### PR TITLE
ci(node): Test newer node versions

### DIFF
--- a/.github/workflows/test_node.yml
+++ b/.github/workflows/test_node.yml
@@ -30,7 +30,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: [10.x, 12.x, 14.x, 16.x, 18.x, 20.x]
+        node-version: [10.x, 12.x, 14.x, 16.x, 18.x, 20.x, 22.x, 24.x]
 
     name: Test Node ${{ matrix.node-version }}
     runs-on: ubuntu-24.04


### PR DESCRIPTION
Test against `22.x` and `24.x`, in addition to the node versions we are already testing against