### PR TITLE
refactor(build): Simplify get_version and add test comment

### DIFF
--- a/src/utils/build/normalize.rs
+++ b/src/utils/build/normalize.rs
@@ -18,13 +18,11 @@ use zip::write::SimpleFileOptions;
 use zip::{DateTime, ZipWriter};
 
 fn get_version() -> Cow<'static, str> {
-    let version = Cow::Borrowed(VERSION);
-
     // Integration tests can override the version for consistent test results.
     // This ensures deterministic checksums in test fixtures by using a fixed version.
     std::env::var("SENTRY_CLI_INTEGRATION_TEST_VERSION_OVERRIDE")
         .map(Cow::Owned)
-        .unwrap_or(version)
+        .unwrap_or(Cow::Borrowed(VERSION))
 }
 
 fn sort_entries(path: &Path) -> Result<impl Iterator<Item = (PathBuf, PathBuf)>> {

--- a/tests/integration/build/upload.rs
+++ b/tests/integration/build/upload.rs
@@ -176,6 +176,8 @@ fn command_build_upload_apk_chunked() {
             .expect(2),
         )
         .register_trycmd_test("build/build-upload-apk.trycmd")
+        // We override the version in the metadata field to ensure a consistent checksum
+        // for the uploaded files.
         .env("SENTRY_CLI_INTEGRATION_TEST_VERSION_OVERRIDE", "0.0.0-test")
         .with_default_token();
 }


### PR DESCRIPTION
## Summary

Minor refactoring to simplify the `get_version` function and add clarifying comment in integration test.

## Changes

- Simplify `get_version` by removing intermediate variable and returning expression directly
- Add comment in integration test explaining why we override the version (for consistent checksums)

🤖 Generated with [Claude Code](https://claude.com/claude-code)