### PR TITLE
meta: Test github-workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,7 +47,7 @@ jobs:
     if: ${{ github.event_name == 'pull_request' }}
     steps:
       - name: Run Danger
-        uses: getsentry/github-workflows/danger@95603f4efe938315ff0dd427a1f2bb40b1889a92 # 3.2.0
+        uses: getsentry/github-workflows/danger@95603f4efe938315ff0dd427a1f2bb40b1889a92 # testing branch
 
   required:
     name: Check required jobs


### PR DESCRIPTION
Pin to latest commit on https://github.com/getsentry/github-workflows/pull/145 to test that change out.

This PR should not have any failures, despite missing a legal notice, as I am a Sentry employee. We will open a PR on top with a non-Sentry-affiliated GH account to validate that the workflow correctly detects the legal notice missing.