### PR TITLE
ref(api): Remove `Copy` from `ApiErrorKind`

### DIFF
--- a/src/api/errors/api_error.rs
+++ b/src/api/errors/api_error.rs
@@ -8,7 +8,7 @@ pub struct ApiError {
 }
 
 /// Represents API errors.
-#[derive(Copy, Clone, Eq, PartialEq, Debug, thiserror::Error)]
+#[derive(Clone, Eq, PartialEq, Debug, thiserror::Error)]
 pub(in crate::api) enum ApiErrorKind {
     #[error("could not serialize value as JSON")]
     CannotSerializeAsJson,
@@ -63,8 +63,8 @@ impl ApiError {
         }
     }
 
-    pub(in crate::api) fn kind(&self) -> ApiErrorKind {
-        self.inner
+    pub(in crate::api) fn kind(&self) -> &ApiErrorKind {
+        &self.inner
     }
 
     fn set_source<E: Into<anyhow::Error>>(mut self, source: E) -> ApiError {

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -311,7 +311,7 @@ impl Api {
             match self.request(Method::Get, url, None)?.send() {
                 Ok(_) => return Ok(true),
                 Err(err) => {
-                    if err.kind() != ApiErrorKind::RequestFailed {
+                    if err.kind() != &ApiErrorKind::RequestFailed {
                         return Err(err);
                     }
                 }
@@ -964,7 +964,7 @@ impl<'a> AuthenticatedApi<'a> {
         {
             Ok(options) => Ok(Some(options)),
             Err(error) => {
-                if error.kind() == ApiErrorKind::ChunkUploadNotSupported {
+                if error.kind() == &ApiErrorKind::ChunkUploadNotSupported {
                     Ok(None)
                 } else {
                     Err(error)


### PR DESCRIPTION
### Description

This will allow us to add additional information to `ApiErrorKind` via `String`s.

### Issues
- Ref #2820

<!--
#### Reminders
- Add GH Issue ID _&_ Linear ID (if applicable)
- PR title should use [conventional commit](https://develop.sentry.dev/engineering-practices/commit-messages/#type) style (`feat:`, `fix:`, `ref:`, `meta:`)
- For external contributors: [CONTRIBUTING.md](https://github.com/getsentry/sentry-cli/blob/master/CONTRIBUTING.md), [Sentry SDK development docs](https://develop.sentry.dev/sdk/), [Discord community](https://discord.gg/Ww9hbqr)
-->



