### PR TITLE
ref(build): Use `u32` instead of `&u32` in `VcsInfo`

### DIFF
--- a/src/api/data_types/chunking/build.rs
+++ b/src/api/data_types/chunking/build.rs
@@ -42,5 +42,5 @@ pub struct VcsInfo<'a> {
     #[serde(skip_serializing_if = "str::is_empty")]
     pub base_ref: &'a str,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub pr_number: Option<&'a u32>,
+    pub pr_number: Option<u32>,
 }

--- a/src/commands/build/upload.rs
+++ b/src/commands/build/upload.rs
@@ -341,7 +341,7 @@ pub fn execute(matches: &ArgMatches) -> Result<()> {
             base_repo_name: &base_repo_name,
             head_ref: &head_ref,
             base_ref: &base_ref,
-            pr_number: pr_number.as_ref(),
+            pr_number,
         };
         match upload_file(
             &authenticated_api,


### PR DESCRIPTION
`u32` is `Copy`, and it is also smaller than a `&u32` (at least, on 64-bit systems). `u32` is also simpler to use, so there's no reason not to use it.