### PR TITLE
feat(snapshots): Upload image metadata json data as part of snapshots job

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Experimental Feature 🧑‍🔬 (internal-only)
+
+- Pipe snapshot sidecar metadata into upload as part of `sentry-cli build snapshots` command ([#3163](https://github.com/getsentry/sentry-cli/pull/3163)).
+
 ## 3.3.0
 
 ### New Features
@@ -13,7 +19,6 @@
 ### Experimental Feature 🧑‍🔬 (internal-only)
 
 - Print snapshot URL after successful upload ([#3167](https://github.com/getsentry/sentry-cli/pull/3167)).
-- Pipe snapshot sidecar metadata into upload as part of `sentry-cli build snapshots` command ([#3163](https://github.com/getsentry/sentry-cli/pull/3163)).
 
 ## 3.2.3
 

--- a/src/api/data_types/snapshots.rs
+++ b/src/api/data_types/snapshots.rs
@@ -29,8 +29,6 @@ pub struct SnapshotsManifest {
 // Keep in sync with https://github.com/getsentry/sentry/blob/master/src/sentry/preprod/snapshots/manifest.py
 /// Metadata for a single image in a snapshot manifest.
 ///
-/// Serializes as a flat JSON object.
-///
 /// CLI-managed fields (`image_file_name`, `width`, `height`) override any
 /// identically named fields provided by user sidecar metadata.
 #[derive(Debug, Serialize)]

--- a/src/commands/build/snapshots.rs
+++ b/src/commands/build/snapshots.rs
@@ -351,3 +351,28 @@ fn upload_images(
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn make_image(width: u32, height: u32) -> ImageInfo {
+        ImageInfo {
+            path: PathBuf::from("img.png"),
+            relative_path: PathBuf::from("img.png"),
+            width,
+            height,
+        }
+    }
+
+    #[test]
+    fn test_validate_image_sizes_at_limit_passes() {
+        assert!(validate_image_sizes(&[make_image(8000, 5000)]).is_ok());
+    }
+
+    #[test]
+    fn test_validate_image_sizes_over_limit_fails() {
+        let err = validate_image_sizes(&[make_image(8001, 5000)]).unwrap_err();
+        assert!(err.to_string().contains("exceed the maximum pixel limit"));
+    }
+}


### PR DESCRIPTION
### Description
First-class supported platforms (web library, iOS/Android in future) will be outputting a "sidecar" json file with each image containing custom metadata set by the framework and provided by the user. This will contain things like the "display name" among other items.

This updates our snapshots command to process these sidecar files if present and upload them as part of the image manifest data in the POST body.

