### PR TITLE
ref(build): Use `VcsInfo` directly in `ChunkedBuildRequest`

### DIFF
--- a/src/api/data_types/chunking/build.rs
+++ b/src/api/data_types/chunking/build.rs
@@ -1,6 +1,8 @@
 use serde::{Deserialize, Serialize};
 use sha1_smol::Digest;
 
+use crate::api::VcsInfo;
+
 use super::ChunkedFileState;
 
 #[derive(Debug, Serialize)]
@@ -11,23 +13,8 @@ pub struct ChunkedBuildRequest<'a> {
     pub build_configuration: Option<&'a str>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub release_notes: Option<&'a str>,
-    // VCS fields
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub head_sha: Option<&'a str>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub base_sha: Option<&'a str>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub provider: Option<&'a str>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub head_repo_name: Option<&'a str>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub base_repo_name: Option<&'a str>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub head_ref: Option<&'a str>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub base_ref: Option<&'a str>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub pr_number: Option<&'a u32>,
+    #[serde(flatten)]
+    pub vcs_info: &'a VcsInfo<'a>,
 }
 
 #[derive(Debug, Deserialize)]

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -2521,15 +2521,23 @@ struct LogsResponse {
 }
 
 /// VCS information for build app uploads
-#[derive(Debug)]
+#[derive(Debug, Serialize)]
 pub struct VcsInfo<'a> {
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub head_sha: Option<&'a str>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub base_sha: Option<&'a str>,
+    #[serde(skip_serializing_if = "Option::is_none", rename = "provider")]
     pub vcs_provider: Option<&'a str>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub head_repo_name: Option<&'a str>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub base_repo_name: Option<&'a str>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub head_ref: Option<&'a str>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub base_ref: Option<&'a str>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub pr_number: Option<&'a u32>,
 }
 

--- a/src/commands/build/upload.rs
+++ b/src/commands/build/upload.rs
@@ -566,14 +566,7 @@ fn upload_file(
                 chunks: &checksums,
                 build_configuration,
                 release_notes,
-                head_sha: vcs_info.head_sha,
-                base_sha: vcs_info.base_sha,
-                provider: vcs_info.vcs_provider,
-                head_repo_name: vcs_info.head_repo_name,
-                base_repo_name: vcs_info.base_repo_name,
-                head_ref: vcs_info.head_ref,
-                base_ref: vcs_info.base_ref,
-                pr_number: vcs_info.pr_number,
+                vcs_info,
             },
         )?;
         chunks.retain(|Chunk((digest, _))| response.missing_chunks.contains(digest));


### PR DESCRIPTION
### Description
`serde(flatten)` tells serde to directly serialize these fields into the same level as the rest of the struct, without any nesting. That way, we don't need to redefine all the VCS fields on `ChunkedBuildRequest`.