### PR TITLE
chore: Update js-yaml

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3378,9 +3378,9 @@
       "dev": true
     },
     "js-yaml": {
-      "version": "3.14.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
-      "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
+      "version": "3.14.2",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.2.tgz",
+      "integrity": "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==",
       "dev": true,
       "requires": {
         "argparse": "^1.0.7",


### PR DESCRIPTION
### Description

This updates js-yaml to 3.14.2: https://nvd.nist.gov/vuln/detail/CVE-2025-64718.

We were not quite affected by it, since only ESLint and Jest uses it (and we didn't use it directly)

<img width="367" height="184" alt="Screenshot 2025-11-19 at 10 00 16" src="https://github.com/user-attachments/assets/26920547-e290-4e8b-a593-4165544cf7cc" />




