### PR TITLE
chore(pypi): Remove inaccurate license classifier

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -9,7 +9,6 @@ author_email = oss@sentry.io
 license = FSL-1.1-MIT
 license_file = LICENSE
 classifiers =
-    License :: OSI Approved :: BSD License
     Programming Language :: Python :: 3
     Programming Language :: Python :: 3 :: Only
     Programming Language :: Python :: Implementation :: CPython


### PR DESCRIPTION
### Description
This license classifier is inaccurate, as it is still referencing the old BSD license.

Since [license classifiers are deprecated anyhow](https://packaging.python.org/en/latest/specifications/core-metadata/#classifier-multiple-use), we just remove the license classifier.

### Issues
- Resolves #2987 
- Resolves [CLI-237](https://linear.app/getsentry/issue/CLI-237/update-all-references-to-old-bsd-license)