### PR TITLE
feat(bundle-jvm): Automatically collect JVM source files with respecting excludes and gitignore 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,8 @@
 
 ### Features
 
-- (bundle-jvm) Allow running directly on a project root (including multi-module repos) by automatically collecting only JVM source files (`.java`, `.kt`, `.scala`, `.groovy`), respecting `.gitignore`, and excluding common build output directories. Add `--exclude` option for custom glob patterns ([#3260](https://github.com/getsentry/sentry-cli/pull/3260))
+- (bundle-jvm) Allow running directly on a project root (including multi-module repos) by automatically collecting only JVM source files (`.java`, `.kt`, `.scala`, `.groovy`), respecting `.gitignore`, and excluding common build output directories ([#3260](https://github.com/getsentry/sentry-cli/pull/3260))
+- (bundle-jvm) Add `--exclude` option for custom glob patterns to exclude files/directories from source collection ([#3260](https://github.com/getsentry/sentry-cli/pull/3260))
 
 ### Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Features
 
-- (bundle-jvm) Filter sources by JVM extensions, respect `.gitignore`, and add default directory excludes and `--exclude` option ([#3260](https://github.com/getsentry/sentry-cli/pull/3260))
+- (bundle-jvm) Allow running directly on a project root (including multi-module repos) by automatically collecting only JVM source files (`.java`, `.kt`, `.scala`, `.groovy`), respecting `.gitignore`, and excluding common build output directories. Add `--exclude` option for custom glob patterns ([#3260](https://github.com/getsentry/sentry-cli/pull/3260))
 
 ### Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Features
+
+- (bundle-jvm) Filter sources by JVM extensions, respect `.gitignore`, and add default directory excludes and `--exclude` option ([#3260](https://github.com/getsentry/sentry-cli/pull/3260))
+
 ### Fixes
 
 - Replace `eprintln!` with `log::info!` for progress bar completion messages when the progress bar is disabled (e.g. in CI). This avoids spurious stderr output that some CI systems treat as errors ([#3223](https://github.com/getsentry/sentry-cli/pull/3223)).

--- a/src/commands/debug_files/bundle_jvm.rs
+++ b/src/commands/debug_files/bundle_jvm.rs
@@ -8,11 +8,13 @@ use crate::utils::fs::path_as_url;
 use crate::utils::source_bundle::{self, BundleContext};
 use anyhow::{bail, Context as _, Result};
 use clap::{Arg, ArgAction, ArgMatches, Command};
+use log::debug;
 use sentry::types::DebugId;
 use std::borrow::Cow;
 use std::collections::BTreeMap;
+use std::ffi::OsStr;
 use std::fs;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::str::FromStr as _;
 use std::sync::Arc;
 use symbolic::debuginfo::sourcebundle::SourceFileType;
@@ -22,8 +24,9 @@ const JVM_EXTENSIONS: &[&str] = &[
     "java", "kt", "scala", "sc", "groovy", "gvy", "gy", "gsh", "clj", "cljc",
 ];
 
-/// Default directory patterns to exclude from source collection.
-const DEFAULT_EXCLUDES: &[&str] = &[
+/// Directory patterns that are always safe to exclude globally (can never be
+/// valid JVM package names due to leading dots or conventions).
+const SAFE_EXCLUDES: &[&str] = &[
     "!.cxx",
     "!.eclipse",
     "!.fleet",
@@ -33,12 +36,37 @@ const DEFAULT_EXCLUDES: &[&str] = &[
     "!.mvn",
     "!.settings",
     "!.vscode",
-    "!bin",
-    "!build",
     "!node_modules",
-    "!out",
-    "!target",
 ];
+
+/// Directory names that are common build output dirs but could also be valid
+/// JVM package names (e.g. `com.example.build`). These are only excluded when
+/// they appear outside of `src/` directories to avoid filtering out legitimate
+/// source packages.
+const AMBIGUOUS_EXCLUDES: &[&str] = &["bin", "build", "out", "target"];
+
+/// Returns true if `path` has a `src` ancestor before the given directory name.
+/// E.g. `src/main/java/com/example/build/Foo.java` → true (under src/).
+/// E.g. `app/build/generated/Foo.java` → false (not under src/).
+fn is_under_src(relative_path: &Path) -> bool {
+    relative_path
+        .ancestors()
+        .any(|a| a.file_name() == Some(OsStr::new("src")))
+}
+
+/// Returns true if the file should be excluded because it sits inside an
+/// ambiguous build-output directory that is NOT under a `src/` ancestor.
+fn is_in_ambiguous_build_dir(relative_path: &Path) -> bool {
+    for ancestor in relative_path.ancestors() {
+        let Some(name) = ancestor.file_name().and_then(|n| n.to_str()) else {
+            continue;
+        };
+        if AMBIGUOUS_EXCLUDES.contains(&name) {
+            return !is_under_src(relative_path);
+        }
+    }
+    false
+}
 
 pub fn make_command(command: Command) -> Command {
     command
@@ -116,7 +144,7 @@ pub fn execute(matches: &ArgMatches) -> Result<()> {
         .flatten()
         .map(|v| format!("!{v}"));
 
-    let all_excludes = DEFAULT_EXCLUDES
+    let all_excludes = SAFE_EXCLUDES
         .iter()
         .copied()
         .map(Cow::Borrowed)
@@ -127,6 +155,19 @@ pub fn execute(matches: &ArgMatches) -> Result<()> {
         .ignores(all_excludes)
         .respect_ignores(true)
         .collect_files()?;
+
+    let sources: Vec<_> = sources
+        .into_iter()
+        .filter(|source| {
+            let relative = source.path.strip_prefix(&source.base_path).unwrap();
+            if is_in_ambiguous_build_dir(relative) {
+                debug!("excluding (build output): {}", source.path.display());
+                return false;
+            }
+            true
+        })
+        .collect();
+
     let files = sources.iter().map(|source| {
         let local_path = source.path.strip_prefix(&source.base_path).unwrap();
         let local_path_jvm_ext = local_path.with_extension("jvm");

--- a/src/commands/debug_files/bundle_jvm.rs
+++ b/src/commands/debug_files/bundle_jvm.rs
@@ -17,10 +17,25 @@ use std::sync::Arc;
 use symbolic::debuginfo::sourcebundle::SourceFileType;
 
 /// File extensions for JVM-based languages.
-const JVM_EXTENSIONS: &[&str] = &["java", "kt", "scala", "groovy"];
+const JVM_EXTENSIONS: &[&str] = &["java", "kt", "scala", "groovy", "clj", "cljc"];
 
 /// Default directory patterns to exclude from source collection.
-const DEFAULT_EXCLUDES: &[&str] = &["!build", "!.gradle", "!.cxx", "!node_modules"];
+const DEFAULT_EXCLUDES: &[&str] = &[
+    "!build",
+    "!.gradle",
+    "!.cxx",
+    "!node_modules",
+    "!target",
+    "!.mvn",
+    "!.idea",
+    "!.vscode",
+    "!.eclipse",
+    "!.settings",
+    "!bin",
+    "!out",
+    "!.kotlin",
+    "!.fleet",
+];
 
 pub fn make_command(command: Command) -> Command {
     command
@@ -60,7 +75,8 @@ pub fn make_command(command: Command) -> Command {
                 .action(ArgAction::Append)
                 .help(
                     "Glob pattern to exclude files/directories. Can be repeated. \
-                     By default, 'build', '.gradle', '.cxx', and 'node_modules' directories are excluded.",
+                     By default, common build output and IDE directories are excluded \
+                     (build, .gradle, target, .idea, .vscode, out, bin, etc.).",
                 ),
         )
 }

--- a/src/commands/debug_files/bundle_jvm.rs
+++ b/src/commands/debug_files/bundle_jvm.rs
@@ -17,7 +17,7 @@ use std::sync::Arc;
 use symbolic::debuginfo::sourcebundle::SourceFileType;
 
 /// File extensions for JVM-based languages.
-const JVM_EXTENSIONS: &[&str] = &["java", "kt", "scala", "groovy", "kts"];
+const JVM_EXTENSIONS: &[&str] = &["java", "kt", "scala", "groovy"];
 
 /// Default directory patterns to exclude from source collection.
 const DEFAULT_EXCLUDES: &[&str] = &["!build", "!.gradle", "!.cxx", "!node_modules"];

--- a/src/commands/debug_files/bundle_jvm.rs
+++ b/src/commands/debug_files/bundle_jvm.rs
@@ -10,7 +10,6 @@ use anyhow::{bail, Context as _, Result};
 use clap::{Arg, ArgAction, ArgMatches, Command};
 use log::debug;
 use sentry::types::DebugId;
-use std::borrow::Cow;
 use std::collections::BTreeMap;
 use std::ffi::OsStr;
 use std::fs;
@@ -19,39 +18,32 @@ use std::str::FromStr as _;
 use std::sync::Arc;
 use symbolic::debuginfo::sourcebundle::SourceFileType;
 
-/// File extensions for JVM-based languages.
 const JVM_EXTENSIONS: &[&str] = &[
     "java", "kt", "scala", "sc", "groovy", "gvy", "gy", "gsh", "clj", "cljc",
 ];
 
-/// Directory patterns that are always safe to exclude globally (can never be
-/// valid JVM package names due to leading dots or conventions).
+/// Safe to exclude globally — can never be valid JVM package names.
 const SAFE_EXCLUDES: &[&str] = &[
-    "!.cxx",
-    "!.eclipse",
-    "!.fleet",
-    "!.gradle",
-    "!.idea",
-    "!.kotlin",
-    "!.mvn",
-    "!.settings",
-    "!.vscode",
-    "!node_modules",
+    ".cxx",
+    ".eclipse",
+    ".fleet",
+    ".gradle",
+    ".idea",
+    ".kotlin",
+    ".mvn",
+    ".settings",
+    ".vscode",
+    "node_modules",
 ];
 
-/// Directory names that are common build output dirs but could also be valid
-/// JVM package names (e.g. `com.example.build`). These are only excluded when
-/// they appear outside of `src/` directories to avoid filtering out legitimate
-/// source packages.
+/// Common build output dirs that could also be valid JVM package names
+/// (e.g. `com.example.build`). Only excluded outside of `src/` directories.
 const AMBIGUOUS_EXCLUDES: &[&str] = &["bin", "build", "out", "target"];
 
-/// Returns true if the file should be excluded because it sits inside an
-/// ambiguous build-output directory that is NOT under a `src/` ancestor.
-///
-/// We check *all* ambiguous directories in the path and exclude if any of them
-/// is not under a `src/` ancestor. This handles nested cases like
-/// `build/src/main/java/com/example/target/Foo.java` where the inner `target`
-/// is under `src`, but the outer `build` is not — the file should be excluded.
+/// Checks *all* ambiguous directories in the path and excludes if any of them
+/// is not under a `src/` ancestor. Handles nested cases like
+/// `build/src/main/java/com/example/target/Foo.java` — inner `target` is under
+/// `src`, but outer `build` is not, so the file is excluded.
 fn is_in_ambiguous_build_dir(relative_path: &Path) -> bool {
     for ancestor in relative_path.ancestors() {
         let Some(name) = ancestor.file_name().and_then(|n| n.to_str()) else {
@@ -141,17 +133,17 @@ pub fn execute(matches: &ArgMatches) -> Result<()> {
         ))?;
     }
 
-    let user_excludes = matches
-        .get_many::<String>("exclude")
-        .into_iter()
-        .flatten()
-        .map(|v| format!("!{v}"));
-
     let all_excludes = SAFE_EXCLUDES
         .iter()
         .copied()
-        .map(Cow::Borrowed)
-        .chain(user_excludes.map(Cow::Owned));
+        .chain(
+            matches
+                .get_many::<String>("exclude")
+                .into_iter()
+                .flatten()
+                .map(|s| s.as_str()),
+        )
+        .map(|v| format!("!{v}"));
 
     let sources = ReleaseFileSearch::new(path.clone())
         .extensions(JVM_EXTENSIONS.iter().copied())
@@ -159,32 +151,24 @@ pub fn execute(matches: &ArgMatches) -> Result<()> {
         .respect_ignores(true)
         .collect_files()?;
 
-    let sources: Vec<_> = sources
-        .into_iter()
-        .filter(|source| {
-            let relative = source.path.strip_prefix(&source.base_path).unwrap();
-            if is_in_ambiguous_build_dir(relative) {
-                debug!("excluding (build output): {}", source.path.display());
-                return false;
-            }
-            true
-        })
-        .collect();
-
-    let files = sources.iter().map(|source| {
+    let files = sources.into_iter().filter_map(|source| {
         let local_path = source.path.strip_prefix(&source.base_path).unwrap();
+        if is_in_ambiguous_build_dir(local_path) {
+            debug!("excluding (build output): {}", source.path.display());
+            return None;
+        }
         let local_path_jvm_ext = local_path.with_extension("jvm");
         let url = format!("~/{}", path_as_url(&local_path_jvm_ext));
 
-        SourceFile {
+        Some(SourceFile {
             url,
-            path: source.path.clone(),
-            contents: Arc::new(source.contents.clone()),
+            path: source.path,
+            contents: Arc::new(source.contents),
             ty: SourceFileType::Source,
             headers: BTreeMap::new(),
             messages: vec![],
             already_uploaded: false,
-        }
+        })
     });
 
     let tempfile = source_bundle::build(context, files, Some(*debug_id))

--- a/src/commands/debug_files/bundle_jvm.rs
+++ b/src/commands/debug_files/bundle_jvm.rs
@@ -19,7 +19,7 @@ use symbolic::debuginfo::sourcebundle::SourceFileType;
 
 /// File extensions for JVM-based languages.
 const JVM_EXTENSIONS: &[&str] = &[
-    "java", "kt", "scala", "sc", "groovy", "gvy", "gy", "gsh", "clj", "cljs", "cljc",
+    "java", "kt", "scala", "sc", "groovy", "gvy", "gy", "gsh", "clj", "cljc",
 ];
 
 /// Default directory patterns to exclude from source collection.

--- a/src/commands/debug_files/bundle_jvm.rs
+++ b/src/commands/debug_files/bundle_jvm.rs
@@ -192,3 +192,50 @@ pub fn execute(matches: &ArgMatches) -> Result<()> {
 
     Ok(())
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::Path;
+
+    #[test]
+    fn test_excludes_build_output_at_module_root() {
+        assert!(is_in_ambiguous_build_dir(Path::new(
+            "app/build/generated/Foo.java"
+        )));
+        assert!(is_in_ambiguous_build_dir(Path::new(
+            "build/generated/Foo.java"
+        )));
+        assert!(is_in_ambiguous_build_dir(Path::new(
+            "module/target/classes/Foo.java"
+        )));
+        assert!(is_in_ambiguous_build_dir(Path::new("bin/Foo.class")));
+        assert!(is_in_ambiguous_build_dir(Path::new(
+            "out/production/Foo.java"
+        )));
+    }
+
+    #[test]
+    fn test_keeps_source_packages_under_src() {
+        assert!(!is_in_ambiguous_build_dir(Path::new(
+            "src/main/java/com/example/build/Builder.java"
+        )));
+        assert!(!is_in_ambiguous_build_dir(Path::new(
+            "app/src/main/java/com/example/target/Target.java"
+        )));
+        assert!(!is_in_ambiguous_build_dir(Path::new(
+            "src/main/kotlin/com/example/out/Output.kt"
+        )));
+    }
+
+    #[test]
+    fn test_keeps_files_without_ambiguous_dirs() {
+        assert!(!is_in_ambiguous_build_dir(Path::new(
+            "src/main/java/com/example/Foo.java"
+        )));
+        assert!(!is_in_ambiguous_build_dir(Path::new("Foo.java")));
+        assert!(!is_in_ambiguous_build_dir(Path::new(
+            "app/src/main/java/Foo.java"
+        )));
+    }
+}

--- a/src/commands/debug_files/bundle_jvm.rs
+++ b/src/commands/debug_files/bundle_jvm.rs
@@ -45,24 +45,26 @@ const SAFE_EXCLUDES: &[&str] = &[
 /// source packages.
 const AMBIGUOUS_EXCLUDES: &[&str] = &["bin", "build", "out", "target"];
 
-/// Returns true if `path` has a `src` ancestor before the given directory name.
-/// E.g. `src/main/java/com/example/build/Foo.java` → true (under src/).
-/// E.g. `app/build/generated/Foo.java` → false (not under src/).
-fn is_under_src(relative_path: &Path) -> bool {
-    relative_path
-        .ancestors()
-        .any(|a| a.file_name() == Some(OsStr::new("src")))
-}
-
 /// Returns true if the file should be excluded because it sits inside an
 /// ambiguous build-output directory that is NOT under a `src/` ancestor.
+///
+/// We walk the path's ancestors and when we find an ambiguous directory name,
+/// we check whether any ancestor *above* it is named `src`. This ensures that
+/// `build/src/main/java/Foo.java` is correctly excluded (build is not under
+/// src), while `src/main/java/com/example/build/Foo.java` is kept (build is
+/// under src).
 fn is_in_ambiguous_build_dir(relative_path: &Path) -> bool {
     for ancestor in relative_path.ancestors() {
         let Some(name) = ancestor.file_name().and_then(|n| n.to_str()) else {
             continue;
         };
         if AMBIGUOUS_EXCLUDES.contains(&name) {
-            return !is_under_src(relative_path);
+            // Check if any ancestor *above* this directory is named "src".
+            let has_src_above = ancestor
+                .ancestors()
+                .skip(1) // skip the ambiguous dir itself
+                .any(|a| a.file_name() == Some(OsStr::new("src")));
+            return !has_src_above;
         }
     }
     false
@@ -225,6 +227,17 @@ mod tests {
         )));
         assert!(!is_in_ambiguous_build_dir(Path::new(
             "src/main/kotlin/com/example/out/Output.kt"
+        )));
+    }
+
+    #[test]
+    fn test_excludes_build_dir_containing_src() {
+        // build/src/... should still be excluded — src is *inside* build, not above it
+        assert!(is_in_ambiguous_build_dir(Path::new(
+            "build/src/main/java/Foo.java"
+        )));
+        assert!(is_in_ambiguous_build_dir(Path::new(
+            "app/build/src/generated/Foo.java"
         )));
     }
 

--- a/src/commands/debug_files/bundle_jvm.rs
+++ b/src/commands/debug_files/bundle_jvm.rs
@@ -18,8 +18,7 @@ use symbolic::debuginfo::sourcebundle::SourceFileType;
 
 /// File extensions for JVM-based languages.
 const JVM_EXTENSIONS: &[&str] = &[
-    "java", "kt", "scala", "sc", "groovy", "gvy", "gy", "gsh", "gradle", "clj", "cljs", "cljc",
-    "edn", "rb", "py",
+    "java", "kt", "scala", "sc", "groovy", "gvy", "gy", "gsh", "clj", "cljs", "cljc",
 ];
 
 /// Default directory patterns to exclude from source collection.

--- a/src/commands/debug_files/bundle_jvm.rs
+++ b/src/commands/debug_files/bundle_jvm.rs
@@ -9,6 +9,7 @@ use crate::utils::source_bundle::{self, BundleContext};
 use anyhow::{bail, Context as _, Result};
 use clap::{Arg, ArgAction, ArgMatches, Command};
 use sentry::types::DebugId;
+use std::borrow::Cow;
 use std::collections::BTreeMap;
 use std::fs;
 use std::path::PathBuf;
@@ -23,20 +24,20 @@ const JVM_EXTENSIONS: &[&str] = &[
 
 /// Default directory patterns to exclude from source collection.
 const DEFAULT_EXCLUDES: &[&str] = &[
-    "!build",
-    "!.gradle",
     "!.cxx",
-    "!node_modules",
-    "!target",
-    "!.mvn",
-    "!.idea",
-    "!.vscode",
     "!.eclipse",
-    "!.settings",
-    "!bin",
-    "!out",
-    "!.kotlin",
     "!.fleet",
+    "!.gradle",
+    "!.idea",
+    "!.kotlin",
+    "!.mvn",
+    "!.settings",
+    "!.vscode",
+    "!bin",
+    "!build",
+    "!node_modules",
+    "!out",
+    "!target",
 ];
 
 pub fn make_command(command: Command) -> Command {
@@ -109,16 +110,17 @@ pub fn execute(matches: &ArgMatches) -> Result<()> {
         ))?;
     }
 
-    let user_excludes: Vec<String> = matches
+    let user_excludes = matches
         .get_many::<String>("exclude")
-        .map(|vals| vals.map(|v| format!("!{v}")).collect())
-        .unwrap_or_default();
+        .into_iter()
+        .flatten()
+        .map(|v| format!("!{v}"));
 
-    let all_excludes: Vec<&str> = DEFAULT_EXCLUDES
+    let all_excludes = DEFAULT_EXCLUDES
         .iter()
         .copied()
-        .chain(user_excludes.iter().map(|s| s.as_str()))
-        .collect();
+        .map(Cow::Borrowed)
+        .chain(user_excludes.map(Cow::Owned));
 
     let sources = ReleaseFileSearch::new(path.clone())
         .extensions(JVM_EXTENSIONS.iter().copied())

--- a/src/commands/debug_files/bundle_jvm.rs
+++ b/src/commands/debug_files/bundle_jvm.rs
@@ -7,7 +7,7 @@ use crate::utils::file_upload::SourceFile;
 use crate::utils::fs::path_as_url;
 use crate::utils::source_bundle::{self, BundleContext};
 use anyhow::{bail, Context as _, Result};
-use clap::{Arg, ArgMatches, Command};
+use clap::{Arg, ArgAction, ArgMatches, Command};
 use sentry::types::DebugId;
 use std::collections::BTreeMap;
 use std::fs;
@@ -15,6 +15,12 @@ use std::path::PathBuf;
 use std::str::FromStr as _;
 use std::sync::Arc;
 use symbolic::debuginfo::sourcebundle::SourceFileType;
+
+/// File extensions for JVM-based languages.
+const JVM_EXTENSIONS: &[&str] = &["java", "kt", "scala", "groovy", "kts"];
+
+/// Default directory patterns to exclude from source collection.
+const DEFAULT_EXCLUDES: &[&str] = &["!build", "!.gradle", "!.cxx", "!node_modules"];
 
 pub fn make_command(command: Command) -> Command {
     command
@@ -47,6 +53,16 @@ pub fn make_command(command: Command) -> Command {
                 .value_parser(DebugId::from_str)
                 .help("Debug ID (UUID) to use for the source bundle."),
         )
+        .arg(
+            Arg::new("exclude")
+                .long("exclude")
+                .value_name("PATTERN")
+                .action(ArgAction::Append)
+                .help(
+                    "Glob pattern to exclude files/directories. Can be repeated. \
+                     By default, 'build', '.gradle', and '.cxx' directories are excluded.",
+                ),
+        )
 }
 
 pub fn execute(matches: &ArgMatches) -> Result<()> {
@@ -75,7 +91,22 @@ pub fn execute(matches: &ArgMatches) -> Result<()> {
         ))?;
     }
 
-    let sources = ReleaseFileSearch::new(path.clone()).collect_files()?;
+    let user_excludes: Vec<String> = matches
+        .get_many::<String>("exclude")
+        .map(|vals| vals.map(|v| format!("!{v}")).collect())
+        .unwrap_or_default();
+
+    let all_excludes: Vec<&str> = DEFAULT_EXCLUDES
+        .iter()
+        .copied()
+        .chain(user_excludes.iter().map(|s| s.as_str()))
+        .collect();
+
+    let sources = ReleaseFileSearch::new(path.clone())
+        .extensions(JVM_EXTENSIONS.iter().copied())
+        .ignores(all_excludes)
+        .respect_ignores(true)
+        .collect_files()?;
     let files = sources.iter().map(|source| {
         let local_path = source.path.strip_prefix(&source.base_path).unwrap();
         let local_path_jvm_ext = local_path.with_extension("jvm");

--- a/src/commands/debug_files/bundle_jvm.rs
+++ b/src/commands/debug_files/bundle_jvm.rs
@@ -60,7 +60,7 @@ pub fn make_command(command: Command) -> Command {
                 .action(ArgAction::Append)
                 .help(
                     "Glob pattern to exclude files/directories. Can be repeated. \
-                     By default, 'build', '.gradle', and '.cxx' directories are excluded.",
+                     By default, 'build', '.gradle', '.cxx', and 'node_modules' directories are excluded.",
                 ),
         )
 }

--- a/src/commands/debug_files/bundle_jvm.rs
+++ b/src/commands/debug_files/bundle_jvm.rs
@@ -17,7 +17,10 @@ use std::sync::Arc;
 use symbolic::debuginfo::sourcebundle::SourceFileType;
 
 /// File extensions for JVM-based languages.
-const JVM_EXTENSIONS: &[&str] = &["java", "kt", "scala", "groovy", "clj", "cljc"];
+const JVM_EXTENSIONS: &[&str] = &[
+    "java", "kt", "scala", "sc", "groovy", "gvy", "gy", "gsh", "gradle", "clj", "cljs", "cljc",
+    "edn", "rb", "py",
+];
 
 /// Default directory patterns to exclude from source collection.
 const DEFAULT_EXCLUDES: &[&str] = &[

--- a/src/commands/debug_files/bundle_jvm.rs
+++ b/src/commands/debug_files/bundle_jvm.rs
@@ -48,11 +48,10 @@ const AMBIGUOUS_EXCLUDES: &[&str] = &["bin", "build", "out", "target"];
 /// Returns true if the file should be excluded because it sits inside an
 /// ambiguous build-output directory that is NOT under a `src/` ancestor.
 ///
-/// We walk the path's ancestors and when we find an ambiguous directory name,
-/// we check whether any ancestor *above* it is named `src`. This ensures that
-/// `build/src/main/java/Foo.java` is correctly excluded (build is not under
-/// src), while `src/main/java/com/example/build/Foo.java` is kept (build is
-/// under src).
+/// We check *all* ambiguous directories in the path and exclude if any of them
+/// is not under a `src/` ancestor. This handles nested cases like
+/// `build/src/main/java/com/example/target/Foo.java` where the inner `target`
+/// is under `src`, but the outer `build` is not — the file should be excluded.
 fn is_in_ambiguous_build_dir(relative_path: &Path) -> bool {
     for ancestor in relative_path.ancestors() {
         let Some(name) = ancestor.file_name().and_then(|n| n.to_str()) else {
@@ -64,7 +63,9 @@ fn is_in_ambiguous_build_dir(relative_path: &Path) -> bool {
                 .ancestors()
                 .skip(1) // skip the ambiguous dir itself
                 .any(|a| a.file_name() == Some(OsStr::new("src")));
-            return !has_src_above;
+            if !has_src_above {
+                return true;
+            }
         }
     }
     false
@@ -238,6 +239,17 @@ mod tests {
         )));
         assert!(is_in_ambiguous_build_dir(Path::new(
             "app/build/src/generated/Foo.java"
+        )));
+    }
+
+    #[test]
+    fn test_excludes_nested_ambiguous_dirs_under_build() {
+        // build/src/.../target/ — inner `target` is under src, but outer `build` is not
+        assert!(is_in_ambiguous_build_dir(Path::new(
+            "build/src/main/java/com/example/target/Foo.java"
+        )));
+        assert!(is_in_ambiguous_build_dir(Path::new(
+            "target/src/main/java/com/example/out/Foo.java"
         )));
     }
 

--- a/src/utils/file_search.rs
+++ b/src/utils/file_search.rs
@@ -20,6 +20,7 @@ pub struct ReleaseFileSearch {
     ignores: BTreeSet<String>,
     ignore_file: Option<String>,
     decompress: bool,
+    respect_ignores: bool,
 }
 
 #[derive(Eq, PartialEq, Hash)]
@@ -37,6 +38,7 @@ impl ReleaseFileSearch {
             ignore_file: None,
             ignores: BTreeSet::new(),
             decompress: false,
+            respect_ignores: false,
         }
     }
 
@@ -78,6 +80,11 @@ impl ReleaseFileSearch {
         self
     }
 
+    pub fn respect_ignores(&mut self, respect: bool) -> &mut Self {
+        self.respect_ignores = respect;
+        self
+    }
+
     pub fn collect_file(path: PathBuf) -> Result<ReleaseFileMatch> {
         // NOTE: `collect_file` currently do not handle gzip decompression,
         // as its mostly used for 3rd tools like xcode or gradle.
@@ -105,11 +112,11 @@ impl ReleaseFileSearch {
         let mut collected = Vec::new();
 
         let mut builder = WalkBuilder::new(&self.path);
-        builder
-            .follow_links(true)
-            .git_exclude(false)
-            .git_ignore(false)
-            .ignore(false);
+        builder.follow_links(true);
+
+        if !self.respect_ignores {
+            builder.git_exclude(false).git_ignore(false).ignore(false);
+        }
 
         if !&self.extensions.is_empty() {
             let mut types_builder = TypesBuilder::new();

--- a/tests/integration/_cases/debug_files/debug_files-bundle-jvm-help.trycmd
+++ b/tests/integration/_cases/debug_files/debug_files-bundle-jvm-help.trycmd
@@ -18,6 +18,9 @@ Options:
       --debug-id <UUID>          Debug ID (UUID) to use for the source bundle.
       --log-level <LOG_LEVEL>    Set the log output verbosity. [possible values: trace, debug, info,
                                  warn, error]
+      --exclude <PATTERN>        Glob pattern to exclude files/directories. Can be repeated. By
+                                 default, 'build', '.gradle', '.cxx', and 'node_modules' directories
+                                 are excluded.
       --quiet                    Do not print any output while preserving correct exit code. This
                                  flag is currently implemented only for selected subcommands.
                                  [aliases: --silent]

--- a/tests/integration/_cases/debug_files/debug_files-bundle-jvm-help.trycmd
+++ b/tests/integration/_cases/debug_files/debug_files-bundle-jvm-help.trycmd
@@ -19,8 +19,8 @@ Options:
       --log-level <LOG_LEVEL>    Set the log output verbosity. [possible values: trace, debug, info,
                                  warn, error]
       --exclude <PATTERN>        Glob pattern to exclude files/directories. Can be repeated. By
-                                 default, 'build', '.gradle', '.cxx', and 'node_modules' directories
-                                 are excluded.
+                                 default, common build output and IDE directories are excluded
+                                 (build, .gradle, target, .idea, .vscode, out, bin, etc.).
       --quiet                    Do not print any output while preserving correct exit code. This
                                  flag is currently implemented only for selected subcommands.
                                  [aliases: --silent]


### PR DESCRIPTION
## Summary
- Filter collected sources by JVM file extensions (`java`, `kt`, `scala`, `groovy`) instead of collecting all files
- Exclude common build output directories by default (`build`, `.gradle`, `.cxx`, `node_modules`)
- Respect `.gitignore` / `.ignore` rules as an additional layer of defense
- Add `--exclude` CLI arg for user-provided glob patterns on top of defaults

This enables invoking `bundle-jvm` directly on a project root without needing to pre-copy sources into a separate directory (e.g. from the Android Gradle plugin's `CollectSourcesTask`).

This also does not break the existing plugins' workflows, only in subtle cases where a non-JVM file has been included into the `src/main/java` source set, but this is likely not supported on the product side either.

## Test plan
- [ ] Run `bundle-jvm` on an Android project root and verify only `.java`/`.kt` files are collected
- [ ] Verify `build/` directory contents are excluded
- [ ] Verify `.gitignore`d paths are respected
- [ ] Test `--exclude` with custom glob patterns
- [ ] Verify existing callers of `ReleaseFileSearch` are unaffected (default `respect_ignores: false`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)