### PR TITLE
chore(auth): Remove API key authentication

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,18 @@
 
 ### Breaking Changes
 
+- Removed support for the legacy API key authentication method ([#2935](https://github.com/getsentry/sentry-cli/pull/2935)). Sentry CLI now only supports authenticating with Auth Tokens. If you are using API key authentication via any of the following methods, you need to generate and use an [Auth Token](https://docs.sentry.io/account/auth-tokens/), instead:
+  - `--api-key` CLI flag
+  - `SENTRY_API_KEY` environment variable
+  - `api_key` configuration file field
+  - `apiKey` option in the JavaScript API
 - Removed the `upload-proguard` subcommand's `--app-id`, `--version`, and `--version-code` arguments ([#2876](https://github.com/getsentry/sentry-cli/pull/2876)). Users using these arguments should stop using them, as they are unnecessary. The information passed to these arguments is no longer visible in Sentry.
+
+#### Node.js Wrapper Breakages
+
+The following changes only apply when using `sentry-cli` via the npm package [`@sentry/cli`](https://www.npmjs.com/package/@sentry/cli):
+
+- Removed the `apiKey` option from `SentryCliOptions` ([#2935](https://github.com/getsentry/sentry-cli/pull/2935)). If you are using `apiKey`, you need to generate and use an [Auth Token](https://docs.sentry.io/account/auth-tokens/) via the `authToken` option, instead.
 
 ### Improvements
 

--- a/lib/helper.js
+++ b/lib/helper.js
@@ -302,9 +302,6 @@ async function execute(args, live, silent, configFile, config = {}) {
   if (config.authToken) {
     env.SENTRY_AUTH_TOKEN = config.authToken;
   }
-  if (config.apiKey) {
-    env.SENTRY_API_KEY = config.apiKey;
-  }
   if (config.dsn) {
     env.SENTRY_DSN = config.dsn;
   }

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -17,13 +17,6 @@ export interface SentryCliOptions {
    */
   authToken?: string;
   /**
-   * API key to authenticate any HTTP requests to Sentry (legacy authentication method).
-   * This value will update `SENTRY_API_KEY` env variable.
-   * @deprecated Use auth-token-based authentication via `authToken` instead.
-   *     This option is scheduled for removal in the next major release.
-   */
-  apiKey?: string;
-  /**
    * Sentry DSN.
    * This value will update `SENTRY_DSN` env variable.
    */
@@ -67,7 +60,6 @@ export interface SentryCliOptions {
 export type SourceMapsPathDescriptor = Omit<SentryCliUploadSourceMapsOptions, 'include'> & {
   paths: string[];
 };
-
 
 /**
  * Options for uploading source maps
@@ -222,7 +214,7 @@ export interface SentryCliCommitsOptions {
  * Release management interface
  */
 export interface SentryCliReleases {
-  new(release: string, options?: { projects: string[] } | string[]): Promise<string>;
+  new (release: string, options?: { projects: string[] } | string[]): Promise<string>;
 
   setCommits(release: string, options: SentryCliCommitsOptions): Promise<string>;
 
@@ -241,4 +233,3 @@ export interface SentryCliReleases {
 
   execute(args: string[], live: boolean | 'rejectOnError'): Promise<string>;
 }
-

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -1370,14 +1370,6 @@ impl<'a> AuthenticatedApi<'a> {
                     region_url.ok().map(|url| url.into())
                 }
             },
-            #[expect(deprecated, reason = "Auth key is deprecated.")]
-            Auth::Key(_) => {
-                log::warn!(
-                    "Auth key is not supported for region-specific API. Falling back to default region."
-                );
-
-                None
-            }
         };
 
         RegionSpecificApi {
@@ -1731,12 +1723,6 @@ impl ApiRequest {
     pub fn with_auth(mut self, auth: &Auth) -> ApiResult<Self> {
         self.is_authenticated = true;
         match *auth {
-            #[expect(deprecated, reason = "API key is deprecated.")]
-            Auth::Key(ref key) => {
-                self.handle.username(key)?;
-                debug!("using deprecated key based authentication");
-                Ok(self)
-            }
             Auth::Token(ref token) => {
                 debug!("using token authentication");
                 self.with_header(

--- a/src/commands/info.rs
+++ b/src/commands/info.rs
@@ -59,8 +59,6 @@ fn describe_auth(auth: Option<&Auth>) -> &str {
     match auth {
         None => "Unauthorized",
         Some(&Auth::Token(_)) => "Auth Token",
-        #[expect(deprecated, reason = "API key is deprecated.")]
-        Some(&Auth::Key(_)) => "API Key (deprecated)",
     }
 }
 
@@ -75,8 +73,6 @@ fn get_config_status_json() -> Result<()> {
 
     rv.auth.auth_type = config.get_auth().map(|val| match val {
         Auth::Token(_) => "token".into(),
-        #[expect(deprecated, reason = "API key is deprecated.")]
-        Auth::Key(_) => "api_key".into(),
     });
     rv.auth.successful =
         config.get_auth().is_some() && Api::current().authenticated()?.get_auth_info().is_ok();

--- a/src/commands/login.rs
+++ b/src/commands/login.rs
@@ -140,8 +140,6 @@ pub fn execute(matches: &ArgMatches) -> Result<()> {
 fn get_org_from_auth(auth: &Auth) -> Option<&str> {
     match auth {
         Auth::Token(token) => get_org_from_token(token),
-        #[expect(deprecated, reason = "API key is deprecated.")]
-        Auth::Key(_) => None,
     }
 }
 

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -137,18 +137,6 @@ fn preexecute_hooks() -> Result<bool> {
 }
 
 fn configure_args(config: &mut Config, matches: &ArgMatches) {
-    if let Some(api_key) = matches.get_one::<String>("api_key") {
-        log::warn!(
-            "[DEPRECTATION NOTICE] API key authentication and the --api-key argument are \
-            deprecated. \
-            Please generate an auth token, and use the --auth-token argument instead."
-        );
-
-        #[expect(deprecated, reason = "Auth key is deprecated.")]
-        let auth = Auth::Key(api_key.to_owned());
-        config.set_auth(auth);
-    }
-
     if let Some(auth_token) = matches.get_one::<AuthToken>("auth_token") {
         config.set_auth(Auth::Token(auth_token.to_owned()));
     }
@@ -191,13 +179,6 @@ fn app() -> Command {
                 .global(true)
                 .value_parser(auth_token_parser)
                 .help("Use the given Sentry auth token."),
-        )
-        .arg(
-            Arg::new("api_key")
-                .value_name("API_KEY")
-                .long("api-key")
-                .hide(true)
-                .help("[DEPRECATED] Use the given Sentry API key."),
         )
         .arg(
             Arg::new("log_level")

--- a/src/config.rs
+++ b/src/config.rs
@@ -36,8 +36,6 @@ const MAX_RETRIES_INI_KEY: &str = "max_retries";
 /// Represents the auth information
 #[derive(Debug, Clone)]
 pub enum Auth {
-    #[deprecated(note = "Auth Key authentication is deprecated.")]
-    Key(String),
     Token(AuthToken),
 }
 
@@ -181,7 +179,6 @@ impl Config {
     pub fn set_auth(&mut self, auth: Auth) {
         self.cached_auth = Some(auth);
 
-        self.ini.delete_from(Some("auth"), "api_key");
         self.ini.delete_from(Some("auth"), "token");
         match self.cached_auth {
             Some(Auth::Token(ref val)) => {
@@ -196,10 +193,6 @@ impl Config {
                     "token".into(),
                     val.raw().expose_secret().clone(),
                 );
-            }
-            #[expect(deprecated, reason = "API key is deprecated.")]
-            Some(Auth::Key(ref val)) => {
-                self.ini.set_to(Some("auth"), "api_key".into(), val.clone());
             }
             None => {}
         }
@@ -739,26 +732,9 @@ impl Clone for Config {
 fn get_default_auth(ini: &Ini) -> Option<Auth> {
     if let Ok(val) = env::var("SENTRY_AUTH_TOKEN") {
         Some(Auth::Token(val.into()))
-    } else if let Ok(val) = env::var("SENTRY_API_KEY") {
-        log::warn!(
-            "[DEPRECTATION NOTICE] API key authentication and the `SENTRY_API_KEY` environment \
-            variable are deprecated. \
-            Please generate and set an auth token using `SENTRY_AUTH_TOKEN` instead."
-        );
-        #[expect(deprecated, reason = "API key is deprecated.")]
-        Some(Auth::Key(val))
-    } else if let Some(val) = ini.get_from(Some("auth"), "token") {
-        Some(Auth::Token(val.into()))
-    } else if let Some(val) = ini.get_from(Some("auth"), "api_key") {
-        log::warn!(
-            "[DEPRECTATION NOTICE] API key authentication and the `api_key` field in the \
-            Sentry CLI config file are deprecated. \
-            Please generate and set an auth token instead."
-        );
-        #[expect(deprecated, reason = "API key is deprecated.")]
-        Some(Auth::Key(val.to_owned()))
     } else {
-        None
+        ini.get_from(Some("auth"), "token")
+            .map(|val| Auth::Token(val.into()))
     }
 }
 

--- a/tests/integration/_cases/build/build-upload-help-macos.trycmd
+++ b/tests/integration/_cases/build/build-upload-help-macos.trycmd
@@ -26,15 +26,15 @@ Options:
           current and remote branch will be used.
       --log-level <LOG_LEVEL>
           Set the log output verbosity. [possible values: trace, debug, info, warn, error]
+      --quiet
+          Do not print any output while preserving correct exit code. This flag is currently
+          implemented only for selected subcommands. [aliases: --silent]
       --vcs-provider <vcs_provider>
           The VCS provider to use for the upload. If not provided, the current provider will be
           used.
       --head-repo-name <head_repo_name>
           The name of the git repository to use for the upload (e.g. organization/repository). If
           not provided, the current repository will be used.
-      --quiet
-          Do not print any output while preserving correct exit code. This flag is currently
-          implemented only for selected subcommands. [aliases: --silent]
       --base-repo-name <base_repo_name>
           The name of the git repository to use for the upload (e.g. organization/repository). If
           not provided, the current repository will be used.

--- a/tests/integration/_cases/build/build-upload-help-not-macos.trycmd
+++ b/tests/integration/_cases/build/build-upload-help-not-macos.trycmd
@@ -25,15 +25,15 @@ Options:
           current and remote branch will be used.
       --log-level <LOG_LEVEL>
           Set the log output verbosity. [possible values: trace, debug, info, warn, error]
+      --quiet
+          Do not print any output while preserving correct exit code. This flag is currently
+          implemented only for selected subcommands. [aliases: --silent]
       --vcs-provider <vcs_provider>
           The VCS provider to use for the upload. If not provided, the current provider will be
           used.
       --head-repo-name <head_repo_name>
           The name of the git repository to use for the upload (e.g. organization/repository). If
           not provided, the current repository will be used.
-      --quiet
-          Do not print any output while preserving correct exit code. This flag is currently
-          implemented only for selected subcommands. [aliases: --silent]
       --base-repo-name <base_repo_name>
           The name of the git repository to use for the upload (e.g. organization/repository). If
           not provided, the current repository will be used.

--- a/tests/integration/_cases/debug_files/not_windows/debug_files-upload-help.trycmd
+++ b/tests/integration/_cases/debug_files/not_windows/debug_files-upload-help.trycmd
@@ -17,22 +17,22 @@ Options:
   -t, --type <TYPE>              Only consider debug information files of the given type.  By
                                  default, all types are considered. [possible values: bcsymbolmap,
                                  breakpad, dsym, elf, jvm, pdb, pe, portablepdb, sourcebundle, wasm]
+      --log-level <LOG_LEVEL>    Set the log output verbosity. [possible values: trace, debug, info,
+                                 warn, error]
       --no-unwind                Do not scan for stack unwinding information. Specify this flag for
                                  builds with disabled FPO, or when stackwalking occurs on the
                                  device. This usually excludes executables and dynamic libraries.
                                  They might still be uploaded, if they contain additional
                                  processable information (see other flags).
-      --log-level <LOG_LEVEL>    Set the log output verbosity. [possible values: trace, debug, info,
-                                 warn, error]
       --no-debug                 Do not scan for debugging information. This will usually exclude
                                  debug companion files. They might still be uploaded, if they
                                  contain additional processable information (see other flags).
-      --no-sources               Do not scan for source information. This will usually exclude
-                                 source bundle files. They might still be uploaded, if they contain
-                                 additional processable information (see other flags).
       --quiet                    Do not print any output while preserving correct exit code. This
                                  flag is currently implemented only for selected subcommands.
                                  [aliases: --silent]
+      --no-sources               Do not scan for source information. This will usually exclude
+                                 source bundle files. They might still be uploaded, if they contain
+                                 additional processable information (see other flags).
       --id <ID>                  Search for specific debug identifiers.
       --require-all              Errors if not all identifiers specified with --id could be found.
       --symbol-maps <PATH>       Optional path to BCSymbolMap files which are used to resolve hidden

--- a/tests/integration/_cases/events/events-list-help.trycmd
+++ b/tests/integration/_cases/events/events-list-help.trycmd
@@ -14,9 +14,9 @@ Options:
   -T, --show-tags                Display the Tags column.
       --auth-token <AUTH_TOKEN>  Use the given Sentry auth token.
       --max-rows <MAX_ROWS>      Maximum number of rows to print.
-      --pages <PAGES>            Maximum number of pages to fetch (100 events/page). [default: 5]
       --log-level <LOG_LEVEL>    Set the log output verbosity. [possible values: trace, debug, info,
                                  warn, error]
+      --pages <PAGES>            Maximum number of pages to fetch (100 events/page). [default: 5]
       --quiet                    Do not print any output while preserving correct exit code. This
                                  flag is currently implemented only for selected subcommands.
                                  [aliases: --silent]

--- a/tests/integration/_cases/issues/issues-help.trycmd
+++ b/tests/integration/_cases/issues/issues-help.trycmd
@@ -22,9 +22,9 @@ Options:
   -s, --status <STATUS>          Select all issues matching a given status. [possible values:
                                  resolved, muted, unresolved]
   -a, --all                      Select all issues (this might be limited).
-  -i, --id <ID>                  Select the issue with the given ID.
       --log-level <LOG_LEVEL>    Set the log output verbosity. [possible values: trace, debug, info,
                                  warn, error]
+  -i, --id <ID>                  Select the issue with the given ID.
       --quiet                    Do not print any output while preserving correct exit code. This
                                  flag is currently implemented only for selected subcommands.
                                  [aliases: --silent]

--- a/tests/integration/_cases/issues/issues-list-help.trycmd
+++ b/tests/integration/_cases/issues/issues-list-help.trycmd
@@ -19,9 +19,9 @@ Options:
   -s, --status <STATUS>          Select all issues matching a given status. [possible values:
                                  resolved, muted, unresolved]
   -a, --all                      Select all issues (this might be limited).
-  -i, --id <ID>                  Select the issue with the given ID.
       --log-level <LOG_LEVEL>    Set the log output verbosity. [possible values: trace, debug, info,
                                  warn, error]
+  -i, --id <ID>                  Select the issue with the given ID.
       --quiet                    Do not print any output while preserving correct exit code. This
                                  flag is currently implemented only for selected subcommands.
                                  [aliases: --silent]

--- a/tests/integration/_cases/logs/logs-list-help.trycmd
+++ b/tests/integration/_cases/logs/logs-list-help.trycmd
@@ -28,6 +28,9 @@ Options:
           
           [default: 100]
 
+      --log-level <LOG_LEVEL>
+          Set the log output verbosity. [possible values: trace, debug, info, warn, error]
+
       --query <QUERY>
           Query to filter logs. Example: "level:error". If omitted, no filtering is applied. See
           https://docs.sentry.io/concepts/search/ for syntax.
@@ -35,19 +38,16 @@ Options:
       --live
           Live stream logs.
 
-      --log-level <LOG_LEVEL>
-          Set the log output verbosity. [possible values: trace, debug, info, warn, error]
-
-      --poll-interval <POLL_INTERVAL>
-          Poll interval in seconds (must be > 0). Only used when --live is specified.
-          
-          [default: 2]
-
       --quiet
           Do not print any output while preserving correct exit code. This flag is currently
           implemented only for selected subcommands.
           
           [aliases: --silent]
+
+      --poll-interval <POLL_INTERVAL>
+          Poll interval in seconds (must be > 0). Only used when --live is specified.
+          
+          [default: 2]
 
   -h, --help
           Print help (see a summary with '-h')

--- a/tests/integration/_cases/monitors/monitors-run-help.trycmd
+++ b/tests/integration/_cases/monitors/monitors-run-help.trycmd
@@ -21,20 +21,20 @@ Options:
       --check-in-margin <checkin_margin>
           The allowed margin of minutes after the expected check-in time that the monitor will not
           be considered missed for. Requires --schedule.
+      --log-level <LOG_LEVEL>
+          Set the log output verbosity. [possible values: trace, debug, info, warn, error]
       --max-runtime <max_runtime>
           The allowed duration in minutes that the monitor may be in progress for before being
           considered failed due to timeout. Requires --schedule.
-      --log-level <LOG_LEVEL>
-          Set the log output verbosity. [possible values: trace, debug, info, warn, error]
+      --quiet
+          Do not print any output while preserving correct exit code. This flag is currently
+          implemented only for selected subcommands. [aliases: --silent]
       --timezone <timezone>
           A tz database string (e.g. "Europe/Vienna") representing the monitor's execution
           schedule's timezone. Requires --schedule.
       --failure-issue-threshold <failure_issue_threshold>
           The number of consecutive missed or error check-ins that trigger an issue. Requires
           --schedule.
-      --quiet
-          Do not print any output while preserving correct exit code. This flag is currently
-          implemented only for selected subcommands. [aliases: --silent]
       --recovery-threshold <recovery_threshold>
           The number of consecutive successful check-ins that resolve an issue. Requires --schedule.
   -h, --help

--- a/tests/integration/_cases/send_event/send_event-help.trycmd
+++ b/tests/integration/_cases/send_event/send_event-help.trycmd
@@ -31,23 +31,23 @@ Options:
       --timestamp <TIMESTAMP>
           Optional event timestamp in one of supported formats: unix timestamp, RFC2822 or RFC3339.
 
+      --log-level <LOG_LEVEL>
+          Set the log output verbosity. [possible values: trace, debug, info, warn, error]
+
   -r, --release <RELEASE>
           Optional identifier of the release.
 
   -d, --dist <DISTRIBUTION>
           Set the distribution.
 
-      --log-level <LOG_LEVEL>
-          Set the log output verbosity. [possible values: trace, debug, info, warn, error]
-
-  -E, --env <ENVIRONMENT>
-          Send with a specific environment.
-
       --quiet
           Do not print any output while preserving correct exit code. This flag is currently
           implemented only for selected subcommands.
           
           [aliases: --silent]
+
+  -E, --env <ENVIRONMENT>
+          Send with a specific environment.
 
       --no-environ
           Do not send environment variables along

--- a/tests/integration/_cases/send_metric/send_metric-distribution-help.trycmd
+++ b/tests/integration/_cases/send_metric/send_metric-distribution-help.trycmd
@@ -27,11 +27,11 @@ Options:
           Metric tags as key:value pairs. Tags allow you to add dimensions to your metrics and can
           be filtered or grouped by in Sentry.
 
-  -v, --value <VALUE>
-          Metric value, any finite 64 bit float.
-
       --log-level <LOG_LEVEL>
           Set the log output verbosity. [possible values: trace, debug, info, warn, error]
+
+  -v, --value <VALUE>
+          Metric value, any finite 64 bit float.
 
       --quiet
           Do not print any output while preserving correct exit code. This flag is currently

--- a/tests/integration/_cases/send_metric/send_metric-gauge-help.trycmd
+++ b/tests/integration/_cases/send_metric/send_metric-gauge-help.trycmd
@@ -27,16 +27,16 @@ Options:
           Metric tags as key:value pairs. Tags allow you to add dimensions to your metrics and can
           be filtered or grouped by in Sentry.
 
-  -v, --value <VALUE>
-          Metric value, any finite 64 bit float.
-
       --log-level <LOG_LEVEL>
           Set the log output verbosity. [possible values: trace, debug, info, warn, error]
+
+  -v, --value <VALUE>
+          Metric value, any finite 64 bit float.
 
       --quiet
           Do not print any output while preserving correct exit code. This flag is currently
           implemented only for selected subcommands.
-[..]
+          
           [aliases: --silent]
 
   -h, --help

--- a/tests/integration/_cases/send_metric/send_metric-increment-help.trycmd
+++ b/tests/integration/_cases/send_metric/send_metric-increment-help.trycmd
@@ -27,18 +27,18 @@ Options:
           Metric tags as key:value pairs. Tags allow you to add dimensions to your metrics and can
           be filtered or grouped by in Sentry.
 
-  -v, --value <VALUE>
-          Value to increment the metric by, any finite 64 bit float.
-[..]
-          [default: 1]
-
       --log-level <LOG_LEVEL>
           Set the log output verbosity. [possible values: trace, debug, info, warn, error]
+
+  -v, --value <VALUE>
+          Value to increment the metric by, any finite 64 bit float.
+          
+          [default: 1]
 
       --quiet
           Do not print any output while preserving correct exit code. This flag is currently
           implemented only for selected subcommands.
-[..]
+          
           [aliases: --silent]
 
   -h, --help

--- a/tests/integration/_cases/send_metric/send_metric-set-help.trycmd
+++ b/tests/integration/_cases/send_metric/send_metric-set-help.trycmd
@@ -27,17 +27,17 @@ Options:
           Metric tags as key:value pairs. Tags allow you to add dimensions to your metrics and can
           be filtered or grouped by in Sentry.
 
+      --log-level <LOG_LEVEL>
+          Set the log output verbosity. [possible values: trace, debug, info, warn, error]
+
   -v, --value <VALUE>
           Value to add to the set. If the set already contains the provided value, the set's unique
           count will not increase.
 
-      --log-level <LOG_LEVEL>
-          Set the log output verbosity. [possible values: trace, debug, info, warn, error]
-
       --quiet
           Do not print any output while preserving correct exit code. This flag is currently
           implemented only for selected subcommands.
-[..]
+          
           [aliases: --silent]
 
   -h, --help

--- a/tests/integration/_cases/upload_dif/upload_dif-help.trycmd
+++ b/tests/integration/_cases/upload_dif/upload_dif-help.trycmd
@@ -17,22 +17,22 @@ Options:
   -t, --type <TYPE>              Only consider debug information files of the given type.  By
                                  default, all types are considered. [possible values: bcsymbolmap,
                                  breakpad, dsym, elf, jvm, pdb, pe, portablepdb, sourcebundle, wasm]
+      --log-level <LOG_LEVEL>    Set the log output verbosity. [possible values: trace, debug, info,
+                                 warn, error]
       --no-unwind                Do not scan for stack unwinding information. Specify this flag for
                                  builds with disabled FPO, or when stackwalking occurs on the
                                  device. This usually excludes executables and dynamic libraries.
                                  They might still be uploaded, if they contain additional
                                  processable information (see other flags).
-      --log-level <LOG_LEVEL>    Set the log output verbosity. [possible values: trace, debug, info,
-                                 warn, error]
       --no-debug                 Do not scan for debugging information. This will usually exclude
                                  debug companion files. They might still be uploaded, if they
                                  contain additional processable information (see other flags).
-      --no-sources               Do not scan for source information. This will usually exclude
-                                 source bundle files. They might still be uploaded, if they contain
-                                 additional processable information (see other flags).
       --quiet                    Do not print any output while preserving correct exit code. This
                                  flag is currently implemented only for selected subcommands.
                                  [aliases: --silent]
+      --no-sources               Do not scan for source information. This will usually exclude
+                                 source bundle files. They might still be uploaded, if they contain
+                                 additional processable information (see other flags).
       --id <ID>                  Search for specific debug identifiers.
       --require-all              Errors if not all identifiers specified with --id could be found.
       --symbol-maps <PATH>       Optional path to BCSymbolMap files which are used to resolve hidden

--- a/tests/integration/_cases/upload_dsym/upload_dsym-help.trycmd
+++ b/tests/integration/_cases/upload_dsym/upload_dsym-help.trycmd
@@ -17,22 +17,22 @@ Options:
   -t, --type <TYPE>              Only consider debug information files of the given type.  By
                                  default, all types are considered. [possible values: bcsymbolmap,
                                  breakpad, dsym, elf, jvm, pdb, pe, portablepdb, sourcebundle, wasm]
+      --log-level <LOG_LEVEL>    Set the log output verbosity. [possible values: trace, debug, info,
+                                 warn, error]
       --no-unwind                Do not scan for stack unwinding information. Specify this flag for
                                  builds with disabled FPO, or when stackwalking occurs on the
                                  device. This usually excludes executables and dynamic libraries.
                                  They might still be uploaded, if they contain additional
                                  processable information (see other flags).
-      --log-level <LOG_LEVEL>    Set the log output verbosity. [possible values: trace, debug, info,
-                                 warn, error]
       --no-debug                 Do not scan for debugging information. This will usually exclude
                                  debug companion files. They might still be uploaded, if they
                                  contain additional processable information (see other flags).
-      --no-sources               Do not scan for source information. This will usually exclude
-                                 source bundle files. They might still be uploaded, if they contain
-                                 additional processable information (see other flags).
       --quiet                    Do not print any output while preserving correct exit code. This
                                  flag is currently implemented only for selected subcommands.
                                  [aliases: --silent]
+      --no-sources               Do not scan for source information. This will usually exclude
+                                 source bundle files. They might still be uploaded, if they contain
+                                 additional processable information (see other flags).
       --id <ID>                  Search for specific debug identifiers.
       --require-all              Errors if not all identifiers specified with --id could be found.
       --symbol-maps <PATH>       Optional path to BCSymbolMap files which are used to resolve hidden

--- a/tests/integration/_cases/upload_proguard/upload_proguard-help.trycmd
+++ b/tests/integration/_cases/upload_proguard/upload_proguard-help.trycmd
@@ -14,12 +14,12 @@ Options:
                                  in key:value format.
   -p, --project <PROJECT>        The project ID or slug.
       --auth-token <AUTH_TOKEN>  Use the given Sentry auth token.
+      --log-level <LOG_LEVEL>    Set the log output verbosity. [possible values: trace, debug, info,
+                                 warn, error]
       --no-upload                Disable the actual upload.
                                  This runs all steps for the processing but does not trigger the
                                  upload.  This is useful if you just want to verify the mapping
                                  files and write the proguard UUIDs into a properties file.
-      --log-level <LOG_LEVEL>    Set the log output verbosity. [possible values: trace, debug, info,
-                                 warn, error]
       --quiet                    Do not print any output while preserving correct exit code. This
                                  flag is currently implemented only for selected subcommands.
                                  [aliases: --silent]


### PR DESCRIPTION
### Description
⚠️ **Breaking change:** Do not merge until ready to release in a major.

Removed support for the legacy API key authentication method. Users must now use auth tokens instead.

Specifically, users supplying an API key via any of the following options need to generate and use an auth token instead:

  - `--api-key` CLI flag
  - `SENTRY_API_KEY` environment variable
  - `api_key` configuration file field
  - `apiKey` option in the JavaScript API

### Issues
- Resolves #2873
- Resolves [CLI-199](https://linear.app/getsentry/issue/CLI-199/remove-api-key-authentication)

_____

BREAKING CHANGE: API-key based authentication is no longer supported. The `--api-key` CLI flag and `apiKey` JS option have been removed; the `SENTRY_API_KEY` environment variable and `api_key` configuration file field are no longer read.