### PR TITLE
fix(jest): Use relative path for setupFiles in Jest 30

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,8 +1,8 @@
 module.exports = {
   collectCoverage: true,
   testEnvironment: 'node',
-  setupFiles: ['<rootDir>/setupTests.js'],
-  testPathIgnorePatterns: ['<rootDir>/src/', '<rootDir>/tests/integration/'],
+  setupFiles: ['./setupTests.js'],
+  testPathIgnorePatterns: ['./src/', './tests/integration/'],
   transform: {
     '^.+\\.ts$': 'ts-jest',
   },


### PR DESCRIPTION
## Summary
- Jest 30 no longer resolves `<rootDir>/setupTests.js` correctly, causing `test:jest` to fail with `Module <rootDir>/setupTests.js in the setupFiles option was not found`
- Switches to `./setupTests.js` which works with both Jest 27 and 30
- Fixes CI failure on `release/3.3.1` branch https://github.com/getsentry/sentry-cli/actions/runs/22861477547

## Test plan
- [x] `npx jest --listTests` resolves correctly
- [x] Reproduced the failure locally and verified the fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)