### PR TITLE
ci: NPM package depends on signed macOS binaries

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -247,7 +247,7 @@ jobs:
   node:
     name: NPM Package
     runs-on: ubuntu-24.04
-    needs: [linux, macos, macos_universal, windows]
+    needs: [linux, sign-macos-binaries, windows]
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # 6.0.2


### PR DESCRIPTION
Split from #3212, thanks @runningcode for noticing!