### PR TITLE
feat(build): Add --selective flag to snapshots command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Features
 
+- (snapshots) Add `--all-image-names` flag to `build snapshots` to accept a file listing all expected preview names (newline or comma-delimited). Images in the list but not uploaded are reported as 'skipped' instead of 'removed' ([#3268](https://github.com/getsentry/sentry-cli/pull/3268))
 - (bundle-jvm) Allow running directly on a project root (including multi-module repos) by automatically collecting only JVM source files (`.java`, `.kt`, `.scala`, `.groovy`), respecting `.gitignore`, and excluding common build output directories ([#3260](https://github.com/getsentry/sentry-cli/pull/3260))
 - (bundle-jvm) Add `--exclude` option for custom glob patterns to exclude files/directories from source collection ([#3260](https://github.com/getsentry/sentry-cli/pull/3260))
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Features
 
-- (snapshots) Add `--all-image-names` flag to `build snapshots` to accept a file listing all expected preview names (newline or comma-delimited). Images in the list but not uploaded are reported as 'skipped' instead of 'removed' ([#3268](https://github.com/getsentry/sentry-cli/pull/3268))
+- (snapshots) Add `--selective` flag to `build snapshots` to indicate the upload contains only a subset of images. Without `--all-image-file-names`, removals and renames cannot be detected on PRs. Optionally pass `--all-image-file-names` (only valid with `--selective`) with a file listing all expected image names (newline or comma-delimited) to enable detection of removals and renames ([#3268](https://github.com/getsentry/sentry-cli/pull/3268))
 - (bundle-jvm) Allow running directly on a project root (including multi-module repos) by automatically collecting only JVM source files (`.java`, `.kt`, `.scala`, `.groovy`), respecting `.gitignore`, and excluding common build output directories ([#3260](https://github.com/getsentry/sentry-cli/pull/3260))
 - (bundle-jvm) Add `--exclude` option for custom glob patterns to exclude files/directories from source collection ([#3260](https://github.com/getsentry/sentry-cli/pull/3260))
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Features
 
-- (snapshots) Add `--selective` flag to `build snapshots` to indicate the upload contains only a subset of images. Without `--all-image-file-names`, removals and renames cannot be detected on PRs. Optionally pass `--all-image-file-names` (only valid with `--selective`) with a file listing all expected image names (newline or comma-delimited) to enable detection of removals and renames ([#3268](https://github.com/getsentry/sentry-cli/pull/3268))
+- (snapshots) Add `--selective` flag to `build snapshots` to indicate the upload contains only a subset of images ([#3268](https://github.com/getsentry/sentry-cli/pull/3268))
 - (bundle-jvm) Allow running directly on a project root (including multi-module repos) by automatically collecting only JVM source files (`.java`, `.kt`, `.scala`, `.groovy`), respecting `.gitignore`, and excluding common build output directories ([#3260](https://github.com/getsentry/sentry-cli/pull/3260))
 - (bundle-jvm) Add `--exclude` option for custom glob patterns to exclude files/directories from source collection ([#3260](https://github.com/getsentry/sentry-cli/pull/3260))
 

--- a/src/api/data_types/snapshots.rs
+++ b/src/api/data_types/snapshots.rs
@@ -29,6 +29,8 @@ pub struct SnapshotsManifest<'a> {
     /// is greater than this value (e.g. 0.01 = only report changes >= 1%).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub diff_threshold: Option<f64>,
+    /// Full list of expected preview names. When provided, images in this list
+    /// but absent from the upload are reported as "skipped" instead of "removed".
     #[serde(skip_serializing_if = "Option::is_none")]
     pub all_image_names: Option<Vec<String>>,
     #[serde(flatten)]

--- a/src/api/data_types/snapshots.rs
+++ b/src/api/data_types/snapshots.rs
@@ -30,6 +30,7 @@ pub struct SnapshotsManifest<'a> {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub diff_threshold: Option<f64>,
     /// When true, this upload contains only a subset of images.
+    /// Removals and renames will not be detected on PRs.
     #[serde(skip_serializing_if = "std::ops::Not::not")]
     pub selective: bool,
     #[serde(flatten)]

--- a/src/api/data_types/snapshots.rs
+++ b/src/api/data_types/snapshots.rs
@@ -29,14 +29,9 @@ pub struct SnapshotsManifest<'a> {
     /// is greater than this value (e.g. 0.01 = only report changes >= 1%).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub diff_threshold: Option<f64>,
-    /// When true, this upload contains only a subset of images. Without
-    /// `all_image_file_names`, removals and renames cannot be detected on PRs.
+    /// When true, this upload contains only a subset of images.
     #[serde(skip_serializing_if = "std::ops::Not::not")]
     pub selective: bool,
-    /// Only used with `selective`. Full list of image file names; enables
-    /// detection of removals and renames on PRs.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub all_image_file_names: Option<Vec<String>>,
     #[serde(flatten)]
     pub vcs_info: VcsInfo<'a>,
 }
@@ -87,30 +82,23 @@ mod tests {
             images: HashMap::new(),
             diff_threshold: None,
             selective: false,
-            all_image_file_names: None,
             vcs_info: empty_vcs_info(),
         };
         let json = serde_json::to_value(&manifest).unwrap();
         assert!(!json.as_object().unwrap().contains_key("selective"));
-        assert!(!json
-            .as_object()
-            .unwrap()
-            .contains_key("all_image_file_names"));
     }
 
     #[test]
-    fn manifest_includes_selective_and_all_image_file_names() {
+    fn manifest_includes_selective_when_true() {
         let manifest = SnapshotsManifest {
             app_id: "app".into(),
             images: HashMap::new(),
             diff_threshold: None,
             selective: true,
-            all_image_file_names: Some(vec!["a.png".into(), "b.png".into()]),
             vcs_info: empty_vcs_info(),
         };
         let json = serde_json::to_value(&manifest).unwrap();
         assert_eq!(json["selective"], json!(true));
-        assert_eq!(json["all_image_file_names"], json!(["a.png", "b.png"]));
     }
 
     #[test]

--- a/src/api/data_types/snapshots.rs
+++ b/src/api/data_types/snapshots.rs
@@ -29,6 +29,8 @@ pub struct SnapshotsManifest<'a> {
     /// is greater than this value (e.g. 0.01 = only report changes >= 1%).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub diff_threshold: Option<f64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub all_image_names: Option<Vec<String>>,
     #[serde(flatten)]
     pub vcs_info: VcsInfo<'a>,
 }

--- a/src/api/data_types/snapshots.rs
+++ b/src/api/data_types/snapshots.rs
@@ -29,10 +29,14 @@ pub struct SnapshotsManifest<'a> {
     /// is greater than this value (e.g. 0.01 = only report changes >= 1%).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub diff_threshold: Option<f64>,
-    /// Full list of expected preview names. When provided, images in this list
-    /// but absent from the upload are reported as "skipped" instead of "removed".
+    /// When true, this upload contains only a subset of images. Without
+    /// `all_image_file_names`, removals and renames cannot be detected on PRs.
+    #[serde(skip_serializing_if = "std::ops::Not::not")]
+    pub selective: bool,
+    /// Only used with `selective`. Full list of image file names; enables
+    /// detection of removals and renames on PRs.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub all_image_names: Option<Vec<String>>,
+    pub all_image_file_names: Option<Vec<String>>,
     #[serde(flatten)]
     pub vcs_info: VcsInfo<'a>,
 }
@@ -62,6 +66,52 @@ mod tests {
     use super::*;
 
     use serde_json::json;
+
+    fn empty_vcs_info() -> VcsInfo<'static> {
+        VcsInfo {
+            head_sha: None,
+            base_sha: None,
+            vcs_provider: "".into(),
+            head_repo_name: "".into(),
+            base_repo_name: "".into(),
+            head_ref: "".into(),
+            base_ref: "".into(),
+            pr_number: None,
+        }
+    }
+
+    #[test]
+    fn manifest_omits_selective_when_false() {
+        let manifest = SnapshotsManifest {
+            app_id: "app".into(),
+            images: HashMap::new(),
+            diff_threshold: None,
+            selective: false,
+            all_image_file_names: None,
+            vcs_info: empty_vcs_info(),
+        };
+        let json = serde_json::to_value(&manifest).unwrap();
+        assert!(!json.as_object().unwrap().contains_key("selective"));
+        assert!(!json
+            .as_object()
+            .unwrap()
+            .contains_key("all_image_file_names"));
+    }
+
+    #[test]
+    fn manifest_includes_selective_and_all_image_file_names() {
+        let manifest = SnapshotsManifest {
+            app_id: "app".into(),
+            images: HashMap::new(),
+            diff_threshold: None,
+            selective: true,
+            all_image_file_names: Some(vec!["a.png".into(), "b.png".into()]),
+            vcs_info: empty_vcs_info(),
+        };
+        let json = serde_json::to_value(&manifest).unwrap();
+        assert_eq!(json["selective"], json!(true));
+        assert_eq!(json["all_image_file_names"], json!(["a.png", "b.png"]));
+    }
 
     #[test]
     fn cli_managed_fields_override_sidecar_fields() {

--- a/src/commands/build/snapshots.rs
+++ b/src/commands/build/snapshots.rs
@@ -69,15 +69,26 @@ pub fn make_command(command: Command) -> Command {
                 ),
         )
         .arg(
-            Arg::new("all_image_names")
-                .long("all-image-names")
-                .value_name("PATH")
+            Arg::new("selective")
+                .long("selective")
+                .action(clap::ArgAction::SetTrue)
                 .help(
-                    "Path to a file containing the full list of preview names \
-                     (one per line, comma-separated, or both). When provided, \
-                     only images in the upload directory are compared; missing \
-                     images listed here are reported as 'skipped' rather than \
-                     'removed'.",
+                    "Indicates this upload contains only a subset of images. \
+                     Without --all-image-file-names, removals and renames cannot \
+                     be detected on PRs. With --all-image-file-names, removals \
+                     and renames are still detected.",
+                ),
+        )
+        .arg(
+            Arg::new("all_image_file_names")
+                .long("all-image-file-names")
+                .value_name("PATH")
+                .requires("selective")
+                .help(
+                    "Only used with --selective. Path to a file containing the \
+                     full list of image file names (one per line, comma-separated, \
+                     or both). Enables detection of removals and renames on PRs \
+                     even when uploading only a subset of images.",
                 ),
         )
         .git_metadata_args()
@@ -141,11 +152,11 @@ pub fn execute(matches: &ArgMatches) -> Result<()> {
 
     validate_image_sizes(&images)?;
 
-    let all_image_names = matches
-        .get_one::<String>("all_image_names")
+    let all_image_file_names = matches
+        .get_one::<String>("all_image_file_names")
         .map(|path| -> Result<Vec<String>> {
             let content = std::fs::read_to_string(path)
-                .with_context(|| format!("Failed to read all-image-names file: {path}"))?;
+                .with_context(|| format!("Failed to read all-image-file-names file: {path}"))?;
             Ok(content
                 .lines()
                 .flat_map(|l| l.split(','))
@@ -156,9 +167,9 @@ pub fn execute(matches: &ArgMatches) -> Result<()> {
         })
         .transpose()?;
 
-    if let Some(ref names) = all_image_names {
+    if let Some(ref names) = all_image_file_names {
         if names.is_empty() {
-            anyhow::bail!("--all-image-names file is empty or contains no names");
+            anyhow::bail!("--all-image-file-names file is empty or contains no names");
         }
         let names_set: std::collections::HashSet<&str> = names.iter().map(String::as_str).collect();
         let missing: Vec<String> = images
@@ -178,7 +189,7 @@ pub fn execute(matches: &ArgMatches) -> Result<()> {
             .collect();
         if !missing.is_empty() {
             anyhow::bail!(
-                "These uploaded images are not listed in --all-image-names: {}",
+                "These uploaded images are not listed in --all-image-file-names: {}",
                 missing.join(", ")
             );
         }
@@ -197,11 +208,14 @@ pub fn execute(matches: &ArgMatches) -> Result<()> {
     // Build manifest from discovered images
     let diff_threshold = matches.get_one::<f64>("diff_threshold").copied();
 
+    let selective = matches.get_flag("selective");
+
     let manifest = SnapshotsManifest {
         app_id: app_id.clone(),
         images: manifest_entries,
         diff_threshold,
-        all_image_names,
+        selective,
+        all_image_file_names,
         vcs_info,
     };
 

--- a/src/commands/build/snapshots.rs
+++ b/src/commands/build/snapshots.rs
@@ -141,20 +141,7 @@ pub fn execute(matches: &ArgMatches) -> Result<()> {
 
     validate_image_sizes(&images)?;
 
-    // Upload image files to objectstore
-    println!(
-        "{} Uploading {} image {}",
-        style(">").dim(),
-        style(images.len()).yellow(),
-        if images.len() == 1 { "file" } else { "files" }
-    );
-
-    let manifest_entries = upload_images(images, &org, &project)?;
-
-    // Build manifest from discovered images
-    let diff_threshold = matches.get_one::<f64>("diff_threshold").copied();
-
-    let all_image_names: Option<Vec<String>> = matches
+    let all_image_names = matches
         .get_one::<String>("all_image_names")
         .map(|path| -> Result<Vec<String>> {
             let content = std::fs::read_to_string(path)
@@ -174,10 +161,20 @@ pub fn execute(matches: &ArgMatches) -> Result<()> {
             anyhow::bail!("--all-image-names file is empty or contains no names");
         }
         let names_set: std::collections::HashSet<&str> = names.iter().map(String::as_str).collect();
-        let missing: Vec<&str> = manifest_entries
-            .keys()
-            .filter(|k| !names_set.contains(k.as_str()))
-            .map(String::as_str)
+        let missing: Vec<String> = images
+            .iter()
+            .filter_map(|img| {
+                let name = img
+                    .relative_path
+                    .file_name()?
+                    .to_string_lossy()
+                    .into_owned();
+                if names_set.contains(name.as_str()) {
+                    None
+                } else {
+                    Some(name)
+                }
+            })
             .collect();
         if !missing.is_empty() {
             anyhow::bail!(
@@ -186,6 +183,19 @@ pub fn execute(matches: &ArgMatches) -> Result<()> {
             );
         }
     }
+
+    // Upload image files to objectstore
+    println!(
+        "{} Uploading {} image {}",
+        style(">").dim(),
+        style(images.len()).yellow(),
+        if images.len() == 1 { "file" } else { "files" }
+    );
+
+    let manifest_entries = upload_images(images, &org, &project)?;
+
+    // Build manifest from discovered images
+    let diff_threshold = matches.get_one::<f64>("diff_threshold").copied();
 
     let manifest = SnapshotsManifest {
         app_id: app_id.clone(),

--- a/src/commands/build/snapshots.rs
+++ b/src/commands/build/snapshots.rs
@@ -74,9 +74,10 @@ pub fn make_command(command: Command) -> Command {
                 .value_name("PATH")
                 .help(
                     "Path to a file containing the full list of preview names \
-                     (one per line). When provided, only images in the upload \
-                     directory are compared; missing images listed here are \
-                     reported as 'skipped' rather than 'removed'.",
+                     (one per line, comma-separated, or both). When provided, \
+                     only images in the upload directory are compared; missing \
+                     images listed here are reported as 'skipped' rather than \
+                     'removed'.",
                 ),
         )
         .git_metadata_args()
@@ -160,7 +161,9 @@ pub fn execute(matches: &ArgMatches) -> Result<()> {
                 .with_context(|| format!("Failed to read all-image-names file: {path}"))?;
             Ok(content
                 .lines()
-                .filter(|l| !l.is_empty())
+                .flat_map(|l| l.split(','))
+                .map(str::trim)
+                .filter(|s| !s.is_empty())
                 .map(String::from)
                 .collect())
         })
@@ -170,8 +173,7 @@ pub fn execute(matches: &ArgMatches) -> Result<()> {
         if names.is_empty() {
             anyhow::bail!("--all-image-names file is empty or contains no names");
         }
-        let names_set: std::collections::HashSet<&str> =
-            names.iter().map(String::as_str).collect();
+        let names_set: std::collections::HashSet<&str> = names.iter().map(String::as_str).collect();
         let missing: Vec<&str> = manifest_entries
             .keys()
             .filter(|k| !names_set.contains(k.as_str()))

--- a/src/commands/build/snapshots.rs
+++ b/src/commands/build/snapshots.rs
@@ -74,21 +74,7 @@ pub fn make_command(command: Command) -> Command {
                 .action(clap::ArgAction::SetTrue)
                 .help(
                     "Indicates this upload contains only a subset of images. \
-                     Without --all-image-file-names, removals and renames cannot \
-                     be detected on PRs. With --all-image-file-names, removals \
-                     and renames are still detected.",
-                ),
-        )
-        .arg(
-            Arg::new("all_image_file_names")
-                .long("all-image-file-names")
-                .value_name("PATH")
-                .requires("selective")
-                .help(
-                    "Only used with --selective. Path to a file containing the \
-                     full list of image file names (one per line, comma-separated, \
-                     or both). Enables detection of removals and renames on PRs \
-                     even when uploading only a subset of images.",
+                     Removals and renames cannot be detected on PRs.",
                 ),
         )
         .git_metadata_args()
@@ -152,49 +138,6 @@ pub fn execute(matches: &ArgMatches) -> Result<()> {
 
     validate_image_sizes(&images)?;
 
-    let all_image_file_names = matches
-        .get_one::<String>("all_image_file_names")
-        .map(|path| -> Result<Vec<String>> {
-            let content = std::fs::read_to_string(path)
-                .with_context(|| format!("Failed to read all-image-file-names file: {path}"))?;
-            Ok(content
-                .lines()
-                .flat_map(|l| l.split(','))
-                .map(str::trim)
-                .filter(|s| !s.is_empty())
-                .map(String::from)
-                .collect())
-        })
-        .transpose()?;
-
-    if let Some(ref names) = all_image_file_names {
-        if names.is_empty() {
-            anyhow::bail!("--all-image-file-names file is empty or contains no names");
-        }
-        let names_set: std::collections::HashSet<&str> = names.iter().map(String::as_str).collect();
-        let missing: Vec<String> = images
-            .iter()
-            .filter_map(|img| {
-                let name = img
-                    .relative_path
-                    .file_name()?
-                    .to_string_lossy()
-                    .into_owned();
-                if names_set.contains(name.as_str()) {
-                    None
-                } else {
-                    Some(name)
-                }
-            })
-            .collect();
-        if !missing.is_empty() {
-            anyhow::bail!(
-                "These uploaded images are not listed in --all-image-file-names: {}",
-                missing.join(", ")
-            );
-        }
-    }
-
     // Upload image files to objectstore
     println!(
         "{} Uploading {} image {}",
@@ -215,7 +158,6 @@ pub fn execute(matches: &ArgMatches) -> Result<()> {
         images: manifest_entries,
         diff_threshold,
         selective,
-        all_image_file_names,
         vcs_info,
     };
 

--- a/src/commands/build/snapshots.rs
+++ b/src/commands/build/snapshots.rs
@@ -68,6 +68,17 @@ pub fn make_command(command: Command) -> Command {
                      Example: 0.01 = only report image changes >= 1%.",
                 ),
         )
+        .arg(
+            Arg::new("all_image_names")
+                .long("all-image-names")
+                .value_name("PATH")
+                .help(
+                    "Path to a file containing the full list of preview names \
+                     (one per line). When provided, only images in the upload \
+                     directory are compared; missing images listed here are \
+                     reported as 'skipped' rather than 'removed'.",
+                ),
+        )
         .git_metadata_args()
 }
 
@@ -142,10 +153,43 @@ pub fn execute(matches: &ArgMatches) -> Result<()> {
     // Build manifest from discovered images
     let diff_threshold = matches.get_one::<f64>("diff_threshold").copied();
 
+    let all_image_names: Option<Vec<String>> = matches
+        .get_one::<String>("all_image_names")
+        .map(|path| -> Result<Vec<String>> {
+            let content = std::fs::read_to_string(path)
+                .with_context(|| format!("Failed to read all-image-names file: {path}"))?;
+            Ok(content
+                .lines()
+                .filter(|l| !l.is_empty())
+                .map(String::from)
+                .collect())
+        })
+        .transpose()?;
+
+    if let Some(ref names) = all_image_names {
+        if names.is_empty() {
+            anyhow::bail!("--all-image-names file is empty or contains no names");
+        }
+        let names_set: std::collections::HashSet<&str> =
+            names.iter().map(String::as_str).collect();
+        let missing: Vec<&str> = manifest_entries
+            .keys()
+            .filter(|k| !names_set.contains(k.as_str()))
+            .map(String::as_str)
+            .collect();
+        if !missing.is_empty() {
+            anyhow::bail!(
+                "These uploaded images are not listed in --all-image-names: {}",
+                missing.join(", ")
+            );
+        }
+    }
+
     let manifest = SnapshotsManifest {
         app_id: app_id.clone(),
         images: manifest_entries,
         diff_threshold,
+        all_image_names,
         vcs_info,
     };
 

--- a/tests/integration/_cases/build/build-snapshots-help.trycmd
+++ b/tests/integration/_cases/build/build-snapshots-help.trycmd
@@ -36,16 +36,21 @@ Options:
       --log-level <LOG_LEVEL>
           Set the log output verbosity. [possible values: trace, debug, info, warn, error]
 
-      --all-image-names <PATH>
-          Path to a file containing the full list of preview names (one per line, comma-separated,
-          or both). When provided, only images in the upload directory are compared; missing images
-          listed here are reported as 'skipped' rather than 'removed'.
-
       --quiet
           Do not print any output while preserving correct exit code. This flag is currently
           implemented only for selected subcommands.
           
           [aliases: --silent]
+
+      --selective
+          Indicates this upload contains only a subset of images. Without --all-image-file-names,
+          removals and renames cannot be detected on PRs. With --all-image-file-names, removals and
+          renames are still detected.
+
+      --all-image-file-names <PATH>
+          Only used with --selective. Path to a file containing the full list of image file names
+          (one per line, comma-separated, or both). Enables detection of removals and renames on PRs
+          even when uploading only a subset of images.
 
       --head-sha <head_sha>
           The VCS commit sha to use for the upload. If not provided, the current commit sha will be

--- a/tests/integration/_cases/build/build-snapshots-help.trycmd
+++ b/tests/integration/_cases/build/build-snapshots-help.trycmd
@@ -36,15 +36,20 @@ Options:
       --log-level <LOG_LEVEL>
           Set the log output verbosity. [possible values: trace, debug, info, warn, error]
 
-      --head-sha <head_sha>
-          The VCS commit sha to use for the upload. If not provided, the current commit sha will be
-          used.
+      --all-image-names <PATH>
+          Path to a file containing the full list of preview names (one per line). When provided,
+          only images in the upload directory are compared; missing images listed here are reported
+          as 'skipped' rather than 'removed'.
 
       --quiet
           Do not print any output while preserving correct exit code. This flag is currently
           implemented only for selected subcommands.
           
           [aliases: --silent]
+
+      --head-sha <head_sha>
+          The VCS commit sha to use for the upload. If not provided, the current commit sha will be
+          used.
 
       --base-sha <base_sha>
           The VCS commit's base sha to use for the upload. If not provided, the merge-base of the

--- a/tests/integration/_cases/build/build-snapshots-help.trycmd
+++ b/tests/integration/_cases/build/build-snapshots-help.trycmd
@@ -43,14 +43,8 @@ Options:
           [aliases: --silent]
 
       --selective
-          Indicates this upload contains only a subset of images. Without --all-image-file-names,
-          removals and renames cannot be detected on PRs. With --all-image-file-names, removals and
-          renames are still detected.
-
-      --all-image-file-names <PATH>
-          Only used with --selective. Path to a file containing the full list of image file names
-          (one per line, comma-separated, or both). Enables detection of removals and renames on PRs
-          even when uploading only a subset of images.
+          Indicates this upload contains only a subset of images. Removals and renames cannot be
+          detected on PRs.
 
       --head-sha <head_sha>
           The VCS commit sha to use for the upload. If not provided, the current commit sha will be

--- a/tests/integration/_cases/build/build-snapshots-help.trycmd
+++ b/tests/integration/_cases/build/build-snapshots-help.trycmd
@@ -37,9 +37,9 @@ Options:
           Set the log output verbosity. [possible values: trace, debug, info, warn, error]
 
       --all-image-names <PATH>
-          Path to a file containing the full list of preview names (one per line). When provided,
-          only images in the upload directory are compared; missing images listed here are reported
-          as 'skipped' rather than 'removed'.
+          Path to a file containing the full list of preview names (one per line, comma-separated,
+          or both). When provided, only images in the upload directory are compared; missing images
+          listed here are reported as 'skipped' rather than 'removed'.
 
       --quiet
           Do not print any output while preserving correct exit code. This flag is currently


### PR DESCRIPTION
Add `--selective` flag to `sentry-cli build snapshots` to indicate the upload
contains only a subset of images (e.g. due to sharding or selective test
execution).

The command validates that every uploaded image is listed in the provided
file, failing early if an unknown image is found.