### PR TITLE
Allow to use uppercase Y and N to continue

### DIFF
--- a/src/utils/ui.rs
+++ b/src/utils/ui.rs
@@ -11,7 +11,7 @@ pub fn prompt_to_continue(message: &str) -> io::Result<bool> {
 
         let mut buf = String::new();
         io::stdin().read_line(&mut buf)?;
-        let input = buf.trim();
+        let input = buf.trim().to_lowercase();
 
         if input == "y" {
             return Ok(true);


### PR DESCRIPTION
### Description

I just did this:

```
Sentry server: sentry.io
Open browser now? [y/n] Y
invalid input!
Open browser now? [y/n] y
```

### Issues

It is totally fine to accept the upper case variants here.