### PR TITLE
feat(proguard): Remove release association arguments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 `sentry-cli` 3.0.0 and above only officially supports Sentry SaaS and Sentry self-hosted versions [25.11.1](https://github.com/getsentry/sentry/releases/tag/25.11.1) and higher. While many Sentry CLI features may, in practice, continue working with some older Sentry versions, continued support for Sentry versions older than 25.11.1 is not guaranteed. Changes which break support for Sentry versions below 25.11.1 may occur in minor or patch releases.
 
+### Breaking Changes
+
+- Removed the `upload-proguard` subcommand's `--app-id`, `--version`, and `--version-code` arguments ([#2876](https://github.com/getsentry/sentry-cli/pull/2876)). Users using these arguments should stop using them, as they are unnecessary. The information passed to these arguments is no longer visible in Sentry.
+
 ## 2.58.4
 
 ### Fixes

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -1059,36 +1059,6 @@ impl<'a> AuthenticatedApi<'a> {
             .convert_rnf(ApiErrorKind::ProjectNotFound)
     }
 
-    pub fn associate_proguard_mappings(
-        &self,
-        org: &str,
-        project: &str,
-        data: &AssociateProguard,
-    ) -> ApiResult<()> {
-        let path = format!(
-            "/projects/{}/{}/files/proguard-artifact-releases",
-            PathArg(org),
-            PathArg(project)
-        );
-        let resp: ApiResponse = self
-            .request(Method::Post, &path)?
-            .with_json_body(data)?
-            .send()?;
-        if resp.status() == 201 {
-            Ok(())
-        } else if resp.status() == 409 {
-            info!(
-                "Release association for release '{}', UUID '{}' already exists.",
-                data.release_name, data.proguard_uuid
-            );
-            Ok(())
-        } else if resp.status() == 404 {
-            Err(ApiErrorKind::ResourceNotFound.into())
-        } else {
-            resp.convert()
-        }
-    }
-
     /// List all organizations associated with the authenticated token
     /// in the given `Region`. If no `Region` is provided, we assume
     /// we're issuing a request to a monolith deployment.
@@ -2244,12 +2214,6 @@ impl DebugInfoFile {
     pub fn id(&self) -> DebugId {
         self.id.or(self.uuid).unwrap_or_default()
     }
-}
-
-#[derive(Debug, Serialize)]
-pub struct AssociateProguard {
-    pub release_name: String,
-    pub proguard_uuid: String,
 }
 
 #[derive(Deserialize)]

--- a/src/commands/upload_proguard.rs
+++ b/src/commands/upload_proguard.rs
@@ -9,7 +9,6 @@ use symbolic::common::ByteView;
 use uuid::Uuid;
 
 use crate::api::Api;
-use crate::api::AssociateProguard;
 use crate::config::Config;
 use crate::utils::android::dump_proguard_uuids_as_properties;
 use crate::utils::args::ArgExt as _;
@@ -34,61 +33,10 @@ pub fn make_command(command: Command) -> Command {
                 .action(ArgAction::Append),
         )
         .arg(
-            Arg::new("version")
-                .hide(true)
-                .long("version")
-                .value_name("VERSION")
-                .requires("app_id")
-                .help(
-                    "[DEPRECATED] Optionally associate the mapping files \
-                     with a human readable version.{n}This helps you \
-                     understand which ProGuard files go with which version \
-                     of your app.\n\
-                     Sentry SaaS and self-hosted version 25.9.0 and later no \
-                     longer display this association, as it has no effect on \
-                     deobfuscation. This flag is scheduled for removal in \
-                     Sentry CLI 3.0.0.",
-                ),
-        )
-        .arg(
-            Arg::new("version_code")
-                .hide(true)
-                .long("version-code")
-                .value_name("VERSION_CODE")
-                .requires("app_id")
-                .requires("version")
-                .help(
-                    "[DEPRECATED] Optionally associate the mapping files with a version \
-                     code.{n}This helps you understand which ProGuard files \
-                     go with which version of your app.\n\
-                     Sentry SaaS and self-hosted version 25.9.0 and later no \
-                     longer display this association, as it has no effect on \
-                     deobfuscation. This flag is scheduled for removal in \
-                     Sentry CLI 3.0.0.",
-                ),
-        )
-        .arg(
-            Arg::new("app_id")
-                .hide(true)
-                .long("app-id")
-                .value_name("APP_ID")
-                .requires("version")
-                .help(
-                    "[DEPRECATED] Optionally associate the mapping files with an application \
-                     ID.{n}If you have multiple apps in one sentry project, you can \
-                     then easily tell them apart.\n\
-                     Sentry SaaS and self-hosted version 25.9.0 and later no \
-                     longer display this association, as it has no effect on \
-                     deobfuscation. This flag is scheduled for removal in \
-                     Sentry CLI 3.0.0.",
-                ),
-        )
-        .arg(
             Arg::new("platform")
                 .hide(true)
                 .long("platform")
                 .value_name("PLATFORM")
-                .requires("app_id")
                 .help(
                     "[DEPRECATED] This flag is a no-op, scheduled \
                     for removal in Sentry CLI 3.0.0.",
@@ -109,7 +57,6 @@ pub fn make_command(command: Command) -> Command {
             Arg::new("android_manifest")
                 .long("android-manifest")
                 .value_name("PATH")
-                .conflicts_with("app_id")
                 .hide(true)
                 .help(
                     "[DEPRECATED] This flag is a no-op, scheduled \
@@ -301,41 +248,6 @@ pub fn execute(matches: &ArgMatches) -> Result<()> {
             for df in rv {
                 println!("  {}", style(&df.id()).dim());
             }
-        }
-    }
-
-    // if values are given associate
-    if let Some(app_id) = matches.get_one::<String>("app_id") {
-        log::warn!(
-            "[DEPRECATION NOTICE] The --app-id, --version, and --version-code flags are deprecated. \
-            and scheduled for removal in Sentry CLI 3.0.0. \
-            These values have no effect on deobfuscation, and are no longer displayed anywhere \
-            in the Sentry UI (neither in SaaS nor in self-hosted versions 25.9.0 and later)."
-        );
-
-        #[expect(clippy::unwrap_used, reason = "legacy code")]
-        let version = matches.get_one::<String>("version").unwrap().to_owned();
-        let build: Option<String> = matches.get_one::<String>("version_code").cloned();
-
-        let mut release_name = app_id.to_owned();
-        release_name.push('@');
-        release_name.push_str(&version);
-
-        if let Some(build_str) = build {
-            release_name.push('+');
-            release_name.push_str(&build_str);
-        }
-
-        for mapping in &mappings {
-            let uuid = forced_uuid.copied().unwrap_or(mapping.uuid());
-            authenticated_api.associate_proguard_mappings(
-                &org,
-                &project,
-                &AssociateProguard {
-                    release_name: release_name.clone(),
-                    proguard_uuid: uuid.to_string(),
-                },
-            )?;
         }
     }
 

--- a/src/utils/proguard/upload.rs
+++ b/src/utils/proguard/upload.rs
@@ -4,18 +4,11 @@
 //! Proguard mappings, while we work on a more permanent solution, which will
 //! work for all different types of debug files.
 
-use std::time::Duration;
-
 use anyhow::Result;
 
 use crate::api::ChunkServerOptions;
 use crate::utils::chunks::{upload_chunked_objects, ChunkOptions, Chunked};
 use crate::utils::proguard::ProguardMapping;
-
-/// How long to wait for the server to assemble the mappings before giving up.
-// 120 seconds was chosen somewhat arbitrarily, but in my testing, assembly
-// usually was almost instantaneous, so this should probably be enough time.
-const ASSEMBLE_POLL_TIMEOUT: Duration = Duration::from_secs(120);
 
 /// Uploads a set of Proguard mappings to Sentry.
 /// Blocks until the mappings have been assembled (up to ASSEMBLE_POLL_TIMEOUT).
@@ -32,8 +25,7 @@ pub fn chunk_upload(
         .map(|mapping| Chunked::from(mapping, chunk_size))
         .collect::<Vec<_>>();
 
-    let options =
-        ChunkOptions::new(chunk_upload_options, org, project).with_max_wait(ASSEMBLE_POLL_TIMEOUT);
+    let options = ChunkOptions::new(chunk_upload_options, org, project);
 
     let (_, has_processing_errors) = upload_chunked_objects(&chunked_mappings, options)?;
 

--- a/tests/integration/_cases/upload_proguard/upload_proguard-help.trycmd
+++ b/tests/integration/_cases/upload_proguard/upload_proguard-help.trycmd
@@ -14,15 +14,15 @@ Options:
                                  in key:value format.
   -p, --project <PROJECT>        The project ID or slug.
       --auth-token <AUTH_TOKEN>  Use the given Sentry auth token.
+      --no-upload                Disable the actual upload.
+                                 This runs all steps for the processing but does not trigger the
+                                 upload.  This is useful if you just want to verify the mapping
+                                 files and write the proguard UUIDs into a properties file.
       --log-level <LOG_LEVEL>    Set the log output verbosity. [possible values: trace, debug, info,
                                  warn, error]
       --quiet                    Do not print any output while preserving correct exit code. This
                                  flag is currently implemented only for selected subcommands.
                                  [aliases: --silent]
-      --no-upload                Disable the actual upload.
-                                 This runs all steps for the processing but does not trigger the
-                                 upload.  This is useful if you just want to verify the mapping
-                                 files and write the proguard UUIDs into a properties file.
       --write-properties <PATH>  Write the UUIDs for the processed mapping files into the given
                                  properties file.
       --require-one              Requires at least one file to upload or the command will error.

--- a/tests/integration/upload_proguard.rs
+++ b/tests/integration/upload_proguard.rs
@@ -152,38 +152,14 @@ fn chunk_upload_needs_upload() {
                             }\
                         }"
                     }
-                    2 => {
-                        // Third call: Assembly completed
-                        "{\
-                            \"297ecd9143fc2882e4b6758c1ccd13ea82930eeb\":{\
-                                \"state\":\"ok\",\
-                                \"detail\":null,\
-                                \"missingChunks\":[],\
-                                \"dif\":{\
-                                    \"id\":\"12\",\
-                                    \"uuid\":\"c038584d-c366-570c-ad1e-034fa0d194d7\",\
-                                    \"debugId\":\"c038584d-c366-570c-ad1e-034fa0d194d7\",\
-                                    \"codeId\":null,\
-                                    \"cpuName\":\"any\",\
-                                    \"objectName\":\"proguard-mapping\",\
-                                    \"symbolType\":\"proguard\",\
-                                    \"headers\":{\"Content-Type\":\"text/x-proguard+plain\"},\
-                                    \"size\":155,\
-                                    \"sha1\":\"297ecd9143fc2882e4b6758c1ccd13ea82930eeb\",\
-                                    \"dateCreated\":\"1776-07-04T12:00:00.000Z\",\
-                                    \"data\":{\"features\":[\"mapping\"]}\
-                                }\
-                            }\
-                        }"
-                    }
                     n => panic!(
-                        "Only 3 calls to the assemble endpoint expected, but there were {}.",
+                        "Only 2 calls to the assemble endpoint expected, but there were {}.",
                         n + 1
                     ),
                 }
                 .into()
             })
-            .expect(3),
+            .expect(2),
         )
         .assert_cmd([
             "upload-proguard",
@@ -298,57 +274,14 @@ fn chunk_upload_two_files() {
                             }\
                         }"
                     }
-                    2 => {
-                        // Third call: Assembly completed
-                        "{\
-                            \"297ecd9143fc2882e4b6758c1ccd13ea82930eeb\":{\
-                                \"state\":\"ok\",\
-                                \"detail\":null,\
-                                \"missingChunks\":[],\
-                                \"dif\":{\
-                                    \"id\":\"12\",\
-                                    \"uuid\":\"c038584d-c366-570c-ad1e-034fa0d194d7\",\
-                                    \"debugId\":\"c038584d-c366-570c-ad1e-034fa0d194d7\",\
-                                    \"codeId\":null,\
-                                    \"cpuName\":\"any\",\
-                                    \"objectName\":\"proguard-mapping\",\
-                                    \"symbolType\":\"proguard\",\
-                                    \"headers\":{\"Content-Type\":\"text/x-proguard+plain\"},\
-                                    \"size\":155,\
-                                    \"sha1\":\"297ecd9143fc2882e4b6758c1ccd13ea82930eeb\",\
-                                    \"dateCreated\":\"1776-07-04T12:00:00.000Z\",\
-                                    \"data\":{\"features\":[\"mapping\"]}\
-                                }\
-                            },\
-                            \"e5329624a8d06e084941f133c75b5874f793ee7c\":{\
-                                \"state\":\"ok\",\
-                                \"detail\":null,\
-                                \"missingChunks\":[],\
-                                \"dif\":{\
-                                    \"id\":\"13\",\
-                                    \"uuid\":\"747e1d76-509b-5225-8a5b-db7b7d4067d4\",\
-                                    \"debugId\":\"747e1d76-509b-5225-8a5b-db7b7d4067d4\",\
-                                    \"codeId\":null,\
-                                    \"cpuName\":\"any\",\
-                                    \"objectName\":\"proguard-mapping\",\
-                                    \"symbolType\":\"proguard\",\
-                                    \"headers\":{\"Content-Type\":\"text/x-proguard+plain\"},\
-                                    \"size\":158,\
-                                    \"sha1\":\"e5329624a8d06e084941f133c75b5874f793ee7c\",\
-                                    \"dateCreated\":\"1776-07-04T12:00:00.000Z\",\
-                                    \"data\":{\"features\":[\"mapping\"]}\
-                                }\
-                            }\
-                        }"
-                    }
                     n => panic!(
-                        "Only 3 calls to the assemble endpoint expected, but there were {}.",
+                        "Only 2 calls to the assemble endpoint expected, but there were {}.",
                         n + 1
                     ),
                 }
                 .into()
             })
-            .expect(3),
+            .expect(2),
         )
         .assert_cmd([
             "upload-proguard",


### PR DESCRIPTION
⚠️ **Breaking change:** Do not merge until ready to release in a major.

### Description

Remove the `--app-id`, `--version`, and `--version-code` arguments to the `sentry-cli upload-proguard` command. Users currently using these arguments should simply stop using them. With this change, we also no longer wait for assembly of the mapping to finish on the backend; previously we needed to wait to associate the release.

This change also removes any code that had been called when these flags were specified.

### Issues
 - Resolves #2868
 - Resolves [CLI-197](https://linear.app/getsentry/issue/CLI-197/remove-flags-for-setting-release)

<!--
#### Reminders
- Add GH Issue ID _&_ Linear ID (if applicable)
- PR title should use [conventional commit](https://develop.sentry.dev/engineering-practices/commit-messages/#type) style (`feat:`, `fix:`, `ref:`, `meta:`)
- For external contributors: [CONTRIBUTING.md](https://github.com/getsentry/sentry-cli/blob/master/CONTRIBUTING.md), [Sentry SDK development docs](https://develop.sentry.dev/sdk/), [Discord community](https://discord.gg/Ww9hbqr)
-->



