### PR TITLE
ci(build): Add packages:write permission to snapshot workflow

### DIFF
--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -6,6 +6,7 @@ on:
 
 permissions:
   contents: write
+  packages: write
 
 jobs:
   prepare:


### PR DESCRIPTION
## Summary

- Add missing `packages: write` permission to the snapshot workflow so that the called `build.yml` nested jobs (`platform-specific-docker`, `multiarch-docker`) can push Docker images.

TIL: AI lies even if you ask it to check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)