### PR TITLE
docs(api): Remove confusing comment

### DIFF
--- a/src/api/errors/api_error.rs
+++ b/src/api/errors/api_error.rs
@@ -61,8 +61,6 @@ impl ApiError {
         }
     }
 
-    // This method is currently only used in the macOS binary, there is no reason
-    // why not to expose it on other platforms, if we ever need it.
     #[cfg(target_os = "macos")]
     pub(in crate::api) fn kind(&self) -> ApiErrorKind {
         self.inner


### PR DESCRIPTION
### Description
This comment [is confusing](https://github.com/getsentry/sentry-cli/pull/2930/changes#r2542519816), and on further reflection, I believe it is unnecessary.

### Issues
- Resolves #3035 
- Resolves [CLI-249](https://linear.app/getsentry/issue/CLI-249/fix-leftover-pr-comment)