### PR TITLE
chore(auth): Deprecate API keys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Deprecations
+
+- Deprecated API key authentication (#2934)[https://github.com/getsentry/sentry-cli/pull/2934]. Users who are still using API keys to authenticate Sentry CLI should generate and use an [Auth Token](https://docs.sentry.io/account/auth-tokens/) instead. 
+
 ### Improvements
 
 - The `sentry-cli debug-files bundle-jvm` no longer makes any HTTP requests to Sentry, meaning auth tokens are no longer needed, and the command can be run offline ([#2926](https://github.com/getsentry/sentry-cli/pull/2926)).

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -1411,6 +1411,7 @@ impl<'a> AuthenticatedApi<'a> {
                     region_url.ok().map(|url| url.into())
                 }
             },
+            #[expect(deprecated, reason = "Auth key is deprecated.")]
             Auth::Key(_) => {
                 log::warn!(
                     "Auth key is not supported for region-specific API. Falling back to default region."
@@ -1771,9 +1772,10 @@ impl ApiRequest {
     pub fn with_auth(mut self, auth: &Auth) -> ApiResult<Self> {
         self.is_authenticated = true;
         match *auth {
+            #[expect(deprecated, reason = "API key is deprecated.")]
             Auth::Key(ref key) => {
                 self.handle.username(key)?;
-                debug!("using key based authentication");
+                debug!("using deprecated key based authentication");
                 Ok(self)
             }
             Auth::Token(ref token) => {

--- a/src/commands/info.rs
+++ b/src/commands/info.rs
@@ -59,7 +59,8 @@ fn describe_auth(auth: Option<&Auth>) -> &str {
     match auth {
         None => "Unauthorized",
         Some(&Auth::Token(_)) => "Auth Token",
-        Some(&Auth::Key(_)) => "API Key",
+        #[expect(deprecated, reason = "API key is deprecated.")]
+        Some(&Auth::Key(_)) => "API Key (deprecated)",
     }
 }
 
@@ -74,6 +75,7 @@ fn get_config_status_json() -> Result<()> {
 
     rv.auth.auth_type = config.get_auth().map(|val| match val {
         Auth::Token(_) => "token".into(),
+        #[expect(deprecated, reason = "API key is deprecated.")]
         Auth::Key(_) => "api_key".into(),
     });
     rv.auth.successful =

--- a/src/commands/login.rs
+++ b/src/commands/login.rs
@@ -140,6 +140,7 @@ pub fn execute(matches: &ArgMatches) -> Result<()> {
 fn get_org_from_auth(auth: &Auth) -> Option<&str> {
     match auth {
         Auth::Token(token) => get_org_from_token(token),
+        #[expect(deprecated, reason = "API key is deprecated.")]
         Auth::Key(_) => None,
     }
 }

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -138,7 +138,15 @@ fn preexecute_hooks() -> Result<bool> {
 
 fn configure_args(config: &mut Config, matches: &ArgMatches) {
     if let Some(api_key) = matches.get_one::<String>("api_key") {
-        config.set_auth(Auth::Key(api_key.to_owned()));
+        log::warn!(
+            "[DEPRECTATION NOTICE] API key authentication and the --api-key argument are \
+            deprecated. \
+            Please generate an auth token, and use the --auth-token argument instead."
+        );
+
+        #[expect(deprecated, reason = "Auth key is deprecated.")]
+        let auth = Auth::Key(api_key.to_owned());
+        config.set_auth(auth);
     }
 
     if let Some(auth_token) = matches.get_one::<AuthToken>("auth_token") {
@@ -188,7 +196,8 @@ fn app() -> Command {
             Arg::new("api_key")
                 .value_name("API_KEY")
                 .long("api-key")
-                .help("Use the given Sentry API key."),
+                .hide(true)
+                .help("[DEPRECATED] Use the given Sentry API key."),
         )
         .arg(
             Arg::new("log_level")

--- a/src/config.rs
+++ b/src/config.rs
@@ -36,6 +36,7 @@ const MAX_RETRIES_INI_KEY: &str = "max_retries";
 /// Represents the auth information
 #[derive(Debug, Clone)]
 pub enum Auth {
+    #[deprecated(note = "Auth Key authentication is deprecated.")]
     Key(String),
     Token(AuthToken),
 }
@@ -196,6 +197,7 @@ impl Config {
                     val.raw().expose_secret().clone(),
                 );
             }
+            #[expect(deprecated, reason = "API key is deprecated.")]
             Some(Auth::Key(ref val)) => {
                 self.ini.set_to(Some("auth"), "api_key".into(), val.clone());
             }
@@ -734,15 +736,26 @@ impl Clone for Config {
     }
 }
 
-#[expect(clippy::manual_map)]
 fn get_default_auth(ini: &Ini) -> Option<Auth> {
     if let Ok(val) = env::var("SENTRY_AUTH_TOKEN") {
         Some(Auth::Token(val.into()))
     } else if let Ok(val) = env::var("SENTRY_API_KEY") {
+        log::warn!(
+            "[DEPRECTATION NOTICE] API key authentication and the `SENTRY_API_KEY` environment \
+            variable are deprecated. \
+            Please generate and set an auth token using `SENTRY_AUTH_TOKEN` instead."
+        );
+        #[expect(deprecated, reason = "API key is deprecated.")]
         Some(Auth::Key(val))
     } else if let Some(val) = ini.get_from(Some("auth"), "token") {
         Some(Auth::Token(val.into()))
     } else if let Some(val) = ini.get_from(Some("auth"), "api_key") {
+        log::warn!(
+            "[DEPRECTATION NOTICE] API key authentication and the `api_key` field in the \
+            Sentry CLI config file are deprecated. \
+            Please generate and set an auth token instead."
+        );
+        #[expect(deprecated, reason = "API key is deprecated.")]
         Some(Auth::Key(val.to_owned()))
     } else {
         None

--- a/tests/integration/_cases/help/help-windows.trycmd
+++ b/tests/integration/_cases/help/help-windows.trycmd
@@ -38,7 +38,6 @@ Options:
       --header <KEY:VALUE>       Custom headers that should be attached to all requests
                                  in key:value format.
       --auth-token <AUTH_TOKEN>  Use the given Sentry auth token.
-      --api-key <API_KEY>        Use the given Sentry API key.
       --log-level <LOG_LEVEL>    Set the log output verbosity. [possible values: trace, debug, info,
                                  warn, error]
       --quiet                    Do not print any output while preserving correct exit code. This

--- a/tests/integration/_cases/help/help.trycmd
+++ b/tests/integration/_cases/help/help.trycmd
@@ -39,7 +39,6 @@ Options:
       --header <KEY:VALUE>       Custom headers that should be attached to all requests
                                  in key:value format.
       --auth-token <AUTH_TOKEN>  Use the given Sentry auth token.
-      --api-key <API_KEY>        Use the given Sentry API key.
       --log-level <LOG_LEVEL>    Set the log output verbosity. [possible values: trace, debug, info,
                                  warn, error]
       --quiet                    Do not print any output while preserving correct exit code. This


### PR DESCRIPTION
### Description
API keys have been deprecated in favor of Auth Tokens over seven years ago on the backend. Here, we deprecate them in the CLI, in preparation to drop support from Sentry CLI 3.0.0.


### Issues
- Resolves #2872
- Resolves [CLI-198](https://linear.app/getsentry/issue/CLI-198/deprecate-api-key-authentication)