### PR TITLE
fix: Support self-signed SSL certs in macOS keychain (x86_64)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -72,6 +72,34 @@ jobs:
       - name: Add Rustup Target
         run: rustup target add ${{ matrix.target }}
 
+      # On x86_64, this environment variable specifies to the openssl-sys crate
+      # where to find the OpenSSL library.
+      - name: Set OpenSSL env (x86_64)
+        if: matrix.arch == 'x86_64'
+        run: echo "X86_64_APPLE_DARWIN_OPENSSL_DIR=${{ github.workspace }}/openssl-x86_64" >> $GITHUB_ENV
+
+      - name: Get OpenSSL cache month (x86_64)
+        if: matrix.arch == 'x86_64'
+        id: cache-date
+        run: echo "month=$(date +%Y-%m)" >> $GITHUB_OUTPUT
+
+      - name: Cache x86_64 OpenSSL
+        if: matrix.arch == 'x86_64'
+        id: cache-openssl-x86
+        uses: actions/cache@9255dc7a253b0ccc959486e2bca901246202afeb # 5.0.1
+        with:
+          path: ${{ env.X86_64_APPLE_DARWIN_OPENSSL_DIR }}
+          key: openssl-x86_64-${{ runner.os }}-${{ steps.cache-date.outputs.month }}
+
+      # To cross-compile for x86_64 from an ARM-based macOS runner, we need to have the
+      # x86_64 OpenSSL libraries installed locally.
+      - name: Download x86_64 OpenSSL
+        if: matrix.arch == 'x86_64' && steps.cache-openssl-x86.outputs.cache-hit != 'true'
+        run: |
+          brew fetch --bottle-tag=sonoma openssl@3
+          mkdir -p $X86_64_APPLE_DARWIN_OPENSSL_DIR
+          tar xzf $(brew --cache --bottle-tag=sonoma openssl@3) -C $X86_64_APPLE_DARWIN_OPENSSL_DIR --strip-components=2
+
       - name: Cache Dependencies
         uses: swatinem/rust-cache@779680da715d629ac1d338a641029a2f4372abb5 # 2.8.2
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -36,6 +36,7 @@ jobs:
 
     name: ${{ matrix.display-os }}
     runs-on: ${{ matrix.os }}
+
     steps:
       - name: Checkout Repository
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # 6.0.1
@@ -51,6 +52,34 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y musl-tools
+
+      # On x86_64, this environment variable specifies to the openssl-sys crate
+      # where to find the OpenSSL library.
+      - name: Set OpenSSL env (x86_64)
+        if: matrix.target == 'x86_64-apple-darwin'
+        run: echo "X86_64_APPLE_DARWIN_OPENSSL_DIR=${{ github.workspace }}/openssl-x86_64" >> $GITHUB_ENV
+
+      - name: Get OpenSSL cache month (x86_64)
+        if: matrix.target == 'x86_64-apple-darwin'
+        id: cache-date
+        run: echo "month=$(date +%Y-%m)" >> $GITHUB_OUTPUT
+
+      - name: Cache x86_64 OpenSSL
+        if: matrix.target == 'x86_64-apple-darwin'
+        id: cache-openssl-x86
+        uses: actions/cache@9255dc7a253b0ccc959486e2bca901246202afeb # 5.0.1
+        with:
+          path: ${{ env.X86_64_APPLE_DARWIN_OPENSSL_DIR }}
+          key: openssl-x86_64-${{ runner.os }}-${{ steps.cache-date.outputs.month }}
+
+      # To cross-compile for x86_64 from an ARM-based macOS runner, we need to have the
+      # x86_64 OpenSSL libraries installed locally.
+      - name: Download x86_64 OpenSSL
+        if: matrix.target == 'x86_64-apple-darwin' && steps.cache-openssl-x86.outputs.cache-hit != 'true'
+        run: |
+          brew fetch --bottle-tag=sonoma openssl@3
+          mkdir -p $X86_64_APPLE_DARWIN_OPENSSL_DIR
+          tar xzf $(brew --cache --bottle-tag=sonoma openssl@3) -C $X86_64_APPLE_DARWIN_OPENSSL_DIR --strip-components=2
 
       - name: Cache Dependencies
         uses: swatinem/rust-cache@779680da715d629ac1d338a641029a2f4372abb5 # 2.8.2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -52,6 +52,34 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y musl-tools
 
+      # On x86_64, this environment variable specifies to the openssl-sys crate
+      # where to find the OpenSSL library.
+      - name: Set OpenSSL env (x86_64)
+        if: matrix.target == 'x86_64-apple-darwin'
+        run: echo "X86_64_APPLE_DARWIN_OPENSSL_DIR=${{ github.workspace }}/openssl-x86_64" >> $GITHUB_ENV
+
+      - name: Get OpenSSL cache month (x86_64)
+        if: matrix.target == 'x86_64-apple-darwin'
+        id: cache-date
+        run: echo "month=$(date +%Y-%m)" >> $GITHUB_OUTPUT
+
+      - name: Cache x86_64 OpenSSL
+        if: matrix.target == 'x86_64-apple-darwin'
+        id: cache-openssl-x86
+        uses: actions/cache@9255dc7a253b0ccc959486e2bca901246202afeb # 5.0.1
+        with:
+          path: ${{ env.X86_64_APPLE_DARWIN_OPENSSL_DIR }}
+          key: openssl-x86_64-${{ runner.os }}-${{ steps.cache-date.outputs.month }}
+
+      # To cross-compile for x86_64 from an ARM-based macOS runner, we need to have the
+      # x86_64 OpenSSL libraries installed locally.
+      - name: Download x86_64 OpenSSL
+        if: matrix.target == 'x86_64-apple-darwin' && steps.cache-openssl-x86.outputs.cache-hit != 'true'
+        run: |
+          brew fetch --bottle-tag=sonoma openssl@3
+          mkdir -p $X86_64_APPLE_DARWIN_OPENSSL_DIR
+          tar xzf $(brew --cache --bottle-tag=sonoma openssl@3) -C $X86_64_APPLE_DARWIN_OPENSSL_DIR --strip-components=2
+
       - name: Cache Dependencies
         uses: swatinem/rust-cache@779680da715d629ac1d338a641029a2f4372abb5 # 2.8.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Fixes
+
+- Fixed a bug on Intel-based macOS systems that prevented Sentry CLI from respecting self-signed certificates trusted in the macOS keychain ([#3059](https://github.com/getsentry/sentry-cli/issues/#3059)).
+
 ## 3.0.2
 
 ### Fixes

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1908,9 +1908,9 @@ checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
 
 [[package]]
 name = "openssl-src"
-version = "300.5.2+3.5.2"
+version = "300.5.4+3.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d270b79e2926f5150189d475bc7e9d2c69f9c4697b185fa917d5a32b792d21b4"
+checksum = "a507b3792995dae9b0df8a1c1e3771e8418b7c2d9f0baeba32e6fe8b06c7cb72"
 dependencies = [
  "cc",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ clap = { version = "4.1.6", default-features = false, features = [
 ] }
 clap_complete = "4.4.3"
 console = "0.15.5"
-curl = { version = "0.4.46" }
+curl = "0.4.46"
 dirs = "4.0.0"
 dotenvy = "0.15.7"
 elementtree = "1.2.3"
@@ -127,10 +127,10 @@ openssl-probe = "0.1.5"
 [target."cfg(windows)".dependencies]
 windows-sys = { version = "0.59.0", features = ["Win32_Storage_FileSystem"] }
 
-# Use static curl/SSL on all platforms except ARM-based macOS.
-# We link dynamically on ARM macOS; that way we can support self-signed certificates
+# Use static curl/SSL on non-macOS platforms
+# We link dynamically on macOS; that way we can support self-signed certificates
 # trusted in the macOS keychain.
-[target."cfg(not(all(target_os = \"macos\", target_arch = \"aarch64\")))".dependencies]
+[target."cfg(not(target_os = \"macos\"))".dependencies]
 curl = { version = "0.4.46", features = ["static-curl", "static-ssl"] }
 
 # We optimize the release build for size.


### PR DESCRIPTION
### Description
Expand #3057 to Intel Macs. I have tested the binary built with this PR on an Intel Mac, and it appears to work.

### Issues
- Resolves https://github.com/getsentry/sentry-cli/issues/3060
- Resolves [CLI-258](https://linear.app/getsentry/issue/CLI-258/fix-self-signed-cert-issue-on-intel-macs)


