### PR TITLE
test: Add #[serial] to GitHub env var tests

### DIFF
--- a/src/utils/vcs.rs
+++ b/src/utils/vcs.rs
@@ -1517,6 +1517,7 @@ mod tests {
     }
 
     #[test]
+    #[serial(github_env)]
     fn test_get_github_pr_number() {
         std::env::set_var("GITHUB_EVENT_NAME", "pull_request");
         std::env::set_var("GITHUB_REF", "refs/pull/123/merge");
@@ -1534,6 +1535,7 @@ mod tests {
     }
 
     #[test]
+    #[serial(github_env)]
     fn test_get_github_base_ref() {
         std::env::set_var("GITHUB_EVENT_NAME", "pull_request");
         std::env::set_var("GITHUB_BASE_REF", "main");
@@ -1658,7 +1660,7 @@ mod tests {
     }
 
     #[test]
-    #[serial(github_event_path)]
+    #[serial(github_env)]
     fn test_find_head_with_github_event_path() {
         use std::fs;
 
@@ -1738,7 +1740,7 @@ mod tests {
     }
 
     #[test]
-    #[serial(github_event_path)]
+    #[serial(github_env)]
     fn test_find_base_sha() {
         use std::fs;
 


### PR DESCRIPTION
## Summary
- Add `#[serial(github_env)]` to `test_get_github_pr_number`
- Add `#[serial(github_env)]` to `test_get_github_base_ref`
- Rename serial key from `github_event_path` to `github_env` for all tests

These tests manipulate GitHub environment variables (`GITHUB_EVENT_PATH`, `GITHUB_EVENT_NAME`, `GITHUB_REF`, `GITHUB_BASE_REF`) and should not run in parallel with other tests that use the same environment variables to avoid race conditions.

The serial key has been renamed from `github_event_path` to `github_env` to better reflect that it encompasses all GitHub environment variables, not just `GITHUB_EVENT_PATH`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)