### PR TITLE
meta: Add Zed editor settings

### DIFF
--- a/.zed/settings.json
+++ b/.zed/settings.json
@@ -1,0 +1,14 @@
+{
+  "lsp": {
+    "rust-analyzer": {
+      "initialization_options": {
+        "check": {
+          "command": "clippy"
+        },
+        "cargo": {
+          "allFeatures": true
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Configure Zed editor to run `cargo clippy` when checking via `rust-analyzer` and to enable all features.