### PR TITLE
fix(chunk): Fail with org not found on 404 to chunk endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@
 
 - Removed the `upload-proguard` subcommand's `--app-id`, `--version`, and `--version-code` arguments ([#2876](https://github.com/getsentry/sentry-cli/pull/2876)). Users using these arguments should stop using them, as they are unnecessary. The information passed to these arguments is no longer visible in Sentry.
 
+### Fixes
+
+- Fixed misleading error message claiming the server doesn't support chunk uploading when the actual error was a non-existent organization ([#2930](https://github.com/getsentry/sentry-cli/pull/2930)).
+
 ## 2.58.4
 
 ### Fixes

--- a/src/api/errors/api_error.rs
+++ b/src/api/errors/api_error.rs
@@ -28,8 +28,6 @@ pub(in crate::api) enum ApiErrorKind {
     ProjectNotFound,
     #[error("Release not found. Ensure that you configured the correct release, project, and organization.")]
     ReleaseNotFound,
-    #[error("chunk upload endpoint not supported by sentry server")]
-    ChunkUploadNotSupported,
     #[error("API request failed")]
     RequestFailed,
     #[error("could not compress data")]
@@ -63,6 +61,9 @@ impl ApiError {
         }
     }
 
+    // This method is currently only used in the macOS binary, there is no reason
+    // why not to expose it on other platforms, if we ever need it.
+    #[cfg(target_os = "macos")]
     pub(in crate::api) fn kind(&self) -> ApiErrorKind {
         self.inner
     }

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -956,21 +956,10 @@ impl<'a> AuthenticatedApi<'a> {
     }
 
     /// Get the server configuration for chunked file uploads.
-    pub fn get_chunk_upload_options(&self, org: &str) -> ApiResult<Option<ChunkServerOptions>> {
+    pub fn get_chunk_upload_options(&self, org: &str) -> ApiResult<ChunkServerOptions> {
         let url = format!("/organizations/{}/chunk-upload/", PathArg(org));
-        match self
-            .get(&url)?
-            .convert_rnf::<ChunkServerOptions>(ApiErrorKind::ChunkUploadNotSupported)
-        {
-            Ok(options) => Ok(Some(options)),
-            Err(error) => {
-                if error.kind() == ApiErrorKind::ChunkUploadNotSupported {
-                    Ok(None)
-                } else {
-                    Err(error)
-                }
-            }
-        }
+        self.get(&url)?
+            .convert_rnf::<ChunkServerOptions>(ApiErrorKind::OrganizationNotFound)
     }
 
     /// Request DIF assembling and processing from chunks.

--- a/src/commands/build/upload.rs
+++ b/src/commands/build/upload.rs
@@ -607,12 +607,7 @@ fn upload_file(
         build_configuration.unwrap_or("unknown"),
     );
 
-    let chunk_upload_options = api.get_chunk_upload_options(org)?.ok_or_else(|| {
-        anyhow!(
-            "The Sentry server lacks chunked uploading support, which \
-                is required for build uploads. {SELF_HOSTED_ERROR_HINT}"
-        )
-    })?;
+    let chunk_upload_options = api.get_chunk_upload_options(org)?;
 
     if !chunk_upload_options.supports(ChunkUploadCapability::PreprodArtifacts) {
         bail!(

--- a/src/commands/dart_symbol_map/upload.rs
+++ b/src/commands/dart_symbol_map/upload.rs
@@ -132,10 +132,7 @@ pub(super) fn execute(args: DartSymbolMapUploadArgs) -> Result<()> {
                 ))?;
             let chunk_upload_options = api
                 .authenticated()?
-                .get_chunk_upload_options(org)?
-                .ok_or_else(|| anyhow::anyhow!(
-                    "server does not support chunked uploading. Please update your Sentry server."
-                ))?;
+                .get_chunk_upload_options(org)?;
 
             if !chunk_upload_options.supports(ChunkUploadCapability::DartSymbolMap) {
                 bail!(

--- a/src/commands/files/upload.rs
+++ b/src/commands/files/upload.rs
@@ -159,7 +159,7 @@ pub fn execute(matches: &ArgMatches) -> Result<()> {
         note: None,
         wait,
         max_wait,
-        chunk_upload_options: chunk_upload_options.as_ref(),
+        chunk_upload_options: &chunk_upload_options,
     };
 
     let path = Path::new(matches.get_one::<String>("path").unwrap());

--- a/src/commands/react_native/appcenter.rs
+++ b/src/commands/react_native/appcenter.rs
@@ -202,7 +202,7 @@ pub fn execute(matches: &ArgMatches) -> Result<()> {
                 note: None,
                 wait,
                 max_wait,
-                chunk_upload_options: chunk_upload_options.as_ref(),
+                chunk_upload_options: &chunk_upload_options,
             })?;
         }
         Some(dists) => {
@@ -220,7 +220,7 @@ pub fn execute(matches: &ArgMatches) -> Result<()> {
                     note: None,
                     wait,
                     max_wait,
-                    chunk_upload_options: chunk_upload_options.as_ref(),
+                    chunk_upload_options: &chunk_upload_options,
                 })?;
             }
         }

--- a/src/commands/react_native/gradle.rs
+++ b/src/commands/react_native/gradle.rs
@@ -129,7 +129,7 @@ pub fn execute(matches: &ArgMatches) -> Result<()> {
                 note: None,
                 wait,
                 max_wait,
-                chunk_upload_options: chunk_upload_options.as_ref(),
+                chunk_upload_options: &chunk_upload_options,
             })?;
         }
     } else {
@@ -142,7 +142,7 @@ pub fn execute(matches: &ArgMatches) -> Result<()> {
             note: None,
             wait,
             max_wait,
-            chunk_upload_options: chunk_upload_options.as_ref(),
+            chunk_upload_options: &chunk_upload_options,
         })?;
     }
 

--- a/src/commands/react_native/xcode.rs
+++ b/src/commands/react_native/xcode.rs
@@ -351,7 +351,7 @@ pub fn execute(matches: &ArgMatches) -> Result<()> {
             note: None,
             wait,
             max_wait,
-            chunk_upload_options: chunk_upload_options.as_ref(),
+            chunk_upload_options: &chunk_upload_options,
         })?;
     } else {
         let (dist, release_name) = match (&dist_from_env, &release_from_env) {
@@ -386,7 +386,7 @@ pub fn execute(matches: &ArgMatches) -> Result<()> {
                     note: None,
                     wait,
                     max_wait,
-                    chunk_upload_options: chunk_upload_options.as_ref(),
+                    chunk_upload_options: &chunk_upload_options,
                 })?;
             }
             Some(dists) => {
@@ -399,7 +399,7 @@ pub fn execute(matches: &ArgMatches) -> Result<()> {
                         note: None,
                         wait,
                         max_wait,
-                        chunk_upload_options: chunk_upload_options.as_ref(),
+                        chunk_upload_options: &chunk_upload_options,
                     })?;
                 }
             }

--- a/src/commands/sourcemaps/upload.rs
+++ b/src/commands/sourcemaps/upload.rs
@@ -437,10 +437,10 @@ pub fn execute(matches: &ArgMatches) -> Result<()> {
         log::warn!("The --use-artifact-bundle option and the SENTRY_FORCE_ARTIFACT_BUNDLES environment variable \
                     are both deprecated, and both will be removed in the next major version.");
 
-        if let Some(ref mut options) = chunk_upload_options {
-            if !options.supports(ChunkUploadCapability::ArtifactBundles) {
-                options.accept.push(ChunkUploadCapability::ArtifactBundles);
-            }
+        if !chunk_upload_options.supports(ChunkUploadCapability::ArtifactBundles) {
+            chunk_upload_options
+                .accept
+                .push(ChunkUploadCapability::ArtifactBundles);
         }
     }
 
@@ -461,7 +461,7 @@ pub fn execute(matches: &ArgMatches) -> Result<()> {
         note: matches.get_one::<String>("note").map(String::as_str),
         wait,
         max_wait,
-        chunk_upload_options: chunk_upload_options.as_ref(),
+        chunk_upload_options: &chunk_upload_options,
     };
 
     if matches.get_flag("strict") {

--- a/src/commands/upload_proguard.rs
+++ b/src/commands/upload_proguard.rs
@@ -184,17 +184,7 @@ pub fn execute(matches: &ArgMatches) -> Result<()> {
         authenticated_api = api.authenticated()?;
         (org, project) = config.get_org_and_project(matches)?;
 
-        let chunk_upload_options = authenticated_api
-            .get_chunk_upload_options(&org)
-            .map_err(|e| anyhow::anyhow!(e))
-            .and_then(|options| {
-                options.ok_or_else(|| {
-                    anyhow::anyhow!(
-                        "server does not support chunked uploading. unset \
-                         {CHUNK_UPLOAD_ENV_VAR} to continue."
-                    )
-                })
-            })?;
+        let chunk_upload_options = authenticated_api.get_chunk_upload_options(&org)?;
 
         proguard::chunk_upload(&mappings, chunk_upload_options, &org, &project)?;
     } else {

--- a/src/utils/dif_upload/mod.rs
+++ b/src/utils/dif_upload/mod.rs
@@ -1625,26 +1625,25 @@ impl<'a> DifUpload<'a> {
         }
 
         let api = Api::current();
-        if let Some(chunk_options) = api.authenticated()?.get_chunk_upload_options(self.org)? {
-            if chunk_options.max_file_size > 0 {
-                self.max_file_size = chunk_options.max_file_size;
-            }
-            if chunk_options.max_wait > 0 {
-                self.max_wait = self
-                    .max_wait
-                    .min(Duration::from_secs(chunk_options.max_wait));
-            }
+        let chunk_options = api.authenticated()?.get_chunk_upload_options(self.org)?;
+        if chunk_options.max_file_size > 0 {
+            self.max_file_size = chunk_options.max_file_size;
+        }
+        if chunk_options.max_wait > 0 {
+            self.max_wait = self
+                .max_wait
+                .min(Duration::from_secs(chunk_options.max_wait));
+        }
 
-            self.pdbs_allowed = chunk_options.supports(ChunkUploadCapability::Pdbs);
-            self.portablepdbs_allowed = chunk_options.supports(ChunkUploadCapability::PortablePdbs);
-            self.sources_allowed = chunk_options.supports(ChunkUploadCapability::Sources);
-            self.bcsymbolmaps_allowed = chunk_options.supports(ChunkUploadCapability::BcSymbolmap);
-            self.il2cpp_mappings_allowed = chunk_options.supports(ChunkUploadCapability::Il2Cpp);
+        self.pdbs_allowed = chunk_options.supports(ChunkUploadCapability::Pdbs);
+        self.portablepdbs_allowed = chunk_options.supports(ChunkUploadCapability::PortablePdbs);
+        self.sources_allowed = chunk_options.supports(ChunkUploadCapability::Sources);
+        self.bcsymbolmaps_allowed = chunk_options.supports(ChunkUploadCapability::BcSymbolmap);
+        self.il2cpp_mappings_allowed = chunk_options.supports(ChunkUploadCapability::Il2Cpp);
 
-            if chunk_options.supports(ChunkUploadCapability::DebugFiles) {
-                self.validate_capabilities();
-                return upload_difs_chunked(self, chunk_options);
-            }
+        if chunk_options.supports(ChunkUploadCapability::DebugFiles) {
+            self.validate_capabilities();
+            return upload_difs_chunked(self, chunk_options);
         }
 
         self.validate_capabilities();


### PR DESCRIPTION
### Description
⚠️ **Breaking change:** Do not merge until ready to release in a major.

As Sentry CLI 3.0.0 will only support Sentry servers with chunk uploading support, we can now assume that 404 errors from the `/organizations/{org}/chunk-upload/` endpoint are due to the organization not existing, and not due to the chunk upload endpoint not existing.

### Issues
- Resolves #2900
- Resolves [CLI-211](https://linear.app/getsentry/issue/CLI-211/assume-404-when-getting-chunk-upload-endpoint-is-due-to-non-existent)

________

BREAKING CHANGE: Several subcommands no longer support Sentry servers which lack support for chunked uploads.


