### PR TITLE
feat(preprod): use deflated compression when creating the zip file

### DIFF
--- a/src/utils/build/normalize.rs
+++ b/src/utils/build/normalize.rs
@@ -45,7 +45,7 @@ fn add_entries_to_zip(
     // This is important as an optimization to avoid re-uploading the same chunks if they're already on the server
     // but the last modified time being different will cause checksums to be different.
     let options = SimpleFileOptions::default()
-        .compression_method(zip::CompressionMethod::Stored)
+        .compression_method(zip::CompressionMethod::Deflated)
         .last_modified_time(DateTime::default());
 
     for (entry_path, relative_path) in entries {


### PR DESCRIPTION
We forgot to turn this on and nothing was being compressed. 😅

I'm seeing a 20MB archive get compressed -> ~10MB now which is as expected.

Resolves EME-361