### PR TITLE
docs(versioning): Add min self-hosted version to public API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - We switch to a faster compression algorithm (zstd) for uploading size analysis builds (`sentry build upload`) in preparation for this week's beta release! ([#3038](https://github.com/getsentry/sentry-cli/pull/3038))
 
+### Versioning Policy Update
+
+Our [versioning policy](VERSIONING.md) has reclassified the minimum supported self-hosted Sentry version as being part of the public API. Therefore, we will only increase this minimum supported self-hosted Sentry version in a major release of Sentry CLI.
+
 ## 3.0.0
 
 ### New Sentry Support Policy
@@ -14,10 +18,7 @@
 
 ### New Versioning Policy
 
-Sentry CLI now defines a [semantic versioning policy](VERSIONING.md). We did not explicitly define a versioning policy before, but the new versioning policy contains some notable changes versus the previous implicit policy we had been following. The main change is that dropping support for self-hosted Sentry versions now only requires a minor version bump, although such changes will be clearly communicated in the changelog.
-
-> [!IMPORTANT]
-> **Self-hosted users**: We strongly recommend pinning your Sentry CLI version, since Sentry CLI may drop support for your self-hosted Sentry version in any future minor release. Always check the changelog before upgrading Sentry CLI.
+Sentry CLI now defines a [semantic versioning policy](VERSIONING.md). We did not explicitly define a versioning policy previously, and this new policy should give more clarity about what can change in minor or patch releases versus what requires a major version bump.
 
 ### Breaking Changes
 

--- a/VERSIONING.md
+++ b/VERSIONING.md
@@ -7,6 +7,7 @@ Sentry CLI follows [Semantic Versioning 2.0.0](https://semver.org/spec/v2.0.0.ht
 For the purposes of Semantic Versioning, Sentry CLI's public API is defined as the following:
   - All subcommands and command line arguments.
   - All publicly exposed functions/methods of the JavaScript API (only available via the [NPM package](https://www.npmjs.com/package/@sentry/cli)).
+  - The minimum self-hosted Sentry version that we support.
   - This versioning policy document.
 
 Any of the above items, which are explicitly marked as "experimental," "beta," or similar, are not part of the public API, and are subject to change at any time.
@@ -14,11 +15,7 @@ Any of the above items, which are explicitly marked as "experimental," "beta," o
 **Anything, which is not explicitly defined as part of the public API, is not part of the public API.** In particular, for semantic versioning purposes, the following items are not part of the public API:
   - Compile-time feature flags, dependencies, MSRV, etc., as we expect most users to use the prebuilt binaries we supply.
   - Any changes to output wording/formatting/etc.
-  - The minimum self-hosted Sentry version that we support.
   - Any public items exported from the `sentry-cli` Rust crate, as we do not publish `sentry-cli` to crates.io, and thus do not expect anyone to use it as a library.
-
-> [!NOTE]
-> Although this document intentionally defines the public API narrowly, we aim to avoid unnecessary breakage of features users rely on. We will call out notable behavioral changes in the changelog regardless of version bump.
 
 ## Examples
 
@@ -30,6 +27,7 @@ The following changes would require a major version bump, unless the affected it
   - Removal of a subcommand or an argument to a subcommand.
   - A reduction in the accepted values that can be passed to a command line argument, unless this reduction is necessary to fix a bug, for example, because the argument never handled certain values correctly.
   - Removal of a publicly exposed function/method of the JavaScript API, or any other backwards-incompatible change to these.
+  - The minimum self-hosted Sentry version supported by Sentry CLI is increased.
   - Any change to this versioning policy, which narrows the public API definition.
 
 ### Minor Version
@@ -38,7 +36,7 @@ The following changes would only require a minor version bump:
   - A new subcommand or command line argument is added, unless this new item is "experimental," "beta," or similar.
   - A new public item is added to the JavaScript API, unless this new item is "experimental," "beta," or similar.
   - An item which was previously marked "experimental," "beta," or similar has this designation removed, thus being added to the public API.
-  - The minimum self-hosted Sentry version supported by Sentry CLI is increased. Such changes will always be clearly mentioned in the changelog.
+  - The minimum self-hosted Sentry version supported by Sentry CLI is decreased, i.e., we expand support to additional self-hosted versions.
 
 ### Patch Version
 


### PR DESCRIPTION
### Description

Add the minimum self-hosted version to Sentry CLI's public API. The versioning policy now only allows increasing the minimum supported self-hosted version within a major release of the CLI.

This change partially implements [this DACI](https://www.notion.so/sentry/DACI-Balancing-self-hosted-compatibility-with-easing-maintenance-burden-in-Sentry-CLI-3-x-2ca8b10e4b5d80b4ab4ef379c375f187?source=copy_link).

### Issues
- Resolves #3043 
- Resolves [CLI-251](https://linear.app/getsentry/issue/CLI-251/disallow-self-hosted-compatibility-breakage-in-minor-releases)

