### PR TITLE
ref(vcs): Improve `find_base_sha` debuggability

### DIFF
--- a/src/commands/build/upload.rs
+++ b/src/commands/build/upload.rs
@@ -231,7 +231,13 @@ pub fn execute(matches: &ArgMatches) -> Result<()> {
         .get_one("base_sha")
         .map(String::as_str)
         .map(Cow::Borrowed)
-        .or_else(|| vcs::find_base_sha().ok().map(Cow::Owned));
+        .or_else(|| {
+            vcs::find_base_sha()
+                .inspect_err(|e| debug!("Error finding base SHA: {}", e))
+                .ok()
+                .flatten()
+                .map(Cow::Owned)
+        });
     let pr_number = matches
         .get_one("pr_number")
         .copied()


### PR DESCRIPTION
Rather than emitting `debug!` logs (which we don't show in tests) within the `find_base_sha` and `extract_pr_base_sha_from_event` function, improve these methods by returning proper error types, which include the underlying error as a cause.

The calling code is now responsible for debug-logging these errors, which is still desired, as we expect these functions to error when run outside of a GitHub Actions environment. But, now we will have more information available when debugging test failures, and the debug logs at runtime will also likely be more detailed.