### PR TITLE
feat(build): Add --date-built parameter for artifact uploads (EME-631)

### DIFF
--- a/src/api/data_types/chunking/build.rs
+++ b/src/api/data_types/chunking/build.rs
@@ -11,6 +11,8 @@ pub struct ChunkedBuildRequest<'a> {
     pub build_configuration: Option<&'a str>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub release_notes: Option<&'a str>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub date_built: Option<&'a str>,
     #[serde(flatten)]
     pub vcs_info: &'a VcsInfo<'a>,
 }

--- a/src/commands/build/upload.rs
+++ b/src/commands/build/upload.rs
@@ -106,6 +106,11 @@ pub fn make_command(command: Command) -> Command {
                 .long("release-notes")
                 .help("The release notes to use for the upload.")
         )
+        .arg(
+            Arg::new("date_built")
+                .long("date-built")
+                .help("The date and time when the build was created (ISO 8601 format with timezone, e.g., '2025-11-26T10:30:00Z')")
+        )
 }
 
 pub fn execute(matches: &ArgMatches) -> Result<()> {
@@ -280,6 +285,7 @@ pub fn execute(matches: &ArgMatches) -> Result<()> {
 
     let build_configuration = matches.get_one("build_configuration").map(String::as_str);
     let release_notes = matches.get_one("release_notes").map(String::as_str);
+    let date_built = matches.get_one("date_built").map(String::as_str);
 
     let api = Api::current();
     let authenticated_api = api.authenticated()?;
@@ -350,6 +356,7 @@ pub fn execute(matches: &ArgMatches) -> Result<()> {
             &project,
             build_configuration,
             release_notes,
+            date_built,
             &vcs_info,
         ) {
             Ok(artifact_url) => {
@@ -513,6 +520,7 @@ fn upload_file(
     project: &str,
     build_configuration: Option<&str>,
     release_notes: Option<&str>,
+    date_built: Option<&str>,
     vcs_info: &VcsInfo<'_>,
 ) -> Result<String> {
     const SELF_HOSTED_ERROR_HINT: &str = "If you are using a self-hosted Sentry server, \
@@ -575,6 +583,7 @@ fn upload_file(
                 chunks: &checksums,
                 build_configuration,
                 release_notes,
+                date_built,
                 vcs_info,
             },
         )?;

--- a/tests/integration/_cases/build/build-upload-help-macos.trycmd
+++ b/tests/integration/_cases/build/build-upload-help-macos.trycmd
@@ -53,6 +53,9 @@ Options:
           be used.
       --release-notes <release_notes>
           The release notes to use for the upload.
+      --date-built <date_built>
+          The date and time when the build was created (ISO 8601 format with timezone, e.g.,
+          '2025-11-26T10:30:00Z')
   -h, --help
           Print help
 


### PR DESCRIPTION
## Summary

Adds support for passing build timestamps when uploading Android artifacts via the `build upload` command. This allows the sentry-android-gradle-plugin to capture the build time and send it to Sentry.

## Changes

- Add `--date-built` CLI argument to build upload command
- Add `date_built` field to `ChunkedBuildRequest` struct  
- Pass `date_built` through `upload_file` function to API
- Update help text with ISO 8601 format example (e.g., `2025-11-26T10:30:00Z`)
- Update test snapshots

## Usage

```bash
sentry-cli build upload --date-built '2025-11-26T10:30:00Z' my-app.apk
```

## Related

- Resolves EME-631
- Backend PR: getsentry/sentry#104052
- Requires corresponding changes in sentry-android-gradle-plugin