### PR TITLE
meta: fix changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 - (sourcemaps) Skip non-base64 embedded sourcemaps during injection ([#3243](https://github.com/getsentry/sentry-cli/pull/3243))
 
+## 3.3.4
+
 ### New Features ✨
 
 - Add `sentry-cli build download` command to download installable builds (IPA/APK) by build ID ([#3221](https://github.com/getsentry/sentry-cli/pull/3221)).


### PR DESCRIPTION
Release 3.3.4 was only partially released (it shows in GitHub releases, but I am not sure to where else it was successfully released). As a result, the changelog was not updated after the release. 

This change splits off the changlog material included in the  partial [3.3.4 release](https://github.com/getsentry/sentry-cli/releases/tag/3.3.4).