### PR TITLE
ref(debug-files): Assume server supports all formats

### DIFF
--- a/src/api/data_types/chunking/dif.rs
+++ b/src/api/data_types/chunking/dif.rs
@@ -52,21 +52,6 @@ pub struct ChunkedDifResponse {
 #[serde(transparent)]
 pub struct AssembleDifsRequest<'a>(HashMap<Digest, ChunkedDifRequest<'a>>);
 
-impl AssembleDifsRequest<'_> {
-    /// Strips the debug_id from all requests in the request. We need
-    /// to strip the debug_ids whenever the server does not support chunked
-    /// uploading of PDBs, to maintain backwards compatibility. The
-    /// calling code is responsible for calling this function when needed.
-    ///
-    /// See: https://github.com/getsentry/sentry-cli/issues/980
-    /// See: https://github.com/getsentry/sentry-cli/issues/1056
-    pub fn strip_debug_ids(&mut self) {
-        for r in self.0.values_mut() {
-            r.debug_id = None;
-        }
-    }
-}
-
 impl<'a, T> FromIterator<T> for AssembleDifsRequest<'a>
 where
     T: Into<ChunkedDifRequest<'a>>,

--- a/src/api/data_types/chunking/upload/capability.rs
+++ b/src/api/data_types/chunking/upload/capability.rs
@@ -2,9 +2,6 @@ use serde::{Deserialize, Deserializer};
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum ChunkUploadCapability {
-    /// Chunked upload of debug files
-    DebugFiles,
-
     /// Chunked upload of release files
     ReleaseFiles,
 
@@ -14,21 +11,6 @@ pub enum ChunkUploadCapability {
     /// Like `ArtifactBundles`, but with deduplicated chunk
     /// upload.
     ArtifactBundlesV2,
-
-    /// Upload of PDBs and debug id overrides
-    Pdbs,
-
-    /// Upload of Portable PDBs
-    PortablePdbs,
-
-    /// Uploads of source archives
-    Sources,
-
-    /// Upload of BCSymbolMap and PList auxiliary DIFs
-    BcSymbolmap,
-
-    /// Upload of il2cpp line mappings
-    Il2Cpp,
 
     /// Upload of Dart symbol maps
     DartSymbolMap,
@@ -49,15 +31,9 @@ impl<'de> Deserialize<'de> for ChunkUploadCapability {
         D: Deserializer<'de>,
     {
         Ok(match String::deserialize(deserializer)?.as_str() {
-            "debug_files" => ChunkUploadCapability::DebugFiles,
             "release_files" => ChunkUploadCapability::ReleaseFiles,
             "artifact_bundles" => ChunkUploadCapability::ArtifactBundles,
             "artifact_bundles_v2" => ChunkUploadCapability::ArtifactBundlesV2,
-            "pdbs" => ChunkUploadCapability::Pdbs,
-            "portablepdbs" => ChunkUploadCapability::PortablePdbs,
-            "sources" => ChunkUploadCapability::Sources,
-            "bcsymbolmaps" => ChunkUploadCapability::BcSymbolmap,
-            "il2cpp" => ChunkUploadCapability::Il2Cpp,
             "dartsymbolmap" => ChunkUploadCapability::DartSymbolMap,
             "preprod_artifacts" => ChunkUploadCapability::PreprodArtifacts,
             "proguard" => ChunkUploadCapability::Proguard,

--- a/src/api/data_types/chunking/upload/options.rs
+++ b/src/api/data_types/chunking/upload/options.rs
@@ -23,7 +23,7 @@ pub struct ChunkServerOptions {
     pub concurrency: u8,
     #[serde(default)]
     pub compression: Vec<ChunkCompression>,
-    #[serde(default = "default_chunk_upload_accept")]
+    #[serde(default)]
     pub accept: Vec<ChunkUploadCapability>,
 }
 
@@ -32,18 +32,4 @@ impl ChunkServerOptions {
     pub fn supports(&self, capability: ChunkUploadCapability) -> bool {
         self.accept.contains(&capability)
     }
-
-    /// Determines whether we need to strip debug_ids from the requests. We need
-    /// to strip the debug_ids whenever the server does not support chunked
-    /// uploading of PDBs, to maintain backwards compatibility.
-    ///
-    /// See: https://github.com/getsentry/sentry-cli/issues/980
-    /// See: https://github.com/getsentry/sentry-cli/issues/1056
-    pub fn should_strip_debug_ids(&self) -> bool {
-        !self.supports(ChunkUploadCapability::DebugFiles)
-    }
-}
-
-fn default_chunk_upload_accept() -> Vec<ChunkUploadCapability> {
-    vec![ChunkUploadCapability::DebugFiles]
 }

--- a/src/utils/chunks/options.rs
+++ b/src/utils/chunks/options.rs
@@ -31,10 +31,6 @@ impl<'a> ChunkOptions<'a> {
         self
     }
 
-    pub fn should_strip_debug_ids(&self) -> bool {
-        self.server_options.should_strip_debug_ids()
-    }
-
     pub fn org(&self) -> &str {
         self.org
     }

--- a/src/utils/chunks/upload.rs
+++ b/src/utils/chunks/upload.rs
@@ -53,11 +53,7 @@ where
     T: AsRef<[u8]> + Assemblable,
 {
     let api = Api::current();
-    let mut request: AssembleDifsRequest<'_> = objects.iter().collect();
-
-    if options.should_strip_debug_ids() {
-        request.strip_debug_ids();
-    }
+    let request: AssembleDifsRequest<'_> = objects.iter().collect();
 
     let response =
         api.authenticated()?
@@ -188,10 +184,7 @@ where
 
     let assemble_start = Instant::now();
 
-    let mut request: AssembleDifsRequest<'_> = chunked_objects.iter().copied().collect();
-    if options.should_strip_debug_ids() {
-        request.strip_debug_ids();
-    }
+    let request: AssembleDifsRequest<'_> = chunked_objects.iter().copied().collect();
 
     let response = loop {
         let response =


### PR DESCRIPTION
### Description
All debug file formats have been supported for at least three years, so with the Sentry CLI 3.0 release, all servers we support will support all debug file formats. Therefore, checking supported formats is no longer needed.

### Issues
- Resolves #2953
- Resolves [CLI-229](https://linear.app/getsentry/issue/CLI-229/assume-server-supports-all-debug-file-formats)