### PR TITLE
fix(ci): Install native resolver bindings for Jest 30 on release builds

### DIFF
--- a/.github/workflows/test_node.yml
+++ b/.github/workflows/test_node.yml
@@ -96,6 +96,12 @@ jobs:
         if: ${{ inputs.triggered-by-release }}
         run: npm install --omit=optional --ignore-scripts
 
+      # --omit=optional skips native resolver bindings required by Jest 30.
+      # napi-postinstall installs the correct platform-specific binary.
+      - name: Install native bindings (for pushes to release branch)
+        if: ${{ inputs.triggered-by-release }}
+        run: npx napi-postinstall unrs-resolver
+
       - name: Download build artifact
         uses: actions/download-artifact@70fc10c6e5e1ce46ad2ea6f2b72d43f7d47b13c3 # 8.0.0
         with:


### PR DESCRIPTION
## Summary
- Jest 30 uses `@unrs/resolver` which requires platform-specific native binaries installed as optional dependencies
- The release CI path uses `--omit=optional` which skips these bindings entirely, causing Jest to fail with `Module not found` errors for `setupFiles`, `transform`, etc.
- The regular CI path (`npm ci --ignore-scripts`) installs optional deps from the lockfile, so it's unaffected
- Fix: run `npx napi-postinstall unrs-resolver` after install on release builds to install the correct native binary

Fixes CI failure on `release/3.3.1`: https://github.com/getsentry/sentry-cli/actions/runs/22871154749

## Test plan
- [x] Verified root cause: `--omit=optional` skips `@unrs/resolver-binding-linux-x64-gnu`
- [x] Already pushed to `release/3.3.1` for testing

https://github.com/getsentry/sentry-cli/actions/runs/22871625332 successful run

🤖 Generated with [Claude Code](https://claude.com/claude-code)