### PR TITLE
fix(releases): Allow filtering by a project when listing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 ### Fixes
 
 - Fixed a bug that prevented project IDs from being used with the `sentry-cli releases new` command for users with self-hosted Sentry instances on versions older than 25.12.1 ([#3068](https://github.com/getsentry/sentry-cli/issues/3068)).
+- Fixed a bug, introduced in version 3.0.0, where the `sentry-cli releases list` command ignored the `--project` option ([#3048](https://github.com/getsentry/sentry-cli/pull/3048)). The command now correctly can filter releases by a single project when supplied via `--project`. This change does not enable filtering by multiple projects, which has never been supported.
 
 ## 3.0.3
 

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -540,10 +540,16 @@ impl AuthenticatedApi<'_> {
 
     /// Returns a list of releases for a given project.  This is currently a
     /// capped list by what the server deems an acceptable default limit.
-    pub fn list_releases(&self, org: &str) -> ApiResult<Vec<ReleaseInfo>> {
-        let path = format!("/organizations/{}/releases/", PathArg(org));
-        self.get(&path)?
-            .convert_rnf::<Vec<ReleaseInfo>>(ApiErrorKind::OrganizationNotFound)
+    pub fn list_releases(&self, org: &str, project: Option<&str>) -> ApiResult<Vec<ReleaseInfo>> {
+        if let Some(project) = project {
+            let path = format!("/projects/{}/{}/releases/", PathArg(org), PathArg(project));
+            self.get(&path)?
+                .convert_rnf::<Vec<ReleaseInfo>>(ApiErrorKind::ProjectNotFound)
+        } else {
+            let path = format!("/organizations/{}/releases/", PathArg(org));
+            self.get(&path)?
+                .convert_rnf::<Vec<ReleaseInfo>>(ApiErrorKind::OrganizationNotFound)
+        }
     }
 
     /// Looks up a release commits and returns it.  If it does not exist `None`

--- a/src/commands/releases/list.rs
+++ b/src/commands/releases/list.rs
@@ -43,9 +43,10 @@ pub fn make_command(command: Command) -> Command {
 pub fn execute(matches: &ArgMatches) -> Result<()> {
     let config = Config::current();
     let api = Api::current();
+    let project = config.get_project(matches).ok();
     let releases = api
         .authenticated()?
-        .list_releases(&config.get_org(matches)?)?;
+        .list_releases(&config.get_org(matches)?, project.as_deref())?;
 
     if matches.get_flag("raw") {
         let versions = releases

--- a/tests/integration/releases/list.rs
+++ b/tests/integration/releases/list.rs
@@ -4,7 +4,7 @@ use crate::integration::{MockEndpointBuilder, TestManager};
 fn displays_releases() {
     TestManager::new()
         .mock_endpoint(
-            MockEndpointBuilder::new("GET", "/api/0/organizations/wat-org/releases/")
+            MockEndpointBuilder::new("GET", "/api/0/projects/wat-org/wat-project/releases/")
                 .with_response_file("releases/get-releases.json"),
         )
         .register_trycmd_test("releases/releases-list.trycmd")
@@ -15,7 +15,7 @@ fn displays_releases() {
 fn displays_releases_with_projects() {
     TestManager::new()
         .mock_endpoint(
-            MockEndpointBuilder::new("GET", "/api/0/organizations/wat-org/releases/")
+            MockEndpointBuilder::new("GET", "/api/0/projects/wat-org/wat-project/releases/")
                 .with_response_file("releases/get-releases.json"),
         )
         .register_trycmd_test("releases/releases-list-with-projects.trycmd")
@@ -26,7 +26,7 @@ fn displays_releases_with_projects() {
 fn doesnt_fail_with_empty_response() {
     TestManager::new()
         .mock_endpoint(
-            MockEndpointBuilder::new("GET", "/api/0/organizations/wat-org/releases/")
+            MockEndpointBuilder::new("GET", "/api/0/projects/wat-org/wat-project/releases/")
                 .with_response_body("[]"),
         )
         .register_trycmd_test("releases/releases-list-empty.trycmd")
@@ -37,7 +37,7 @@ fn doesnt_fail_with_empty_response() {
 fn can_override_org() {
     TestManager::new()
         .mock_endpoint(
-            MockEndpointBuilder::new("GET", "/api/0/organizations/whynot/releases/")
+            MockEndpointBuilder::new("GET", "/api/0/projects/whynot/wat-project/releases/")
                 .with_response_file("releases/get-releases.json"),
         )
         .register_trycmd_test("releases/releases-list-override-org.trycmd")
@@ -48,7 +48,7 @@ fn can_override_org() {
 fn displays_releases_in_raw_mode() {
     TestManager::new()
         .mock_endpoint(
-            MockEndpointBuilder::new("GET", "/api/0/organizations/wat-org/releases/")
+            MockEndpointBuilder::new("GET", "/api/0/projects/wat-org/wat-project/releases/")
                 .with_response_file("releases/get-releases.json"),
         )
         .register_trycmd_test("releases/releases-list-raw.trycmd")
@@ -59,7 +59,7 @@ fn displays_releases_in_raw_mode() {
 fn displays_releases_in_raw_mode_with_delimiter() {
     TestManager::new()
         .mock_endpoint(
-            MockEndpointBuilder::new("GET", "/api/0/organizations/wat-org/releases/")
+            MockEndpointBuilder::new("GET", "/api/0/projects/wat-org/wat-project/releases/")
                 .with_response_file("releases/get-releases.json"),
         )
         .register_trycmd_test("releases/releases-list-raw-delimiter.trycmd")


### PR DESCRIPTION
Partially revert https://github.com/getsentry/sentry-cli/pull/2991 to allow filtering by projects when running `releases list`.

Resolves #3046
Resolves [CLI-253](https://linear.app/getsentry/issue/CLI-253/project-does-not-work-when-using-organization-token)