### PR TITLE
chore(releases): Remove `release finalize` `--started` option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
   - `api_key` configuration file field
   - `apiKey` option in the JavaScript API
 - Removed the `upload-proguard` subcommand's `--app-id`, `--version`, `--version-code`, `--android-manifest`, and `--platform` arguments ([#2876](https://github.com/getsentry/sentry-cli/pull/2876), [#2940](https://github.com/getsentry/sentry-cli/pull/2940), [#2948](https://github.com/getsentry/sentry-cli/pull/2948)). Users using these arguments should stop using them, as they are unnecessary. The information passed to these arguments is no longer visible in Sentry.
+- Removed the `--started` argument from the `sentry-cli releases finalize` command ([#2972](https://github.com/getsentry/sentry-cli/pull/2972)). This argument is a no-op, so any users using it should simply stop using it.
 
 #### Node.js Wrapper Breakages
 

--- a/src/commands/releases/finalize.rs
+++ b/src/commands/releases/finalize.rs
@@ -18,14 +18,6 @@ pub fn make_command(command: Command) -> Command {
                 .help("Optional URL to the release for information purposes."),
         )
         .arg(
-            Arg::new("started")
-                .long("started")
-                .hide(true)
-                .value_parser(get_timestamp)
-                .value_name("TIMESTAMP")
-                .help("[DEPRECATED] This value is ignored."),
-        )
-        .arg(
             Arg::new("released")
                 .long("released")
                 .value_parser(get_timestamp)
@@ -39,13 +31,6 @@ pub fn execute(matches: &ArgMatches) -> Result<()> {
     let api = Api::current();
     #[expect(clippy::unwrap_used, reason = "legacy code")]
     let version = matches.get_one::<String>("version").unwrap();
-
-    if matches.get_one::<DateTime<Utc>>("started").is_some() {
-        log::warn!(
-            "The --started flag is deprecated. Its value is ignored, \
-            and the argument will be completely removed in a future version."
-        );
-    }
 
     api.authenticated()?.update_release(
         &config.get_org(matches)?,


### PR DESCRIPTION
### Description
This option has already been deprecated.

### Issues
- Resolves #2516 
- Resolves [CLI-86](https://linear.app/getsentry/issue/CLI-86/remove-releases-finalize-started-option)