### PR TITLE
ci(build): Add packages:write permission to snapshot workflow

### DIFF
--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -6,6 +6,7 @@ on:
 
 permissions:
   contents: write
+  packages: write
 
 jobs:
   prepare:


### PR DESCRIPTION
## Summary

Fixes failed action here: https://github.com/getsentry/sentry-cli/actions/runs/23303634015

- Adds `packages: write` to the snapshot workflow's top-level permissions. GitHub validates reusable workflow permissions statically — even though the docker jobs in `build.yml` have `if: !inputs.is-snapshot` and won't run, the caller must still grant the permissions they declare.

🤖 Generated with [Claude Code](https://claude.com/claude-code)