### PR TITLE
feat: automatically fetch base SHA in GitHub Actions PR workflows

### DIFF
--- a/src/commands/build/upload.rs
+++ b/src/commands/build/upload.rs
@@ -227,7 +227,11 @@ pub fn execute(matches: &ArgMatches) -> Result<()> {
             base_repo_name,
         )
     };
-    let base_sha = matches.get_one("base_sha").map(String::as_str);
+    let base_sha = matches
+        .get_one("base_sha")
+        .map(String::as_str)
+        .map(Cow::Borrowed)
+        .or_else(|| vcs::find_base_sha().ok().map(Cow::Owned));
     let pr_number = matches
         .get_one("pr_number")
         .copied()
@@ -290,7 +294,7 @@ pub fn execute(matches: &ArgMatches) -> Result<()> {
         let bytes = ByteView::open(zip.path())?;
         let vcs_info = VcsInfo {
             head_sha: head_sha.as_deref(),
-            base_sha,
+            base_sha: base_sha.as_deref(),
             vcs_provider: vcs_provider.as_deref(),
             head_repo_name: head_repo_name.as_deref(),
             base_repo_name: base_repo_name.as_deref(),

--- a/src/utils/vcs.rs
+++ b/src/utils/vcs.rs
@@ -1717,15 +1717,16 @@ mod tests {
         );
 
         // Test with push event (should return None)
-        let push_json = r#"{
-  "action": "push",
-  "ref": "refs/heads/main",
-  "head_commit": {
-    "id": "xyz789abc123"
-  }
-}"#;
+        let push_json = serde_json::json!({
+          "action": "push",
+          "ref": "refs/heads/main",
+          "head_commit": {
+            "id": "xyz789abc123"
+          }
+        })
+        .to_string();
 
-        assert_eq!(extract_pr_base_sha_from_event(push_json), None);
+        assert_eq!(extract_pr_base_sha_from_event(&push_json), None);
 
         // Test with malformed JSON
         assert_eq!(extract_pr_base_sha_from_event("invalid json {"), None);


### PR DESCRIPTION
## Summary

Automatically fetch base SHA for the build upload command when running in GitHub Actions pull request workflows. This eliminates the need to manually specify `--base-sha` in most cases.

## How it works

**Priority order:**
1. **User-provided value** takes highest priority (`--base-sha` argument)
2. **Automatic detection** from `GITHUB_EVENT_PATH` payload (`/pull_request/base/sha`) when running in GitHub Actions PR workflows  
3. **Graceful fallback** when no base SHA is available (returns error from `find_base_sha()`)

**Resolves:** EME-349

🤖 Generated with [Claude Code](https://claude.ai/code)