### PR TITLE
feat(preprod): fail upload if app is missing Info.plist

### DIFF
--- a/src/commands/build/upload.rs
+++ b/src/commands/build/upload.rs
@@ -375,7 +375,7 @@ fn validate_is_supported_build(path: &Path, bytes: &[u8]) -> Result<()> {
     debug!("Validating build format for: {}", path.display());
 
     #[cfg(all(target_os = "macos", target_arch = "aarch64"))]
-    if is_apple_app(path) {
+    if is_apple_app(path)? {
         debug!("Detected XCArchive directory");
         return Ok(());
     }
@@ -449,7 +449,7 @@ fn normalize_file(path: &Path, bytes: &[u8]) -> Result<TempFile> {
 fn handle_directory(path: &Path) -> Result<TempFile> {
     let temp_dir = TempDir::create()?;
     #[cfg(all(target_os = "macos", target_arch = "aarch64"))]
-    if is_apple_app(path) {
+    if is_apple_app(path)? {
         handle_asset_catalogs(path, temp_dir.path());
     }
     normalize_directory(path, temp_dir.path())

--- a/src/utils/build/validation.rs
+++ b/src/utils/build/validation.rs
@@ -3,7 +3,6 @@ use anyhow::Result;
 #[cfg(all(target_os = "macos", target_arch = "aarch64"))]
 use {
     glob::{glob_with, MatchOptions},
-    log::error,
     std::path::Path,
 };
 
@@ -57,7 +56,7 @@ pub fn is_ipa_file(bytes: &[u8]) -> Result<bool> {
 }
 
 #[cfg(all(target_os = "macos", target_arch = "aarch64"))]
-pub fn is_xcarchive_directory<P>(path: P) -> bool
+pub fn validate_xcarchive_directory<P>(path: P) -> Result<()>
 where
     P: AsRef<Path>,
 {
@@ -68,41 +67,36 @@ where
     let products_dir = path.join("Products");
 
     if !info_plist.exists() {
-        error!("Invalid XCArchive: Missing required Info.plist file at XCArchive root");
-        return false;
+        anyhow::bail!("Invalid XCArchive: Missing required Info.plist file at XCArchive root");
     }
 
     if !products_dir.exists() || !products_dir.is_dir() {
-        error!("Invalid XCArchive: Missing Products/ directory");
-        return false;
+        anyhow::bail!("Invalid XCArchive: Missing Products/ directory");
     }
 
     // All .app bundles within the XCArchive should have an Info.plist file
-    let paths = match glob_with(
+    let paths = glob_with(
         &path.join("Products/**/*.app").to_string_lossy(),
         MatchOptions::new(),
-    ) {
-        Ok(paths) => paths,
-        Err(err) => {
-            error!("Error creating glob pattern: {}", err);
-            return false;
-        }
-    };
+    )?;
     for app_path in paths.flatten().filter(|path| path.is_dir()) {
         if !app_path.join("Info.plist").exists() {
-            error!(
+            anyhow::bail!(
                 "Invalid XCArchive: Missing required Info.plist file in .app bundle: {}",
                 app_path.display()
             );
-            return false;
         }
     }
 
-    true
+    Ok(())
 }
 
 /// A path is an Apple app if it points to an xarchive directory
 #[cfg(all(target_os = "macos", target_arch = "aarch64"))]
-pub fn is_apple_app(path: &Path) -> bool {
-    path.is_dir() && is_xcarchive_directory(path)
+pub fn is_apple_app(path: &Path) -> Result<bool> {
+    if !path.is_dir() {
+        return Ok(false);
+    }
+    validate_xcarchive_directory(path)?;
+    Ok(true)
 }


### PR DESCRIPTION
Every `.app` inside of the `Product/Applications` directory needs a corresponding `Info.plist` file since we use this to gather important information about the app. Currently we are allowing these uploads to take place which then immediately fail during processing -- not the greatest UX. It would be better to fail immediately so the user knows there is an issue since this means something went wrong with packaging their app.

Worth noting: technically there's a way to embed this file directly in the Mach-O binary but that is seldom used and we don't support parsing that in `launchpad` either.

Now we will fail and produce an error log:
```
  ERROR   2025-09-23 10:28:40.771928 -04:00 Invalid XCArchive: Missing required Info.plist file in .app bundle: /Users/telkins/Downloads/<redacted>.app.xcarchive/Products/Applications/<redacted>.app
error: File is not a recognized supported build format (APK, AAB, XCArchive, or IPA): /Users/telkins/Downloads/<redacted>.app.xcarchive
```

Resolves EME-311