### PR TITLE
chore(sourcemaps): Remove support for non-chunked uploads

### DIFF
--- a/src/api/data_types/chunking/upload/capability.rs
+++ b/src/api/data_types/chunking/upload/capability.rs
@@ -2,9 +2,6 @@ use serde::{Deserialize, Deserializer};
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum ChunkUploadCapability {
-    /// Chunked upload of release files
-    ReleaseFiles,
-
     /// Chunked upload of standalone artifact bundles
     ArtifactBundles,
 
@@ -31,7 +28,6 @@ impl<'de> Deserialize<'de> for ChunkUploadCapability {
         D: Deserializer<'de>,
     {
         Ok(match String::deserialize(deserializer)?.as_str() {
-            "release_files" => ChunkUploadCapability::ReleaseFiles,
             "artifact_bundles" => ChunkUploadCapability::ArtifactBundles,
             "artifact_bundles_v2" => ChunkUploadCapability::ArtifactBundlesV2,
             "dartsymbolmap" => ChunkUploadCapability::DartSymbolMap,

--- a/src/utils/auth_token/org_auth_token.rs
+++ b/src/utils/auth_token/org_auth_token.rs
@@ -14,7 +14,6 @@ pub struct OrgAuthToken {
 /// Represents the payload data of an org auth token.
 #[derive(Clone, Debug, Deserialize)]
 pub struct AuthTokenPayload {
-    pub region_url: String,
     pub org: String,
 
     // URL may be missing from some old auth tokens, see getsentry/sentry#57123


### PR DESCRIPTION
### Description
Remove support for non-chunked sourcemaps uploads. Also, drop `ReleaseFiles` chunk upload capability, as we now assume that all servers support chunked uploads for release files.

### Issues
- Resolves #2949
- Resolves [CLI-226](https://linear.app/getsentry/issue/CLI-226/remove-support-for-non-chunked-sourcemap-uploads)