### PR TITLE
fix(snapshots): Use org/project-scoped object keys for snapshot uploads

### DIFF
--- a/src/commands/build/snapshots.rs
+++ b/src/commands/build/snapshots.rs
@@ -293,9 +293,22 @@ fn upload_images(
         .build()?;
 
     let mut scope = Usecase::new("preprod").scope();
-    for (key, value) in &options.objectstore.scopes {
-        scope = scope.push(key, value);
+    let (mut org_id, mut project_id): (Option<String>, Option<String>) = (None, None);
+    for (key, value) in options.objectstore.scopes.into_iter() {
+        scope = scope.push(&key, value.clone());
+        if key == "org" {
+            org_id = Some(value);
+        } else if key == "project" {
+            project_id = Some(value);
+        }
     }
+    let Some(org_id) = org_id else {
+        anyhow::bail!("Missing org in UploadOptions scope");
+    };
+    let Some(project_id) = project_id else {
+        anyhow::bail!("Missing project in UploadOptions scope");
+    };
+
     let session = scope.session(&client)?;
 
     let runtime = tokio::runtime::Builder::new_current_thread()
@@ -317,12 +330,13 @@ fn upload_images(
                 format!("Failed to open image for upload: {}", image.path.display())
             })?;
 
-        info!("Queueing {} as {hash}", image.relative_path.display());
+        let key = format!("{org_id}/{project_id}/{hash}");
+        info!("Queueing {} as {key}", image.relative_path.display());
 
         many_builder = many_builder.push(
             session
                 .put_file(file)
-                .key(&hash)
+                .key(&key)
                 .expiration_policy(expiration),
         );
 


### PR DESCRIPTION
Changes the objectstore key format from `{hash}` to `{org_id}/{project_id}/{hash}` for snapshot image uploads.

This is needed because the the ProjectPreprodArtifactImageEndpoint https://github.com/getsentry/sentry/blob/948dfedb37bd20bda491a233568f5e711899368a/src/sentry/preprod/api/endpoints/project_preprod_artifact_image.py expects this format, including org and project id in the key, not just the hash.
That endpoint is also used by app icons which were using roughly the same format, so we cannot easily change it.

The org and project IDs are extracted from the objectstore scopes that are already provided in the upload options, with explicit validation that both are present.
This creates an implicit contract on the snapshots upload options endpoint, requiring it to always return organization and project IDs as scopes in the ObjectstoreUploadOptions struct.
This is not ideal, but in practice this should always be the case and there's no logical reason for that to change over time. It would be a breaking change for anything else that needs to read or write the snapshots.