### PR TITLE
meta: Remove codeowner protection from `CHANGELOG.md`

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -17,3 +17,6 @@
 /src/commands/build @getsentry/emerge-tools @getsentry/owners-sentry-cli
 /src/utils/build @getsentry/emerge-tools @getsentry/owners-sentry-cli
 /tests/integration/build @getsentry/emerge-tools @getsentry/owners-sentry-cli
+
+# Files without codeowner protection
+/CHANGELOG.md


### PR DESCRIPTION
As the changelog often needs to be updated with changes that have a broader set of codeowners than the default `*`, we should exclude it from codeowner protection to allow approvals by those codeowners, rather than blocking PRs on the `*` rule only because of the changelog updates