### PR TITLE
chore: Drop Node <18 support

### DIFF
--- a/.github/workflows/test_node.yml
+++ b/.github/workflows/test_node.yml
@@ -72,7 +72,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: [10.x, 12.x, 14.x, 16.x, 18.x, 20.x, 22.x, 24.x]
+        node-version: [18.x, 20.x, 22.x, 24.x]
 
     name: Test Node ${{ matrix.node-version }}
     runs-on: ubuntu-24.04
@@ -101,9 +101,5 @@ jobs:
         with:
           name: artifact-build
           path: js
-
-      # older node versions need an older nft
-      - run: SENTRYCLI_SKIP_DOWNLOAD=1 npm install @vercel/nft@0.22.1
-        if: matrix.node-version == '10.x' || matrix.node-version == '12.x'
 
       - run: npm test

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ The following changes only apply when using `sentry-cli` via the npm package [`@
 - The `SentryCli.execute` method's `live` parameter now only takes boolean values ([#2971](https://github.com/getsentry/sentry-cli/pull/2971)). Setting `live` to `true` now behaves like `'rejectOnError'` did previously, with a zero exit status resolving the returned promise with `"success (live mode)"` and a non-zero status rejecting the promise with an error message.
 - The `option` parameter to `Releases.uploadSourceMaps` no longer takes a `live` property ([#2971](https://github.com/getsentry/sentry-cli/pull/2971)). We now always execute the command with `live` set to `true`.
 - Removed the `apiKey` option from `SentryCliOptions` ([#2935](https://github.com/getsentry/sentry-cli/pull/2935)). If you are using `apiKey`, you need to generate and use an [Auth Token](https://docs.sentry.io/account/auth-tokens/) via the `authToken` option, instead.
+- Drop support for Node.js <18. The minimum required Node.js version is now 18.0.0 ([#2985](https://github.com/getsentry/sentry-cli/issues/2985)).
 
 ### Improvements
 

--- a/npm-binary-distributions/darwin/package.json
+++ b/npm-binary-distributions/darwin/package.json
@@ -8,7 +8,7 @@
     "access": "public"
   },
   "engines": {
-    "node": ">=10"
+    "node": ">=18"
   },
   "os": [
     "darwin"

--- a/npm-binary-distributions/linux-arm/package.json
+++ b/npm-binary-distributions/linux-arm/package.json
@@ -8,7 +8,7 @@
     "access": "public"
   },
   "engines": {
-    "node": ">=10"
+    "node": ">=18"
   },
   "os": [
     "linux",

--- a/npm-binary-distributions/linux-arm64/package.json
+++ b/npm-binary-distributions/linux-arm64/package.json
@@ -8,7 +8,7 @@
     "access": "public"
   },
   "engines": {
-    "node": ">=10"
+    "node": ">=18"
   },
   "os": [
     "linux",

--- a/npm-binary-distributions/linux-i686/package.json
+++ b/npm-binary-distributions/linux-i686/package.json
@@ -8,7 +8,7 @@
     "access": "public"
   },
   "engines": {
-    "node": ">=10"
+    "node": ">=18"
   },
   "os": [
     "linux",

--- a/npm-binary-distributions/linux-x64/package.json
+++ b/npm-binary-distributions/linux-x64/package.json
@@ -8,7 +8,7 @@
     "access": "public"
   },
   "engines": {
-    "node": ">=10"
+    "node": ">=18"
   },
   "os": [
     "linux",

--- a/npm-binary-distributions/win32-arm64/package.json
+++ b/npm-binary-distributions/win32-arm64/package.json
@@ -8,7 +8,7 @@
     "access": "public"
   },
   "engines": {
-    "node": ">=10"
+    "node": ">=18"
   },
   "os": [
     "win32"

--- a/npm-binary-distributions/win32-i686/package.json
+++ b/npm-binary-distributions/win32-i686/package.json
@@ -8,7 +8,7 @@
     "access": "public"
   },
   "engines": {
-    "node": ">=10"
+    "node": ">=18"
   },
   "os": [
     "win32"

--- a/npm-binary-distributions/win32-x64/package.json
+++ b/npm-binary-distributions/win32-x64/package.json
@@ -8,7 +8,7 @@
     "access": "public"
   },
   "engines": {
-    "node": ">=10"
+    "node": ">=18"
   },
   "os": [
     "win32"

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "author": "Sentry",
   "license": "FSL-1.1-MIT",
   "engines": {
-    "node": ">= 10"
+    "node": ">= 18"
   },
   "main": "js/index.js",
   "types": "js/index.d.ts",


### PR DESCRIPTION
closes #2985 

This will ensure that in the future don't have to work around certain features which are not available in older Node versions.