### PR TITLE
fix(build): Ungate ProgressBarMode::Response from managed feature

### DIFF
--- a/src/utils/progress.rs
+++ b/src/utils/progress.rs
@@ -128,7 +128,6 @@ impl ProgressBar {
 #[derive(Clone)]
 pub enum ProgressBarMode {
     Disabled,
-    #[cfg(not(feature = "managed"))]
     Response,
     Shared((Arc<ProgressBar>, u64, usize, Arc<RwLock<Vec<u64>>>)),
 }
@@ -141,12 +140,6 @@ impl ProgressBarMode {
 
     /// Returns whether a progress bar should be displayed during download.
     pub fn response(&self) -> bool {
-        #[cfg(not(feature = "managed"))]
-        let rv = matches!(*self, ProgressBarMode::Response);
-
-        #[cfg(feature = "managed")]
-        let rv = false;
-
-        rv
+        matches!(*self, ProgressBarMode::Response)
     }
 }


### PR DESCRIPTION
## Summary
- `ProgressBarMode::Response` was gated behind `#[cfg(not(feature = "managed"))]` because its only consumer (`download_with_progress`) was also managed-gated
- The new `download_installable_build` method (used by `build download`) references this variant without a managed gate, breaking the Docker build (`--features managed`)
- The progress bar has nothing to do with managed mode — remove the feature gate from the variant and simplify the `response()` method

#skip-changelog

🤖 Generated with [Claude Code](https://claude.com/claude-code)