### PR TITLE
ci(rust): Run CI against toolchain update bot PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,8 @@ on:
 
   pull_request:
 
+  workflow_dispatch:
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true

--- a/.github/workflows/rust-toolchain-update.yml
+++ b/.github/workflows/rust-toolchain-update.yml
@@ -13,6 +13,7 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
+      actions: write
 
     steps:
       - name: Checkout Repository
@@ -127,3 +128,12 @@ jobs:
             });
 
             console.log(`Created PR #${pr.number}: ${pr.title}`);
+
+            // Run the CI workflow on the PR branch. Needed because GITHUB_TOKEN
+            // doesn't trigger workflows, except for workflow_dispatch.
+            await github.rest.actions.createWorkflowDispatch({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              workflow_id: 'ci.yml',
+              ref: branchName,
+            });


### PR DESCRIPTION
The PRs from the Rust toolchain update bot don't trigger the `pull_request`-triggered workflows. This is a [GitHub feature, not a bug.](https://docs.github.com/en/actions/concepts/security/github_token?utm_source=chatgpt.com#when-github_token-triggers-workflow-runs) This change adds a `workflow_dispatch` trigger to our CI action, and has the Rust toolchain update bot automatically trigger the action after opening the PR.

I tested this change with #2781. Although the workflow run does not show on that PR, we can see that, in fact, the [CI did run](https://github.com/getsentry/sentry-cli/actions/runs/17911030223) against the commit. My guess is maybe it has to do with the fact that the #2781 is against #2780, rather than the `master` branch.