### PR TITLE
chore(proguard): Remove `--platform` argument

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@
   - `SENTRY_API_KEY` environment variable
   - `api_key` configuration file field
   - `apiKey` option in the JavaScript API
-- Removed the `upload-proguard` subcommand's `--app-id`, `--version`, `--version-code`, and `--android-manifest` arguments ([#2876](https://github.com/getsentry/sentry-cli/pull/2876), [#2940](https://github.com/getsentry/sentry-cli/pull/2940)). Users using these arguments should stop using them, as they are unnecessary. The information passed to these arguments is no longer visible in Sentry.
+- Removed the `upload-proguard` subcommand's `--app-id`, `--version`, `--version-code`, `--android-manifest`, and `--platform` arguments ([#2876](https://github.com/getsentry/sentry-cli/pull/2876), [#2940](https://github.com/getsentry/sentry-cli/pull/2940), [#2948](https://github.com/getsentry/sentry-cli/pull/2948)). Users using these arguments should stop using them, as they are unnecessary. The information passed to these arguments is no longer visible in Sentry.
 
 #### Node.js Wrapper Breakages
 

--- a/src/commands/upload_proguard.rs
+++ b/src/commands/upload_proguard.rs
@@ -29,16 +29,6 @@ pub fn make_command(command: Command) -> Command {
                 .action(ArgAction::Append),
         )
         .arg(
-            Arg::new("platform")
-                .hide(true)
-                .long("platform")
-                .value_name("PLATFORM")
-                .help(
-                    "[DEPRECATED] This flag is a no-op, scheduled \
-                    for removal in Sentry CLI 3.0.0.",
-                ),
-        )
-        .arg(
             Arg::new("no_upload")
                 .long("no-upload")
                 .action(ArgAction::SetTrue)
@@ -82,14 +72,6 @@ pub fn make_command(command: Command) -> Command {
 }
 
 pub fn execute(matches: &ArgMatches) -> Result<()> {
-    if matches.get_one::<String>("platform").is_some() {
-        log::warn!(
-            "[DEPRECATION NOTICE] The --platform argument is deprecated, \
-            and is scheduled for removal in Sentry CLI 3.0.0. \
-            The argument is a no-op."
-        );
-    }
-
     let paths: Vec<_> = match matches.get_many::<String>("paths") {
         Some(paths) => paths.collect(),
         None => {

--- a/tests/integration/_cases/upload_proguard/upload_proguard-help.trycmd
+++ b/tests/integration/_cases/upload_proguard/upload_proguard-help.trycmd
@@ -14,17 +14,17 @@ Options:
                                  in key:value format.
   -p, --project <PROJECT>        The project ID or slug.
       --auth-token <AUTH_TOKEN>  Use the given Sentry auth token.
-      --log-level <LOG_LEVEL>    Set the log output verbosity. [possible values: trace, debug, info,
-                                 warn, error]
       --no-upload                Disable the actual upload.
                                  This runs all steps for the processing but does not trigger the
                                  upload.  This is useful if you just want to verify the mapping
                                  files and write the proguard UUIDs into a properties file.
+      --log-level <LOG_LEVEL>    Set the log output verbosity. [possible values: trace, debug, info,
+                                 warn, error]
+      --write-properties <PATH>  Write the UUIDs for the processed mapping files into the given
+                                 properties file.
       --quiet                    Do not print any output while preserving correct exit code. This
                                  flag is currently implemented only for selected subcommands.
                                  [aliases: --silent]
-      --write-properties <PATH>  Write the UUIDs for the processed mapping files into the given
-                                 properties file.
       --require-one              Requires at least one file to upload or the command will error.
   -u, --uuid <UUID>              Explicitly override the UUID of the mapping file with another one.
                                  This should be used with caution as it means that you can upload


### PR DESCRIPTION
### Description
Remove the deprecated `--platform` argument.

### Issues
- Resolves #2851
- Resolves [CLI-193](https://linear.app/getsentry/issue/CLI-193/remove-upload-proguard-platform-flag)
