### PR TITLE
chore(proguard): Add ProGuard chunk upload capability

### DIFF
--- a/src/api/data_types/chunking/upload/capability.rs
+++ b/src/api/data_types/chunking/upload/capability.rs
@@ -36,6 +36,9 @@ pub enum ChunkUploadCapability {
     /// Upload of preprod artifacts
     PreprodArtifacts,
 
+    /// Upload of ProGuard mappings
+    Proguard,
+
     /// Any other unsupported capability (ignored)
     Unknown,
 }
@@ -57,6 +60,7 @@ impl<'de> Deserialize<'de> for ChunkUploadCapability {
             "il2cpp" => ChunkUploadCapability::Il2Cpp,
             "dartsymbolmap" => ChunkUploadCapability::DartSymbolMap,
             "preprod_artifacts" => ChunkUploadCapability::PreprodArtifacts,
+            "proguard" => ChunkUploadCapability::Proguard,
             _ => ChunkUploadCapability::Unknown,
         })
     }


### PR DESCRIPTION
### Description
The server already returns `"proguard"` chunk upload capability (https://github.com/getsentry/sentry/pull/82304). This change adds support for reading this capability.

### Issues
- Resolves #2866
- Resolves [CLI-196](https://linear.app/getsentry/issue/CLI-196/add-chunkuploadcapability-for-proguard-uploads)