### PR TITLE
fix(sourcemaps): Fix incorrect chunk upload not supported error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Fixes
 
 - Skip setting `base_sha` and `base_ref` when they equal `head_sha` during auto-inference, since comparing a commit to itself provides no meaningful baseline ([#2924](https://github.com/getsentry/sentry-cli/pull/2924)).
+- Improved error message when supplying a non-existent organization to `sentry-cli sourcemaps upload`. The error now correctly indicates the organization doesn't exist, rather than incorrectly suggesting the Sentry server lacks artifact bundle support ([#2931](https://github.com/getsentry/sentry-cli/pull/2931)).
 
 ## 2.58.0
 

--- a/src/utils/file_upload.rs
+++ b/src/utils/file_upload.rs
@@ -75,8 +75,19 @@ pub fn initialize_legacy_release_upload(context: &UploadContext) -> Result<()> {
                 ..Default::default()
             },
         )?;
-    } else {
+    } else if context.chunk_upload_options.is_some() {
         bail!("This version of Sentry does not support artifact bundles. A release slug is required (provide with --release or by setting the SENTRY_RELEASE environment variable)");
+    } else {
+        // We got a 404 when trying to get the chunk options from the server. Most likely, the
+        // organization does not exist, though old self-hosted Sentry servers may also completely
+        // lack support for chunked uploads.
+        bail!(
+            "The provided organization \"{}\" does not exist. If you are using a self-hosted \
+            Sentry server, it is also possible that your Sentry server lacks support for \
+            uploading artifact bundles, in which case you need to provide a release slug with \
+            --release or by setting the SENTRY_RELEASE environment variable.",
+            context.org
+        );
     }
     Ok(())
 }


### PR DESCRIPTION
### Description
Supplying a non-existent organization to the `sentry-cli sourcemaps upload` can cause an error, which states "This version of Sentry does not support artifact bundles ...", even though this is not true. The reason is that the endpoint to get the chunk upload options contains the organization, and if a non-existent organization is supplied, we get a 404 error.

Here, we fix the error message to indicate that an incorrect organization is the most likely explanation, while acknowledging that lacking support for artifact bundles could also cause the problem.

### Issues
- Resolves #2820
- Resolves [CLI-176](https://linear.app/getsentry/issue/CLI-176/non-existent-org-causes-chunk-upload-not-supported-error)