### PR TITLE
perf(sourcemaps): Elminate unnecessary HTTP call

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,10 +10,15 @@
 
 - Deprecated the `upload-proguard` subcommand's `--platform` flag ([#2863](https://github.com/getsentry/sentry-cli/pull/2863)). This flag appears to have been a no-op for some time, so we will remove it in the next major.
 - Deprecated the `upload-proguard` subcommand's `--android-manifest` flag ([#2891](https://github.com/getsentry/sentry-cli/pull/2891)). This flag appears to have been a no-op for some time, so we will remove it in the next major.
+- Deprecated the `sentry-cli sourcemaps upload` command's `--no-dedupe` flag ([#2913](https://github.com/getsentry/sentry-cli/pull/2913)). The flag was no longer relevant for sourcemap uploads to modern Sentry servers; the flag is now a no-op.
 
 ### Fixes
 
 - Fix autofilled git base metadata (`--base-ref`, `--base-sha`) when using the `build upload` subcommand in git repos. Previously this worked only in the contexts of GitHub workflows ([#2897](https://github.com/getsentry/sentry-cli/pull/2897), [#2898](https://github.com/getsentry/sentry-cli/pull/2898)).
+
+### Performance
+
+- Slightly sped up the `sentry-cli sourcemaps upload` command by elminating an HTTP request to the Sentry server, which was not required in most cases ([#2913](https://github.com/getsentry/sentry-cli/pull/2913)).
 
 ## 2.57.0
 

--- a/src/commands/debug_files/bundle_jvm.rs
+++ b/src/commands/debug_files/bundle_jvm.rs
@@ -65,7 +65,6 @@ pub fn execute(matches: &ArgMatches) -> Result<()> {
         note: None,
         wait: true,
         max_wait: DEFAULT_MAX_WAIT,
-        dedupe: false,
         chunk_upload_options: chunk_upload_options.as_ref(),
     };
     let path = matches.get_one::<PathBuf>("path").unwrap();

--- a/src/commands/files/upload.rs
+++ b/src/commands/files/upload.rs
@@ -159,7 +159,6 @@ pub fn execute(matches: &ArgMatches) -> Result<()> {
         note: None,
         wait,
         max_wait,
-        dedupe: false,
         chunk_upload_options: chunk_upload_options.as_ref(),
     };
 

--- a/src/commands/react_native/appcenter.rs
+++ b/src/commands/react_native/appcenter.rs
@@ -202,7 +202,6 @@ pub fn execute(matches: &ArgMatches) -> Result<()> {
                 note: None,
                 wait,
                 max_wait,
-                dedupe: false,
                 chunk_upload_options: chunk_upload_options.as_ref(),
             })?;
         }
@@ -221,7 +220,6 @@ pub fn execute(matches: &ArgMatches) -> Result<()> {
                     note: None,
                     wait,
                     max_wait,
-                    dedupe: false,
                     chunk_upload_options: chunk_upload_options.as_ref(),
                 })?;
             }

--- a/src/commands/react_native/gradle.rs
+++ b/src/commands/react_native/gradle.rs
@@ -129,7 +129,6 @@ pub fn execute(matches: &ArgMatches) -> Result<()> {
                 note: None,
                 wait,
                 max_wait,
-                dedupe: false,
                 chunk_upload_options: chunk_upload_options.as_ref(),
             })?;
         }
@@ -143,7 +142,6 @@ pub fn execute(matches: &ArgMatches) -> Result<()> {
             note: None,
             wait,
             max_wait,
-            dedupe: false,
             chunk_upload_options: chunk_upload_options.as_ref(),
         })?;
     }

--- a/src/commands/react_native/xcode.rs
+++ b/src/commands/react_native/xcode.rs
@@ -351,7 +351,6 @@ pub fn execute(matches: &ArgMatches) -> Result<()> {
             note: None,
             wait,
             max_wait,
-            dedupe: false,
             chunk_upload_options: chunk_upload_options.as_ref(),
         })?;
     } else {
@@ -387,7 +386,6 @@ pub fn execute(matches: &ArgMatches) -> Result<()> {
                     note: None,
                     wait,
                     max_wait,
-                    dedupe: false,
                     chunk_upload_options: chunk_upload_options.as_ref(),
                 })?;
             }
@@ -401,7 +399,6 @@ pub fn execute(matches: &ArgMatches) -> Result<()> {
                         note: None,
                         wait,
                         max_wait,
-                        dedupe: false,
                         chunk_upload_options: chunk_upload_options.as_ref(),
                     })?;
                 }

--- a/src/commands/sourcemaps/upload.rs
+++ b/src/commands/sourcemaps/upload.rs
@@ -193,11 +193,8 @@ pub fn make_command(command: Command) -> Command {
             Arg::new("no_dedupe")
                 .long("no-dedupe")
                 .action(ArgAction::SetTrue)
-                .help(
-                    "Skip artifacts deduplication prior to uploading. \
-                    This will force all artifacts to be uploaded, \
-                    no matter whether they are already present on the server.",
-                ),
+                .hide(true)
+                .help("[DEPRECATED] This flag has no effect and is scheduled for removal."),
         )
         .arg(
             Arg::new("extensions")
@@ -419,6 +416,13 @@ fn process_sources_from_paths(
 }
 
 pub fn execute(matches: &ArgMatches) -> Result<()> {
+    if matches.get_flag("no_dedupe") {
+        log::warn!(
+            "[DEPRECATION NOTICE] The --no-dedupe flag is deprecated and has no \
+            effect. It will be removed in the next major version."
+        );
+    }
+
     let config = Config::current();
     let version = config.get_release_with_legacy_fallback(matches).ok();
     let org = config.get_org(matches)?;
@@ -457,7 +461,6 @@ pub fn execute(matches: &ArgMatches) -> Result<()> {
         note: matches.get_one::<String>("note").map(String::as_str),
         wait,
         max_wait,
-        dedupe: !matches.get_flag("no_dedupe"),
         chunk_upload_options: chunk_upload_options.as_ref(),
     };
 

--- a/src/utils/file_upload.rs
+++ b/src/utils/file_upload.rs
@@ -28,7 +28,7 @@ use crate::api::NewRelease;
 use crate::api::{Api, ChunkServerOptions, ChunkUploadCapability};
 use crate::constants::DEFAULT_MAX_WAIT;
 use crate::utils::chunks::{upload_chunks, Chunk, ASSEMBLE_POLL_INTERVAL};
-use crate::utils::fs::{get_sha1_checksum, get_sha1_checksums, TempFile};
+use crate::utils::fs::{get_sha1_checksums, TempFile};
 use crate::utils::non_empty::NonEmptySlice;
 use crate::utils::progress::{ProgressBar, ProgressBarMode, ProgressStyle};
 
@@ -95,7 +95,6 @@ pub struct UploadContext<'a> {
     pub note: Option<&'a str>,
     pub wait: bool,
     pub max_wait: Duration,
-    pub dedupe: bool,
     pub chunk_upload_options: Option<&'a ChunkServerOptions>,
 }
 
@@ -306,11 +305,6 @@ impl SourceFile {
             source_file.set_debug_id(debug_id.to_string());
         }
         source_file
-    }
-
-    /// Calculates and returns the SHA1 checksum of the file.
-    pub fn checksum(&self) -> Result<Digest> {
-        get_sha1_checksum(&**self.contents)
     }
 
     /// Returns the value of the "debug-id" header.
@@ -902,7 +896,6 @@ mod tests {
             note: None,
             wait: false,
             max_wait: DEFAULT_MAX_WAIT,
-            dedupe: true,
             chunk_upload_options: None,
         };
 

--- a/tests/integration/_cases/sourcemaps/sourcemaps-upload-help.trycmd
+++ b/tests/integration/_cases/sourcemaps/sourcemaps-upload-help.trycmd
@@ -74,9 +74,6 @@ Options:
           Path to the application bundle (indexed, file, or regular)
       --bundle-sourcemap <BUNDLE_SOURCEMAP>
           Path to the bundle sourcemap
-      --no-dedupe
-          Skip artifacts deduplication prior to uploading. This will force all artifacts to be
-          uploaded, no matter whether they are already present on the server.
   -x, --ext <EXT>
           Set the file extensions that are considered for upload. This overrides the default
           extensions. To add an extension, all default extensions must be repeated. Specify once per

--- a/tests/integration/_cases/sourcemaps/sourcemaps-upload-no-dedupe.trycmd
+++ b/tests/integration/_cases/sourcemaps/sourcemaps-upload-no-dedupe.trycmd
@@ -1,6 +1,7 @@
 ```
 $ sentry-cli sourcemaps upload tests/integration/_fixtures/bundle.min.js.map tests/integration/_fixtures/vendor.min.js.map --release=wat-release --no-dedupe
 ? success
+  WARN    [..] [DEPRECATION NOTICE] The --no-dedupe flag is deprecated and has no effect. It will be removed in the next major version.
 > Found 1 file
 > Found 1 file
 > Analyzing 2 sources

--- a/tests/integration/_cases/sourcemaps/sourcemaps-upload-skip-already-uploaded.trycmd
+++ b/tests/integration/_cases/sourcemaps/sourcemaps-upload-skip-already-uploaded.trycmd
@@ -9,7 +9,7 @@ $ sentry-cli sourcemaps upload tests/integration/_fixtures/bundle.min.js.map tes
 > Rewriting completed in [..]
 > Adding source map references
 > Bundling completed in [..]
-> Bundled 1 file for upload
+> Bundled 2 files for upload
 > Bundle ID: [..]-[..]-[..]-[..]-[..]
 > Optimizing completed in [..]
 > Uploading completed in [..]
@@ -26,6 +26,6 @@ $ sentry-cli sourcemaps upload tests/integration/_fixtures/bundle.min.js.map tes
 Source Map Upload Report
   Source Maps
     ~/bundle.min.js.map
-    ~/vendor.min.js.map (skipped; already uploaded)
+    ~/vendor.min.js.map
 
 ```

--- a/tests/integration/sourcemaps/upload.rs
+++ b/tests/integration/sourcemaps/upload.rs
@@ -14,13 +14,6 @@ fn command_sourcemaps_upload() {
 fn command_sourcemaps_upload_successfully_upload_file() {
     TestManager::new()
         .mock_common_upload_endpoints(ServerBehavior::Legacy, Default::default())
-        .mock_endpoint(
-            MockEndpointBuilder::new(
-                "GET",
-                "/api/0/projects/wat-org/wat-project/releases/wat-release/files/?cursor=&checksum=38ed853073df85147960ea3a5bced6170ec389b0",
-            )
-            .with_response_body("[]"),
-        )
         .register_trycmd_test("sourcemaps/sourcemaps-upload-successfully-upload-file.trycmd")
         .with_default_token()
         .assert_mock_endpoints();
@@ -30,22 +23,6 @@ fn command_sourcemaps_upload_successfully_upload_file() {
 fn command_sourcemaps_upload_skip_already_uploaded() {
     TestManager::new()
         .mock_common_upload_endpoints(ServerBehavior::Legacy, Default::default())
-        .mock_endpoint(
-            MockEndpointBuilder::new(
-                "GET",
-                "/api/0/projects/wat-org/wat-project/releases/wat-release/files/?cursor=&checksum=38ed853073df85147960ea3a5bced6170ec389b0&checksum=f3673e2cea68bcb86bb74254a9efaa381d74929f",
-            )
-            .with_response_body(
-                r#"[{
-                    "id": "1337",
-                    "name": "~/vendor.min.js.map",
-                    "headers": {},
-                    "size": 1522,
-                    "sha1": "f3673e2cea68bcb86bb74254a9efaa381d74929f",
-                    "dateCreated": "2022-05-12T11:08:01.496220Z"
-                }]"#,
-            ),
-        )
         .register_trycmd_test("sourcemaps/sourcemaps-upload-skip-already-uploaded.trycmd")
         .with_default_token()
         .assert_mock_endpoints();


### PR DESCRIPTION
### Description

In some cases, we were making an HTTP call to list release files to determine whether certain sources were already uploaded. However, if the sources are uploaded as artifact bundles (the default), they would not get returned from this endpoint, so the HTTP call is unnecessary. Removing the call should speed up the `sourcemaps upload` command somewhat.

### Issues

- Resolves #2912
- Resolves CLI-213