### PR TITLE
chore(preprod): Improve error messaging for zip normalizing step in case of duplicate filename case

### DIFF
--- a/src/utils/build/normalize.rs
+++ b/src/utils/build/normalize.rs
@@ -61,12 +61,12 @@ fn add_entries_to_zip(
             let target_str = target.to_string_lossy();
 
             // Create a symlink entry in the zip
-            zip.add_symlink(&zip_path, &target_str, options)
-                .with_context(|| format!("Failed to add symlink '{}' to zip archive", zip_path))?;
+            zip.add_symlink(zip_path.as_str(), &target_str, options)
+                .with_context(|| format!("Failed to add symlink '{zip_path}' to zip archive"))?;
         } else {
             // Handle regular files
-            zip.start_file(&zip_path, options)
-                .with_context(|| format!("Failed to add file '{}' to zip archive", zip_path))?;
+            zip.start_file(zip_path.as_str(), options)
+                .with_context(|| format!("Failed to add file '{zip_path}' to zip archive"))?;
             let file_byteview = ByteView::open(&entry_path)?;
             zip.write_all(file_byteview.as_slice())?;
         }


### PR DESCRIPTION
If a user hits this case, they will have more context for what's going wrong