### PR TITLE
fix: lower log level for missing base ref detection (EME-369)

### DIFF
--- a/src/commands/build/upload.rs
+++ b/src/commands/build/upload.rs
@@ -192,7 +192,7 @@ pub fn execute(matches: &ArgMatches) -> Result<()> {
                             Some(base_ref_name)
                         }
                         Err(e) => {
-                            warn!("Could not detect base branch reference: {}", e);
+                            info!("Could not detect base branch reference: {}", e);
                             None
                         }
                     })

--- a/tests/integration/_cases/build/build-upload-apk-all-uploaded.trycmd
+++ b/tests/integration/_cases/build/build-upload-apk-all-uploaded.trycmd
@@ -1,6 +1,7 @@
 ```
-$ sentry-cli build upload tests/integration/_fixtures/build/apk.apk --log-level=error
+$ sentry-cli build upload tests/integration/_fixtures/build/apk.apk
 ? success
+  WARN    [..] EXPERIMENTAL: The build subcommand is experimental. The command is subject to breaking changes and may be removed without notice in any release.
 Successfully uploaded 1 file to Sentry
   - tests/integration/_fixtures/build/apk.apk (http[..]/wat-org/preprod/wat-project/42)
 

--- a/tests/integration/_cases/build/build-upload-apk-no-token.trycmd
+++ b/tests/integration/_cases/build/build-upload-apk-no-token.trycmd
@@ -1,6 +1,7 @@
 ```
-$ sentry-cli build upload tests/integration/_fixtures/build/apk.apk --log-level=error
+$ sentry-cli build upload tests/integration/_fixtures/build/apk.apk
 ? failed
+  WARN    [..] EXPERIMENTAL: The build subcommand is experimental. The command is subject to breaking changes and may be removed without notice in any release.
 error: Auth token is required for this request. Please run `sentry-cli login` and try again!
 
 Add --log-level=[info|debug] or export SENTRY_LOG_LEVEL=[info|debug] to see more output.

--- a/tests/integration/_cases/build/build-upload-apk.trycmd
+++ b/tests/integration/_cases/build/build-upload-apk.trycmd
@@ -1,6 +1,7 @@
 ```
-$ sentry-cli build upload tests/integration/_fixtures/build/apk.apk --head-sha test_head_sha --log-level=error
+$ sentry-cli build upload tests/integration/_fixtures/build/apk.apk --head-sha test_head_sha
 ? success
+  WARN    [..] EXPERIMENTAL: The build subcommand is experimental. The command is subject to breaking changes and may be removed without notice in any release.
 Successfully uploaded 1 file to Sentry
   - tests/integration/_fixtures/build/apk.apk (http[..]/wat-org/preprod/wat-project/42)
 

--- a/tests/integration/_cases/build/build-upload-ipa.trycmd
+++ b/tests/integration/_cases/build/build-upload-ipa.trycmd
@@ -1,6 +1,7 @@
 ```
-$ sentry-cli build upload tests/integration/_fixtures/build/ipa.ipa --head-sha test_head_sha --log-level=error
+$ sentry-cli build upload tests/integration/_fixtures/build/ipa.ipa --head-sha test_head_sha
 ? success
+  WARN    [..] EXPERIMENTAL: The build subcommand is experimental. The command is subject to breaking changes and may be removed without notice in any release.
 Successfully uploaded 1 file to Sentry
   - tests/integration/_fixtures/build/ipa.ipa (http[..]/wat-org/preprod/wat-project/some-text-id)
 


### PR DESCRIPTION
## Summary

Lowers the logging level from `warn` to `info` when failing to detect base branch reference in build uploads.

## Why

The warning message confuses users as it appears even in cases where we don't expect there to be a base reference (detached HEAD states, main/master builds, etc.). Changing to info level keeps the message available for debugging while hiding it by default.

## Changes

- Changed `warn!` to `info!` in base ref detection error handling
- Removed `--log-level=error` from build upload tests to ensure info messages work correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Lower base-ref detection logging to info and update build upload trycmd tests to remove log-level flag and assert experimental warning output.
> 
> - **Build upload**:
>   - Lower log level from `warn!` to `info!` when failing to detect base branch reference in `src/commands/build/upload.rs`.
> - **Tests**:
>   - Update `trycmd` cases (`tests/integration/_cases/build/*`) to remove `--log-level=error` and expect the experimental warning line in output.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a0961a16429ae84702065d0f85abe05dec84a043. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->