### PR TITLE
feat: Move javascript files to native typescript

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,25 @@ The following changes only apply when using `sentry-cli` via the npm package [`@
 - Removed the `apiKey` option from `SentryCliOptions` ([#2935](https://github.com/getsentry/sentry-cli/pull/2935)). If you are using `apiKey`, you need to generate and use an [Auth Token](https://docs.sentry.io/account/auth-tokens/) via the `authToken` option, instead.
 - Removed the `useArtifactBundle` option from `SentryCliUploadSourceMapsOptions` ([#3002](https://github.com/getsentry/sentry-cli/pull/3002)). This deprecated option was a no-op that users should simply stop passing.
 - Drop support for Node.js <18. The minimum required Node.js version is now 18.0.0 ([#2985](https://github.com/getsentry/sentry-cli/issues/2985)).
+- The type export `SentryCliReleases` has been removed.
+- The JavaScript wrapper now uses named exports instead of default exports ([#2989](https://github.com/getsentry/sentry-cli/pull/2989)). You need to update your imports:
+  ```js
+  // Old (default import)
+  const SentryCli = require('@sentry/cli');
+
+  // New (named import)
+  const { SentryCli } = require('@sentry/cli');
+  ```
+
+  For ESM imports:
+  ```js
+  // Old
+  import SentryCli from '@sentry/cli';
+
+  // New
+  import { SentryCli } from '@sentry/cli';
+  ```
+
 
 ### Improvements
 

--- a/bin/sentry-cli
+++ b/bin/sentry-cli
@@ -3,7 +3,7 @@
 'use strict';
 
 const childProcess = require('child_process');
-const SentryCli = require('../js');
+const { SentryCli } = require('../js');
 
 const child = childProcess
   .spawn(SentryCli.getPath(), process.argv.slice(2), {

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,4 +1,7 @@
 module.exports = {
   setupFiles: ['<rootDir>/setupTests.js'],
   testPathIgnorePatterns: ['<rootDir>/src/'],
+  transform: {
+    '^.+\\.ts$': 'ts-jest',
+  },
 };

--- a/lib/__tests__/helper.test.js
+++ b/lib/__tests__/helper.test.js
@@ -2,7 +2,7 @@ const os = require('os');
 
 const helper = require('../helper');
 
-const SOURCEMAPS_OPTIONS = require('../releases/options/uploadSourcemaps');
+const { SOURCEMAPS_OPTIONS } = require('../releases/options/uploadSourcemaps');
 
 describe('SentryCli helper', () => {
   test('call sentry-cli --version', () => {

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -1,17 +1,17 @@
 'use strict';
 
-const pkgInfo = require('../package.json');
-const helper = require('./helper');
-const Releases = require('./releases');
+import * as pkgInfo from '../package.json';
+import * as helper from './helper';
+import { Releases } from './releases';
+import type { SentryCliOptions } from './types';
 
-/**
- * @typedef {import('./types').SentryCliOptions} SentryCliOptions
- * @typedef {import('./types').SentryCliUploadSourceMapsOptions} SentryCliUploadSourceMapsOptions
- * @typedef {import('./types').SourceMapsPathDescriptor} SourceMapsPathDescriptor
- * @typedef {import('./types').SentryCliNewDeployOptions} SentryCliNewDeployOptions
- * @typedef {import('./types').SentryCliCommitsOptions} SentryCliCommitsOptions
- * @typedef {import('./types').SentryCliReleases} SentryCliReleases
- */
+export type {
+  SentryCliOptions,
+  SentryCliUploadSourceMapsOptions,
+  SourceMapsPathDescriptor,
+  SentryCliNewDeployOptions,
+  SentryCliCommitsOptions,
+} from './types';
 
 /**
  * Interface to and wrapper around the `sentry-cli` executable.
@@ -28,7 +28,9 @@ const Releases = require('./releases');
  * const release = await cli.releases.proposeVersion());
  * console.log(release);
  */
-class SentryCli {
+export class SentryCli {
+  public releases: Releases;
+
   /**
    * Creates a new `SentryCli` instance.
    *
@@ -36,47 +38,43 @@ class SentryCli {
    * location and the value specified in the `SENTRY_PROPERTIES` environment variable is
    * overridden.
    *
-   * @param {string | null} [configFile] - Path to Sentry CLI config properties, as described in https://docs.sentry.io/learn/cli/configuration/#properties-files.
+   * @param configFile Path to Sentry CLI config properties, as described in https://docs.sentry.io/learn/cli/configuration/#properties-files.
    * By default, the config file is looked for upwards from the current path and defaults from ~/.sentryclirc are always loaded.
    * This value will update `SENTRY_PROPERTIES` env variable.
-   * @param {SentryCliOptions} [options] - More options to pass to the CLI
+   * @param options More options to pass to the CLI
    */
-  constructor(configFile, options) {
+  constructor(public configFile: string | null, public options: SentryCliOptions) {
     if (typeof configFile === 'string') {
       this.configFile = configFile;
     }
     this.options = options || { silent: false };
-    this.releases = new Releases({ ...this.options, configFile });
+    this.releases = new Releases(this.options, configFile);
   }
 
   /**
    * Returns the version of the installed `sentry-cli` binary.
-   * @returns {string}
    */
-  static getVersion() {
+  static getVersion(): string {
     return pkgInfo.version;
   }
 
   /**
    * Returns an absolute path to the `sentry-cli` binary.
-   * @returns {string}
    */
-  static getPath() {
+  static getPath(): string {
     return helper.getPath();
   }
 
   /**
    * See {helper.execute} docs.
-   * @param {string[]} args Command line arguments passed to `sentry-cli`.
-   * @param {boolean} live can be set to:
+   * @param args Command line arguments passed to `sentry-cli`.
+   * @param live can be set to:
    *  - `true` to inherit stdio and reject the promise if the command
    *    exits with a non-zero exit code.
    *  - `false` to not inherit stdio and return the output as a string.
-   * @returns {Promise<string>} A promise that resolves to the standard output.
+   * @returns A promise that resolves to the standard output.
    */
-  execute(args, live) {
+  execute(args: string[], live: boolean): Promise<string> {
     return helper.execute(args, live, this.options.silent, this.configFile, this.options);
   }
 }
-
-module.exports = SentryCli;

--- a/lib/logger.ts
+++ b/lib/logger.ts
@@ -1,11 +1,9 @@
 'use strict';
 
-const format = require('util').format;
+import { format } from 'node:util';
 
-module.exports = class Logger {
-  constructor(stream) {
-    this.stream = stream;
-  }
+export class Logger {
+  constructor(public stream: NodeJS.WriteStream) {}
 
   log() {
     const message = format(...arguments);

--- a/lib/releases/__tests__/index.test.js
+++ b/lib/releases/__tests__/index.test.js
@@ -1,4 +1,4 @@
-const SentryCli = require('../..');
+const { SentryCli } = require('../..');
 
 describe('SentryCli releases', () => {
   afterEach(() => {
@@ -23,7 +23,7 @@ describe('SentryCli releases', () => {
     beforeEach(() => {
       mockExecute.mockClear();
       // eslint-disable-next-line global-require
-      const SentryCliLocal = require('../..');
+      const { SentryCli: SentryCliLocal } = require('../..');
       cli = new SentryCliLocal();
     });
     describe('new', () => {

--- a/lib/releases/options/deploys.ts
+++ b/lib/releases/options/deploys.ts
@@ -1,7 +1,9 @@
+import { OptionsSchema } from '../../helper';
+
 /**
- * @type {import('../../helper').OptionsSchema}
+ * Schema for the `deploys new` command.
  */
-module.exports = {
+export const DEPLOYS_OPTIONS = {
   env: {
     param: '--env',
     type: 'string',
@@ -26,4 +28,4 @@ module.exports = {
     param: '--url',
     type: 'string',
   },
-};
+} satisfies OptionsSchema;

--- a/lib/releases/options/uploadSourcemaps.ts
+++ b/lib/releases/options/uploadSourcemaps.ts
@@ -1,7 +1,9 @@
+import { OptionsSchema } from '../../helper';
+
 /**
- * @type {import('../../helper').OptionsSchema}
+ * Schema for the `upload-sourcemaps` command.
  */
-module.exports = {
+export const SOURCEMAPS_OPTIONS = {
   ignore: {
     param: '--ignore',
     type: 'array',
@@ -55,4 +57,4 @@ module.exports = {
     param: '--ext',
     type: 'array',
   },
-};
+} satisfies OptionsSchema;

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -5,7 +5,7 @@
 /**
  * Options for configuring the Sentry CLI
  */
-export interface SentryCliOptions {
+export type SentryCliOptions = {
   /**
    * The URL of the Sentry instance you are connecting to. Defaults to https://sentry.io/.
    * This value will update `SENTRY_URL` env variable.
@@ -64,7 +64,7 @@ export type SourceMapsPathDescriptor = Omit<SentryCliUploadSourceMapsOptions, 'i
 /**
  * Options for uploading source maps
  */
-export interface SentryCliUploadSourceMapsOptions {
+export type SentryCliUploadSourceMapsOptions = {
   /**
    * One or more paths that Sentry CLI should scan recursively for sources.
    * It will upload all .map files and match associated .js files.
@@ -142,7 +142,7 @@ export interface SentryCliUploadSourceMapsOptions {
 /**
  * Options for creating a new deployment
  */
-export interface SentryCliNewDeployOptions {
+export type SentryCliNewDeployOptions = {
   /**
    * Environment for this release. Values that make sense here would be `production` or `staging`.
    */
@@ -172,7 +172,7 @@ export interface SentryCliNewDeployOptions {
 /**
  * Options for setting commits on a release
  */
-export interface SentryCliCommitsOptions {
+export type SentryCliCommitsOptions = {
   /**
    * Automatically choose the associated commit (uses the current commit). Overrides other setCommit options.
    */
@@ -200,28 +200,4 @@ export interface SentryCliCommitsOptions {
    * When the flag is set, command will not fail and just exit silently if no new commits for a given release have been found.
    */
   ignoreEmpty?: boolean;
-}
-
-/**
- * Release management interface
- */
-export interface SentryCliReleases {
-  new (release: string, options?: { projects: string[] } | string[]): Promise<string>;
-
-  setCommits(release: string, options: SentryCliCommitsOptions): Promise<string>;
-
-  finalize(release: string): Promise<string>;
-
-  proposeVersion(): Promise<string>;
-
-  uploadSourceMaps(
-    release: string,
-    options: SentryCliUploadSourceMapsOptions & { live?: boolean }
-  ): Promise<string[]>;
-
-  listDeploys(release: string): Promise<string>;
-
-  newDeploy(release: string, options: SentryCliNewDeployOptions): Promise<string>;
-
-  execute(args: string[], live: boolean): Promise<string>;
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1293,6 +1293,15 @@
         "update-browserslist-db": "^1.1.3"
       }
     },
+    "bs-logger": {
+      "version": "0.2.6",
+      "resolved": "https://registry.npmjs.org/bs-logger/-/bs-logger-0.2.6.tgz",
+      "integrity": "sha512-pd8DCoxmbgc7hyPKOvxtqNcjYoOsABPQdcCUjGp3d42VR2CX1ORhk2A87oqqu5R1kk+76nsxZupkmyd+MVtCog==",
+      "dev": true,
+      "requires": {
+        "fast-json-stable-stringify": "2.x"
+      }
+    },
     "bser": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/bser/-/bser-2.1.1.tgz",
@@ -3546,6 +3555,12 @@
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
       "dev": true
     },
+    "lodash.memoize": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
+      "integrity": "sha512-t7j+NzmgnQzTAYXcsHYLgimltOV1MXHtlOWf6GjL9Kj8GK5FInw5JotxvbOs+IvV1/Dzo04/fCGfLVs7aXb4Ag==",
+      "dev": true
+    },
     "lodash.merge": {
       "version": "4.6.2",
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
@@ -3583,6 +3598,12 @@
           "dev": true
         }
       }
+    },
+    "make-error": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
+      "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
+      "dev": true
     },
     "makeerror": {
       "version": "1.0.12",
@@ -4882,6 +4903,22 @@
       "dev": true,
       "requires": {
         "punycode": "^2.1.1"
+      }
+    },
+    "ts-jest": {
+      "version": "27.1.5",
+      "resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-27.1.5.tgz",
+      "integrity": "sha512-Xv6jBQPoBEvBq/5i2TeSG9tt/nqkbpcurrEG1b+2yfBrcJelOZF9Ml6dmyMh7bcW9JyFbRYpR5rxROSlBLTZHA==",
+      "dev": true,
+      "requires": {
+        "bs-logger": "0.x",
+        "fast-json-stable-stringify": "2.x",
+        "jest-util": "^27.0.0",
+        "json5": "2.x",
+        "lodash.memoize": "4.x",
+        "make-error": "1.x",
+        "semver": "7.x",
+        "yargs-parser": "20.x"
       }
     },
     "type-check": {

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "jest": "^27.5.1",
     "npm-run-all": "^4.1.5",
     "prettier": "2.8.8",
+    "ts-jest": "^27.1.5",
     "typescript": "5.8.3"
   },
   "optionalDependencies": {

--- a/scripts/install.js
+++ b/scripts/install.js
@@ -18,7 +18,7 @@ const which = require('which');
 
 const helper = require('../js/helper');
 const pkgInfo = require('../package.json');
-const Logger = require('../js/logger');
+const { Logger } = require('../js/logger');
 
 const logger = new Logger(getLogStream('stderr'));
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,6 +4,7 @@
     "checkJs": true,
     "resolveJsonModule": true,
     "target": "ES2015",
+    "module": "commonjs",
     "moduleResolution": "node",
     "skipLibCheck": true,
     "rootDir": "lib",


### PR DESCRIPTION
(closes #2617)
(closes [CLI-142](https://linear.app/getsentry/issue/CLI-142/use-typescript-to-generate-type-declarations))

This PR migrates all JavaScript files in the `lib/` directory to native TypeScript, removing the need for JSDoc type annotations and improving type safety.

### Main Changes

- Converted all `.js` files to `.ts` with proper TypeScript syntax
- Changed module system from CommonJS to ES6 modules for better TypeScript interoperability
- Updated exports to use ES6 `export` syntax instead of `module.exports`
- All types are now exported as named exports for better type inference and IDE support
- `OptionsSchema` is now a union to satisfy `SOURCEMAPS_OPTIONS`, as this one didn't had the required `param`
- The exports of `lib/releases/options` has changed its name

### Breaking Changes

**Module Exports**
- **Before**: `module.exports = SentryCli;` (CommonJS)
- **After**: `export class SentryCli { ... }` (ES6 named export)

We could have maintained backwards compatibility with `export = SentryCli;`. The only problem were the types which needed to be exported as well. With ES6 named exports, we can now export all types alongside the class.

### Internal Improvements

Simplified `Release` constructor
- **Before**: `new Releases({ ...this.options, configFile })` - configFile was merged into options
- **After**: `new Releases(this.options, configFile)` - two separate parameters

With 2 parameters it's easier to maintain and makes the separation of concerns clearer.