### PR TITLE
chore: Remove support for `brotli` chunk compression

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -61,21 +61,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "alloc-no-stdlib"
-version = "2.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc7bb162ec39d46ab1ca8c77bf72e890535becd1751bb45f64c597edb4c8c6b3"
-
-[[package]]
-name = "alloc-stdlib"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94fb8275041c72129eb51b7d0322c29b8387a0386127718b096429201a5d6ece"
-dependencies = [
- "alloc-no-stdlib",
-]
-
-[[package]]
 name = "allocator-api2"
 version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -305,27 +290,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
  "generic-array",
-]
-
-[[package]]
-name = "brotli"
-version = "8.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4bd8b9603c7aa97359dbd97ecf258968c95f3adddd6db2f7e7a5bef101c84560"
-dependencies = [
- "alloc-no-stdlib",
- "alloc-stdlib",
- "brotli-decompressor",
-]
-
-[[package]]
-name = "brotli-decompressor"
-version = "5.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "874bb8112abecc98cbd6d81ea4fa7e94fb9449648c93cc89aa40c81c24d7de03"
-dependencies = [
- "alloc-no-stdlib",
- "alloc-stdlib",
 ]
 
 [[package]]
@@ -2733,7 +2697,6 @@ dependencies = [
  "apple-catalog-parsing",
  "assert_cmd",
  "backon",
- "brotli",
  "bytecount",
  "chrono",
  "chrono-tz",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -78,7 +78,6 @@ chrono-tz = "0.8.4"
 secrecy = "0.8.0"
 lru = "0.16.0"
 backon = { version = "1.5.2", features = ["std", "std-blocking-sleep"] }
-brotli = "8.0.2"
 
 [dev-dependencies]
 assert_cmd = "2.0.11"

--- a/src/api/data_types/chunking/compression.rs
+++ b/src/api/data_types/chunking/compression.rs
@@ -7,8 +7,6 @@ use serde::Deserialize;
 pub enum ChunkCompression {
     /// GZIP compression (including header)
     Gzip = 10,
-    /// Brotli compression
-    Brotli = 20,
     /// No compression should be applied
     #[default]
     #[serde(other)]
@@ -20,7 +18,6 @@ impl ChunkCompression {
         match self {
             ChunkCompression::Uncompressed => "file",
             ChunkCompression::Gzip => "file_gzip",
-            ChunkCompression::Brotli => "file_brotli",
         }
     }
 }
@@ -30,7 +27,6 @@ impl fmt::Display for ChunkCompression {
         match *self {
             ChunkCompression::Uncompressed => write!(f, "uncompressed"),
             ChunkCompression::Gzip => write!(f, "gzip"),
-            ChunkCompression::Brotli => write!(f, "brotli"),
         }
     }
 }

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -22,8 +22,6 @@ use std::{fmt, thread};
 
 use anyhow::{Context as _, Result};
 use backon::BlockingRetryable as _;
-use brotli::enc::BrotliEncoderParams;
-use brotli::CompressorWriter;
 #[cfg(target_os = "macos")]
 use chrono::Duration;
 use chrono::{DateTime, FixedOffset, Utc};
@@ -358,20 +356,6 @@ impl Api {
     /// Compresses a file with the given compression.
     fn compress(data: &[u8], compression: ChunkCompression) -> Result<Vec<u8>, io::Error> {
         Ok(match compression {
-            ChunkCompression::Brotli => {
-                let mut encoder = CompressorWriter::with_params(
-                    Vec::new(),
-                    0,
-                    &BrotliEncoderParams {
-                        quality: 6,
-                        ..Default::default()
-                    },
-                );
-                encoder.write_all(data)?;
-                encoder.flush()?;
-                encoder.into_inner()
-            }
-
             ChunkCompression::Gzip => {
                 let mut encoder = GzEncoder::new(Vec::new(), Default::default());
                 encoder.write_all(data)?;


### PR DESCRIPTION
### Description
It appears we have never supported `brotli` server-side so there is no reason to support it in the CLI, either.

### Issues
- Resolves #2808 
- Resolves [CLI-174](https://linear.app/getsentry/issue/CLI-174/remove-brotli-support-for-chunk-uploads)