### PR TITLE
chore(api): Stop calling project-release endpoints

### DIFF
--- a/src/commands/releases/delete.rs
+++ b/src/commands/releases/delete.rs
@@ -17,13 +17,11 @@ pub fn execute(matches: &ArgMatches) -> Result<()> {
     let api = Api::current();
     #[expect(clippy::unwrap_used, reason = "legacy code")]
     let version = matches.get_one::<String>("version").unwrap();
-    let project = config.get_project(matches).ok();
 
-    if api.authenticated()?.delete_release(
-        &config.get_org(matches)?,
-        project.as_deref(),
-        version,
-    )? {
+    if api
+        .authenticated()?
+        .delete_release(&config.get_org(matches)?, version)?
+    {
         println!("Deleted release {version}!");
     } else {
         println!("Did nothing. Release with this version ({version}) does not exist.");

--- a/src/commands/releases/info.rs
+++ b/src/commands/releases/info.rs
@@ -36,8 +36,7 @@ pub fn execute(matches: &ArgMatches) -> Result<()> {
     let version = matches.get_one::<String>("version").unwrap();
     let config = Config::current();
     let org = config.get_org(matches)?;
-    let project = config.get_project(matches).ok();
-    let release = authenticated_api.get_release(&org, project.as_deref(), version)?;
+    let release = authenticated_api.get_release(&org, version)?;
 
     if is_quiet_mode() {
         if release.is_none() {
@@ -85,9 +84,7 @@ pub fn execute(matches: &ArgMatches) -> Result<()> {
         }
 
         if matches.get_flag("show_commits") {
-            if let Ok(Some(commits)) =
-                authenticated_api.get_release_commits(&org, project.as_deref(), version)
-            {
+            if let Ok(Some(commits)) = authenticated_api.get_release_commits(&org, version) {
                 if !commits.is_empty() {
                     data_row.add(
                         commits

--- a/src/commands/releases/list.rs
+++ b/src/commands/releases/list.rs
@@ -43,10 +43,9 @@ pub fn make_command(command: Command) -> Command {
 pub fn execute(matches: &ArgMatches) -> Result<()> {
     let config = Config::current();
     let api = Api::current();
-    let project = config.get_project(matches).ok();
     let releases = api
         .authenticated()?
-        .list_releases(&config.get_org(matches)?, project.as_deref())?;
+        .list_releases(&config.get_org(matches)?)?;
 
     if matches.get_flag("raw") {
         let versions = releases

--- a/tests/integration/releases/delete.rs
+++ b/tests/integration/releases/delete.rs
@@ -6,7 +6,7 @@ fn successfully_deletes() {
         .mock_endpoint(
             MockEndpointBuilder::new(
                 "DELETE",
-                "/api/0/projects/wat-org/wat-project/releases/wat-release/",
+                "/api/0/organizations/wat-org/releases/wat-release/",
             )
             .with_status(204),
         )
@@ -20,7 +20,7 @@ fn allows_for_release_to_start_with_hyphen() {
         .mock_endpoint(
             MockEndpointBuilder::new(
                 "DELETE",
-                "/api/0/projects/wat-org/wat-project/releases/-hyphenated-release/",
+                "/api/0/organizations/wat-org/releases/-hyphenated-release/",
             )
             .with_status(204),
         )
@@ -32,11 +32,8 @@ fn allows_for_release_to_start_with_hyphen() {
 fn informs_about_nonexisting_releases() {
     TestManager::new()
         .mock_endpoint(
-            MockEndpointBuilder::new(
-                "DELETE",
-                "/api/0/projects/wat-org/wat-project/releases/whoops/",
-            )
-            .with_status(404),
+            MockEndpointBuilder::new("DELETE", "/api/0/organizations/wat-org/releases/whoops/")
+                .with_status(404),
         )
         .register_trycmd_test("releases/releases-delete-nonexisting.trycmd")
         .with_default_token();
@@ -48,7 +45,7 @@ fn doesnt_allow_to_delete_active_releases() {
         .mock_endpoint(
             MockEndpointBuilder::new(
                 "DELETE",
-                "/api/0/projects/wat-org/wat-project/releases/wat-release/",
+                "/api/0/organizations/wat-org/releases/wat-release/",
             )
             .with_status(400)
             .with_response_file("releases/delete-active-release.json"),

--- a/tests/integration/releases/finalize.rs
+++ b/tests/integration/releases/finalize.rs
@@ -6,11 +6,8 @@ use serde_json::json;
 fn successfully_creates_a_release() {
     TestManager::new()
         .mock_endpoint(
-            MockEndpointBuilder::new(
-                "PUT",
-                "/api/0/projects/wat-org/wat-project/releases/wat-release/",
-            )
-            .with_response_file("releases/get-release.json"),
+            MockEndpointBuilder::new("PUT", "/api/0/organizations/wat-org/releases/wat-release/")
+                .with_response_file("releases/get-release.json"),
         )
         .register_trycmd_test("releases/releases-finalize.trycmd")
         .with_default_token();
@@ -22,7 +19,7 @@ fn allows_for_release_to_start_with_hyphen() {
         .mock_endpoint(
             MockEndpointBuilder::new(
                 "PUT",
-                "/api/0/projects/wat-org/wat-project/releases/-hyphenated-release/",
+                "/api/0/organizations/wat-org/releases/-hyphenated-release/",
             )
             .with_response_file("releases/get-release.json"),
         )
@@ -34,15 +31,12 @@ fn allows_for_release_to_start_with_hyphen() {
 fn release_with_custom_dates() {
     TestManager::new()
         .mock_endpoint(
-            MockEndpointBuilder::new(
-                "PUT",
-                "/api/0/projects/wat-org/wat-project/releases/wat-release/",
-            )
-            .with_response_file("releases/get-release.json")
-            .with_matcher(Matcher::PartialJson(json!({
-                "projects": ["wat-project"],
-                "dateReleased": "2015-05-15T00:00:00Z"
-            }))),
+            MockEndpointBuilder::new("PUT", "/api/0/organizations/wat-org/releases/wat-release/")
+                .with_response_file("releases/get-release.json")
+                .with_matcher(Matcher::PartialJson(json!({
+                    "projects": ["wat-project"],
+                    "dateReleased": "2015-05-15T00:00:00Z"
+                }))),
         )
         .register_trycmd_test("releases/releases-finalize-dates.trycmd")
         .with_default_token();

--- a/tests/integration/releases/info.rs
+++ b/tests/integration/releases/info.rs
@@ -4,11 +4,8 @@ use crate::integration::{MockEndpointBuilder, TestManager};
 fn shows_release_details() {
     TestManager::new()
         .mock_endpoint(
-            MockEndpointBuilder::new(
-                "GET",
-                "/api/0/projects/wat-org/wat-project/releases/wat-release/",
-            )
-            .with_response_file("releases/get-release.json"),
+            MockEndpointBuilder::new("GET", "/api/0/organizations/wat-org/releases/wat-release/")
+                .with_response_file("releases/get-release.json"),
         )
         .register_trycmd_test("releases/releases-info.trycmd")
         .with_default_token();
@@ -18,16 +15,13 @@ fn shows_release_details() {
 fn shows_release_details_with_projects_and_commits() {
     TestManager::new()
         .mock_endpoint(
-            MockEndpointBuilder::new(
-                "GET",
-                "/api/0/projects/wat-org/wat-project/releases/wat-release/",
-            )
-            .with_response_file("releases/get-release.json"),
+            MockEndpointBuilder::new("GET", "/api/0/organizations/wat-org/releases/wat-release/")
+                .with_response_file("releases/get-release.json"),
         )
         .mock_endpoint(
             MockEndpointBuilder::new(
                 "GET",
-                "/api/0/projects/wat-org/wat-project/releases/wat-release/commits/",
+                "/api/0/organizations/wat-org/releases/wat-release/commits/",
             )
             .with_response_file("releases/get-release-commits.json"),
         )
@@ -39,11 +33,8 @@ fn shows_release_details_with_projects_and_commits() {
 fn doesnt_print_output_with_quiet_flag() {
     TestManager::new()
         .mock_endpoint(
-            MockEndpointBuilder::new(
-                "GET",
-                "/api/0/projects/wat-org/wat-project/releases/wat-release/",
-            )
-            .with_response_file("releases/get-release.json"),
+            MockEndpointBuilder::new("GET", "/api/0/organizations/wat-org/releases/wat-release/")
+                .with_response_file("releases/get-release.json"),
         )
         .register_trycmd_test("releases/releases-info-quiet.trycmd")
         .with_default_token();
@@ -53,11 +44,8 @@ fn doesnt_print_output_with_quiet_flag() {
 fn doesnt_print_output_with_silent_flag() {
     TestManager::new()
         .mock_endpoint(
-            MockEndpointBuilder::new(
-                "GET",
-                "/api/0/projects/wat-org/wat-project/releases/wat-release/",
-            )
-            .with_response_file("releases/get-release.json"),
+            MockEndpointBuilder::new("GET", "/api/0/organizations/wat-org/releases/wat-release/")
+                .with_response_file("releases/get-release.json"),
         )
         .register_trycmd_test("releases/releases-info-silent.trycmd")
         .with_default_token();
@@ -69,7 +57,7 @@ fn preserve_valid_exit_code_with_quiet_flag() {
         .mock_endpoint(
             MockEndpointBuilder::new(
                 "GET",
-                "/api/0/projects/wat-org/wat-project/releases/unknown-release/",
+                "/api/0/organizations/wat-org/releases/unknown-release/",
             )
             .with_status(404),
         )
@@ -81,11 +69,8 @@ fn preserve_valid_exit_code_with_quiet_flag() {
 fn exits_if_no_release_found() {
     TestManager::new()
         .mock_endpoint(
-            MockEndpointBuilder::new(
-                "GET",
-                "/api/0/projects/wat-org/wat-project/releases/wat-release/",
-            )
-            .with_status(404),
+            MockEndpointBuilder::new("GET", "/api/0/organizations/wat-org/releases/wat-release/")
+                .with_status(404),
         )
         .register_trycmd_test("releases/releases-info-not-found.trycmd")
         .with_default_token();

--- a/tests/integration/releases/list.rs
+++ b/tests/integration/releases/list.rs
@@ -4,7 +4,7 @@ use crate::integration::{MockEndpointBuilder, TestManager};
 fn displays_releases() {
     TestManager::new()
         .mock_endpoint(
-            MockEndpointBuilder::new("GET", "/api/0/projects/wat-org/wat-project/releases/")
+            MockEndpointBuilder::new("GET", "/api/0/organizations/wat-org/releases/")
                 .with_response_file("releases/get-releases.json"),
         )
         .register_trycmd_test("releases/releases-list.trycmd")
@@ -15,7 +15,7 @@ fn displays_releases() {
 fn displays_releases_with_projects() {
     TestManager::new()
         .mock_endpoint(
-            MockEndpointBuilder::new("GET", "/api/0/projects/wat-org/wat-project/releases/")
+            MockEndpointBuilder::new("GET", "/api/0/organizations/wat-org/releases/")
                 .with_response_file("releases/get-releases.json"),
         )
         .register_trycmd_test("releases/releases-list-with-projects.trycmd")
@@ -26,7 +26,7 @@ fn displays_releases_with_projects() {
 fn doesnt_fail_with_empty_response() {
     TestManager::new()
         .mock_endpoint(
-            MockEndpointBuilder::new("GET", "/api/0/projects/wat-org/wat-project/releases/")
+            MockEndpointBuilder::new("GET", "/api/0/organizations/wat-org/releases/")
                 .with_response_body("[]"),
         )
         .register_trycmd_test("releases/releases-list-empty.trycmd")
@@ -37,7 +37,7 @@ fn doesnt_fail_with_empty_response() {
 fn can_override_org() {
     TestManager::new()
         .mock_endpoint(
-            MockEndpointBuilder::new("GET", "/api/0/projects/whynot/wat-project/releases/")
+            MockEndpointBuilder::new("GET", "/api/0/organizations/whynot/releases/")
                 .with_response_file("releases/get-releases.json"),
         )
         .register_trycmd_test("releases/releases-list-override-org.trycmd")
@@ -48,7 +48,7 @@ fn can_override_org() {
 fn displays_releases_in_raw_mode() {
     TestManager::new()
         .mock_endpoint(
-            MockEndpointBuilder::new("GET", "/api/0/projects/wat-org/wat-project/releases/")
+            MockEndpointBuilder::new("GET", "/api/0/organizations/wat-org/releases/")
                 .with_response_file("releases/get-releases.json"),
         )
         .register_trycmd_test("releases/releases-list-raw.trycmd")
@@ -59,7 +59,7 @@ fn displays_releases_in_raw_mode() {
 fn displays_releases_in_raw_mode_with_delimiter() {
     TestManager::new()
         .mock_endpoint(
-            MockEndpointBuilder::new("GET", "/api/0/projects/wat-org/wat-project/releases/")
+            MockEndpointBuilder::new("GET", "/api/0/organizations/wat-org/releases/")
                 .with_response_file("releases/get-releases.json"),
         )
         .register_trycmd_test("releases/releases-list-raw-delimiter.trycmd")

--- a/tests/integration/releases/new.rs
+++ b/tests/integration/releases/new.rs
@@ -12,7 +12,7 @@ fn command_releases_new_help() {
 fn creates_release() {
     TestManager::new()
         .mock_endpoint(
-            MockEndpointBuilder::new("POST", "/api/0/projects/wat-org/wat-project/releases/")
+            MockEndpointBuilder::new("POST", "/api/0/organizations/wat-org/releases/")
                 .with_status(201)
                 .with_response_file("releases/get-release.json")
                 .with_matcher(Matcher::PartialJson(json!({
@@ -28,7 +28,7 @@ fn creates_release() {
 fn allows_for_release_to_start_with_hyphen() {
     TestManager::new()
         .mock_endpoint(
-            MockEndpointBuilder::new("POST", "/api/0/projects/wat-org/wat-project/releases/")
+            MockEndpointBuilder::new("POST", "/api/0/organizations/wat-org/releases/")
                 .with_status(201)
                 .with_response_file("releases/get-release.json")
                 .with_matcher(Matcher::PartialJson(json!({
@@ -44,7 +44,7 @@ fn allows_for_release_to_start_with_hyphen() {
 fn creates_release_with_project() {
     TestManager::new()
         .mock_endpoint(
-            MockEndpointBuilder::new("POST", "/api/0/projects/wat-org/wat-project/releases/")
+            MockEndpointBuilder::new("POST", "/api/0/organizations/wat-org/releases/")
                 .with_status(201)
                 .with_response_file("releases/get-release.json")
                 .with_matcher(Matcher::PartialJson(json!({
@@ -60,7 +60,7 @@ fn creates_release_with_project() {
 fn allows_for_release_with_project_to_start_with_hyphen() {
     TestManager::new()
         .mock_endpoint(
-            MockEndpointBuilder::new("POST", "/api/0/projects/wat-org/wat-project/releases/")
+            MockEndpointBuilder::new("POST", "/api/0/organizations/wat-org/releases/")
                 .with_status(201)
                 .with_response_file("releases/get-release.json")
                 .with_matcher(Matcher::PartialJson(json!({
@@ -76,7 +76,7 @@ fn allows_for_release_with_project_to_start_with_hyphen() {
 fn creates_release_even_if_one_already_exists() {
     TestManager::new()
         .mock_endpoint(
-            MockEndpointBuilder::new("POST", "/api/0/projects/wat-org/wat-project/releases/")
+            MockEndpointBuilder::new("POST", "/api/0/organizations/wat-org/releases/")
                 .with_status(208)
                 .with_response_file("releases/get-release.json")
                 .with_matcher(Matcher::PartialJson(json!({
@@ -92,7 +92,7 @@ fn creates_release_even_if_one_already_exists() {
 fn creates_release_with_custom_url() {
     TestManager::new()
         .mock_endpoint(
-            MockEndpointBuilder::new("POST", "/api/0/projects/wat-org/wat-project/releases/")
+            MockEndpointBuilder::new("POST", "/api/0/organizations/wat-org/releases/")
                 .with_status(208)
                 .with_response_file("releases/get-release.json")
                 .with_matcher(Matcher::PartialJson(json!({
@@ -109,7 +109,7 @@ fn creates_release_with_custom_url() {
 fn creates_release_which_is_instantly_finalized() {
     TestManager::new()
         .mock_endpoint(
-            MockEndpointBuilder::new("POST", "/api/0/projects/wat-org/wat-project/releases/")
+            MockEndpointBuilder::new("POST", "/api/0/organizations/wat-org/releases/")
                 .with_status(208)
                 .with_response_file("releases/get-release.json")
                 .with_matcher(Matcher::AllOf(vec![


### PR DESCRIPTION
### Description
We should instead use the organization-release endpoints. The project-release endpoints have been kept around for backwards compatibility with ancient self-hosted versions, which we are dropping support for.

### Issues
- Resolves #2840 
- Resolves [CLI-186](https://linear.app/getsentry/issue/CLI-186/remove-calls-to-projectsreleases-endpoints)