### PR TITLE
test(vcs): Fix local find_base_sha test

### DIFF
--- a/src/utils/vcs.rs
+++ b/src/utils/vcs.rs
@@ -1795,7 +1795,7 @@ mod tests {
 
         // Test without GITHUB_EVENT_PATH
         std::env::remove_var("GITHUB_EVENT_PATH");
-        let result = find_base_sha("origin");
+        let result = find_base_sha("no_such_remote");
         assert!(result.is_err());
     }
 }


### PR DESCRIPTION
The following test:
```
// Test without GITHUB_EVENT_PATH
std::env::remove_var("GITHUB_EVENT_PATH");
let result = find_base_sha("orgin");
assert!(result.is_err());
```
can't really work well both in CI and locally.

Locally there will (almost) always be a merge-base between the local HEAD and the default
merge branch. In GitHub CI there will almost never be a merge-base which is why we need
to inspect `GITHUB_EVENT_PATH` sometimes in the first place.

For now replace that with:
```
// Test without GITHUB_EVENT_PATH
std::env::remove_var("GITHUB_EVENT_PATH");
let result = find_base_sha("no_such_branch");
assert!(result.is_err());
```

Which tests a different code path which should fail on both.