### PR TITLE
chore(proguard): Remove `--android-manifest` argument

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@
   - `SENTRY_API_KEY` environment variable
   - `api_key` configuration file field
   - `apiKey` option in the JavaScript API
-- Removed the `upload-proguard` subcommand's `--app-id`, `--version`, and `--version-code` arguments ([#2876](https://github.com/getsentry/sentry-cli/pull/2876)). Users using these arguments should stop using them, as they are unnecessary. The information passed to these arguments is no longer visible in Sentry.
+- Removed the `upload-proguard` subcommand's `--app-id`, `--version`, `--version-code`, and `--android-manifest` arguments ([#2876](https://github.com/getsentry/sentry-cli/pull/2876), [#2940](https://github.com/getsentry/sentry-cli/pull/2940)). Users using these arguments should stop using them, as they are unnecessary. The information passed to these arguments is no longer visible in Sentry.
 
 #### Node.js Wrapper Breakages
 

--- a/src/commands/upload_proguard.rs
+++ b/src/commands/upload_proguard.rs
@@ -50,16 +50,6 @@ pub fn make_command(command: Command) -> Command {
                 ),
         )
         .arg(
-            Arg::new("android_manifest")
-                .long("android-manifest")
-                .value_name("PATH")
-                .hide(true)
-                .help(
-                    "[DEPRECATED] This flag is a no-op, scheduled \
-                    for removal in Sentry CLI 3.0.0.",
-                ),
-        )
-        .arg(
             Arg::new("write_properties")
                 .long("write-properties")
                 .value_name("PATH")
@@ -95,14 +85,6 @@ pub fn execute(matches: &ArgMatches) -> Result<()> {
     if matches.get_one::<String>("platform").is_some() {
         log::warn!(
             "[DEPRECATION NOTICE] The --platform argument is deprecated, \
-            and is scheduled for removal in Sentry CLI 3.0.0. \
-            The argument is a no-op."
-        );
-    }
-
-    if matches.get_one::<String>("android_manifest").is_some() {
-        log::warn!(
-            "[DEPRECATION NOTICE] The --android-manifest argument is deprecated, \
             and is scheduled for removal in Sentry CLI 3.0.0. \
             The argument is a no-op."
         );


### PR DESCRIPTION
### Description
This argument does not do anything, so we will remove it.

### Issues
- Resolves #2874
- Resolves [CLI-200](https://linear.app/getsentry/issue/CLI-200/remove-upload-proguards-android-manifest-argument)



