### PR TITLE
fix(preprod): Understand ghe.com as github_enterprise

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ### Fixes
 
+- Recognize `*.ghe.com` URLs as `github_enterprise` VCS provider ([#3127](https://github.com/getsentry/sentry-cli/pull/3127)).
 - Fixed a bug where the `dart-symbol-map` command did not accept the `--url` argument ([#3108](https://github.com/getsentry/sentry-cli/pull/3108)).
 - Add timeout to `build upload` polling loop to prevent infinite loop when server returns unexpected state ([#3118](https://github.com/getsentry/sentry-cli/pull/3118)).
 


### PR DESCRIPTION
To determine vcs_provider we use part of the origin of the URL:

https://github.com/foo/bar -> github
https://gitlab.com/abcdef -> gitlab

This adds special handling for github enterprize remotes. Now instead
of:

https://foo.ghe.com/foo/bar -> ghe

we end up with:

https://foo.ghe.com/foo/bar -> github_enterprise

as the backend expects.

Resolves EME-821
