### PR TITLE
test: Resolves setupFiles instead of letting Jest handling it

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,7 +1,7 @@
 module.exports = {
   collectCoverage: true,
   testEnvironment: 'node',
-  setupFiles: ['<rootDir>/setupTests.js'],
+  setupFiles: [require.resolve('./setupTests.js')],
   testPathIgnorePatterns: ['<rootDir>/src/', '<rootDir>/tests/integration/'],
   transform: {
     '^.+\\.ts$': 'ts-jest',


### PR DESCRIPTION
This would hopefully help to fix releasing: https://github.com/getsentry/sentry-cli/actions/runs/22871154749/job/66351058690

It is hard to tell as it works locally with every Node version. But it could be that when there is a `<rootDir>` it is resolved a little differently internally (it is resolved [here](https://github.com/jestjs/jest/blob/efb59c2e81083f8dc941f20d6d20a3af2dc8d068/packages/jest-runner/src/runTest.ts#L237))