### PR TITLE
ref(chunks): Make `get_sha1_checksums` infallible

### DIFF
--- a/src/commands/build/upload.rs
+++ b/src/commands/build/upload.rs
@@ -508,7 +508,7 @@ fn upload_file(
     pb.set_style(progress_style);
 
     let chunk_size = chunk_upload_options.chunk_size as usize;
-    let (checksum, checksums) = get_sha1_checksums(bytes, chunk_size)?;
+    let (checksum, checksums) = get_sha1_checksums(bytes, chunk_size.try_into()?);
     let mut chunks = bytes
         .chunks(chunk_size)
         .zip(checksums.iter())

--- a/src/utils/chunks/types.rs
+++ b/src/utils/chunks/types.rs
@@ -64,7 +64,7 @@ where
     /// Creates a new `ChunkedObject` from the given object, using
     /// the given chunk size.
     pub fn from(object: T, chunk_size: usize) -> Result<Self> {
-        let (checksum, chunks) = fs::get_sha1_checksums(object.as_ref(), chunk_size)?;
+        let (checksum, chunks) = fs::get_sha1_checksums(object.as_ref(), chunk_size.try_into()?);
         Ok(Self {
             object,
             checksum,

--- a/src/utils/file_upload.rs
+++ b/src/utils/file_upload.rs
@@ -638,7 +638,8 @@ fn upload_files_chunked(
     pb.set_style(progress_style);
 
     let view = ByteView::open(archive.path())?;
-    let (checksum, checksums) = get_sha1_checksums(&view, options.chunk_size as usize)?;
+    let (checksum, checksums) =
+        get_sha1_checksums(&view, (options.chunk_size as usize).try_into()?);
     let mut chunks = view
         .chunks(options.chunk_size as usize)
         .zip(checksums.iter())


### PR DESCRIPTION
### Description
Refactor `get_sha1_checksums` to be infallible by using `NonZeroUsize` for the chunk size. Is the only possible failure reason was the chunk size being zero, the method no longer needs to return a `Result`.
    
This change will slightly simplify the implementation for #2328.

### Issues
- Ref #2328

<!--
#### Reminders
- Add GH Issue ID _&_ Linear ID (if applicable)
- PR title should use [conventional commit](https://develop.sentry.dev/engineering-practices/commit-messages/#type) style (`feat:`, `fix:`, `ref:`, `meta:`)
- For external contributors: [CONTRIBUTING.md](https://github.com/getsentry/sentry-cli/blob/master/CONTRIBUTING.md), [Sentry SDK development docs](https://develop.sentry.dev/sdk/), [Discord community](https://discord.gg/Ww9hbqr)
-->



