### PR TITLE
ref(snapshots): Use async I/O for snapshot image processing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2322,9 +2322,9 @@ dependencies = [
 
 [[package]]
 name = "objectstore-client"
-version = "0.0.19"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3bcaf8bc0ea7c50905631df108126c6a075ce5a9c16713ec4b68cc872a408e08"
+checksum = "033eedf125e31b30962c0172842e964fc9983bbccd99d9ff033e7e413946861c"
 dependencies = [
  "async-compression",
  "async-stream",
@@ -2346,9 +2346,9 @@ dependencies = [
 
 [[package]]
 name = "objectstore-types"
-version = "0.0.19"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f190038e8988112a4e593f1796612941117d88753574ef6476f99324d4605aae"
+checksum = "956cbdef3971ea108a15e5248625d6229870da3a3c637b6e7aada213526f8014"
 dependencies = [
  "http",
  "humantime",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,7 +44,7 @@ java-properties = "2.0.0"
 lazy_static = "1.4.0"
 libc = "0.2.139"
 log = { version = "0.4.17", features = ["std"] }
-objectstore-client = { version = "0.0.19" , default-features = false, features = ["native-tls"] }
+objectstore-client = { version = "0.1.2" , default-features = false, features = ["native-tls"] }
 open = "3.2.0"
 parking_lot = "0.12.1"
 percent-encoding = "2.2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -69,7 +69,7 @@ sha2 = "0.10.9"
 sourcemap = { version = "9.3.0", features = ["ram_bundle"] }
 symbolic = { version = "12.13.3", features = ["debuginfo-serde", "il2cpp"] }
 thiserror = "1.0.38"
-tokio = { version = "1.47", features = ["rt"] }
+tokio = { version = "1.47", features = ["rt", "fs", "io-util"] }
 url = "2.3.1"
 uuid = { version = "1.3.0", features = ["v4", "serde"] }
 walkdir = "2.3.2"

--- a/src/commands/build/snapshots.rs
+++ b/src/commands/build/snapshots.rs
@@ -267,9 +267,22 @@ fn upload_images(
         .build()?;
 
     let mut scope = Usecase::new("preprod").scope();
-    for (key, value) in &options.objectstore.scopes {
-        scope = scope.push(key, value);
+    let (mut org_id, mut project_id): (Option<String>, Option<String>) = (None, None);
+    for (key, value) in options.objectstore.scopes.into_iter() {
+        scope = scope.push(&key, value.clone());
+        if key == "org" {
+            org_id = Some(value);
+        } else if key == "project" {
+            project_id = Some(value);
+        }
     }
+    let Some(org_id) = org_id else {
+        anyhow::bail!("Missing org in UploadOptions scope");
+    };
+    let Some(project_id) = project_id else {
+        anyhow::bail!("Missing project in UploadOptions scope");
+    };
+
     let session = scope.session(&client)?;
 
     let runtime = tokio::runtime::Builder::new_current_thread()
@@ -289,12 +302,13 @@ fn upload_images(
             format!("Failed to open image for upload: {}", image.path.display())
         })?;
 
-        info!("Queueing {} as {hash}", image.relative_path.display());
+        let key = format!("{org_id}/{project_id}/{hash}");
+        info!("Queueing {} as {key}", image.relative_path.display());
 
         many_builder = many_builder.push(
             session
                 .put_file(file)
-                .key(&hash)
+                .key(&key)
                 .expiration_policy(expiration),
         );
 

--- a/src/commands/build/snapshots.rs
+++ b/src/commands/build/snapshots.rs
@@ -1,6 +1,7 @@
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 use std::str::FromStr as _;
+use std::sync::Arc;
 
 use anyhow::{Context as _, Result};
 use clap::{Arg, ArgMatches, Command};
@@ -10,7 +11,8 @@ use log::{debug, info, warn};
 use objectstore_client::{ClientBuilder, ExpirationPolicy, Usecase};
 use secrecy::ExposeSecret as _;
 use sha2::{Digest as _, Sha256};
-use tokio::fs::File;
+use tokio::io::AsyncReadExt as _;
+use tokio::sync::Mutex;
 use walkdir::WalkDir;
 
 use crate::api::{Api, CreateSnapshotResponse, ImageMetadata, SnapshotsManifest};
@@ -209,16 +211,16 @@ fn validate_image_sizes(images: &[ImageInfo]) -> Result<()> {
     Ok(())
 }
 
-fn compute_sha256_hash(path: &Path) -> Result<String> {
-    use std::io::Read as _;
-
-    let mut file = std::fs::File::open(path)
+async fn compute_sha256_hash(path: &Path) -> Result<String> {
+    let mut file = tokio::fs::File::open(path)
+        .await
         .with_context(|| format!("Failed to open image for hashing: {}", path.display()))?;
     let mut hasher = Sha256::new();
     let mut buffer = [0u8; 8192];
     loop {
         let bytes_read = file
             .read(&mut buffer)
+            .await
             .with_context(|| format!("Failed to read image for hashing: {}", path.display()))?;
         if bytes_read == 0 {
             break;
@@ -290,66 +292,72 @@ fn upload_images(
         .build()
         .context("Failed to create tokio runtime")?;
 
-    let mut many_builder = session.many();
-    let mut manifest_entries = HashMap::new();
     let image_count = images.len();
+    let manifest_entries = Arc::new(Mutex::new(HashMap::new()));
 
-    for image in images {
-        debug!("Processing image: {}", image.path.display());
+    runtime.block_on(async {
+        let mut many_builder = session.many();
 
-        let hash = compute_sha256_hash(&image.path)?;
-        let file = runtime.block_on(File::open(&image.path)).with_context(|| {
-            format!("Failed to open image for upload: {}", image.path.display())
-        })?;
+        for image in images {
+            debug!("Processing image: {}", image.path.display());
 
-        let key = format!("{org_id}/{project_id}/{hash}");
-        info!("Queueing {} as {key}", image.relative_path.display());
+            let hash = compute_sha256_hash(&image.path).await?;
+            let file = tokio::fs::File::open(&image.path).await.with_context(|| {
+                format!("Failed to open image for upload: {}", image.path.display())
+            })?;
 
-        many_builder = many_builder.push(
-            session
-                .put_file(file)
-                .key(&key)
-                .expiration_policy(expiration),
-        );
+            let key = format!("{org_id}/{project_id}/{hash}");
+            info!("Queueing {} as {key}", image.relative_path.display());
 
-        let image_file_name = image
-            .relative_path
-            .file_name()
-            .unwrap_or_default()
-            .to_string_lossy()
-            .into_owned();
-        manifest_entries.insert(
-            hash,
-            ImageMetadata {
-                image_file_name,
-                width: image.width,
-                height: image.height,
-            },
-        );
-    }
-
-    let result = runtime.block_on(async { many_builder.send().error_for_failures().await });
-
-    match result {
-        Ok(()) => {
-            println!(
-                "{} Uploaded {} image {}",
-                style(">").dim(),
-                style(image_count).yellow(),
-                if image_count == 1 { "file" } else { "files" }
+            many_builder = many_builder.push(
+                session
+                    .put_file(file)
+                    .key(&key)
+                    .expiration_policy(expiration),
             );
-            Ok(manifest_entries)
+
+            let image_file_name = image
+                .relative_path
+                .file_name()
+                .unwrap_or_default()
+                .to_string_lossy()
+                .into_owned();
+            manifest_entries.lock().await.insert(
+                hash,
+                ImageMetadata {
+                    image_file_name,
+                    width: image.width,
+                    height: image.height,
+                },
+            );
         }
-        Err(errors) => {
-            eprintln!("There were errors uploading images:");
-            let mut error_count = 0;
-            for error in errors {
-                eprintln!("  {}", style(error).red());
-                error_count += 1;
+
+        let result = many_builder.send().error_for_failures().await;
+        match result {
+            Ok(()) => {
+                println!(
+                    "{} Uploaded {} image {}",
+                    style(">").dim(),
+                    style(image_count).yellow(),
+                    if image_count == 1 { "file" } else { "files" }
+                );
+                Ok(())
             }
-            anyhow::bail!("Failed to upload {error_count} out of {image_count} images")
+            Err(errors) => {
+                eprintln!("There were errors uploading images:");
+                let mut error_count = 0;
+                for error in errors {
+                    eprintln!("  {}", style(error).red());
+                    error_count += 1;
+                }
+                anyhow::bail!("Failed to upload {error_count} out of {image_count} images")
+            }
         }
-    }
+    })?;
+
+    Ok(Arc::try_unwrap(manifest_entries)
+        .expect("all references should be dropped after runtime completes")
+        .into_inner())
 }
 
 #[cfg(test)]

--- a/src/commands/build/snapshots.rs
+++ b/src/commands/build/snapshots.rs
@@ -1,5 +1,4 @@
 use std::collections::HashMap;
-use std::fs;
 use std::path::{Path, PathBuf};
 use std::str::FromStr as _;
 
@@ -10,6 +9,7 @@ use log::{debug, info, warn};
 use objectstore_client::{ClientBuilder, ExpirationPolicy, Usecase};
 use secrecy::ExposeSecret as _;
 use sha2::{Digest as _, Sha256};
+use tokio::fs::File;
 use walkdir::WalkDir;
 
 use crate::api::{Api, CreateSnapshotResponse, ImageMetadata, SnapshotsManifest};
@@ -174,11 +174,24 @@ fn collect_image_info(dir: &Path, path: &Path) -> Option<ImageInfo> {
     })
 }
 
-fn compute_sha256_hash(data: &[u8]) -> String {
+fn compute_sha256_hash(path: &Path) -> Result<String> {
+    use std::io::Read as _;
+
+    let mut file = std::fs::File::open(path)
+        .with_context(|| format!("Failed to open image for hashing: {}", path.display()))?;
     let mut hasher = Sha256::new();
-    hasher.update(data);
+    let mut buffer = [0u8; 8192];
+    loop {
+        let bytes_read = file
+            .read(&mut buffer)
+            .with_context(|| format!("Failed to read image for hashing: {}", path.display()))?;
+        if bytes_read == 0 {
+            break;
+        }
+        hasher.update(&buffer[..bytes_read]);
+    }
     let result = hasher.finalize();
-    format!("{result:x}")
+    Ok(format!("{result:x}"))
 }
 
 fn is_hidden(root: &Path, path: &Path) -> bool {
@@ -236,15 +249,16 @@ fn upload_images(
     for image in images {
         debug!("Processing image: {}", image.path.display());
 
-        let contents = fs::read(&image.path)
-            .with_context(|| format!("Failed to read image: {}", image.path.display()))?;
-        let hash = compute_sha256_hash(&contents);
+        let hash = compute_sha256_hash(&image.path)?;
+        let file = runtime.block_on(File::open(&image.path)).with_context(|| {
+            format!("Failed to open image for upload: {}", image.path.display())
+        })?;
 
         info!("Queueing {} as {hash}", image.relative_path.display());
 
         many_builder = many_builder.push(
             session
-                .put(contents)
+                .put_file(file)
                 .key(&hash)
                 .expiration_policy(expiration),
         );


### PR DESCRIPTION
Enters the tokio runtime early with a single `block_on` call wrapping all
async work, instead of calling `block_on` multiple times in the upload loop.

- `compute_sha256_hash` is now async, using `tokio::fs::File` and `AsyncReadExt`
  for chunked reading instead of sync `std::fs::File` / `std::io::Read`
- File opens for uploads also use `tokio::fs::File::open` inside the async block
- `manifest_entries` wrapped in `Arc<tokio::sync::Mutex>` for mutation inside
  the async block, extracted via `Arc::try_unwrap` after the runtime completes
- Added `fs` and `io-util` tokio features in `Cargo.toml`

Stacked on #3186.

We're still computing the hash and enqueuing the files sequentially. Eventually we can make this concurrent or even parallel in case we want to use a multi-threaded runtime.