### PR TITLE
fix(progress): Replace eprintln! with log::info! in CI fallback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Fixes
+
+- Replace `eprintln!` with `log::info!` for progress bar completion messages when the progress bar is disabled (e.g. in CI). This avoids spurious stderr output that some CI systems treat as errors ([#3223](https://github.com/getsentry/sentry-cli/pull/3223)).
+
 ## 3.3.5
 
 ### Performance

--- a/src/utils/progress.rs
+++ b/src/utils/progress.rs
@@ -71,7 +71,7 @@ impl ProgressBar {
             inner.finish_with_message(&msg);
             logging::set_progress_bar(None);
         } else {
-            eprintln!("> {msg}");
+            log::info!("{msg}");
         }
     }
 

--- a/tests/integration/_cases/build/build-upload-apk-all-uploaded.trycmd
+++ b/tests/integration/_cases/build/build-upload-apk-all-uploaded.trycmd
@@ -1,7 +1,6 @@
 ```
 $ sentry-cli build upload tests/integration/_fixtures/build/apk.apk
 ? success
-> Preparing for upload completed in [..]
 Successfully uploaded 1 file to Sentry
   - tests/integration/_fixtures/build/apk.apk (http[..]/wat-org/preprod/wat-project/42)
 

--- a/tests/integration/_cases/build/build-upload-apk.trycmd
+++ b/tests/integration/_cases/build/build-upload-apk.trycmd
@@ -1,8 +1,6 @@
 ```
 $ sentry-cli build upload tests/integration/_fixtures/build/apk.apk --head-sha 12345678deadbeef78900987feebdaed87654321
 ? success
-> Preparing for upload completed in [..]
-> Uploading completed in [..]
 Successfully uploaded 1 file to Sentry
   - tests/integration/_fixtures/build/apk.apk (http[..]/wat-org/preprod/wat-project/42)
 

--- a/tests/integration/_cases/build/build-upload-empty-shas.trycmd
+++ b/tests/integration/_cases/build/build-upload-empty-shas.trycmd
@@ -1,7 +1,6 @@
 ```
 $ sentry-cli build upload tests/integration/_fixtures/build/apk.apk --head-sha "" --base-sha ""
 ? success
-> Preparing for upload completed in [..]
 Successfully uploaded 1 file to Sentry
   - tests/integration/_fixtures/build/apk.apk (http://sentry.io/wat-org/preprod/wat-project/42)
 

--- a/tests/integration/_cases/build/build-upload-ipa.trycmd
+++ b/tests/integration/_cases/build/build-upload-ipa.trycmd
@@ -1,8 +1,6 @@
 ```
 $ sentry-cli build upload tests/integration/_fixtures/build/ipa.ipa --head-sha deadbeef12345678deadbeef12345678deadbeef
 ? success
-> Preparing for upload completed in [..]
-> Uploading completed in [..]
 Successfully uploaded 1 file to Sentry
   - tests/integration/_fixtures/build/ipa.ipa (http://sentry.io/wat-org/preprod/wat-project/some-text-id)
 

--- a/tests/integration/_cases/debug_files/bundle_jvm/debug_files-bundle-jvm-input-dir-empty.trycmd
+++ b/tests/integration/_cases/debug_files/bundle_jvm/debug_files-bundle-jvm-input-dir-empty.trycmd
@@ -2,7 +2,6 @@
 $ sentry-cli debug-files bundle-jvm --output . --debug-id 48dee70b-4f3f-4a49-9223-de441738f7cd empty-dir
 ? success
 > Found 0 files
-> Bundling completed in [..]
 > Bundled 0 files for upload
 > Bundle ID: [..]-[..]-[..]-[..]-[..]
 Created ./48dee70b-4f3f-4a49-9223-de441738f7cd.zip

--- a/tests/integration/_cases/debug_files/bundle_jvm/debug_files-bundle-jvm-output-is-file.trycmd
+++ b/tests/integration/_cases/debug_files/bundle_jvm/debug_files-bundle-jvm-output-is-file.trycmd
@@ -2,7 +2,6 @@
 $ sentry-cli debug-files bundle-jvm --output ./file.txt --debug-id D384DC3B-AB2F-4DC7-903D-2C851E27E094 ./io
 ? failed
 > Found 2 files
-> Bundling completed in [..]
 > Bundled 2 files for upload
 > Bundle ID: [..]-[..]-[..]-[..]-[..]
 error: Unable to write source bundle

--- a/tests/integration/_cases/debug_files/bundle_jvm/debug_files-bundle-jvm-output-not-found.trycmd
+++ b/tests/integration/_cases/debug_files/bundle_jvm/debug_files-bundle-jvm-output-not-found.trycmd
@@ -2,7 +2,6 @@
 $ sentry-cli debug-files bundle-jvm --output i-do-not-exist --debug-id 0B693ABA-531C-4EB6-99E4-B7320C3C85DA jvm
 ? success
 > Found 2 files
-> Bundling completed in [..]
 > Bundled 2 files for upload
 > Bundle ID: [..]-[..]-[..]-[..]-[..]
 Created i-do-not-exist/0b693aba-531c-4eb6-99e4-b7320c3c85da.zip

--- a/tests/integration/_cases/debug_files/bundle_jvm/debug_files-bundle-jvm.trycmd
+++ b/tests/integration/_cases/debug_files/bundle_jvm/debug_files-bundle-jvm.trycmd
@@ -2,7 +2,6 @@
 $ sentry-cli debug-files bundle-jvm --output . --debug-id a4368a48-0880-40d7-9a26-c9ef5a84d156 ./io
 ? success
 > Found 2 files
-> Bundling completed in [..]
 > Bundled 2 files for upload
 > Bundle ID: [..]-[..]-[..]-[..]-[..]
 Created ./a4368a48-0880-40d7-9a26-c9ef5a84d156.zip

--- a/tests/integration/_cases/react_native/xcode-upload-source-maps-invalid-plist.trycmd
+++ b/tests/integration/_cases/react_native/xcode-upload-source-maps-invalid-plist.trycmd
@@ -5,9 +5,7 @@ react-native-xcode.sh called with args:
 Using React Native Packager bundle and source map.
 Processing react-native sourcemaps for Sentry upload.
 > Analyzing 2 sources
-> Analyzing completed in [..]
 > Rewriting sources
-> Rewriting completed in [..]
 > Adding source map references
 error: Info.plist was not found or an parsing error occurred
 

--- a/tests/integration/_cases/react_native/xcode-upload-source-maps-release_and_dist_from_env.trycmd
+++ b/tests/integration/_cases/react_native/xcode-upload-source-maps-release_and_dist_from_env.trycmd
@@ -8,17 +8,11 @@ react-native-xcode.sh called with args:
 Using React Native Packager bundle and source map.
 Processing react-native sourcemaps for Sentry upload.
 > Analyzing 2 sources
-> Analyzing completed in [..]
 > Rewriting sources
-> Rewriting completed in [..]
 > Adding source map references
-> Bundling completed in [..]
 > Bundled 2 files for upload
 > Bundle ID: [..]-[..]-[..]-[..]-[..]
-> Optimizing completed in [..]
-> Uploading completed in [..]
 > Uploaded files to Sentry
-> Processing completed in [..]
 > File upload complete (processing pending on server)
 > Organization: wat-org
 > Projects: wat-project

--- a/tests/integration/_cases/sourcemaps/sourcemaps-inject-bundlers.trycmd
+++ b/tests/integration/_cases/sourcemaps/sourcemaps-inject-bundlers.trycmd
@@ -4,7 +4,6 @@ $ sentry-cli sourcemaps inject .
 > Searching .
 > Found 18 files
 > Analyzing 18 sources
-> Analyzing completed in [..]
 > Injecting debug ids
 
 Source Map Debug ID Injection Report

--- a/tests/integration/_cases/sourcemaps/sourcemaps-inject-double-association.trycmd
+++ b/tests/integration/_cases/sourcemaps/sourcemaps-inject-double-association.trycmd
@@ -4,7 +4,6 @@ $ sentry-cli sourcemaps inject ./
 > Searching ./
 > Found 11 files
 > Analyzing 11 sources
-> Analyzing completed in [..]
 > Injecting debug ids
 
 Source Map Debug ID Injection Report

--- a/tests/integration/_cases/sourcemaps/sourcemaps-inject-embedded.trycmd
+++ b/tests/integration/_cases/sourcemaps/sourcemaps-inject-embedded.trycmd
@@ -4,7 +4,6 @@ $ sentry-cli sourcemaps inject .
 > Searching .
 > Found 1 file
 > Analyzing 1 sources
-> Analyzing completed in [..]
 > Injecting debug ids
 
 Source Map Debug ID Injection Report

--- a/tests/integration/_cases/sourcemaps/sourcemaps-inject-nomappings.trycmd
+++ b/tests/integration/_cases/sourcemaps/sourcemaps-inject-nomappings.trycmd
@@ -6,7 +6,6 @@ $ sentry-cli sourcemaps inject ./server ./static
 > Searching ./static
 > Found 8 files
 > Analyzing 19 sources
-> Analyzing completed in [..]
 > Injecting debug ids
 
 Source Map Debug ID Injection Report

--- a/tests/integration/_cases/sourcemaps/sourcemaps-inject-split-ambiguous.trycmd
+++ b/tests/integration/_cases/sourcemaps/sourcemaps-inject-split-ambiguous.trycmd
@@ -8,7 +8,6 @@ $ sentry-cli sourcemaps inject ./code ./maps ./maps2 --log-level warn
 > Searching ./maps2
 > Found 1 file
 > Analyzing 5 sources
-> Analyzing completed in [..]
 > Injecting debug ids
   WARN    [..]-[..]-[..] [..]:[..]:[..].[..] [..]:[..] Ambiguous matches for sourcemap path ./code/foo/index.js.map:
   WARN    [..]-[..]-[..] [..]:[..]:[..].[..] [..]:[..] ./maps/foo/index.js.map

--- a/tests/integration/_cases/sourcemaps/sourcemaps-inject-split.trycmd
+++ b/tests/integration/_cases/sourcemaps/sourcemaps-inject-split.trycmd
@@ -6,7 +6,6 @@ $ sentry-cli sourcemaps inject ./code ./maps
 > Searching ./maps
 > Found 2 files
 > Analyzing 4 sources
-> Analyzing completed in [..]
 > Injecting debug ids
 
 Source Map Debug ID Injection Report

--- a/tests/integration/_cases/sourcemaps/sourcemaps-inject.trycmd
+++ b/tests/integration/_cases/sourcemaps/sourcemaps-inject.trycmd
@@ -6,7 +6,6 @@ $ sentry-cli sourcemaps inject ./server ./static
 > Searching ./static
 > Found 8 files
 > Analyzing 24 sources
-> Analyzing completed in [..]
 > Injecting debug ids
 
 Source Map Debug ID Injection Report

--- a/tests/integration/_cases/sourcemaps/sourcemaps-upload-debugid-alias.trycmd
+++ b/tests/integration/_cases/sourcemaps/sourcemaps-upload-debugid-alias.trycmd
@@ -3,17 +3,11 @@ $ sentry-cli sourcemaps upload tests/integration/_fixtures/upload_debugid_alias
 ? success
 > Found 2 files
 > Analyzing 2 sources
-> Analyzing completed in [..]
 > Rewriting sources
-> Rewriting completed in [..]
 > Adding source map references
-> Bundling completed in [..]
 > Bundled 2 files for upload
 > Bundle ID: [..]-[..]-[..]-[..]-[..]
-> Optimizing completed in [..]
-> Uploading completed in [..]
 > Uploaded files to Sentry
-> Processing completed in [..]
 > File upload complete (processing pending on server)
 > Organization: wat-org
 > Projects: wat-project

--- a/tests/integration/_cases/sourcemaps/sourcemaps-upload-file-hermes-bundle-reference-debug-id.trycmd
+++ b/tests/integration/_cases/sourcemaps/sourcemaps-upload-file-hermes-bundle-reference-debug-id.trycmd
@@ -3,17 +3,11 @@ $ sentry-cli sourcemaps upload --bundle tests/integration/_fixtures/file-hermes-
 ? success
   WARN    [..] Regular bundle found
 > Analyzing 2 sources
-> Analyzing completed in [..]
 > Rewriting sources
-> Rewriting completed in [..]
 > Adding source map references
-> Bundling completed in [..]
 > Bundled 2 files for upload
 > Bundle ID: b87a18c0-0d49-5771-bb15-cb1654bc9129
-> Optimizing completed in [..]
-> Uploading completed in [..]
 > Uploaded files to Sentry
-> Processing completed in [..]
 > File upload complete (processing pending on server)
 > Organization: wat-org
 > Projects: wat-project

--- a/tests/integration/_cases/sourcemaps/sourcemaps-upload-file-ram-bundle.trycmd
+++ b/tests/integration/_cases/sourcemaps/sourcemaps-upload-file-ram-bundle.trycmd
@@ -2,17 +2,11 @@
 $ sentry-cli sourcemaps upload --bundle tests/integration/_fixtures/file-ram-bundle/index.android.bundle --bundle-sourcemap tests/integration/_fixtures/file-ram-bundle/index.android.bundle.packager.map --release=wat-release
 ? success
 > Analyzing 1 sources
-> Analyzing completed in [..]
 > Rewriting sources
-> Rewriting completed in [..]
 > Adding source map references
-> Bundling completed in [..]
 > Bundled 14 files for upload
 > Bundle ID: [..]-[..]-[..]-[..]-[..]
-> Optimizing completed in [..]
-> Uploading completed in [..]
 > Uploaded files to Sentry
-> Processing completed in [..]
 > File upload complete (processing pending on server)
 > Organization: wat-org
 > Projects: wat-project

--- a/tests/integration/_cases/sourcemaps/sourcemaps-upload-indexed-ram-bundle.trycmd
+++ b/tests/integration/_cases/sourcemaps/sourcemaps-upload-indexed-ram-bundle.trycmd
@@ -2,17 +2,11 @@
 $ sentry-cli sourcemaps upload --bundle tests/integration/_fixtures/indexed-ram-bundle/main.jsbundle --bundle-sourcemap tests/integration/_fixtures/indexed-ram-bundle/main.jsbundle.packager.map --release=wat-release
 ? success
 > Analyzing 1 sources
-> Analyzing completed in [..]
 > Rewriting sources
-> Rewriting completed in [..]
 > Adding source map references
-> Bundling completed in [..]
 > Bundled 2107 files for upload
 > Bundle ID: [..]-[..]-[..]-[..]-[..]
-> Optimizing completed in [..]
-> Uploading completed in [..]
 > Uploaded files to Sentry
-> Processing completed in [..]
 > File upload complete (processing pending on server)
 > Organization: wat-org
 > Projects: wat-project

--- a/tests/integration/_cases/sourcemaps/sourcemaps-upload-log-level-info.trycmd
+++ b/tests/integration/_cases/sourcemaps/sourcemaps-upload-log-level-info.trycmd
@@ -1,0 +1,35 @@
+```
+$ sentry-cli sourcemaps upload --log-level=info tests/integration/_fixtures/bundle.min.js.map tests/integration/_fixtures/vendor.min.js.map
+? success
+  INFO    [..] Loaded config from [CWD]/.sentryclirc
+  INFO    [..] sentry-cli was invoked with the following command line: [..]
+  INFO    [..] found: tests/integration/_fixtures/bundle.min.js.map ([..] bytes)
+> Found 1 file
+  INFO    [..] found: tests/integration/_fixtures/vendor.min.js.map ([..] bytes)
+> Found 1 file
+> Analyzing 2 sources
+  INFO    [..] Analyzing completed in [..]s
+> Rewriting sources
+  INFO    [..] Rewriting completed in [..]s
+> Adding source map references
+  INFO    [..] Bundling completed in [..]s
+> Bundled 2 files for upload
+> Bundle ID: [..]-[..]-[..]-[..]-[..]
+  INFO    [..] Optimizing completed in [..]s
+  INFO    [..] using 'uncompressed' compression for chunk upload
+  INFO    [..] Uploading completed in [..]s
+> Uploaded files to Sentry
+  INFO    [..] Processing completed in [..]s
+> File upload complete (processing pending on server)
+> Organization: wat-org
+> Projects: wat-project
+> Release: None
+> Dist: None
+> Upload type: artifact bundle
+
+Source Map Upload Report
+  Source Maps
+    ~/bundle.min.js.map
+    ~/vendor.min.js.map
+
+```

--- a/tests/integration/_cases/sourcemaps/sourcemaps-upload-modern.trycmd
+++ b/tests/integration/_cases/sourcemaps/sourcemaps-upload-modern.trycmd
@@ -4,17 +4,11 @@ $ sentry-cli sourcemaps upload tests/integration/_fixtures/bundle.min.js.map tes
 > Found 1 file
 > Found 1 file
 > Analyzing 2 sources
-> Analyzing completed in [..]
 > Rewriting sources
-> Rewriting completed in [..]
 > Adding source map references
-> Bundling completed in [..]
 > Bundled 2 files for upload
 > Bundle ID: [..]-[..]-[..]-[..]-[..]
-> Optimizing completed in [..]
-> Uploading completed in [..]
 > Uploaded files to Sentry
-> Processing completed in [..]
 > File upload complete (processing pending on server)
 > Organization: wat-org
 > Projects: wat-project

--- a/tests/integration/_cases/sourcemaps/sourcemaps-upload-no-debugids.trycmd
+++ b/tests/integration/_cases/sourcemaps/sourcemaps-upload-no-debugids.trycmd
@@ -3,9 +3,7 @@ $ sentry-cli sourcemaps upload tests/integration/_fixtures/upload_no_debugids
 ? 1
 > Found 20 files
 > Analyzing 20 sources
-> Analyzing completed in [..]
 > Rewriting sources
-> Rewriting completed in [..]
 > Adding source map references
 error: Cannot upload: You must either specify a release or have debug ids injected into your sources
 

--- a/tests/integration/_cases/sourcemaps/sourcemaps-upload-some-debugids.trycmd
+++ b/tests/integration/_cases/sourcemaps/sourcemaps-upload-some-debugids.trycmd
@@ -3,9 +3,7 @@ $ sentry-cli sourcemaps upload tests/integration/_fixtures/upload_some_debugids
 ? success
 > Found 20 files
 > Analyzing 20 sources
-> Analyzing completed in [..]
 > Rewriting sources
-> Rewriting completed in [..]
 > Adding source map references
   WARN    [..]-[..]-[..] [..]:[..]:[..].[..] [..]:[..] Some source files don't have debug ids:
   WARN    [..]-[..]-[..] [..]:[..]:[..].[..] [..]:[..] - ~/server/app/page.js
@@ -15,13 +13,9 @@ $ sentry-cli sourcemaps upload tests/integration/_fixtures/upload_some_debugids
   WARN    [..]-[..]-[..] [..]:[..]:[..].[..] [..]:[..] - ~/server/pages/api/hello.js
   WARN    [..]-[..]-[..] [..]:[..]:[..].[..] [..]:[..] - ~/static/chunks/575-bb7d7e0e6de8d623.js
   WARN    [..]-[..]-[..] [..]:[..]:[..].[..] [..]:[..] - ~/static/chunks/pages/asdf-05b39167abbe433b.js
-> Bundling completed in [..]
 > Bundled 20 files for upload
 > Bundle ID: [..]-[..]-[..]-[..]-[..]
-> Optimizing completed in [..]
-> Uploading completed in [..]
 > Uploaded files to Sentry
-> Processing completed in [..]
 > File upload complete (processing pending on server)
 > Organization: wat-org
 > Projects: wat-project

--- a/tests/integration/sourcemaps/upload.rs
+++ b/tests/integration/sourcemaps/upload.rs
@@ -6,6 +6,15 @@ fn command_sourcemaps_upload_help() {
 }
 
 #[test]
+fn command_sourcemaps_upload_log_level_info() {
+    TestManager::new()
+        .mock_common_upload_endpoints(None, Some(vec!["95d152c0530efb498133138c7e7092612f5abab1"]))
+        .register_trycmd_test("sourcemaps/sourcemaps-upload-log-level-info.trycmd")
+        .with_default_token()
+        .assert_mock_endpoints();
+}
+
+#[test]
 fn command_sourcemaps_upload() {
     TestManager::new().register_trycmd_test("sourcemaps/sourcemaps-upload.trycmd");
 }


### PR DESCRIPTION
When progress bars are disabled (e.g. in CI where stderr is not a terminal), `finish_with_duration` printed its completion message via `eprintln!`. Some CI configurations treat any stderr output as an error, causing false positives.

Use `log::info!` instead, which is suppressed at the default `Warn` log level. Users who want to see these messages can use `--log-level info`. The `> ` prefix is dropped since the log framework adds its own formatting.

Closes #3016
Closes [CLI-244](https://linear.app/getsentry/issue/CLI-244/avoid-eprintln-for-progress-bar-messages-in-ci)
