### PR TITLE
revert: Revert GHA base branch detection (#2776)

### DIFF
--- a/src/commands/build/upload.rs
+++ b/src/commands/build/upload.rs
@@ -24,9 +24,9 @@ use crate::utils::fs::TempDir;
 use crate::utils::fs::TempFile;
 use crate::utils::progress::ProgressBar;
 use crate::utils::vcs::{
-    self, get_github_base_ref, get_github_pr_number, get_provider_from_remote,
-    get_repo_from_remote_preserve_case, git_repo_base_ref, git_repo_base_repo_name_preserve_case,
-    git_repo_head_ref, git_repo_remote_url,
+    self, get_github_pr_number, get_provider_from_remote, get_repo_from_remote_preserve_case,
+    git_repo_base_ref, git_repo_base_repo_name_preserve_case, git_repo_head_ref,
+    git_repo_remote_url,
 };
 
 pub fn make_command(command: Command) -> Command {
@@ -176,11 +176,8 @@ pub fn execute(matches: &ArgMatches) -> Result<()> {
             .map(String::as_str)
             .map(Cow::Borrowed)
             .or_else(|| {
-                // First try GitHub Actions environment variables
-                get_github_base_ref().map(Cow::Owned)
-            })
-            .or_else(|| {
-                // Fallback to git repository introspection
+                // Try to get the base ref from the VCS if not provided
+                // This attempts to find the merge-base with the remote tracking branch
                 repo_ref
                     .and_then(|r| match git_repo_base_ref(r, &cached_remote) {
                         Ok(base_ref_name) => {

--- a/src/utils/vcs.rs
+++ b/src/utils/vcs.rs
@@ -359,21 +359,6 @@ pub fn get_github_pr_number() -> Option<u32> {
     Some(pr_number)
 }
 
-/// Attempts to get the base branch from GitHub Actions environment variables.
-/// Returns the base branch name if running in a GitHub Actions pull request environment.
-pub fn get_github_base_ref() -> Option<String> {
-    let event_name = std::env::var("GITHUB_EVENT_NAME").ok()?;
-
-    if event_name != "pull_request" {
-        debug!("Not running in pull_request event, got: {}", event_name);
-        return None;
-    }
-
-    let base_ref = std::env::var("GITHUB_BASE_REF").ok()?;
-    debug!("Auto-detected base ref from GitHub Actions: {}", base_ref);
-    Some(base_ref)
-}
-
 fn find_reference_url(repo: &str, repos: &[Repo]) -> Result<Option<String>> {
     let mut non_git = false;
     for configured_repo in repos {
@@ -1480,31 +1465,5 @@ mod tests {
         assert_eq!(pr_number, None);
         std::env::remove_var("GITHUB_EVENT_NAME");
         std::env::remove_var("GITHUB_REF");
-    }
-
-    #[test]
-    fn test_get_github_base_ref() {
-        std::env::set_var("GITHUB_EVENT_NAME", "pull_request");
-        std::env::set_var("GITHUB_BASE_REF", "main");
-        let base_ref = get_github_base_ref();
-        assert_eq!(base_ref, Some("main".to_owned()));
-
-        // Test with different base branch
-        std::env::set_var("GITHUB_BASE_REF", "develop");
-        let base_ref = get_github_base_ref();
-        assert_eq!(base_ref, Some("develop".to_owned()));
-
-        // Test when not in pull_request event
-        std::env::set_var("GITHUB_EVENT_NAME", "push");
-        let base_ref = get_github_base_ref();
-        assert_eq!(base_ref, None);
-
-        // Test when GITHUB_BASE_REF is not set
-        std::env::set_var("GITHUB_EVENT_NAME", "pull_request");
-        std::env::remove_var("GITHUB_BASE_REF");
-        let base_ref = get_github_base_ref();
-        assert_eq!(base_ref, None);
-
-        std::env::remove_var("GITHUB_EVENT_NAME");
     }
 }

--- a/tests/integration/_cases/build/build-upload-apk-all-uploaded.trycmd
+++ b/tests/integration/_cases/build/build-upload-apk-all-uploaded.trycmd
@@ -2,6 +2,7 @@
 $ sentry-cli build upload tests/integration/_fixtures/build/apk.apk
 ? success
 [..]WARN[..]EXPERIMENTAL: The build subcommand is experimental. The command is subject to breaking changes and may be removed without notice in any release.
+  WARN    [..] Could not detect base branch reference: [..]
 Successfully uploaded 1 file to Sentry
   - tests/integration/_fixtures/build/apk.apk (http[..]/wat-org/preprod/wat-project/42)
 

--- a/tests/integration/_cases/build/build-upload-apk-no-token.trycmd
+++ b/tests/integration/_cases/build/build-upload-apk-no-token.trycmd
@@ -2,6 +2,7 @@
 $ sentry-cli build upload tests/integration/_fixtures/build/apk.apk
 ? failed
 [..]WARN[..]EXPERIMENTAL: The build subcommand is experimental. The command is subject to breaking changes and may be removed without notice in any release.
+  WARN    [..] Could not detect base branch reference: [..]
 error: Auth token is required for this request. Please run `sentry-cli login` and try again!
 
 Add --log-level=[info|debug] or export SENTRY_LOG_LEVEL=[info|debug] to see more output.

--- a/tests/integration/_cases/build/build-upload-apk.trycmd
+++ b/tests/integration/_cases/build/build-upload-apk.trycmd
@@ -2,6 +2,7 @@
 $ sentry-cli build upload tests/integration/_fixtures/build/apk.apk --head-sha test_head_sha
 ? success
 [..]WARN[..]EXPERIMENTAL: The build subcommand is experimental. The command is subject to breaking changes and may be removed without notice in any release.
+  WARN    [..] Could not detect base branch reference: [..]
 Successfully uploaded 1 file to Sentry
   - tests/integration/_fixtures/build/apk.apk (http[..]/wat-org/preprod/wat-project/42)
 

--- a/tests/integration/_cases/build/build-upload-ipa.trycmd
+++ b/tests/integration/_cases/build/build-upload-ipa.trycmd
@@ -2,6 +2,7 @@
 $ sentry-cli build upload tests/integration/_fixtures/build/ipa.ipa --head-sha test_head_sha
 ? success
 [..]WARN[..]EXPERIMENTAL: The build subcommand is experimental. The command is subject to breaking changes and may be removed without notice in any release.
+  WARN    [..] Could not detect base branch reference: [..]
 Successfully uploaded 1 file to Sentry
   - tests/integration/_fixtures/build/ipa.ipa (http[..]/wat-org/preprod/wat-project/some-text-id)
 


### PR DESCRIPTION
This reverts commit b2595957f8fb63484f6827ecaaff9f3d038b0753 from #2776

This change is causing CI to fail on `master`. As I would like to release Sentry CLI, we need to revert this to unblock the release process.