### PR TITLE
ref(sourcemaps): `UploadContext` always has `projects`

### DIFF
--- a/src/commands/react_native/appcenter.rs
+++ b/src/commands/react_native/appcenter.rs
@@ -196,7 +196,7 @@ pub fn execute(matches: &ArgMatches) -> Result<()> {
 
             processor.upload(&UploadContext {
                 org: &org,
-                projects: Some(projects.as_non_empty_slice()),
+                projects: projects.as_non_empty_slice(),
                 release: Some(&release),
                 dist: None,
                 note: None,
@@ -214,7 +214,7 @@ pub fn execute(matches: &ArgMatches) -> Result<()> {
 
                 processor.upload(&UploadContext {
                     org: &org,
-                    projects: Some(projects.as_non_empty_slice()),
+                    projects: projects.as_non_empty_slice(),
                     release: Some(&release),
                     dist: Some(dist),
                     note: None,

--- a/src/commands/react_native/gradle.rs
+++ b/src/commands/react_native/gradle.rs
@@ -123,7 +123,7 @@ pub fn execute(matches: &ArgMatches) -> Result<()> {
 
             processor.upload(&UploadContext {
                 org: &org,
-                projects: Some(projects.as_non_empty_slice()),
+                projects: projects.as_non_empty_slice(),
                 release: Some(version),
                 dist: Some(dist),
                 note: None,
@@ -136,7 +136,7 @@ pub fn execute(matches: &ArgMatches) -> Result<()> {
         // Debug Id Upload
         processor.upload(&UploadContext {
             org: &org,
-            projects: Some(projects.as_non_empty_slice()),
+            projects: projects.as_non_empty_slice(),
             release: None,
             dist: None,
             note: None,

--- a/src/commands/react_native/xcode.rs
+++ b/src/commands/react_native/xcode.rs
@@ -345,7 +345,7 @@ pub fn execute(matches: &ArgMatches) -> Result<()> {
     if dist_from_env.is_err() && release_from_env.is_err() && matches.get_flag("no_auto_release") {
         processor.upload(&UploadContext {
             org: &org,
-            projects: Some(projects.as_non_empty_slice()),
+            projects: projects.as_non_empty_slice(),
             release: None,
             dist: None,
             note: None,
@@ -380,7 +380,7 @@ pub fn execute(matches: &ArgMatches) -> Result<()> {
             None => {
                 processor.upload(&UploadContext {
                     org: &org,
-                    projects: Some(projects.as_non_empty_slice()),
+                    projects: projects.as_non_empty_slice(),
                     release: release_name.as_deref(),
                     dist: dist.as_deref(),
                     note: None,
@@ -393,7 +393,7 @@ pub fn execute(matches: &ArgMatches) -> Result<()> {
                 for dist in dists {
                     processor.upload(&UploadContext {
                         org: &org,
-                        projects: Some(projects.as_non_empty_slice()),
+                        projects: projects.as_non_empty_slice(),
                         release: release_name.as_deref(),
                         dist: Some(dist),
                         note: None,

--- a/src/commands/sourcemaps/upload.rs
+++ b/src/commands/sourcemaps/upload.rs
@@ -455,7 +455,7 @@ pub fn execute(matches: &ArgMatches) -> Result<()> {
     let max_wait = wait_for_secs.map_or(DEFAULT_MAX_WAIT, Duration::from_secs);
     let upload_context = UploadContext {
         org: &org,
-        projects: Some(projects.as_non_empty_slice()),
+        projects: projects.as_non_empty_slice(),
         release: version.as_deref(),
         dist: matches.get_one::<String>("dist").map(String::as_str),
         note: matches.get_one::<String>("note").map(String::as_str),

--- a/src/utils/source_bundle.rs
+++ b/src/utils/source_bundle.rs
@@ -43,7 +43,7 @@ impl<'a> From<&'a UploadContext<'a>> for BundleContext<'a> {
     fn from(context: &'a UploadContext<'a>) -> Self {
         Self {
             org: context.org,
-            projects: context.projects,
+            projects: Some(context.projects),
             note: context.note,
             release: context.release,
             dist: context.dist,


### PR DESCRIPTION
### Description
Following #2956, the `UploadContext` struct's `projects` field is always `Some`, indicating we have at least one project.

Here, we change the type from `Option<NonEmptySlice>` to `NonEmptySlice` to indicate that we always have a project set.

