### PR TITLE
docs(readme): Set minimum self-hosted version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### New Sentry Support Policy
+
+`sentry-cli` 3.0.0 and above only officially supports Sentry SaaS and Sentry self-hosted versions [25.11.1](https://github.com/getsentry/sentry/releases/tag/25.11.1) and higher. While many Sentry CLI features may, in practice, continue working with some older Sentry versions, continued support for Sentry versions older than 25.11.1 is not guaranteed. Changes which break support for Sentry versions below 25.11.1 may occur in minor or patch releases.
+
 ## 2.58.4
 
 ### Fixes

--- a/README.md
+++ b/README.md
@@ -18,6 +18,23 @@ Sentry CLI can be used for many tasks, including uploading debug symbols and sou
 
 Please refer to [Sentry CLI's documentation page](https://docs.sentry.io/cli/).
 
+## Compatibility
+
+Sentry CLI officially supports [Sentry SaaS](https://sentry.io/) and [Sentry Self-Hosted](https://github.com/getsentry/self-hosted) versions 25.11.1 and above.
+
+### Self-Hosted Sentry
+
+Although some Sentry CLI features may work with versions of Sentry Self-Hosted prior to 25.11.1, we recommend users upgrade their self-hosted installations to a compatible version.
+
+For users who cannot upgrade their self-hosted installation, we recommend using the latest compatible Sentry CLI version, per the table below:
+
+| **Sentry Self-Hosted Version** | **Newest Compatible Sentry CLI Version**                              |
+| ------------------------------ | --------------------------------------------------------------------- |
+| ≥ 25.11.1                      | [latest](https://github.com/getsentry/sentry-cli/releases/latest)     |
+| < 25.11.1                      | [2.58.4](https://github.com/getsentry/sentry-cli/releases/tag/2.58.4) |
+
+Note that we can only provide support for officially-supported Sentry Self-Hosted versions. We will not backport fixes for older Sentry CLI versions, even if they should be compatible with your self-hosted version.
+
 ## Compiling
 
 In case you want to compile this yourself, you need to install at minimum the


### PR DESCRIPTION
### Description
Set minimum supported self-hosted version, and add this to README.

### Issues
- Resolves #3026 
- Resolves [CLI-246](https://linear.app/getsentry/issue/CLI-246/mention-minimum-supported-self-hosted-version-in-readme)