### PR TITLE
feat(proguard): Add UUID command for mapping files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### New Features
+
+- Added `sentry-cli proguard uuid <PATH>` to compute and print the UUID for a ProGuard mapping file ([#3176](https://github.com/getsentry/sentry-cli/pull/3176)).
+
 ### Improvements
 
 - Moved `sentry-cli upload-proguard` to `sentry-cli proguard upload`, aligning the API with similar upload commands like `debug-files upload` and `sourcemaps upload` ([#3174](https://github.com/getsentry/sentry-cli/pull/3174)). `sentry-cli upload-proguard` remains supported as an alias, so no migration is required.

--- a/src/commands/proguard/mod.rs
+++ b/src/commands/proguard/mod.rs
@@ -2,10 +2,12 @@ use anyhow::Result;
 use clap::{ArgMatches, Command};
 
 pub mod upload;
+pub mod uuid;
 
 macro_rules! each_subcommand {
     ($mac:ident) => {
         $mac!(upload);
+        $mac!(uuid);
     };
 }
 

--- a/src/commands/proguard/uuid.rs
+++ b/src/commands/proguard/uuid.rs
@@ -1,0 +1,37 @@
+use anyhow::{Context as _, Result};
+use clap::{Arg, ArgMatches, Command};
+use symbolic::common::ByteView;
+
+use crate::utils::proguard::ProguardMapping;
+
+pub fn make_command(command: Command) -> Command {
+    command
+        .about("Compute the UUID for a ProGuard mapping file.")
+        .long_about(
+            "Compute the UUID for a ProGuard mapping file.\n\n\
+            This command computes and prints to stdout the UUID of the ProGuard \
+            mapping at the specified path. This is the UUID that will be set by \
+            the `proguard upload` command. The UUID is deterministicly computed \
+            based on the file contents.",
+        )
+        .arg(
+            Arg::new("path")
+                .value_name("PATH")
+                .help("The path to the mapping file.")
+                .required(true),
+        )
+}
+
+pub fn execute(matches: &ArgMatches) -> Result<()> {
+    let path = matches
+        .get_one::<String>("path")
+        .expect("required argument");
+
+    let byteview = ByteView::open(path)
+        .with_context(|| format!("failed to open proguard mapping '{path}'"))?;
+    let mapping = ProguardMapping::try_from(byteview)
+        .with_context(|| format!("failed to parse proguard mapping '{path}'"))?;
+
+    println!("{}", mapping.uuid());
+    Ok(())
+}

--- a/tests/integration/_cases/proguard/proguard-help.trycmd
+++ b/tests/integration/_cases/proguard/proguard-help.trycmd
@@ -7,6 +7,7 @@ Usage: sentry-cli[EXE] proguard [OPTIONS] <COMMAND>
 
 Commands:
   upload  Upload ProGuard mapping files to a project.
+  uuid    Compute the UUID for a ProGuard mapping file.
   help    Print this message or the help of the given subcommand(s)
 
 Options:

--- a/tests/integration/_cases/proguard/proguard-uuid-help.trycmd
+++ b/tests/integration/_cases/proguard/proguard-uuid-help.trycmd
@@ -1,0 +1,36 @@
+```
+$ sentry-cli proguard uuid --help
+? success
+Compute the UUID for a ProGuard mapping file.
+
+This command computes and prints to stdout the UUID of the ProGuard mapping at the specified path.
+This is the UUID that will be set by the `proguard upload` command. The UUID is deterministicly
+computed based on the file contents.
+
+Usage: sentry-cli[EXE] proguard uuid [OPTIONS] <PATH>
+
+Arguments:
+  <PATH>
+          The path to the mapping file.
+
+Options:
+      --header <KEY:VALUE>
+          Custom headers that should be attached to all requests
+          in key:value format.
+
+      --auth-token <AUTH_TOKEN>
+          Use the given Sentry auth token.
+
+      --log-level <LOG_LEVEL>
+          Set the log output verbosity. [possible values: trace, debug, info, warn, error]
+
+      --quiet
+          Do not print any output while preserving correct exit code. This flag is currently
+          implemented only for selected subcommands.
+          
+          [aliases: --silent]
+
+  -h, --help
+          Print help (see a summary with '-h')
+
+```

--- a/tests/integration/_cases/proguard/proguard-uuid-invalid-mapping.trycmd
+++ b/tests/integration/_cases/proguard/proguard-uuid-invalid-mapping.trycmd
@@ -1,0 +1,12 @@
+```
+$ sentry-cli proguard uuid tests/integration/_fixtures/proguard.txt
+? failed
+error: failed to parse proguard mapping 'tests/integration/_fixtures/proguard.txt'
+
+Caused by:
+    Proguard mapping does not contain line information
+
+Add --log-level=[info|debug] or export SENTRY_LOG_LEVEL=[info|debug] to see more output.
+Please attach the full debug log to all bug reports.
+
+```

--- a/tests/integration/_cases/proguard/proguard-uuid-missing-file.trycmd
+++ b/tests/integration/_cases/proguard/proguard-uuid-missing-file.trycmd
@@ -1,0 +1,12 @@
+```
+$ sentry-cli proguard uuid tests/integration/_fixtures/proguard/upload/does-not-exist.txt
+? failed
+error: failed to open proguard mapping 'tests/integration/_fixtures/proguard/upload/does-not-exist.txt'
+
+Caused by:
+    [..]
+
+Add --log-level=[info|debug] or export SENTRY_LOG_LEVEL=[info|debug] to see more output.
+Please attach the full debug log to all bug reports.
+
+```

--- a/tests/integration/_cases/proguard/proguard-uuid-success.trycmd
+++ b/tests/integration/_cases/proguard/proguard-uuid-success.trycmd
@@ -1,0 +1,6 @@
+```
+$ sentry-cli proguard uuid tests/integration/_fixtures/proguard/upload/mapping.txt
+? success
+c038584d-c366-570c-ad1e-034fa0d194d7
+
+```

--- a/tests/integration/proguard/mod.rs
+++ b/tests/integration/proguard/mod.rs
@@ -1,1 +1,2 @@
 mod upload;
+mod uuid;

--- a/tests/integration/proguard/uuid.rs
+++ b/tests/integration/proguard/uuid.rs
@@ -1,0 +1,6 @@
+use crate::integration::TestManager;
+
+#[test]
+fn command_proguard_uuid() {
+    TestManager::new().register_trycmd_test("proguard/proguard-uuid*.trycmd");
+}


### PR DESCRIPTION
Add `sentry-cli proguard uuid <PATH>` to compute and print the UUID for a single ProGuard mapping file. This is the same UUID we use when uploading via `sentry-cli proguard upload`

Stacked on #3175

Closes #3173
Closes [CLI-297](https://linear.app/getsentry/issue/CLI-297/expose-command-to-obtain-compute-uuid-for-proguard-mapping)
