### PR TITLE
docs(self-hosted): Expand support to ≥24.11.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - In the JavaScript API, added multi-project support to `releases.newDeploy()` method. This method now accept a `projects` option (array of project slugs), aligning them with the Rust CLI's multi-project capabilities and matching the existing behavior of `releases.new()` and `releases.uploadSourceMaps()` ([#3001](https://github.com/getsentry/sentry-cli/pull/3001)).
 
+### Improvements
+
+- This release includes some changes to enable support for older self-hosted Sentry versions. With these changes, Sentry CLI now officially self-hosted Sentry versions 24.11.1 and above ([#3070](https://github.com/getsentry/sentry-cli/pull/3070))
+
 ### Fixes
 
 - Fixed a bug that prevented project IDs from being used with the `sentry-cli releases new` command for users with self-hosted Sentry instances on versions older than 25.12.1 ([#3068](https://github.com/getsentry/sentry-cli/issues/3068)).

--- a/README.md
+++ b/README.md
@@ -20,20 +20,24 @@ Please refer to [Sentry CLI's documentation page](https://docs.sentry.io/cli/).
 
 ## Compatibility
 
-Sentry CLI officially supports [Sentry SaaS](https://sentry.io/) and [Sentry Self-Hosted](https://github.com/getsentry/self-hosted) versions 25.11.1 and above.
+Sentry CLI officially supports [Sentry SaaS](https://sentry.io/) and [Sentry Self-Hosted](https://github.com/getsentry/self-hosted) versions 24.11.1 and above.
 
-### Self-Hosted Sentry
+<details>
 
-Although some Sentry CLI features may work with versions of Sentry Self-Hosted prior to 25.11.1, we recommend users upgrade their self-hosted installations to a compatible version.
+<summary><h3>Self-Hosted Sentry</h3></summary>
 
-For users who cannot upgrade their self-hosted installation, we recommend using the latest compatible Sentry CLI version, per the table below:
+For self-hosted installations, only those features which were available in Sentry CLI at the time of the release of the given self-hosted version are supported, as new features may require server-side support. Additionally, some features, like the `sentry-cli build` commands, are restricted to Sentry SaaS.
+
+Users who are using Sentry Self-Hosted versions older than 24.11.1 are encouraged to upgrade their Sentry Self-Hosted installations before using Sentry CLI versions 3.0.0 and above. For users who cannot upgrade, please use the version indicated in the table below.
 
 | **Sentry Self-Hosted Version** | **Newest Compatible Sentry CLI Version**                              |
 | ------------------------------ | --------------------------------------------------------------------- |
-| ≥ 25.11.1                      | [latest](https://github.com/getsentry/sentry-cli/releases/latest)     |
-| < 25.11.1                      | [2.58.4](https://github.com/getsentry/sentry-cli/releases/tag/2.58.4) |
+| ≥ 24.11.1                      | [latest](https://github.com/getsentry/sentry-cli/releases/latest)     |
+| < 24.11.1                      | [2.58.4](https://github.com/getsentry/sentry-cli/releases/tag/2.58.4) |
 
 Note that we can only provide support for officially-supported Sentry Self-Hosted versions. We will not backport fixes for older Sentry CLI versions, even if they should be compatible with your self-hosted version.
+
+</details>
 
 ## Versioning
 


### PR DESCRIPTION
### Description
Declare support for Sentry Self-hosted versions 24.11.1 and above. Also, clarify that some features are only supported for SaaS, and that new features will require newer self-hosted versions.

### Issues
- Resolves #3044
- Resolves [CLI-252](https://linear.app/getsentry/issue/CLI-252/lower-3xs-minimum-officially-supported-self-hosted-version)