### PR TITLE
ref(api): Don't set transfer encoding

### DIFF
--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -239,9 +239,6 @@ impl Api {
         handle.ssl_verify_host(self.config.should_verify_ssl())?;
         handle.ssl_verify_peer(self.config.should_verify_ssl())?;
 
-        // This toggles gzipping, useful for uploading large files
-        handle.transfer_encoding(self.config.allow_transfer_encoding())?;
-
         let env = self.config.get_pipeline_env();
         let headers = self.config.get_headers();
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -310,15 +310,6 @@ impl Config {
         }
     }
 
-    /// Indicates whether uploads may use gzip transfer encoding.
-    pub fn allow_transfer_encoding(&self) -> bool {
-        let val = self.ini.get_from(Some("http"), "transfer_encoding");
-        match val {
-            None => true,
-            Some(val) => val == "true",
-        }
-    }
-
     /// Controls the SSL revocation check on windows.  This can be used as a
     /// workaround for misconfigured local SSL proxies.
     pub fn disable_ssl_revocation_check(&self) -> bool {


### PR DESCRIPTION
### Description
Stop sending transfer encoding header. This allows us to support HTTP/2, which disallows the transfer encoding header, thereby unblocking #3057 (the dynamically-linked curl library supports HTTP/2).

Supposedly this was added to support gzipped uploads, but we manually compress files before they reach the transport layer for chunked uploads. Also, per the curl docs, this header only indicates to the server that we would like a [compressed response](https://curl.se/libcurl/c/CURLOPT_TRANSFER_ENCODING.html). I am not sure that Sentry honors this header, or that it is relevant, given we don't really download large files from Sentry in the CLI.



