### PR TITLE
fix: Support self-signed SSL certs in macOS keychain (arm64)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Fixes
+
+- Fixed a bug on ARM-based macOS systems that prevented Sentry CLI from respecting self-signed certificates trusted in the macOS keychain ([#3057](https://github.com/getsentry/sentry-cli/issues/3057)).
+
 ## 3.0.1
 
 ### Performance Improvements

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ clap = { version = "4.1.6", default-features = false, features = [
 ] }
 clap_complete = "4.4.3"
 console = "0.15.5"
-curl = { version = "0.4.46", features = ["static-curl", "static-ssl"] }
+curl = { version = "0.4.46" }
 dirs = "4.0.0"
 dotenvy = "0.15.7"
 elementtree = "1.2.3"
@@ -126,6 +126,12 @@ openssl-probe = "0.1.5"
 
 [target."cfg(windows)".dependencies]
 windows-sys = { version = "0.59.0", features = ["Win32_Storage_FileSystem"] }
+
+# Use static curl/SSL on all platforms except ARM-based macOS.
+# We link dynamically on ARM macOS; that way we can support self-signed certificates
+# trusted in the macOS keychain.
+[target."cfg(not(all(target_os = \"macos\", target_arch = \"aarch64\")))".dependencies]
+curl = { version = "0.4.46", features = ["static-curl", "static-ssl"] }
 
 # We optimize the release build for size.
 [profile.release]


### PR DESCRIPTION
### Description

Fix a regression introduced with the `curl-sys` dependency bump in [2.56.1](https://github.com/getsentry/sentry-cli/releases/tag/2.56.1); the dependency removed support for Secure Transport in libcurl, switching the default to OpenSSL, which was statically linked via the `static-ssl` feature flag. This statically-linked version lacks support for reading trusted certificates from the macOS Keychain.

In this PR, we swap the statically-linked curl (and statically linked OpenSSL) for dynamically linking libcurl on macOS only (keeping the statically linked libraries for other platforms). Since curl is built into macOS, introducing this runtime dependency hopefully will not break anyone. And, since the built-in libcurl does read certs from the macOS Keychain, this should fix the regression from version 2.56.1.

> [!NOTE]
> This change only fixes the bug for ARM-based Macs. #3059 will expand this change to Intel-based Macs; we are waiting with that PR until we can properly test the binary on an Intel-based Mac.

### Issues

- Resolves #3054 
- Resolves [CLI-256](https://linear.app/getsentry/issue/CLI-256/self-signed-certificate-problem-since-2561)

