### PR TITLE
ref(chunks): Use `NonZeroUsize` in `ChunkServerOptions`

### DIFF
--- a/src/api/data_types/chunking/upload/options.rs
+++ b/src/api/data_types/chunking/upload/options.rs
@@ -1,3 +1,5 @@
+use std::num::NonZeroUsize;
+
 use serde::Deserialize;
 
 use super::{ChunkCompression, ChunkHashAlgorithm, ChunkUploadCapability};
@@ -17,7 +19,7 @@ pub struct ChunkServerOptions {
     pub max_wait: u64,
     #[expect(dead_code)]
     pub hash_algorithm: ChunkHashAlgorithm,
-    pub chunk_size: u64,
+    pub chunk_size: NonZeroUsize,
     pub concurrency: u8,
     #[serde(default)]
     pub compression: Vec<ChunkCompression>,

--- a/src/commands/build/upload.rs
+++ b/src/commands/build/upload.rs
@@ -507,10 +507,10 @@ fn upload_file(
     pb.enable_steady_tick(100);
     pb.set_style(progress_style);
 
-    let chunk_size = chunk_upload_options.chunk_size as usize;
-    let (checksum, checksums) = get_sha1_checksums(bytes, chunk_size.try_into()?);
+    let chunk_size = chunk_upload_options.chunk_size;
+    let (checksum, checksums) = get_sha1_checksums(bytes, chunk_size);
     let mut chunks = bytes
-        .chunks(chunk_size)
+        .chunks(chunk_size.into())
         .zip(checksums.iter())
         .map(|(data, checksum)| Chunk((*checksum, data)))
         .collect::<Vec<_>>();

--- a/src/commands/dart_symbol_map/upload.rs
+++ b/src/commands/dart_symbol_map/upload.rs
@@ -159,7 +159,7 @@ pub(super) fn execute(args: DartSymbolMapUploadArgs) -> Result<()> {
             let options = ChunkOptions::new(chunk_upload_options, org, project)
                 .with_max_wait(DEFAULT_MAX_WAIT);
 
-            let chunked = Chunked::from(object, (options.server_options().chunk_size as usize).try_into()?);
+            let chunked = Chunked::from(object, options.server_options().chunk_size);
             let (_uploaded, has_processing_errors) = upload_chunked_objects(&[chunked], options)?;
             if has_processing_errors {
                 bail!("Some symbol maps did not process correctly");

--- a/src/utils/dif_upload/mod.rs
+++ b/src/utils/dif_upload/mod.rs
@@ -1236,7 +1236,7 @@ fn upload_difs_chunked(
         processed.extend(source_bundles);
     }
 
-    let chunk_size = (chunk_options.chunk_size as usize).try_into()?;
+    let chunk_size = chunk_options.chunk_size;
 
     // Calculate checksums and chunks
     let chunked = prepare_difs(processed, |m| Ok(Chunked::from(m, chunk_size)))?;

--- a/src/utils/file_upload.rs
+++ b/src/utils/file_upload.rs
@@ -638,10 +638,9 @@ fn upload_files_chunked(
     pb.set_style(progress_style);
 
     let view = ByteView::open(archive.path())?;
-    let (checksum, checksums) =
-        get_sha1_checksums(&view, (options.chunk_size as usize).try_into()?);
+    let (checksum, checksums) = get_sha1_checksums(&view, options.chunk_size);
     let mut chunks = view
-        .chunks(options.chunk_size as usize)
+        .chunks(options.chunk_size.into())
         .zip(checksums.iter())
         .map(|(data, checksum)| Chunk((*checksum, data)))
         .collect::<Vec<_>>();

--- a/src/utils/proguard/upload.rs
+++ b/src/utils/proguard/upload.rs
@@ -26,7 +26,7 @@ pub fn chunk_upload(
     org: &str,
     project: &str,
 ) -> Result<()> {
-    let chunk_size = (chunk_upload_options.chunk_size as usize).try_into()?;
+    let chunk_size = chunk_upload_options.chunk_size;
     let chunked_mappings = mappings
         .iter()
         .map(|mapping| Chunked::from(mapping, chunk_size))


### PR DESCRIPTION
### Description
Builds on the parent PRs by declaring `chunk_size` as `NonZeroUsize` on the `ChunkServerOptions` struct. This way, `serde` already will validate the value when deserializing; no further checks against zero are needed.

### Issues
- ref #2328