### PR TITLE
meta(cargo): Remove `authors` from `Cargo.toml`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,4 @@
 [package]
-authors = ["Armin Ronacher <armin.ronacher@active-4.com>"]
 build = "build.rs"
 name = "sentry-cli"
 version = "2.58.0"


### PR DESCRIPTION
The `authors` field is [deprecated](https://doc.rust-lang.org/cargo/reference/manifest.html#the-authors-field), and as it is anyways out-of-date, we should remove it.