### PR TITLE
ref(bundle-jvm): No more API calls in `bundle-jvm`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Improvements
+
+- The `sentry-cli debug-files bundle-jvm` no longer makes any HTTP requests to Sentry, meaning auth tokenms are no longer needed, and the command can be run offline ([#2926](https://github.com/getsentry/sentry-cli/pull/2926)).
+
 ## 2.58.0
 
 ### New Features

--- a/src/utils/file_upload.rs
+++ b/src/utils/file_upload.rs
@@ -12,7 +12,6 @@ use console::style;
 use parking_lot::RwLock;
 use rayon::prelude::*;
 use rayon::ThreadPoolBuilder;
-use sentry::types::DebugId;
 use sha1_smol::Digest;
 use symbolic::common::ByteView;
 use symbolic::debuginfo::js;
@@ -23,7 +22,7 @@ use crate::api::NewRelease;
 use crate::api::{Api, ChunkServerOptions, ChunkUploadCapability};
 use crate::constants::DEFAULT_MAX_WAIT;
 use crate::utils::chunks::{upload_chunks, Chunk, ASSEMBLE_POLL_INTERVAL};
-use crate::utils::fs::{get_sha1_checksums, TempFile};
+use crate::utils::fs::get_sha1_checksums;
 use crate::utils::non_empty::NonEmptySlice;
 use crate::utils::progress::{ProgressBar, ProgressBarMode, ProgressStyle};
 use crate::utils::source_bundle;
@@ -408,10 +407,6 @@ impl<'a> FileUpload<'a> {
 
         #[expect(deprecated, reason = "fallback to legacy upload")]
         upload_files_parallel(legacy_context, &self.files, concurrency)
-    }
-
-    pub fn build_jvm_bundle(&self, debug_id: Option<DebugId>) -> Result<TempFile> {
-        source_bundle::build(self.context, self.files.values(), debug_id)
     }
 }
 

--- a/src/utils/source_bundle.rs
+++ b/src/utils/source_bundle.rs
@@ -23,6 +23,22 @@ pub struct BundleContext<'a> {
     dist: Option<&'a str>,
 }
 
+impl<'a> BundleContext<'a> {
+    /// Make a new context with the given organization; other fields
+    /// are left to None.
+    pub fn new(org: &'a str) -> Self {
+        Self {
+            org,
+            ..Default::default()
+        }
+    }
+
+    pub fn with_projects(mut self, projects: &'a [String]) -> Self {
+        self.projects = projects.try_into().ok();
+        self
+    }
+}
+
 impl<'a> From<&'a UploadContext<'a>> for BundleContext<'a> {
     fn from(context: &'a UploadContext<'a>) -> Self {
         Self {


### PR DESCRIPTION
### Description
We don't need to be calling the chunk upload endpoint from `bundle-jvm` following the refactors in previous PRs

### Issues
- Resolves #2927
- Resolves [CLI-220](https://linear.app/getsentry/issue/CLI-220/dont-call-chunk-upload-for-bundle-jvm)

