### PR TITLE
ci: Remove DangerJS from CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,22 +37,10 @@ jobs:
     name: Test Swift
     uses: ./.github/workflows/swift-test.yml
 
-  danger:
-    name: Run Danger Checks
-    runs-on: ubuntu-24.04
-    permissions:
-      contents: read
-      pull-requests: write
-      statuses: write
-    if: ${{ github.event_name == 'pull_request' }}
-    steps:
-      - name: Run Danger
-        uses: getsentry/github-workflows/danger@13be9bec4ec5cd67061b747972b996e9c80f4f3b # 3.1.0
-
   required:
     name: Check required jobs
     runs-on: ubuntu-24.04
-    needs: [lint, test, test_node, test_swift, danger]
+    needs: [lint, test, test_node, test_swift]
     if: always()
     steps:
       - name: Check for failure
@@ -60,8 +48,7 @@ jobs:
           needs.lint.result != 'success' ||
           needs.test.result != 'success' ||
           needs.test_node.result != 'success' ||
-          needs.test_swift.result != 'success' ||
-          (needs.danger.result != 'success' && needs.danger.result != 'skipped')
+          needs.test_swift.result != 'success'
           }}
         run: |
           echo "One or more jobs failed"


### PR DESCRIPTION
### Description

Remove the danger job that enforced manual changelog entries. This enables the transition to auto-generated changelogs.

The DangerJS action (`getsentry/github-workflows/danger`) previously enforced:
- Changelog entry requirements for PRs
- GitHub Actions pinning checks
- Docs update reminders for feature PRs

We considered modifying the action to only disable changelog enforcement while retaining other checks, but decided these checks are not essential for the sentry-cli workflow.

### Issues

* resolves: #3073
* resolves: [CLI-264](https://linear.app/getsentry/issue/CLI-264/remove-enforcement-for-manual-changelog-management)