### PR TITLE
chore(js): Deprecate `apiKey` field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Deprecations
 
-- Deprecated API key authentication ([#2934](https://github.com/getsentry/sentry-cli/pull/2934)). Users who are still using API keys to authenticate Sentry CLI should generate and use an [Auth Token](https://docs.sentry.io/account/auth-tokens/) instead.
+- Deprecated API key authentication ([#2934](https://github.com/getsentry/sentry-cli/pull/2934), [#2937](https://github.com/getsentry/sentry-cli/pull/2937)). Users who are still using API keys to authenticate Sentry CLI should generate and use an [Auth Token](https://docs.sentry.io/account/auth-tokens/) instead.
 
 ### Improvements
 

--- a/js/index.d.ts
+++ b/js/index.d.ts
@@ -9,13 +9,15 @@ declare module '@sentry/cli' {
      */
     url?: string;
     /**
-     * Authentication token for API, interchangeable with `apiKey`.
+     * Authentication token for HTTP requests to Sentry.
      * This value will update `SENTRY_AUTH_TOKEN` env variable.
      */
     authToken?: string;
     /**
-     * Authentication token for API, interchangeable with `authToken`.
+     * API key to authenticate any HTTP requests to Sentry (legacy authentication method).
      * This value will update `SENTRY_API_KEY` env variable.
+     * @deprecated Use auth-token-based authentication via `authToken` instead.
+     *    This option is scheduled for removal in the next major release.
      */
     apiKey?: string;
     /**


### PR DESCRIPTION
### Description
Deprecate the `apiKey` field, which is used to set the already-deprecated `SENTRY_API_KEY` environment variable. Also, update the docstrings for `apiKey` and `authToken` to clarify that the two options are not interchangeable. `apiKey` only takes a legacy API key; `authToken` takes auth tokens.

### Issues
- Resolves #2936
- Resolves CLI-223