### PR TITLE
fix(vcs): Fix base_ref / base_sha for non-github actions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - Deprecated the `upload-proguard` subcommand's `--platform` flag ([#2863](https://github.com/getsentry/sentry-cli/pull/2863)). This flag appears to have been a no-op for some time, so we will remove it in the next major.
 
+### Fixes
+
+- Fix auto filled git metadata when using the `build upload` subcommand in non-github workflow contexts ([#2888](https://github.com/getsentry/sentry-cli/pull/2888))
+
 ## 2.57.0
 
 ### New Features

--- a/src/commands/build/upload.rs
+++ b/src/commands/build/upload.rs
@@ -233,7 +233,7 @@ pub fn execute(matches: &ArgMatches) -> Result<()> {
         .map(String::as_str)
         .map(Cow::Borrowed)
         .or_else(|| {
-            vcs::find_base_sha()
+            vcs::find_base_sha(&cached_remote)
                 .inspect_err(|e| debug!("Error finding base SHA: {e}"))
                 .ok()
                 .flatten()


### PR DESCRIPTION
This resolves EME-473

Both `find_base_sha` and `git_repo_base_ref` were not correct for non-Github workflow contexts.

`find_base_ref` returned previously returned a SHA where the intention of `find_base_ref`
was to return the nice name of the default merge branch of the remote. So in the common case:
```
---o---U---o---o---o---H
```

Where:
- `H` is `some-branch` and
- `U` is `origin/main` and
- `refs/remotes/origin/HEAD` is `refs/remotes/origin/main`

`git_repo_base_ref` should return `main`

`find_base_sha` did not handle the not Github case when it should return the equivalent of:
`git merge-base HEAD origin/HEAD`. For `find_base_sha` we want the merge base of
of `U` and `H`. In the above example this is the SHA of `U`. However they can be different:
e.g. 

```
    o---o---o---origin/main
   /
---1---o---o---o---foo
```

`find_base_ref` should still return `main`
but `find_base_sha` should be the SHA of `1`.