### PR TITLE
chore: Update minimatch to a non-vulnerable version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3643,9 +3643,9 @@
       "dev": true
     },
     "minimatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.3.tgz",
+      "integrity": "sha512-M2GCs7Vk83NxkUyQV1bkABc4yxgz9kILhHImZiBPAZ9ybuvCb0/H7lEl5XvIg3g+9d4eNotkZA5IWwYl0tibaA==",
       "dev": true,
       "requires": {
         "brace-expansion": "^1.1.7"


### PR DESCRIPTION
Basically the same as this: https://github.com/getsentry/sentry-javascript-bundler-plugins/pull/885/changes/7cf8cd004f1f95d11555df198e39032405ce857d