### PR TITLE
chore: Add Claude Code MCP configuration for Rust development

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,5 @@ yarn-error.log
 
 .vscode/*
 !.vscode/settings.json
+
+.claude/settings.local.json

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,10 @@
+{
+  "mcpServers": {
+    "rust-analyzer": {
+      "command": "rust-analyzer-mcp"
+    },
+    "crates": {
+      "command": "crates-mcp"
+    }
+  }
+}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -80,3 +80,9 @@ Treat these rules as **mandatory guidance** that you must follow for all code ch
 # Code Formatting
 
 **ALWAYS** run `cargo fmt` before committing any Rust code changes to ensure consistent formatting across the codebase.
+
+# Rust Documentation
+
+Use rust-analyzer-mcp for local code (hover, definitions, diagnostics at file positions).
+Use crates-mcp for external crate docs.
+Never use WebFetch for docs.rs or crates.io when these MCPs are available.


### PR DESCRIPTION
Configure rust-analyzer-mcp and crates-mcp for improved Rust documentation
access when using Claude Code.

**rust-analyzer-mcp** provides local code analysis including hover info,
go-to-definition, and diagnostics at file positions.

**crates-mcp** enables querying external crate documentation from docs.rs
and crates.io without relying on web fetching.

The CLAUDE.md file instructs the agent to prefer these MCPs over WebFetch
for deterministic, structured documentation access.

Matches the configuration added to sentry-rust in https://github.com/getsentry/sentry-rust/pull/956