### PR TITLE
fix: serialize VCS tests to prevent race conditions (EME-368)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2612,6 +2612,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "scc"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46e6f046b7fef48e2660c57ed794263155d713de679057f2d0c169bfc6e756cc"
+dependencies = [
+ "sdd",
+]
+
+[[package]]
 name = "schannel"
 version = "0.1.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2660,6 +2669,12 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "sdd"
+version = "3.0.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "490dcfcbfef26be6800d11870ff2df8774fa6e86d047e3e8c8a76b25655e41ca"
 
 [[package]]
 name = "secrecy"
@@ -2777,6 +2792,7 @@ dependencies = [
  "sentry",
  "serde",
  "serde_json",
+ "serial_test",
  "sha1_smol",
  "sourcemap",
  "symbolic",
@@ -2888,6 +2904,31 @@ dependencies = [
  "itoa",
  "ryu",
  "serde",
+]
+
+[[package]]
+name = "serial_test"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b258109f244e1d6891bf1053a55d63a5cd4f8f4c30cf9a1280989f80e7a1fa9"
+dependencies = [
+ "futures",
+ "log",
+ "once_cell",
+ "parking_lot",
+ "scc",
+ "serial_test_derive",
+]
+
+[[package]]
+name = "serial_test_derive"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d69265a08751de7844521fd15003ae0a888e035773ba05695c5c759a6f89eef"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -86,6 +86,7 @@ assert_cmd = "2.0.11"
 insta = { version = "1.26.0", features = ["redactions", "yaml"] }
 mockito = "1.6.1"
 rstest = "0.18.2"
+serial_test = "3.1.1"
 tempfile = "3.8.1"
 trycmd = "0.14.11"
 

--- a/src/utils/vcs.rs
+++ b/src/utils/vcs.rs
@@ -805,6 +805,7 @@ pub fn get_commit_time(time: Time) -> DateTime<FixedOffset> {
 mod tests {
     use {
         crate::api::RepoProvider,
+        serial_test::serial,
         insta::{assert_debug_snapshot, assert_yaml_snapshot},
         std::fs::File,
         std::io::Write as _,
@@ -1672,6 +1673,7 @@ mod tests {
     }
 
     #[test]
+    #[serial(github_event_path)]
     fn test_find_head_with_github_event_path() {
         use std::fs;
 
@@ -1751,6 +1753,7 @@ mod tests {
     }
 
     #[test]
+    #[serial(github_event_path)]
     fn test_find_base_sha() {
         use std::fs;
 


### PR DESCRIPTION
## Summary
- Fixes flaky `test_find_base_sha` test that was consistently failing on Windows CI
- Adds `serial_test` dependency to serialize tests that share the `GITHUB_EVENT_PATH` environment variable
- Adds `#[serial(github_event_path)]` attribute to both conflicting tests

## Root Cause
The flakiness was caused by a race condition where two tests run in parallel and both manipulate the same global `GITHUB_EVENT_PATH` environment variable:

- `test_find_base_sha()` 
- `test_find_head_with_github_event_path()`

When running in parallel (Rust's default), these tests could overwrite each other's environment variable settings, causing random failures.

## Solution  
Using the `serial_test` crate with `#[serial(github_event_path)]` ensures these specific tests run sequentially while allowing other tests to continue running in parallel.

## Test Plan
- ✅ Both tests still pass individually 
- ✅ Tests run sequentially when executed together
- ✅ Other VCS tests continue to run in parallel
- ✅ No regression in test performance (only 2 tests are serialized)

Closes EME-368

🤖 Generated with [Claude Code](https://claude.com/claude-code)