### PR TITLE
chore(build): Remove experimental designation from build subcommand in prep for beta release

### DIFF
--- a/src/commands/build/mod.rs
+++ b/src/commands/build/mod.rs
@@ -21,7 +21,7 @@ pub fn make_command(mut command: Command) -> Command {
     }
 
     command = command
-        .about("[EXPERIMENTAL] Manage builds.")
+        .about("Manage builds.")
         .subcommand_required(true)
         .arg_required_else_help(true)
         .org_arg()
@@ -33,12 +33,6 @@ pub fn make_command(mut command: Command) -> Command {
 }
 
 pub fn execute(matches: &ArgMatches) -> Result<()> {
-    log::warn!(
-        "EXPERIMENTAL: The build subcommand is experimental. \
-        The command is subject to breaking changes and may be removed \
-        without notice in any release."
-    );
-
     macro_rules! execute_subcommand {
         ($name:ident) => {{
             if let Some(sub_matches) =

--- a/src/commands/build/upload.rs
+++ b/src/commands/build/upload.rs
@@ -37,7 +37,7 @@ pub fn make_command(command: Command) -> Command {
     const HELP_TEXT: &str =
         "The path to the build to upload. Supported files include Apk, and Aab.";
     command
-        .about("[EXPERIMENTAL] Upload builds to a project.")
+        .about("Upload builds to a project.")
         .org_arg()
         .project_arg(false)
         .arg(

--- a/tests/integration/_cases/build/build-help.trycmd
+++ b/tests/integration/_cases/build/build-help.trycmd
@@ -1,12 +1,12 @@
 ```
 $ sentry-cli build --help
 ? success
-[EXPERIMENTAL] Manage builds.
+Manage builds.
 
 Usage: sentry-cli[EXE] build [OPTIONS] <COMMAND>
 
 Commands:
-  upload  [EXPERIMENTAL] Upload builds to a project.
+  upload  Upload builds to a project.
   help    Print this message or the help of the given subcommand(s)
 
 Options:

--- a/tests/integration/_cases/build/build-upload-apk-all-uploaded.trycmd
+++ b/tests/integration/_cases/build/build-upload-apk-all-uploaded.trycmd
@@ -1,7 +1,6 @@
 ```
 $ sentry-cli build upload tests/integration/_fixtures/build/apk.apk
 ? success
-  WARN    [..] EXPERIMENTAL: The build subcommand is experimental. The command is subject to breaking changes and may be removed without notice in any release.
 > Preparing for upload completed in [..]
 Successfully uploaded 1 file to Sentry
   - tests/integration/_fixtures/build/apk.apk (http[..]/wat-org/preprod/wat-project/42)

--- a/tests/integration/_cases/build/build-upload-apk-no-token.trycmd
+++ b/tests/integration/_cases/build/build-upload-apk-no-token.trycmd
@@ -1,7 +1,6 @@
 ```
 $ sentry-cli build upload tests/integration/_fixtures/build/apk.apk
 ? failed
-  WARN    [..] EXPERIMENTAL: The build subcommand is experimental. The command is subject to breaking changes and may be removed without notice in any release.
 error: Auth token is required for this request. Please run `sentry-cli login` and try again!
 
 Add --log-level=[info|debug] or export SENTRY_LOG_LEVEL=[info|debug] to see more output.

--- a/tests/integration/_cases/build/build-upload-apk.trycmd
+++ b/tests/integration/_cases/build/build-upload-apk.trycmd
@@ -1,7 +1,6 @@
 ```
 $ sentry-cli build upload tests/integration/_fixtures/build/apk.apk --head-sha test_head_sha
 ? success
-  WARN    [..] EXPERIMENTAL: The build subcommand is experimental. The command is subject to breaking changes and may be removed without notice in any release.
 > Preparing for upload completed in [..]
 > Uploading completed in [..]
 Successfully uploaded 1 file to Sentry

--- a/tests/integration/_cases/build/build-upload-help-macos.trycmd
+++ b/tests/integration/_cases/build/build-upload-help-macos.trycmd
@@ -1,7 +1,7 @@
 ```
 $ sentry-cli build upload --help
 ? success
-[EXPERIMENTAL] Upload builds to a project.
+Upload builds to a project.
 
 Usage: sentry-cli[EXE] build upload [OPTIONS] <PATH>...
 

--- a/tests/integration/_cases/build/build-upload-help-not-macos.trycmd
+++ b/tests/integration/_cases/build/build-upload-help-not-macos.trycmd
@@ -1,6 +1,6 @@
 ```
 $ sentry-cli build upload --help
-[EXPERIMENTAL] Upload builds to a project.
+Upload builds to a project.
 
 Usage: sentry-cli[EXE] build upload [OPTIONS] <PATH>...
 

--- a/tests/integration/_cases/build/build-upload-ipa.trycmd
+++ b/tests/integration/_cases/build/build-upload-ipa.trycmd
@@ -1,7 +1,6 @@
 ```
 $ sentry-cli build upload tests/integration/_fixtures/build/ipa.ipa --head-sha test_head_sha
 ? success
-  WARN    [..] EXPERIMENTAL: The build subcommand is experimental. The command is subject to breaking changes and may be removed without notice in any release.
 > Preparing for upload completed in [..]
 Successfully uploaded 1 file to Sentry
   - tests/integration/_fixtures/build/ipa.ipa (http[..]/wat-org/preprod/wat-project/some-text-id)


### PR DESCRIPTION
### Description
Removes `[EXPERIMENTAL]` designation from `build` subcommand in prep for upcoming Nov 6 EA/Beta launch of size analysis and other preprod features.

### Issues
- Resolves EME-71

<!--
#### Reminders
- Add GH Issue ID _&_ Linear ID (if applicable)
- PR title should use [conventional commit](https://develop.sentry.dev/engineering-practices/commit-messages/#type) style (`feat:`, `fix:`, `ref:`, `meta:`)
- For external contributors: [CONTRIBUTING.md](https://github.com/getsentry/sentry-cli/blob/master/CONTRIBUTING.md), [Sentry SDK development docs](https://develop.sentry.dev/sdk/), [Discord community](https://discord.gg/Ww9hbqr)
-->



