### PR TITLE
chore(launchpad): Remove org argument from build upload command

### DIFF
--- a/src/commands/build/upload.rs
+++ b/src/commands/build/upload.rs
@@ -38,7 +38,6 @@ pub fn make_command(command: Command) -> Command {
         "The path to the build to upload. Supported files include Apk, and Aab.";
     command
         .about("[EXPERIMENTAL] Upload builds to a project.")
-        .org_arg()
         .project_arg(false)
         .arg(
             Arg::new("paths")

--- a/tests/integration/_cases/build/build-upload-help-macos.trycmd
+++ b/tests/integration/_cases/build/build-upload-help-macos.trycmd
@@ -9,8 +9,6 @@ Arguments:
   <PATH>...  The path to the build to upload. Supported files include Apk, Aab, XCArchive, and IPA.
 
 Options:
-  -o, --org <ORG>
-          The organization ID or slug.
       --header <KEY:VALUE>
           Custom headers that should be attached to all requests
           in key:value format.

--- a/tests/integration/_cases/build/build-upload-help-not-macos.trycmd
+++ b/tests/integration/_cases/build/build-upload-help-not-macos.trycmd
@@ -8,8 +8,6 @@ Arguments:
   <PATH>...  The path to the build to upload. Supported files include Apk, and Aab.
 
 Options:
-  -o, --org <ORG>
-          The organization ID or slug.
       --header <KEY:VALUE>
           Custom headers that should be attached to all requests
           in key:value format.


### PR DESCRIPTION
There's no point in having the org specified because the project and auth token should be able to infer the organization