### PR TITLE
ci: Add CI enforcement to prevent manual CHANGELOG.md edits

### DIFF
--- a/.github/workflows/changelog-enforcement.yml
+++ b/.github/workflows/changelog-enforcement.yml
@@ -36,8 +36,9 @@ jobs:
             console.log(`Is Changelog PR: ${isChangelogPR}`);
             console.log(`CHANGELOG.md Modified: ${changelogModified}`);
 
-            if (changelogModified && !isChangelogPR) {
-              const commentBody = `## :warning: Manual Changelog Changes Detected
+            const commentMarker = '<!--changelog_enforcement_violation_comment-->';
+            const commentBody = `${commentMarker}
+            ## :warning: Manual Changelog Changes Detected
 
             This PR modifies \`CHANGELOG.md\`, but the PR title does not start with \`meta(changelog):\`.
 
@@ -49,20 +50,20 @@ jobs:
 
             2. **If this was unintentional**: Remove the \`CHANGELOG.md\` changes from this PR.`;
 
-              // Avoid posting duplicate comments on re-runs
-              // Paginate through all comments to handle PRs with many comments
-              const comments = await github.paginate(github.rest.issues.listComments, {
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                issue_number: prNumber,
-                per_page: 100
-              });
+            // Paginate through all comments to handle PRs with many comments
+            const comments = await github.paginate(github.rest.issues.listComments, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: prNumber,
+              per_page: 100
+            });
 
-              const botComment = comments.find(comment =>
-                comment.user.type === 'Bot' &&
-                comment.body.includes('Manual Changelog Changes Detected')
-              );
+            const botComment = comments.find(comment =>
+              comment.body.includes(commentMarker)
+            );
 
+            if (changelogModified && !isChangelogPR) {
+              // Violation: post comment if not already present
               if (!botComment) {
                 await github.rest.issues.createComment({
                   owner: context.repo.owner,
@@ -76,8 +77,20 @@ jobs:
               }
 
               core.setFailed('CHANGELOG.md changes are not allowed unless PR title starts with "meta(changelog):"');
-            } else if (changelogModified && isChangelogPR) {
-              console.log('CHANGELOG.md changes allowed in meta(changelog): PR');
             } else {
-              console.log('No CHANGELOG.md changes detected');
+              // No violation: delete comment if it exists from a previous run
+              if (botComment) {
+                await github.rest.issues.deleteComment({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  comment_id: botComment.id
+                });
+                console.log('Deleted outdated violation comment');
+              }
+
+              if (changelogModified && isChangelogPR) {
+                console.log('CHANGELOG.md changes allowed in meta(changelog): PR');
+              } else {
+                console.log('No CHANGELOG.md changes detected');
+              }
             }

--- a/.github/workflows/changelog-enforcement.yml
+++ b/.github/workflows/changelog-enforcement.yml
@@ -22,7 +22,8 @@ jobs:
             const prTitle = context.payload.pull_request.title;
             const isChangelogPR = prTitle.startsWith('meta(changelog):');
 
-            const { data: files } = await github.rest.pulls.listFiles({
+            // Paginate through all files to handle PRs with >100 changed files
+            const files = await github.paginate(github.rest.pulls.listFiles, {
               owner: context.repo.owner,
               repo: context.repo.repo,
               pull_number: prNumber,
@@ -49,10 +50,12 @@ jobs:
             2. **If this was unintentional**: Remove the \`CHANGELOG.md\` changes from this PR.`;
 
               // Avoid posting duplicate comments on re-runs
-              const { data: comments } = await github.rest.issues.listComments({
+              // Paginate through all comments to handle PRs with many comments
+              const comments = await github.paginate(github.rest.issues.listComments, {
                 owner: context.repo.owner,
                 repo: context.repo.repo,
-                issue_number: prNumber
+                issue_number: prNumber,
+                per_page: 100
               });
 
               const botComment = comments.find(comment =>

--- a/.github/workflows/changelog-enforcement.yml
+++ b/.github/workflows/changelog-enforcement.yml
@@ -1,0 +1,80 @@
+name: Changelog Enforcement
+
+on:
+  workflow_call:
+
+jobs:
+  check-changelog:
+    name: Check Changelog Changes
+    runs-on: ubuntu-24.04
+    if: ${{ github.event_name == 'pull_request' }}
+
+    permissions:
+      contents: read
+      pull-requests: write
+
+    steps:
+      - name: Check for CHANGELOG.md modifications
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # 8.0.0
+        with:
+          script: |
+            const prNumber = context.payload.pull_request.number;
+            const prTitle = context.payload.pull_request.title;
+            const isChangelogPR = prTitle.startsWith('meta(changelog):');
+
+            const { data: files } = await github.rest.pulls.listFiles({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: prNumber,
+              per_page: 100
+            });
+
+            const changelogModified = files.some(file => file.filename === 'CHANGELOG.md');
+
+            console.log(`PR Title: ${prTitle}`);
+            console.log(`Is Changelog PR: ${isChangelogPR}`);
+            console.log(`CHANGELOG.md Modified: ${changelogModified}`);
+
+            if (changelogModified && !isChangelogPR) {
+              const commentBody = `## :warning: Manual Changelog Changes Detected
+
+            This PR modifies \`CHANGELOG.md\`, but the PR title does not start with \`meta(changelog):\`.
+
+            **Changelogs in this repository are generated automatically during releases.** Manual edits to \`CHANGELOG.md\` are not allowed in regular PRs.
+
+            ### What to do:
+
+            1. **If this change is intentional**: Create a separate PR with a title starting with \`meta(changelog):\` to make changelog edits.
+
+            2. **If this was unintentional**: Remove the \`CHANGELOG.md\` changes from this PR.`;
+
+              // Avoid posting duplicate comments on re-runs
+              const { data: comments } = await github.rest.issues.listComments({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: prNumber
+              });
+
+              const botComment = comments.find(comment =>
+                comment.user.type === 'Bot' &&
+                comment.body.includes('Manual Changelog Changes Detected')
+              );
+
+              if (!botComment) {
+                await github.rest.issues.createComment({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: prNumber,
+                  body: commentBody
+                });
+                console.log('Posted comment explaining changelog policy');
+              } else {
+                console.log('Comment already exists, skipping');
+              }
+
+              core.setFailed('CHANGELOG.md changes are not allowed unless PR title starts with "meta(changelog):"');
+            } else if (changelogModified && isChangelogPR) {
+              console.log('CHANGELOG.md changes allowed in meta(changelog): PR');
+            } else {
+              console.log('No CHANGELOG.md changes detected');
+            }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,10 +37,14 @@ jobs:
     name: Test Swift
     uses: ./.github/workflows/swift-test.yml
 
+  changelog:
+    name: Changelog
+    uses: ./.github/workflows/changelog-enforcement.yml
+
   required:
     name: Check required jobs
     runs-on: ubuntu-24.04
-    needs: [lint, test, test_node, test_swift]
+    needs: [lint, test, test_node, test_swift, changelog]
     if: always()
     steps:
       - name: Check for failure
@@ -48,7 +52,8 @@ jobs:
           needs.lint.result != 'success' ||
           needs.test.result != 'success' ||
           needs.test_node.result != 'success' ||
-          needs.test_swift.result != 'success'
+          needs.test_swift.result != 'success' ||
+          (needs.changelog.result != 'success' && needs.changelog.result != 'skipped')
           }}
         run: |
           echo "One or more jobs failed"


### PR DESCRIPTION
### Description

Add a new CI workflow that prevents manual CHANGELOG.md modifications unless the PR title starts with `meta(changelog):`.

This is a follow-up to #3074 which removed DangerJS. Now that changelogs are auto-generated, we need to prevent accidental manual edits. When a violation is detected, the workflow posts a comment explaining the policy and fails the check.

The workflow:
- Checks if CHANGELOG.md is modified in the PR
- Allows changes only when PR title starts with `meta(changelog):`
- Posts an explanatory comment on violation (with duplicate detection)
- Fails the CI check to block the PR

### Issues

* resolves: #3072
* resolves: [CLI-263](https://linear.app/getsentry/issue/CLI-263/add-ci-enforcement-for-no-changelogmd-changes)