### PR TITLE
chore: Remove install script in GitHub Actions

### DIFF
--- a/.github/workflows/test_node.yml
+++ b/.github/workflows/test_node.yml
@@ -102,9 +102,6 @@ jobs:
           name: artifact-build
           path: js
 
-      - name: Install CLI
-        run: npm run install-cli
-
       # older node versions need an older nft
       - run: SENTRYCLI_SKIP_DOWNLOAD=1 npm install @vercel/nft@0.22.1
         if: matrix.node-version == '10.x' || matrix.node-version == '12.x'


### PR DESCRIPTION
This script is actually not needed for our testing purpose. This was initially in #2910 added, since we call `--ignore-scripts` before, which doesn't call the `postinstall` script (so it was mainly added to keep the same functionality as before).

This line actually also caused issues for our release process - that should be fixed now