### PR TITLE
ref(chunks): Use `NonZeroUsize` in `Chunked` type

### DIFF
--- a/src/commands/dart_symbol_map/upload.rs
+++ b/src/commands/dart_symbol_map/upload.rs
@@ -159,7 +159,7 @@ pub(super) fn execute(args: DartSymbolMapUploadArgs) -> Result<()> {
             let options = ChunkOptions::new(chunk_upload_options, org, project)
                 .with_max_wait(DEFAULT_MAX_WAIT);
 
-            let chunked = Chunked::from(object, options.server_options().chunk_size as usize)?;
+            let chunked = Chunked::from(object, (options.server_options().chunk_size as usize).try_into()?);
             let (_uploaded, has_processing_errors) = upload_chunked_objects(&[chunked], options)?;
             if has_processing_errors {
                 bail!("Some symbol maps did not process correctly");

--- a/src/utils/dif_upload/mod.rs
+++ b/src/utils/dif_upload/mod.rs
@@ -1236,10 +1236,10 @@ fn upload_difs_chunked(
         processed.extend(source_bundles);
     }
 
+    let chunk_size = (chunk_options.chunk_size as usize).try_into()?;
+
     // Calculate checksums and chunks
-    let chunked = prepare_difs(processed, |m| {
-        Chunked::from(m, chunk_options.chunk_size as usize)
-    })?;
+    let chunked = prepare_difs(processed, |m| Ok(Chunked::from(m, chunk_size)))?;
 
     if options.no_upload {
         println!("{} skipping upload.", style(">").dim());

--- a/src/utils/proguard/upload.rs
+++ b/src/utils/proguard/upload.rs
@@ -26,10 +26,11 @@ pub fn chunk_upload(
     org: &str,
     project: &str,
 ) -> Result<()> {
+    let chunk_size = (chunk_upload_options.chunk_size as usize).try_into()?;
     let chunked_mappings = mappings
         .iter()
-        .map(|mapping| Chunked::from(mapping, chunk_upload_options.chunk_size as usize))
-        .collect::<Result<Vec<_>>>()?;
+        .map(|mapping| Chunked::from(mapping, chunk_size))
+        .collect::<Vec<_>>();
 
     let options =
         ChunkOptions::new(chunk_upload_options, org, project).with_max_wait(ASSEMBLE_POLL_TIMEOUT);


### PR DESCRIPTION
### Description
This allows us to avoid returning `Result` in `Chunked::from`.

### Issues
- Ref #2328

<!--
#### Reminders
- Add GH Issue ID _&_ Linear ID (if applicable)
- PR title should use [conventional commit](https://develop.sentry.dev/engineering-practices/commit-messages/#type) style (`feat:`, `fix:`, `ref:`, `meta:`)
- For external contributors: [CONTRIBUTING.md](https://github.com/getsentry/sentry-cli/blob/master/CONTRIBUTING.md), [Sentry SDK development docs](https://develop.sentry.dev/sdk/), [Discord community](https://discord.gg/Ww9hbqr)
-->



