### PR TITLE
feat: Add GitHub Actions base branch detection for EME-320

### DIFF
--- a/src/commands/build/upload.rs
+++ b/src/commands/build/upload.rs
@@ -24,8 +24,9 @@ use crate::utils::fs::TempDir;
 use crate::utils::fs::TempFile;
 use crate::utils::progress::ProgressBar;
 use crate::utils::vcs::{
-    self, get_github_pr_number, get_provider_from_remote, get_repo_from_remote, git_repo_base_ref,
-    git_repo_base_repo_name, git_repo_head_ref, git_repo_remote_url,
+    self, get_github_base_ref, get_github_pr_number, get_provider_from_remote,
+    get_repo_from_remote, git_repo_base_ref, git_repo_base_repo_name, git_repo_head_ref,
+    git_repo_remote_url,
 };
 
 pub fn make_command(command: Command) -> Command {
@@ -175,8 +176,11 @@ pub fn execute(matches: &ArgMatches) -> Result<()> {
             .map(String::as_str)
             .map(Cow::Borrowed)
             .or_else(|| {
-                // Try to get the base ref from the VCS if not provided
-                // This attempts to find the merge-base with the remote tracking branch
+                // First try GitHub Actions environment variables
+                get_github_base_ref().map(Cow::Owned)
+            })
+            .or_else(|| {
+                // Fallback to git repository introspection
                 repo_ref
                     .and_then(|r| match git_repo_base_ref(r, &cached_remote) {
                         Ok(base_ref_name) => {

--- a/src/utils/vcs.rs
+++ b/src/utils/vcs.rs
@@ -338,6 +338,21 @@ pub fn get_github_pr_number() -> Option<u32> {
     Some(pr_number)
 }
 
+/// Attempts to get the base branch from GitHub Actions environment variables.
+/// Returns the base branch name if running in a GitHub Actions pull request environment.
+pub fn get_github_base_ref() -> Option<String> {
+    let event_name = std::env::var("GITHUB_EVENT_NAME").ok()?;
+
+    if event_name != "pull_request" {
+        debug!("Not running in pull_request event, got: {}", event_name);
+        return None;
+    }
+
+    let base_ref = std::env::var("GITHUB_BASE_REF").ok()?;
+    debug!("Auto-detected base ref from GitHub Actions: {}", base_ref);
+    Some(base_ref)
+}
+
 fn find_reference_url(repo: &str, repos: &[Repo]) -> Result<Option<String>> {
     let mut non_git = false;
     for configured_repo in repos {
@@ -1350,5 +1365,31 @@ mod tests {
         assert_eq!(pr_number, None);
         std::env::remove_var("GITHUB_EVENT_NAME");
         std::env::remove_var("GITHUB_REF");
+    }
+
+    #[test]
+    fn test_get_github_base_ref() {
+        std::env::set_var("GITHUB_EVENT_NAME", "pull_request");
+        std::env::set_var("GITHUB_BASE_REF", "main");
+        let base_ref = get_github_base_ref();
+        assert_eq!(base_ref, Some("main".to_string()));
+
+        // Test with different base branch
+        std::env::set_var("GITHUB_BASE_REF", "develop");
+        let base_ref = get_github_base_ref();
+        assert_eq!(base_ref, Some("develop".to_string()));
+
+        // Test when not in pull_request event
+        std::env::set_var("GITHUB_EVENT_NAME", "push");
+        let base_ref = get_github_base_ref();
+        assert_eq!(base_ref, None);
+
+        // Test when GITHUB_BASE_REF is not set
+        std::env::set_var("GITHUB_EVENT_NAME", "pull_request");
+        std::env::remove_var("GITHUB_BASE_REF");
+        let base_ref = get_github_base_ref();
+        assert_eq!(base_ref, None);
+
+        std::env::remove_var("GITHUB_EVENT_NAME");
     }
 }

--- a/tests/integration/_cases/build/build-upload-apk-all-uploaded.trycmd
+++ b/tests/integration/_cases/build/build-upload-apk-all-uploaded.trycmd
@@ -2,7 +2,6 @@
 $ sentry-cli build upload tests/integration/_fixtures/build/apk.apk
 ? success
 [..]WARN[..]EXPERIMENTAL: The build subcommand is experimental. The command is subject to breaking changes and may be removed without notice in any release.
-  WARN    [..] Could not detect base branch reference: [..]
 Successfully uploaded 1 file to Sentry
   - tests/integration/_fixtures/build/apk.apk (http[..]/wat-org/preprod/wat-project/42)
 

--- a/tests/integration/_cases/build/build-upload-apk-no-token.trycmd
+++ b/tests/integration/_cases/build/build-upload-apk-no-token.trycmd
@@ -2,7 +2,6 @@
 $ sentry-cli build upload tests/integration/_fixtures/build/apk.apk
 ? failed
 [..]WARN[..]EXPERIMENTAL: The build subcommand is experimental. The command is subject to breaking changes and may be removed without notice in any release.
-  WARN    [..] Could not detect base branch reference: [..]
 error: Auth token is required for this request. Please run `sentry-cli login` and try again!
 
 Add --log-level=[info|debug] or export SENTRY_LOG_LEVEL=[info|debug] to see more output.

--- a/tests/integration/_cases/build/build-upload-apk.trycmd
+++ b/tests/integration/_cases/build/build-upload-apk.trycmd
@@ -2,7 +2,6 @@
 $ sentry-cli build upload tests/integration/_fixtures/build/apk.apk --head-sha test_head_sha
 ? success
 [..]WARN[..]EXPERIMENTAL: The build subcommand is experimental. The command is subject to breaking changes and may be removed without notice in any release.
-  WARN    [..] Could not detect base branch reference: [..]
 Successfully uploaded 1 file to Sentry
   - tests/integration/_fixtures/build/apk.apk (http[..]/wat-org/preprod/wat-project/42)
 

--- a/tests/integration/_cases/build/build-upload-ipa.trycmd
+++ b/tests/integration/_cases/build/build-upload-ipa.trycmd
@@ -2,7 +2,6 @@
 $ sentry-cli build upload tests/integration/_fixtures/build/ipa.ipa --head-sha test_head_sha
 ? success
 [..]WARN[..]EXPERIMENTAL: The build subcommand is experimental. The command is subject to breaking changes and may be removed without notice in any release.
-  WARN    [..] Could not detect base branch reference: [..]
 Successfully uploaded 1 file to Sentry
   - tests/integration/_fixtures/build/ipa.ipa (http[..]/wat-org/preprod/wat-project/some-text-id)
 


### PR DESCRIPTION
## Summary
Implements GitHub Actions-aware base branch detection that works in detached HEAD states commonly found in CI/CD environments.

### Problem
In GitHub Actions pull request workflows, repositories are checked out in detached HEAD state, causing the existing `git_repo_base_ref()` function to fail when trying to detect the base branch for merge-base calculations.

### Solution
- **New Function**: Added `get_github_base_ref()` that reads the `GITHUB_BASE_REF` environment variable
- **Smarter Detection Chain**: GitHub Actions detection now takes priority over git introspection:
  1. Explicit `--base-ref` argument
  2. **GitHub Actions environment variables** (fast, reliable)
  3. Git repository introspection (fallback)
  4. None (final fallback)

This leverages the [GitHub Actions context variables](https://docs.github.com/en/actions/learn-github-actions/contexts#github-context) that are automatically set in pull request workflows, specifically `GITHUB_BASE_REF` which contains the target branch of the pull request.

### Changes
- Add `get_github_base_ref()` function in `src/utils/vcs.rs`
- Update base_ref detection logic in `src/commands/build/upload.rs`
- Add comprehensive tests for the new functionality
- Update integration test snapshots to remove expected warning messages

🤖 Generated with [Claude Code](https://claude.ai/code)