### PR TITLE
meta(codeowners): Grant JS team co-codeownership of some files

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,5 +1,15 @@
 * @szokeasaurusrex @getsentry/owners-sentry-cli
 
+# Files co-owned by JavaScript SDK team
+/.cursor/rules/javascript-development.mdc @getsentry/team-javascript-sdks @getsentry/owners-sentry-cli
+/.npmignore @getsentry/team-javascript-sdks @getsentry/owners-sentry-cli
+/bin/ @getsentry/team-javascript-sdks @getsentry/owners-sentry-cli  # these are the JS "binaries"
+/js @getsentry/team-javascript-sdks @getsentry/owners-sentry-cli
+/package.json @getsentry/team-javascript-sdks @getsentry/owners-sentry-cli
+/scripts/*.js @getsentry/team-javascript-sdks @getsentry/owners-sentry-cli
+/tsconfig.json @getsentry/team-javascript-sdks @getsentry/owners-sentry-cli
+
+# Files co-owned by Emerge Tools team
 /apple-catalog-parsing @getsentry/emerge-tools @getsentry/owners-sentry-cli
 /src/commands/build @getsentry/emerge-tools @getsentry/owners-sentry-cli
 /src/utils/build @getsentry/emerge-tools @getsentry/owners-sentry-cli


### PR DESCRIPTION
As the JavaScript SDK now co-owns the JS API portion of the Sentry CLI, they should also co-own the relevant files, so they can approve their own changes, when they only touch the JS API portion of the CLI.