### PR TITLE
ref(proguard): Redeclare `mappings` as immutable

### DIFF
--- a/src/commands/upload_proguard.rs
+++ b/src/commands/upload_proguard.rs
@@ -214,6 +214,9 @@ pub fn execute(matches: &ArgMatches) -> Result<()> {
         }
     }
 
+    // We are done constructing the mappings, redeclare as immutable.
+    let mappings = mappings;
+
     let api = Api::current();
     let config = Config::current();
 


### PR DESCRIPTION
### Description
To make it easier to reason about the code when working on #2328, we redeclare the `mappings` variable as immutable after we are done constructing it.

### Issues
- Ref #2328

<!--
#### Reminders
- Add GH Issue ID _&_ Linear ID (if applicable)
- PR title should use [conventional commit](https://develop.sentry.dev/engineering-practices/commit-messages/#type) style (`feat:`, `fix:`, `ref:`, `meta:`)
- For external contributors: [CONTRIBUTING.md](https://github.com/getsentry/sentry-cli/blob/master/CONTRIBUTING.md), [Sentry SDK development docs](https://develop.sentry.dev/sdk/), [Discord community](https://discord.gg/Ww9hbqr)
-->



