### PR TITLE
feat(preprod): Increase connect timeout, display full errors

### DIFF
--- a/src/commands/build/snapshots.rs
+++ b/src/commands/build/snapshots.rs
@@ -388,7 +388,7 @@ fn upload_images(
             let mut error_count = 0;
             for error in errors {
                 let error = anyhow::Error::new(error);
-                eprintln!("  {}", style(format!("{:#}", error)).red());
+                eprintln!("  {}", style(format!("{error:#}")).red());
                 error_count += 1;
             }
             anyhow::bail!("Failed to upload {error_count} out of {image_count} images")


### PR DESCRIPTION
We've been running the snapshots command in `sentry`'s CI for some time and observed some failures.
Example: https://github.com/getsentry/sentry/actions/runs/22928756345/job/66545427887?pr=109531

This addresses that by making 2 changes:

- Improves error reporting by wrapping upload errors with `anyhow::Error` and using alternate formatting (`{:#}`) to display the full error chain. Before, you would just see `error sending request for url` and nothing more.
(it would also be possible to print it manually iterating sources, it's just easier to wrap it in anyhow)

- Sets the connect timeout on `objectstore_client`'s underling `reqwest::Client` to a very generous 10s.
We were most likely running into that timeout, which `objectstore_client` sets to 0.1s by default. That's suitable for internal services communicating directly with objectstore in the same VPC, but probably too low for an environment like GH actions.

There's no concrete motivation for choosing specifically 10s, we just need to choose something higher than 0.1s.
I checked what we do for `curl` (used for all other requests) and it seems we don't set any kind of timeout on it.

#skip-changelog as we've been skipping changelog for this command, as it's still experimental and used only for internal testing.