### PR TITLE
meta(readme): Update self-hosted compatibility matrix

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Users who are using Sentry Self-Hosted versions older than 24.11.1 are encourage
 | **Sentry Self-Hosted Version** | **Newest Compatible Sentry CLI Version**                              |
 | ------------------------------ | --------------------------------------------------------------------- |
 | ≥ 24.11.1                      | [latest](https://github.com/getsentry/sentry-cli/releases/latest)     |
-| < 24.11.1                      | [2.58.4](https://github.com/getsentry/sentry-cli/releases/tag/2.58.4) |
+| < 24.11.1                      | [2.58.5](https://github.com/getsentry/sentry-cli/releases/tag/2.58.5) |
 
 Note that we can only provide support for officially-supported Sentry Self-Hosted versions. We will not backport fixes for older Sentry CLI versions, even if they should be compatible with your self-hosted version.
 


### PR DESCRIPTION
We released a new `2.x` version of Sentry CLI last week, [version 2.58.5](https://github.com/getsentry/sentry-cli/releases/tag/2.58.5), to address a security vulnerability.

This change updates the self-hosted compatibility matrix in the `README.md` accordingly.