### PR TITLE
chore(sourcemaps): Remove `--use-artifact-bundle`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
   - `apiKey` option in the JavaScript API
 - Removed the `upload-proguard` subcommand's `--app-id`, `--version`, `--version-code`, `--android-manifest`, and `--platform` arguments ([#2876](https://github.com/getsentry/sentry-cli/pull/2876), [#2940](https://github.com/getsentry/sentry-cli/pull/2940), [#2948](https://github.com/getsentry/sentry-cli/pull/2948)). Users using these arguments should stop using them, as they are unnecessary. The information passed to these arguments is no longer visible in Sentry.
 - Removed the `--started` argument from the `sentry-cli releases finalize` command ([#2972](https://github.com/getsentry/sentry-cli/pull/2972)). This argument is a no-op, so any users using it should simply stop using it.
+- Removed the `--use-artifact-bundle` flag from `sentry-cli sourcemaps upload` ([#3002](https://github.com/getsentry/sentry-cli/pull/3002)). The flag was a no-op that only emitted a deprecation warning.
 
 #### Node.js Wrapper Breakages
 
@@ -25,6 +26,7 @@ The following changes only apply when using `sentry-cli` via the npm package [`@
 - The `SentryCli.execute` method's `live` parameter now only takes boolean values ([#2971](https://github.com/getsentry/sentry-cli/pull/2971)). Setting `live` to `true` now behaves like `'rejectOnError'` did previously, with a zero exit status resolving the returned promise with `"success (live mode)"` and a non-zero status rejecting the promise with an error message.
 - The `option` parameter to `Releases.uploadSourceMaps` no longer takes a `live` property ([#2971](https://github.com/getsentry/sentry-cli/pull/2971)). We now always execute the command with `live` set to `true`.
 - Removed the `apiKey` option from `SentryCliOptions` ([#2935](https://github.com/getsentry/sentry-cli/pull/2935)). If you are using `apiKey`, you need to generate and use an [Auth Token](https://docs.sentry.io/account/auth-tokens/) via the `authToken` option, instead.
+- Removed the `useArtifactBundle` option from `SentryCliUploadSourceMapsOptions` ([#3002](https://github.com/getsentry/sentry-cli/pull/3002)). This deprecated option was a no-op that users should simply stop passing.
 - Drop support for Node.js <18. The minimum required Node.js version is now 18.0.0 ([#2985](https://github.com/getsentry/sentry-cli/issues/2985)).
 
 ### Improvements

--- a/lib/releases/options/uploadSourcemaps.js
+++ b/lib/releases/options/uploadSourcemaps.js
@@ -55,8 +55,4 @@ module.exports = {
     param: '--ext',
     type: 'array',
   },
-  useArtifactBundle: {
-    param: '--use-artifact-bundle',
-    type: 'boolean',
-  },
 };

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -137,14 +137,6 @@ export interface SentryCliUploadSourceMapsOptions {
    * Usually your build number.
    */
   dist?: string;
-  /**
-   * Force use of new Artifact Bundles upload, that enables use of Debug ID for Source Maps discovery,
-   * even when the Sentry server does not declare support for it.
-   *
-   * @deprecated This option is deprecated and will be removed in the next major version. Sentry CLI
-   *     should always respect what the server says it supports.
-   */
-  useArtifactBundle?: boolean;
 }
 
 /**

--- a/src/commands/sourcemaps/upload.rs
+++ b/src/commands/sourcemaps/upload.rs
@@ -1,6 +1,5 @@
 #![expect(clippy::unwrap_used, reason = "contains legacy code which uses unwrap")]
 
-use std::env;
 use std::path::PathBuf;
 use std::time::Duration;
 
@@ -223,17 +222,6 @@ pub fn make_command(command: Command) -> Command {
                      uploaded.",
                 ),
         )
-        .arg(
-            Arg::new("use_artifact_bundle")
-                .long("use-artifact-bundle")
-                .action(ArgAction::SetTrue)
-                .help(
-                    "[DEPRECATED] Force artifact bundles to be used for upload, even when not \
-                    supported by the server. This option has always only been intended for \
-                    internal use, and it is now officially deprecated.",
-                )
-                .hide(true),
-        )
         // Legacy flag that has no effect, left hidden for backward compatibility
         .arg(
             Arg::new("rewrite")
@@ -430,13 +418,6 @@ pub fn execute(matches: &ArgMatches) -> Result<()> {
     let api = Api::current();
     let mut processor = SourceMapProcessor::new();
     let chunk_upload_options = api.authenticated()?.get_chunk_upload_options(&org)?;
-
-    if matches.get_flag("use_artifact_bundle")
-        || env::var("SENTRY_FORCE_ARTIFACT_BUNDLES").ok().as_deref() == Some("1")
-    {
-        log::warn!("The --use-artifact-bundle option and the SENTRY_FORCE_ARTIFACT_BUNDLES environment variable \
-                    are both deprecated, and both will be removed in the next major version.");
-    }
 
     if matches.contains_id("bundle") && matches.contains_id("bundle_sourcemap") {
         process_sources_from_bundle(matches, &mut processor)?;


### PR DESCRIPTION
### Description
Removed the deprecated `--use-artifact-bundle` flag from the `sentry-cli sourcemaps upload` command and its corresponding `useArtifactBundle` option from the Node.js API. This flag was a no-op that only emitted a deprecation warning, and its removal simplifies the CLI and API by eliminating an unused and misleading option.

### Issues
* resolves: #2352
* resolves: CLI-20

---
<a href="https://cursor.com/background-agent?bcId=bc-2137bde5-9602-436e-9260-e3a6e192ae9c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-2137bde5-9602-436e-9260-e3a6e192ae9c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

___

Co-authored-by: Daniel Szoke <daniel.szoke@sentry.io>