### PR TITLE
build: Lint against `dbg_macro`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -96,6 +96,7 @@ with_crash_reporting = []
 
 [workspace.lints.clippy]
 allow-attributes = "warn"
+dbg-macro = "warn"
 str-to-string = "warn"
 string-to-string = "warn"
 tests-outside-test-module = "warn"


### PR DESCRIPTION
Lately, I have been using the `dbg!` macro frequently for local development. Enabling the [`dbg-macro` lint](https://rust-lang.github.io/rust-clippy/master/index.html#dbg_macro) will ensure I don't accidentally commit any of these `dbg!` statements.