### PR TITLE
chore(debug-files): Add deprecation notice for non-chunked uploads

### DIFF
--- a/src/utils/dif_upload/mod.rs
+++ b/src/utils/dif_upload/mod.rs
@@ -1650,10 +1650,10 @@ impl<'a> DifUpload<'a> {
         self.validate_capabilities();
 
         log::warn!(
-            "[DEPRECATION NOTICE] Your Sentry server does not support chunked uploads for debug \\
-            files. Falling back to deprecated upload method. Support for this deprecated upload \\
-            method will be removed in Sentry CLI 3.0.0. Please upgrade your Sentry server, or if \\
-            you cannot upgrade, pin your Sentry CLI version to 2.x, so you don't get upgraded \\
+            "[DEPRECATION NOTICE] Your Sentry server does not support chunked uploads for debug \
+            files. Falling back to deprecated upload method. Support for this deprecated upload \
+            method will be removed in Sentry CLI 3.0.0. Please upgrade your Sentry server, or if \
+            you cannot upgrade, pin your Sentry CLI version to 2.x, so you don't get upgraded \
             to 3.x when it is released."
         );
 


### PR DESCRIPTION
### Description
Support for non-chunked uploads debug file uploads will be removed in the next major release.

Sentry self-hosted versions [since 10.0.0](https://github.com/getsentry/sentry/commit/209e42f64ceaa9fc1c1d2654f918612344bc50fe), which was released six years ago, support chunked uploads for debug file uploads

### Issues
- Resolves #2834
- Resolves CLI-183

<!--
#### Reminders
- Add GH Issue ID _&_ Linear ID (if applicable)
- PR title should use [conventional commit](https://develop.sentry.dev/engineering-practices/commit-messages/#type) style (`feat:`, `fix:`, `ref:`, `meta:`)
- For external contributors: [CONTRIBUTING.md](https://github.com/getsentry/sentry-cli/blob/master/CONTRIBUTING.md), [Sentry SDK development docs](https://develop.sentry.dev/sdk/), [Discord community](https://discord.gg/Ww9hbqr)
-->



