### PR TITLE
ref(build): Add client-side validation for SHA fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Improvements
+
+- Added validation for the `sentry-cli build upload` command's `--head-sha` and `--base-sha` arguments ([#2945](https://github.com/getsentry/sentry-cli/pull/2945)). The CLI now validates that these are valid SHA1 sums. Passing an empty string is also allowed; this prevents the default values from being used, causing the values to instead be unset.
+
 ## 2.58.1
 
 ### Deprecations

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,7 +62,7 @@ sentry = { version = "0.34.0", default-features = false, features = [
 ] }
 serde = { version = "1.0.152", features = ["derive"] }
 serde_json = "1.0.93"
-sha1_smol = { version = "1.0.0", features = ["serde"] }
+sha1_smol = { version = "1.0.0", features = ["serde", "std"] }
 sourcemap = { version = "9.2.0", features = ["ram_bundle"] }
 symbolic = { version = "12.13.3", features = ["debuginfo-serde", "il2cpp"] }
 thiserror = "1.0.38"

--- a/src/api/data_types/chunking/build.rs
+++ b/src/api/data_types/chunking/build.rs
@@ -28,9 +28,9 @@ pub struct AssembleBuildResponse {
 #[derive(Debug, Serialize)]
 pub struct VcsInfo<'a> {
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub head_sha: Option<&'a str>,
+    pub head_sha: Option<Digest>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub base_sha: Option<&'a str>,
+    pub base_sha: Option<Digest>,
     #[serde(skip_serializing_if = "Option::is_none", rename = "provider")]
     pub vcs_provider: Option<&'a str>,
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/src/utils/releases.rs
+++ b/src/utils/releases.rs
@@ -160,7 +160,7 @@ pub fn detect_release_name() -> Result<String> {
 
     // finally try the git sha
     match vcs::find_head_sha() {
-        Ok(head) => Ok(head),
+        Ok(head) => Ok(head.to_string()),
         Err(e) => Err(anyhow!(
             "Could not automatically determine release name:\n\t {e} \n\n\
             Please ensure your version control system is configured correctly, \

--- a/tests/integration/_cases/build/build-invalid-base-sha.trycmd
+++ b/tests/integration/_cases/build/build-invalid-base-sha.trycmd
@@ -1,0 +1,8 @@
+```
+$ sentry-cli build upload tests/integration/_fixtures/build/apk.apk --base-sha test_base_sha
+? failed
+error: invalid value 'test_base_sha' for '--base-sha <base_sha>': test_base_sha is not a valid SHA1 digest
+
+For more information, try '--help'.
+
+```

--- a/tests/integration/_cases/build/build-invalid-head-sha.trycmd
+++ b/tests/integration/_cases/build/build-invalid-head-sha.trycmd
@@ -1,0 +1,8 @@
+```
+$ sentry-cli build upload tests/integration/_fixtures/build/apk.apk --head-sha test_head_sha
+? failed
+error: invalid value 'test_head_sha' for '--head-sha <head_sha>': test_head_sha is not a valid SHA1 digest
+
+For more information, try '--help'.
+
+```

--- a/tests/integration/_cases/build/build-upload-apk.trycmd
+++ b/tests/integration/_cases/build/build-upload-apk.trycmd
@@ -1,5 +1,5 @@
 ```
-$ sentry-cli build upload tests/integration/_fixtures/build/apk.apk --head-sha test_head_sha
+$ sentry-cli build upload tests/integration/_fixtures/build/apk.apk --head-sha 12345678deadbeef78900987feebdaed87654321
 ? success
 > Preparing for upload completed in [..]
 > Uploading completed in [..]

--- a/tests/integration/_cases/build/build-upload-empty-shas.trycmd
+++ b/tests/integration/_cases/build/build-upload-empty-shas.trycmd
@@ -1,0 +1,8 @@
+```
+$ sentry-cli build upload tests/integration/_fixtures/build/apk.apk --head-sha "" --base-sha ""
+? success
+> Preparing for upload completed in [..]
+Successfully uploaded 1 file to Sentry
+  - tests/integration/_fixtures/build/apk.apk (http://sentry.io/wat-org/preprod/wat-project/42)
+
+```

--- a/tests/integration/_cases/build/build-upload-ipa.trycmd
+++ b/tests/integration/_cases/build/build-upload-ipa.trycmd
@@ -1,5 +1,5 @@
 ```
-$ sentry-cli build upload tests/integration/_fixtures/build/ipa.ipa --head-sha test_head_sha
+$ sentry-cli build upload tests/integration/_fixtures/build/ipa.ipa --head-sha deadbeef12345678deadbeef12345678deadbeef
 ? success
 > Preparing for upload completed in [..]
 Successfully uploaded 1 file to Sentry


### PR DESCRIPTION
### Description
Add client-side validation for SHA fields. Also, don't send these fields' values if the user overrides them with an empty string like `--head-sha ""`.

### Issues
- Ref #2941
- Ref [CLI-224](https://linear.app/getsentry/issue/CLI-224/skip-serializing-certain-fields-for-build-upload)



