### PR TITLE
fix(preprod): Mention build upload is non-experimental in CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### New Features
+
+- Promote `sentry-cli build upload` command to non-experimental ([#2899](https://github.com/getsentry/sentry-cli/pull/2899), [#2905](https://github.com/getsentry/sentry-cli/pull/2905)).
+
 ### Deprecations
 
 - Deprecated the `upload-proguard` subcommand's `--platform` flag ([#2863](https://github.com/getsentry/sentry-cli/pull/2863)). This flag appears to have been a no-op for some time, so we will remove it in the next major.

--- a/src/commands/build/mod.rs
+++ b/src/commands/build/mod.rs
@@ -25,9 +25,7 @@ pub fn make_command(mut command: Command) -> Command {
         .subcommand_required(true)
         .arg_required_else_help(true)
         .org_arg()
-        .project_arg(true)
-        // TODO: Remove this when ready for release
-        .hide(true);
+        .project_arg(true);
     each_subcommand!(add_subcommand);
     command
 }

--- a/tests/integration/_cases/help/help-windows.trycmd
+++ b/tests/integration/_cases/help/help-windows.trycmd
@@ -11,6 +11,7 @@ Usage: sentry-cli[EXE] [OPTIONS] <COMMAND>
 
 Commands:
   completions      Generate completions for the specified shell.
+  build            Manage builds.
   debug-files      Locate, analyze or upload debug information files. [aliases: dif]
   deploys          Manage deployments for Sentry releases.
   events           Manage events on Sentry.

--- a/tests/integration/_cases/help/help.trycmd
+++ b/tests/integration/_cases/help/help.trycmd
@@ -11,6 +11,7 @@ Usage: sentry-cli[EXE] [OPTIONS] <COMMAND>
 
 Commands:
   completions      Generate completions for the specified shell.
+  build            Manage builds.
   debug-files      Locate, analyze or upload debug information files. [aliases: dif]
   deploys          Manage deployments for Sentry releases.
   events           Manage events on Sentry.


### PR DESCRIPTION
Follow up from https://github.com/getsentry/sentry-cli/issues/2900
Also unhide the subcommand.