### PR TITLE
fix: simplify debug logging for PR number detection (EME-362)

### DIFF
--- a/src/utils/vcs.rs
+++ b/src/utils/vcs.rs
@@ -350,10 +350,7 @@ pub fn get_github_pr_number() -> Option<u32> {
     }
 
     let pr_number_str = github_ref.strip_prefix("refs/pull/")?;
-    debug!("Extracted PR reference: {}", pr_number_str);
-
     let pr_number_str = pr_number_str.split('/').next()?;
-    debug!("Parsing PR number from: {}", pr_number_str);
 
     let pr_number = pr_number_str.parse().ok()?;
     debug!("Auto-detected PR number from GitHub Actions: {}", pr_number);


### PR DESCRIPTION
## Summary

Fixes [EME-362](https://linear.app/getsentry/issue/EME-362/simplify-debug-logging-for-pr-number-in-sentry-cli) by reducing excessive debug logging when fetching PR numbers during build upload commands.

### Changes

- Reduced debug logging in `get_github_pr_number()` from 4 statements to 2 essential ones
- Removed intermediate debug messages: "Extracted PR reference" and "Parsing PR number from"
- Kept the most important debug logs: event type validation and final PR number detection

### Before
```
debug!("Not running in pull_request event, got: {}", event_name);
debug!("Extracted PR reference: {}", pr_number_str);
debug!("Parsing PR number from: {}", pr_number_str); 
debug!("Auto-detected PR number from GitHub Actions: {}", pr_number);
```

### After
```
debug!("Not running in pull_request event, got: {}", event_name);
debug!("Auto-detected PR number from GitHub Actions: {}", pr_number);
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Remove two intermediate debug logs in `get_github_pr_number()`, keeping only event validation and final PR number detection.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a2ed966d05f1b339a6078d4c2fde9a3fd2fbf283. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->