### PR TITLE
chore(debug-files): Remove non-chunked uploading support

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -19,7 +19,6 @@ use sentry::types::Dsn;
 
 use crate::constants::CONFIG_INI_FILE_PATH;
 use crate::constants::DEFAULT_MAX_DIF_ITEM_SIZE;
-use crate::constants::DEFAULT_MAX_DIF_UPLOAD_SIZE;
 use crate::constants::{CONFIG_RC_FILE_NAME, DEFAULT_RETRIES, DEFAULT_URL};
 use crate::utils::args;
 use crate::utils::auth_token::AuthToken;
@@ -455,17 +454,6 @@ impl Config {
                     .map(str::to_owned)
             }),
         )
-    }
-
-    /// Returns the maximum DIF upload size
-    pub fn get_max_dif_archive_size(&self) -> u64 {
-        let key = "max_upload_size";
-
-        self.ini
-            .get_from(Some("dif"), key)
-            .or_else(|| self.ini.get_from(Some("dsym"), key))
-            .and_then(|x| x.parse().ok())
-            .unwrap_or(DEFAULT_MAX_DIF_UPLOAD_SIZE)
     }
 
     /// Returns the maximum file size of a single file inside DIF bundle

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -42,7 +42,6 @@ pub const DEFAULT_MAX_DIF_SIZE: u64 = 2 * 1024 * 1024 * 1024; // 2GB
 /// Default maximum file size of a single file inside DIF bundle.
 pub const DEFAULT_MAX_DIF_ITEM_SIZE: u64 = 1024 * 1024; // 1MB
 /// Default maximum DIF upload size.
-pub const DEFAULT_MAX_DIF_UPLOAD_SIZE: u64 = 35 * 1024 * 1024; // 35MB
 /// Default maximum time to wait for file assembly.
 pub const DEFAULT_MAX_WAIT: Duration = Duration::from_secs(5 * 60);
 /// Maximum length for commit SHA values, enforced in backend.

--- a/src/utils/fs.rs
+++ b/src/utils/fs.rs
@@ -143,21 +143,6 @@ pub fn set_executable_mode<P: AsRef<Path>>(path: P) -> Result<()> {
     Ok(())
 }
 
-/// Returns the SHA1 hash of the given input.
-pub fn get_sha1_checksum<R: Read>(rdr: R) -> Result<Digest> {
-    let mut sha = Sha1::new();
-    let mut buf = [0u8; 16384];
-    let mut rdr = io::BufReader::new(rdr);
-    loop {
-        let read = rdr.read(&mut buf)?;
-        if read == 0 {
-            break;
-        }
-        sha.update(&buf[..read]);
-    }
-    Ok(sha.digest())
-}
-
 /// Returns the SHA1 hash for the entire input, as well as each chunk of it. The
 /// `chunk_size` must be non-zero.
 pub fn get_sha1_checksums(data: &[u8], chunk_size: NonZeroUsize) -> (Digest, Vec<Digest>) {

--- a/src/utils/ui.rs
+++ b/src/utils/ui.rs
@@ -1,5 +1,5 @@
 use std::io;
-use std::io::{Read, Write};
+use std::io::Write as _;
 
 use crate::utils::progress::{ProgressBar, ProgressStyle};
 
@@ -43,27 +43,6 @@ pub fn capitalize_string(s: &str) -> String {
     bytes[0] = bytes[0].to_ascii_uppercase();
     #[expect(clippy::unwrap_used, reason = "legacy code")]
     String::from_utf8(bytes).unwrap()
-}
-
-/// Like ``io::copy`` but advances a progress bar set to bytes.
-pub fn copy_with_progress<R, W>(pb: &ProgressBar, reader: &mut R, writer: &mut W) -> io::Result<u64>
-where
-    R: Read + ?Sized,
-    W: Write + ?Sized,
-{
-    let mut buf = [0; 16384];
-    let mut written = 0;
-    loop {
-        let len = match reader.read(&mut buf) {
-            Ok(0) => return Ok(written),
-            Ok(len) => len,
-            Err(ref e) if e.kind() == io::ErrorKind::Interrupted => continue,
-            Err(e) => return Err(e),
-        };
-        writer.write_all(&buf[..len])?;
-        written += len as u64;
-        pb.inc(len as u64);
-    }
 }
 
 /// Creates a progress bar for byte stuff


### PR DESCRIPTION
### Description
Removed support for non-chunked uploads of debug files.

### Issues
- Resolves #2950
- Resolves [CLI-227](https://linear.app/getsentry/issue/CLI-227/remove-support-for-non-chunked-debug-file-uploads)