### PR TITLE
Save PDFs and SVGs with content hash

### DIFF
--- a/apple-catalog-parsing/native/swift/AssetCatalogParser/Sources/AssetCatalogParser/AssetCatalogReader.swift
+++ b/apple-catalog-parsing/native/swift/AssetCatalogParser/Sources/AssetCatalogParser/AssetCatalogReader.swift
@@ -228,7 +228,8 @@ enum AssetUtil {
                 
                 // Compute content hash for PDFs/SVGs without saving to disk
                 if fileExtension == "pdf" || fileExtension == "svg" {
-                    contentHash = data.sha256Hash()
+                  // Hash PDFs/SVGs in-memory (Python can't access _srcData without parsing binary .car format)
+                  contentHash = data.sha256Hash()
                 }
                 // Save images that can be converted to CGImage (excluding PDFs/SVGs)
                 else if let unslicedImage = unslicedImage {


### PR DESCRIPTION
Related to https://linear.app/getsentry/issue/EME-550/ios-insights-duplicate-files

Write PDF/SVG raw data to disk during asset catalog parsing to enable duplicate detection of SVG and pdf files