### PR TITLE
feat(proguard): Upload ProGuard with chunked uploading

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@
 
 - Removed the `upload-proguard` subcommand's `--app-id`, `--version`, and `--version-code` arguments ([#2876](https://github.com/getsentry/sentry-cli/pull/2876)). Users using these arguments should stop using them, as they are unnecessary. The information passed to these arguments is no longer visible in Sentry.
 
+### Improvements
+
+- The `sentry-cli upload-proguard` command now uses chunked uploading by default ([#2918](https://github.com/getsentry/sentry-cli/pull/2918)). Users who previously set the `SENTRY_EXPERIMENTAL_PROGUARD_CHUNK_UPLOAD` environment variable to opt into this behavior no longer need to set the variable.
+
 ### Fixes
 
 - Fixed misleading error message claiming the server doesn't support chunk uploading when the actual error was a non-existent organization ([#2930](https://github.com/getsentry/sentry-cli/pull/2930)).

--- a/src/utils/proguard/mapping.rs
+++ b/src/utils/proguard/mapping.rs
@@ -19,11 +19,6 @@ pub struct ProguardMapping<'a> {
 }
 
 impl<'a> ProguardMapping<'a> {
-    /// Get the length of the mapping in bytes.
-    pub fn len(&self) -> usize {
-        self.bytes.len()
-    }
-
     /// Get the UUID of the mapping.
     pub fn uuid(&self) -> Uuid {
         self.uuid

--- a/tests/integration/_cases/upload_proguard/upload_proguard-no-upload.trycmd
+++ b/tests/integration/_cases/upload_proguard/upload_proguard-no-upload.trycmd
@@ -2,7 +2,6 @@
 $ sentry-cli upload-proguard tests/integration/_fixtures/proguard.txt --no-upload
 ? success
 warning: ignoring proguard mapping 'tests/integration/_fixtures/proguard.txt': Proguard mapping does not contain line information
-> compressing mappings
 > skipping upload.
 
 ```

--- a/tests/integration/_cases/upload_proguard/upload_proguard.trycmd
+++ b/tests/integration/_cases/upload_proguard/upload_proguard.trycmd
@@ -1,9 +1,0 @@
-```
-$ sentry-cli upload-proguard tests/integration/_fixtures/proguard.txt
-? success
-warning: ignoring proguard mapping 'tests/integration/_fixtures/proguard.txt': Proguard mapping does not contain line information
-> compressing mappings
-> uploading mappings
-> Uploaded a total of 0 new mapping files
-
-```

--- a/tests/integration/_responses/debug_files/get-chunk-upload.json
+++ b/tests/integration/_responses/debug_files/get-chunk-upload.json
@@ -7,5 +7,5 @@
   "concurrency": 8,
   "hashAlgorithm": "sha1",
   "compression": ["gzip"],
-  "accept": ["debug_files", "release_files", "pdbs", "portablepdbs", "sources", "bcsymbolmaps"]
+  "accept": ["debug_files", "release_files", "pdbs", "portablepdbs", "sources", "bcsymbolmaps", "proguard"]
 }

--- a/tests/integration/test_utils/test_manager.rs
+++ b/tests/integration/test_utils/test_manager.rs
@@ -201,12 +201,6 @@ impl AssertCmdTestManager {
         self
     }
 
-    /// Set a custom environment variable for the test.
-    pub fn env(mut self, variable: impl AsRef<OsStr>, value: impl AsRef<OsStr>) -> Self {
-        self.command.env(variable, value);
-        self
-    }
-
     /// Run the command and perform assertions.
     ///
     /// This function asserts both the mocks and the command result.

--- a/tests/integration/upload_proguard.rs
+++ b/tests/integration/upload_proguard.rs
@@ -8,13 +8,7 @@ use crate::integration::{MockEndpointBuilder, TestManager};
 
 #[test]
 fn command_upload_proguard() {
-    TestManager::new()
-        .mock_endpoint(
-            MockEndpointBuilder::new("POST", "/api/0/projects/wat-org/wat-project/files/dsyms/")
-                .with_response_body("[]"),
-        )
-        .register_trycmd_test("upload_proguard/*.trycmd")
-        .with_default_token();
+    TestManager::new().register_trycmd_test("upload_proguard/*.trycmd");
 }
 
 #[test]
@@ -72,7 +66,6 @@ fn chunk_upload_already_there() {
             "tests/integration/_fixtures/upload_proguard/mapping.txt",
         ])
         .with_default_token()
-        .env("SENTRY_EXPERIMENTAL_PROGUARD_CHUNK_UPLOAD", "1")
         .run_and_assert(AssertCommand::Success)
 }
 
@@ -166,7 +159,6 @@ fn chunk_upload_needs_upload() {
             "tests/integration/_fixtures/upload_proguard/mapping.txt",
         ])
         .with_default_token()
-        .env("SENTRY_EXPERIMENTAL_PROGUARD_CHUNK_UPLOAD", "1")
         .run_and_assert(AssertCommand::Success)
 }
 
@@ -289,6 +281,5 @@ fn chunk_upload_two_files() {
             "tests/integration/_fixtures/upload_proguard/mapping-2.txt",
         ])
         .with_default_token()
-        .env("SENTRY_EXPERIMENTAL_PROGUARD_CHUNK_UPLOAD", "1")
         .run_and_assert(AssertCommand::Success)
 }


### PR DESCRIPTION
### Description
⚠️ **Breaking change:** Do not merge until ready to release in a major.

Use chunked uploading for `sentry-cli upload-proguard`, as chunked uploads are generally more reliable than non-chunked uploads, and chunked uploading is the uploading method used by all other file uploading commands in Sentry CLI.

Users who previously had set the `SENTRY_EXPERIMENTAL_PROGUARD_CHUNK_UPLOAD` environment variable to opt into the chunk uploading behavior no longer need to set this variable, as all ProGuard files are always uploaded with chunked uploading.

### Issues
- Resolves #2328 
- Resolves [CLI-13](https://linear.app/getsentry/issue/CLI-13/make-chunk-uploads-the-default-for-proguard-files)

_______

BREAKING CHANGE: The `sentry-cli upload-proguard` file can no longer upload to Sentry servers which lack support for receiving ProGuard mappings via chunked upload.