### PR TITLE
chore: Add macOS 26 for asset caatalogs

### DIFF
--- a/apple-catalog-parsing/native/swift/AssetCatalogParser/Sources/AssetCatalogParser/AssetCatalogReader.swift
+++ b/apple-catalog-parsing/native/swift/AssetCatalogParser/Sources/AssetCatalogParser/AssetCatalogReader.swift
@@ -11,7 +11,7 @@ public func swift_inspect_asset_catalog(_ path: UnsafePointer<CChar>, outputPath
     let pathString = String(cString: path)
     let outputPathString = String(cString: outputPath)
     if #available(macOS 13.0, *) {
-        let supportedVersions = [13, 14, 15]
+        let supportedVersions = [13, 14, 15, 26]
         let version = ProcessInfo.processInfo.operatingSystemVersion
         if supportedVersions.contains(version.majorVersion) {
             AssetUtil.disect(file: URL(filePath: pathString), outputURL: URL(filePath: outputPathString))


### PR DESCRIPTION
### Description
Adding support for macOS 26 in the asset catalog parsing, now that macOS 26 is released. Tested it out by uploading a build without issues from macOS 26

