### PR TITLE
feat: auto-fetch head-ref from GitHub Actions in detached HEAD state

### DIFF
--- a/src/commands/build/upload.rs
+++ b/src/commands/build/upload.rs
@@ -24,7 +24,7 @@ use crate::utils::fs::TempDir;
 use crate::utils::fs::TempFile;
 use crate::utils::progress::ProgressBar;
 use crate::utils::vcs::{
-    self, get_github_base_ref, get_github_pr_number, get_provider_from_remote,
+    self, get_github_base_ref, get_github_head_ref, get_github_pr_number, get_provider_from_remote,
     get_repo_from_remote_preserve_case, git_repo_base_ref, git_repo_base_repo_name_preserve_case,
     git_repo_head_ref, git_repo_remote_url,
 };
@@ -150,7 +150,11 @@ pub fn execute(matches: &ArgMatches) -> Result<()> {
             .map(String::as_str)
             .map(Cow::Borrowed)
             .or_else(|| {
-                // Try to get the current ref from the VCS if not provided
+                // First try GitHub Actions environment variables
+                get_github_head_ref().map(Cow::Owned)
+            })
+            .or_else(|| {
+                // Fallback to git repository introspection
                 // Note: git_repo_head_ref will return an error for detached HEAD states,
                 // which the error handling converts to None - this prevents sending "HEAD" as a branch name
                 // In that case, the user will need to provide a valid branch name.

--- a/src/utils/vcs.rs
+++ b/src/utils/vcs.rs
@@ -375,6 +375,21 @@ pub fn get_github_base_ref() -> Option<String> {
     Some(base_ref)
 }
 
+/// Attempts to get the head branch from GitHub Actions environment variables.
+/// Returns the head branch name if running in a GitHub Actions pull request environment.
+pub fn get_github_head_ref() -> Option<String> {
+    let event_name = std::env::var("GITHUB_EVENT_NAME").ok()?;
+
+    if event_name != "pull_request" {
+        debug!("Not running in pull_request event, got: {}", event_name);
+        return None;
+    }
+
+    let head_ref = std::env::var("GITHUB_HEAD_REF").ok()?;
+    debug!("Auto-detected head ref from GitHub Actions: {}", head_ref);
+    Some(head_ref)
+}
+
 fn find_reference_url(repo: &str, repos: &[Repo]) -> Result<Option<String>> {
     let mut non_git = false;
     for configured_repo in repos {


### PR DESCRIPTION
## Summary
- Add `get_github_head_ref()` function to automatically detect head branch from GitHub Actions environment variables
- Integrate with upload command fallback chain to resolve detached HEAD scenarios
- Use `GITHUB_HEAD_REF` for automatic head-ref detection in PR workflows

See context reference: https://docs.github.com/en/actions/reference/workflows-and-actions/contexts

## Context
Resolves EME-367 - Auto-fetch correct head-ref value in detached HEAD state using GitHub Actions env variables. Follows the same pattern as recent work on base SHA auto-fetching (#2799).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds get_github_head_ref() (reads GITHUB_HEAD_REF in pull_request) and makes build upload prefer it before git head ref to handle detached HEAD.
> 
> - **Build Upload**:
>   - Update `src/commands/build/upload.rs` head-ref resolution to first use `get_github_head_ref()`; fall back to `git_repo_head_ref`.
> - **VCS Utils**:
>   - Add `get_github_head_ref()` to read `GITHUB_HEAD_REF` when `GITHUB_EVENT_NAME` is `pull_request` with debug logging.
>   - Export and import updated in `utils::vcs` and upload command.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 332fe760a1b8ffd0dc6e416f5213190e75a705c7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->