### PR TITLE
feat(preprod): make sure at least one app bundle is present for upload

### DIFF
--- a/src/utils/build/validation.rs
+++ b/src/utils/build/validation.rs
@@ -3,7 +3,6 @@ use anyhow::Result;
 #[cfg(all(target_os = "macos", target_arch = "aarch64"))]
 use {
     glob::{glob_with, MatchOptions},
-    log::error,
     std::path::Path,
 };
 


### PR DESCRIPTION
Another edge case we see is users accidentally uploading an empty xcarchive to us. This will flag an error log if we detect no `.app` bundles were detected.

```
  ERROR   2025-09-23 12:41:50.487294 -04:00 Invalid XCArchive: No .app bundles found in the Products/ directory
error: File is not a recognized supported build format (APK, AAB, XCArchive, or IPA): /Users/telkins/Downloads/<redacted>.xcarchive
```

Resolves EME-310