### PR TITLE
feat: restore GitHub Actions base branch detection

### DIFF
--- a/src/commands/build/upload.rs
+++ b/src/commands/build/upload.rs
@@ -24,9 +24,9 @@ use crate::utils::fs::TempDir;
 use crate::utils::fs::TempFile;
 use crate::utils::progress::ProgressBar;
 use crate::utils::vcs::{
-    self, get_github_pr_number, get_provider_from_remote, get_repo_from_remote_preserve_case,
-    git_repo_base_ref, git_repo_base_repo_name_preserve_case, git_repo_head_ref,
-    git_repo_remote_url,
+    self, get_github_base_ref, get_github_pr_number, get_provider_from_remote,
+    get_repo_from_remote_preserve_case, git_repo_base_ref, git_repo_base_repo_name_preserve_case,
+    git_repo_head_ref, git_repo_remote_url,
 };
 
 pub fn make_command(command: Command) -> Command {
@@ -176,8 +176,11 @@ pub fn execute(matches: &ArgMatches) -> Result<()> {
             .map(String::as_str)
             .map(Cow::Borrowed)
             .or_else(|| {
-                // Try to get the base ref from the VCS if not provided
-                // This attempts to find the merge-base with the remote tracking branch
+                // First try GitHub Actions environment variables
+                get_github_base_ref().map(Cow::Owned)
+            })
+            .or_else(|| {
+                // Fallback to git repository introspection
                 repo_ref
                     .and_then(|r| match git_repo_base_ref(r, &cached_remote) {
                         Ok(base_ref_name) => {

--- a/src/utils/vcs.rs
+++ b/src/utils/vcs.rs
@@ -359,6 +359,21 @@ pub fn get_github_pr_number() -> Option<u32> {
     Some(pr_number)
 }
 
+/// Attempts to get the base branch from GitHub Actions environment variables.
+/// Returns the base branch name if running in a GitHub Actions pull request environment.
+pub fn get_github_base_ref() -> Option<String> {
+    let event_name = std::env::var("GITHUB_EVENT_NAME").ok()?;
+
+    if event_name != "pull_request" {
+        debug!("Not running in pull_request event, got: {}", event_name);
+        return None;
+    }
+
+    let base_ref = std::env::var("GITHUB_BASE_REF").ok()?;
+    debug!("Auto-detected base ref from GitHub Actions: {}", base_ref);
+    Some(base_ref)
+}
+
 fn find_reference_url(repo: &str, repos: &[Repo]) -> Result<Option<String>> {
     let mut non_git = false;
     for configured_repo in repos {
@@ -1465,5 +1480,31 @@ mod tests {
         assert_eq!(pr_number, None);
         std::env::remove_var("GITHUB_EVENT_NAME");
         std::env::remove_var("GITHUB_REF");
+    }
+
+    #[test]
+    fn test_get_github_base_ref() {
+        std::env::set_var("GITHUB_EVENT_NAME", "pull_request");
+        std::env::set_var("GITHUB_BASE_REF", "main");
+        let base_ref = get_github_base_ref();
+        assert_eq!(base_ref, Some("main".to_owned()));
+
+        // Test with different base branch
+        std::env::set_var("GITHUB_BASE_REF", "develop");
+        let base_ref = get_github_base_ref();
+        assert_eq!(base_ref, Some("develop".to_owned()));
+
+        // Test when not in pull_request event
+        std::env::set_var("GITHUB_EVENT_NAME", "push");
+        let base_ref = get_github_base_ref();
+        assert_eq!(base_ref, None);
+
+        // Test when GITHUB_BASE_REF is not set
+        std::env::set_var("GITHUB_EVENT_NAME", "pull_request");
+        std::env::remove_var("GITHUB_BASE_REF");
+        let base_ref = get_github_base_ref();
+        assert_eq!(base_ref, None);
+
+        std::env::remove_var("GITHUB_EVENT_NAME");
     }
 }


### PR DESCRIPTION
## Summary

Reverts commit c0beb4708a217bad4bacbcff9e4625829c120868 to restore the GitHub Actions base branch detection functionality that was previously implemented in #2776.

## Background

The original GHA base branch detection was reverted in #2789 due to CI failures on master. However, those test failures were actually resolved separately in #2791 by adding `--log-level=error` to suppress warning messages in the integration tests.

## Changes

This PR restores:
- `get_github_base_ref()` function in `src/utils/vcs.rs` that detects base branch from `GITHUB_BASE_REF` environment variable
- Integration of GHA base branch detection in the build upload command logic
- Tests for the `get_github_base_ref()` function

The test failures that caused the original revert have been resolved by the test fixes in #2791, so this functionality can now be safely restored.

🤖 Generated with [Claude Code](https://claude.ai/code)