### PR TITLE
fix: Validate `SENTRY_RELEASE` environment variable

### DIFF
--- a/src/utils/args.rs
+++ b/src/utils/args.rs
@@ -28,25 +28,28 @@ pub fn validate_project(v: &str) -> Result<String, String> {
     }
 }
 
-fn validate_release(v: &str) -> Result<String, String> {
+/// Validate a release string.
+pub fn validate_release(v: &str) -> Result<()> {
     if v.trim() != v {
-        Err(
+        anyhow::bail!(
             "Invalid release version. Releases must not contain leading or trailing spaces."
-                .to_owned(),
-        )
+        );
     } else if v.is_empty()
         || v == "."
         || v == ".."
         || v.find(&['\n', '\t', '\x0b', '\x0c', '\t', '/'][..])
             .is_some()
     {
-        Err(
+        anyhow::bail!(
             "Invalid release version. Slashes and certain whitespace characters are not permitted."
-                .to_owned(),
-        )
-    } else {
-        Ok(v.to_owned())
+        );
     }
+
+    Ok(())
+}
+
+fn parse_release(v: &str) -> Result<String> {
+    validate_release(v).map(|_| v.to_owned())
 }
 
 pub fn validate_distribution(v: &str) -> Result<String, String> {
@@ -123,7 +126,7 @@ impl ArgExt for Command {
                 .short('r')
                 .global(true)
                 .allow_hyphen_values(true)
-                .value_parser(validate_release)
+                .value_parser(parse_release)
                 .help("The release slug."),
         )
     }
@@ -135,7 +138,7 @@ impl ArgExt for Command {
                 // either specified for subcommands (global=true) or for this command (required=true)
                 .required(!global)
                 .global(global)
-                .value_parser(validate_release)
+                .value_parser(parse_release)
                 .help("The version of the release"),
         )
     }


### PR DESCRIPTION
Apply the same validation to `SENTRY_RELEASE` that we also apply to the `--release` argument.

Fixes #2444
Fixes [CLI-7](https://linear.app/getsentry/issue/CLI-7/validate-release-strings-locally)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Validate SENTRY_RELEASE with the same rules as --release and refactor release validation/parsing for clap.
> 
> - **Config (`src/config.rs`)**:
>   - Validate `SENTRY_RELEASE` via `args::validate_release`; ignore with warning if invalid; require release if missing.
> - **CLI Args (`src/utils/args.rs`)**:
>   - Refactor release validation: expose `validate_release` returning `anyhow::Result<()>` and add `parse_release` for clap.
>   - Use `parse_release` for `--release` and `--version` value parsers.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 383ec69dbe5cf77917047be4f2487270b31b8cdb. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->