### PR TITLE
fix(bundle-jvm): Strip source-set prefix from bundle URLs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,11 +4,11 @@
 
 ### Improvements
 
-- (bundle-jvm) Warn and skip subsequent duplicates when multiple files strip to the same URL (e.g. Android build variants contributing the same FQCN). The warning points users at `--exclude` to scope the bundle to a single variant.
+- (bundle-jvm) Warn and skip subsequent duplicates when multiple files strip to the same URL (e.g. Android build variants contributing the same FQCN). The warning points users at `--exclude` to scope the bundle to a single variant ([#3275](https://github.com/getsentry/sentry-cli/pull/3275)).
 
 ### Fixes
 
-- (bundle-jvm) Strip the `[<module>/]src/<sourceset>/<lang>/` prefix from bundle URLs so Symbolicator can resolve them from package-based stack traces (e.g. `sentry-android-core/src/main/java/io/sentry/android/core/ANRWatchDog.java` → `~/io/sentry/android/core/ANRWatchDog.jvm`).
+- (bundle-jvm) Strip the `[<module>/]src/<sourceset>/<lang>/` prefix from bundle URLs so Symbolicator can resolve them from package-based stack traces (e.g. `sentry-android-core/src/main/java/io/sentry/android/core/ANRWatchDog.java` → `~/io/sentry/android/core/ANRWatchDog.jvm`) ([#3275](https://github.com/getsentry/sentry-cli/pull/3275)).
 
 ## 3.4.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## Unreleased
+
+### Improvements
+
+- (bundle-jvm) Warn and skip subsequent duplicates when multiple files strip to the same URL (e.g. Android build variants contributing the same FQCN). The warning points users at `--exclude` to scope the bundle to a single variant.
+
+### Fixes
+
+- (bundle-jvm) Strip the `[<module>/]src/<sourceset>/<lang>/` prefix from bundle URLs so Symbolicator can resolve them from package-based stack traces (e.g. `sentry-android-core/src/main/java/io/sentry/android/core/ANRWatchDog.java` → `~/io/sentry/android/core/ANRWatchDog.jvm`).
+
 ## 3.4.0
 
 ### Features

--- a/src/commands/debug_files/bundle_jvm.rs
+++ b/src/commands/debug_files/bundle_jvm.rs
@@ -244,6 +244,7 @@ pub fn execute(matches: &ArgMatches) -> Result<()> {
         .extensions(JVM_EXTENSIONS.iter().copied())
         .ignores(all_excludes)
         .respect_ignores(true)
+        .sort_entries(true)
         .collect_files()?;
 
     let (files, collisions) = build_source_files(sources);
@@ -452,9 +453,11 @@ mod tests {
 
     #[test]
     fn test_build_source_files_records_collision_for_android_variants() {
+        // Sources arrive pre-sorted from `ReleaseFileSearch` (which configures
+        // `WalkBuilder::sort_by_file_name`); the first-seen wins in the dedup.
         let sources = vec![
-            fake_source("/app", "src/main/java/com/example/Config.java"),
             fake_source("/app", "src/debug/java/com/example/Config.java"),
+            fake_source("/app", "src/main/java/com/example/Config.java"),
         ];
         let (files, collisions) = build_source_files(sources);
 
@@ -462,18 +465,18 @@ mod tests {
         assert_eq!(files[0].url, "~/com/example/Config.jvm");
         assert_eq!(
             files[0].path,
-            Path::new("/app/src/main/java/com/example/Config.java")
+            Path::new("/app/src/debug/java/com/example/Config.java")
         );
 
         assert_eq!(collisions.len(), 1);
         assert_eq!(collisions[0].url, "~/com/example/Config.jvm");
         assert_eq!(
             collisions[0].skipped_path,
-            Path::new("/app/src/debug/java/com/example/Config.java")
+            Path::new("/app/src/main/java/com/example/Config.java")
         );
         assert_eq!(
             collisions[0].kept_path,
-            Path::new("/app/src/main/java/com/example/Config.java")
+            Path::new("/app/src/debug/java/com/example/Config.java")
         );
     }
 

--- a/src/commands/debug_files/bundle_jvm.rs
+++ b/src/commands/debug_files/bundle_jvm.rs
@@ -8,9 +8,10 @@ use crate::utils::fs::path_as_url;
 use crate::utils::source_bundle::{self, BundleContext};
 use anyhow::{bail, Context as _, Result};
 use clap::{Arg, ArgAction, ArgMatches, Command};
-use log::debug;
+use log::{debug, warn};
 use sentry::types::DebugId;
-use std::collections::BTreeMap;
+use std::collections::hash_map::Entry;
+use std::collections::{BTreeMap, HashMap};
 use std::ffi::OsStr;
 use std::fs;
 use std::path::{Path, PathBuf};
@@ -21,6 +22,44 @@ use symbolic::debuginfo::sourcebundle::SourceFileType;
 const JVM_EXTENSIONS: &[&str] = &[
     "java", "kt", "scala", "sc", "groovy", "gvy", "gy", "gsh", "clj", "cljc",
 ];
+
+/// Directory names that mark the root of a JVM source set (i.e. the parent of
+/// the package hierarchy). Matches the Gradle/Maven convention
+/// `src/<sourceset>/<lang>/<package>/...`.
+const SOURCE_SET_LANGS: &[&str] = &["java", "kotlin", "scala", "groovy"];
+
+/// Strips the `[<module>/]src/<sourceset>/<lang>/` prefix from a relative source
+/// path so the remaining portion matches what Symbolicator looks up by URL
+/// (e.g. `io/sentry/android/core/ANRWatchDog.java`). This is needed because
+/// JVM stack traces reference classes by their package path, with no knowledge
+/// of the containing Gradle module or source-set layout on disk.
+///
+/// Returns the path unchanged if no `src/<sourceset>/<lang>/` segment is found.
+fn strip_source_set_prefix(relative_path: &Path) -> PathBuf {
+    let mut iter = relative_path.components();
+    let mut src_two_back = false;
+    let mut src_one_back = false;
+    while let Some(curr) = iter.next() {
+        let curr_is_lang = curr
+            .as_os_str()
+            .to_str()
+            .is_some_and(|s| SOURCE_SET_LANGS.contains(&s));
+        if src_two_back && curr_is_lang {
+            return iter.collect();
+        }
+        src_two_back = src_one_back;
+        src_one_back = curr.as_os_str() == "src";
+    }
+    relative_path.to_path_buf()
+}
+
+/// Builds the Symbolicator-compatible URL for a relative source path
+/// (e.g. `~/io/sentry/android/core/ANRWatchDog.jvm`).
+fn build_source_url(relative_path: &Path) -> String {
+    let package_path = strip_source_set_prefix(relative_path);
+    let package_path_jvm_ext = package_path.with_extension("jvm");
+    format!("~/{}", path_as_url(&package_path_jvm_ext))
+}
 
 /// Safe to exclude globally — can never be valid JVM package names.
 const SAFE_EXCLUDES: &[&str] = &[
@@ -151,25 +190,49 @@ pub fn execute(matches: &ArgMatches) -> Result<()> {
         .respect_ignores(true)
         .collect_files()?;
 
-    let files = sources.into_iter().filter_map(|source| {
-        let local_path = source.path.strip_prefix(&source.base_path).unwrap();
-        if is_in_ambiguous_build_dir(local_path) {
-            debug!("excluding (build output): {}", source.path.display());
-            return None;
-        }
-        let local_path_jvm_ext = local_path.with_extension("jvm");
-        let url = format!("~/{}", path_as_url(&local_path_jvm_ext));
+    // Android build variants commonly contribute the same FQCN from
+    // different source sets (e.g. `src/main/` and `src/debug/` both
+    // defining `com.example.Foo`). After stripping, both map to the same
+    // URL — drop all but the first and tell the user how to scope the bundle.
+    let mut seen_urls: HashMap<String, PathBuf> = HashMap::new();
+    let files: Vec<SourceFile> = sources
+        .into_iter()
+        .filter_map(|source| {
+            let local_path = source.path.strip_prefix(&source.base_path).unwrap();
+            if is_in_ambiguous_build_dir(local_path) {
+                debug!("excluding (build output): {}", source.path.display());
+                return None;
+            }
+            let url = build_source_url(local_path);
 
-        Some(SourceFile {
-            url,
-            path: source.path,
-            contents: Arc::new(source.contents),
-            ty: SourceFileType::Source,
-            headers: BTreeMap::new(),
-            messages: vec![],
-            already_uploaded: false,
+            match seen_urls.entry(url) {
+                Entry::Occupied(existing) => {
+                    warn!(
+                        "URL collision on {}: skipping '{}' (already bundled from '{}'). \
+                         Use --exclude to drop the unwanted source set \
+                         (e.g. --exclude='**src/debug/**').",
+                        existing.key(),
+                        source.path.display(),
+                        existing.get().display(),
+                    );
+                    None
+                }
+                Entry::Vacant(slot) => {
+                    let url = slot.key().clone();
+                    slot.insert(source.path.clone());
+                    Some(SourceFile {
+                        url,
+                        path: source.path,
+                        contents: Arc::new(source.contents),
+                        ty: SourceFileType::Source,
+                        headers: BTreeMap::new(),
+                        messages: vec![],
+                        already_uploaded: false,
+                    })
+                }
+            }
         })
-    });
+        .collect();
 
     let tempfile = source_bundle::build(context, files, Some(*debug_id))
         .context("Unable to create source bundle")?;
@@ -235,6 +298,101 @@ mod tests {
         assert!(is_in_ambiguous_build_dir(Path::new(
             "target/src/main/java/com/example/out/Foo.java"
         )));
+    }
+
+    #[test]
+    fn test_strip_source_set_prefix_drops_module_and_source_set() {
+        assert_eq!(
+            strip_source_set_prefix(Path::new(
+                "sentry-android-core/src/main/java/io/sentry/android/core/ANRWatchDog.java"
+            )),
+            Path::new("io/sentry/android/core/ANRWatchDog.java")
+        );
+        assert_eq!(
+            strip_source_set_prefix(Path::new("src/main/kotlin/com/example/Foo.kt")),
+            Path::new("com/example/Foo.kt")
+        );
+    }
+
+    #[test]
+    fn test_strip_source_set_prefix_kt_under_java_source_set() {
+        // Mixed Java/Kotlin projects commonly place .kt files under src/main/java/
+        // — stripping is driven by the directory name, not the file extension.
+        assert_eq!(
+            strip_source_set_prefix(Path::new("src/main/java/com/example/Foo.kt")),
+            Path::new("com/example/Foo.kt")
+        );
+        assert_eq!(
+            strip_source_set_prefix(Path::new(
+                "app/src/main/java/io/sentry/android/core/ANRWatchDog.kt"
+            )),
+            Path::new("io/sentry/android/core/ANRWatchDog.kt")
+        );
+    }
+
+    #[test]
+    fn test_strip_source_set_prefix_handles_nested_modules() {
+        assert_eq!(
+            strip_source_set_prefix(Path::new(
+                "sentry-opentelemetry/sentry-opentelemetry-agent/src/main/java/io/sentry/opentelemetry/agent/Foo.java"
+            )),
+            Path::new("io/sentry/opentelemetry/agent/Foo.java")
+        );
+    }
+
+    #[test]
+    fn test_strip_source_set_prefix_handles_android_variants() {
+        assert_eq!(
+            strip_source_set_prefix(Path::new("app/src/debug/java/com/example/Foo.java")),
+            Path::new("com/example/Foo.java")
+        );
+        assert_eq!(
+            strip_source_set_prefix(Path::new("lib/src/release/kotlin/com/example/Bar.kt")),
+            Path::new("com/example/Bar.kt")
+        );
+    }
+
+    #[test]
+    fn test_strip_source_set_prefix_supports_scala_and_groovy() {
+        assert_eq!(
+            strip_source_set_prefix(Path::new("mod/src/main/scala/com/example/Foo.scala")),
+            Path::new("com/example/Foo.scala")
+        );
+        assert_eq!(
+            strip_source_set_prefix(Path::new("mod/src/main/groovy/com/example/Foo.groovy")),
+            Path::new("com/example/Foo.groovy")
+        );
+    }
+
+    #[test]
+    fn test_strip_source_set_prefix_handles_default_package() {
+        assert_eq!(
+            strip_source_set_prefix(Path::new("src/main/java/NoPackage.java")),
+            Path::new("NoPackage.java")
+        );
+    }
+
+    #[test]
+    fn test_strip_source_set_prefix_falls_back_when_no_match() {
+        // No `src/<sourceset>/<lang>/` triplet — path is returned unchanged.
+        assert_eq!(
+            strip_source_set_prefix(Path::new("sources/com/example/Foo.java")),
+            Path::new("sources/com/example/Foo.java")
+        );
+        assert_eq!(
+            strip_source_set_prefix(Path::new("Foo.java")),
+            Path::new("Foo.java")
+        );
+    }
+
+    #[test]
+    fn test_strip_source_set_prefix_does_not_match_package_named_like_lang() {
+        // `kotlin` as a package name (under `src/main/java/`) must not be
+        // mistaken for the source-set language dir.
+        assert_eq!(
+            strip_source_set_prefix(Path::new("src/main/java/com/example/kotlin/Foo.java")),
+            Path::new("com/example/kotlin/Foo.java")
+        );
     }
 
     #[test]

--- a/src/commands/debug_files/bundle_jvm.rs
+++ b/src/commands/debug_files/bundle_jvm.rs
@@ -492,18 +492,16 @@ mod tests {
         // `WalkBuilder::sort_by_file_name`); the first-seen wins in the dedup.
         log_capture::setup();
 
-        let sources = vec![
-            fake_source("/app", "src/debug/java/com/example/Config.java"),
-            fake_source("/app", "src/main/java/com/example/Config.java"),
-        ];
-        let files = build_source_files(sources);
+        let debug_src = fake_source("/app", "src/debug/java/com/example/Config.java");
+        let main_src = fake_source("/app", "src/main/java/com/example/Config.java");
+        let kept_display = debug_src.path.display().to_string();
+        let skipped_display = main_src.path.display().to_string();
+
+        let files = build_source_files(vec![debug_src, main_src]);
 
         assert_eq!(files.len(), 1);
         assert_eq!(files[0].url, "~/com/example/Config.jvm");
-        assert_eq!(
-            files[0].path,
-            Path::new("/app/src/debug/java/com/example/Config.java")
-        );
+        assert_eq!(files[0].path.display().to_string(), kept_display);
 
         let warnings = log_capture::warnings();
         assert_eq!(warnings.len(), 1);
@@ -513,12 +511,12 @@ mod tests {
             "{msg}"
         );
         assert!(
-            msg.contains("/app/src/main/java/com/example/Config.java"),
-            "missing skipped path in: {msg}"
+            msg.contains(&skipped_display),
+            "missing skipped path '{skipped_display}' in: {msg}"
         );
         assert!(
-            msg.contains("/app/src/debug/java/com/example/Config.java"),
-            "missing kept path in: {msg}"
+            msg.contains(&kept_display),
+            "missing kept path '{kept_display}' in: {msg}"
         );
     }
 

--- a/src/commands/debug_files/bundle_jvm.rs
+++ b/src/commands/debug_files/bundle_jvm.rs
@@ -2,7 +2,7 @@
 
 use crate::config::Config;
 use crate::utils::args::ArgExt as _;
-use crate::utils::file_search::ReleaseFileSearch;
+use crate::utils::file_search::{ReleaseFileMatch, ReleaseFileSearch};
 use crate::utils::file_upload::SourceFile;
 use crate::utils::fs::path_as_url;
 use crate::utils::source_bundle::{self, BundleContext};
@@ -59,6 +59,62 @@ fn build_source_url(relative_path: &Path) -> String {
     let package_path = strip_source_set_prefix(relative_path);
     let package_path_jvm_ext = package_path.with_extension("jvm");
     format!("~/{}", path_as_url(&package_path_jvm_ext))
+}
+
+/// Records a dropped duplicate file whose URL was already seen.
+#[derive(Debug, PartialEq, Eq)]
+struct UrlCollision {
+    url: String,
+    skipped_path: PathBuf,
+    kept_path: PathBuf,
+}
+
+/// Turns walked source files into `SourceFile`s for bundling, filtering out
+/// build-output directories and deduplicating by URL.
+///
+/// Android build variants can contribute the same FQCN from different source
+/// sets (e.g. `src/main/` and `src/debug/` both defining `com.example.Foo`).
+/// After stripping, both map to the same URL — this keeps the first-seen
+/// entry and records the rest as collisions so the caller can warn the user.
+fn build_source_files(sources: Vec<ReleaseFileMatch>) -> (Vec<SourceFile>, Vec<UrlCollision>) {
+    let mut seen_urls: HashMap<String, PathBuf> = HashMap::new();
+    let mut collisions: Vec<UrlCollision> = Vec::new();
+    let files = sources
+        .into_iter()
+        .filter_map(|source| {
+            let local_path = source.path.strip_prefix(&source.base_path).unwrap();
+            if is_in_ambiguous_build_dir(local_path) {
+                debug!("excluding (build output): {}", source.path.display());
+                return None;
+            }
+            let url = build_source_url(local_path);
+
+            match seen_urls.entry(url) {
+                Entry::Occupied(existing) => {
+                    collisions.push(UrlCollision {
+                        url: existing.key().clone(),
+                        skipped_path: source.path,
+                        kept_path: existing.get().clone(),
+                    });
+                    None
+                }
+                Entry::Vacant(slot) => {
+                    let url = slot.key().clone();
+                    slot.insert(source.path.clone());
+                    Some(SourceFile {
+                        url,
+                        path: source.path,
+                        contents: Arc::new(source.contents),
+                        ty: SourceFileType::Source,
+                        headers: BTreeMap::new(),
+                        messages: vec![],
+                        already_uploaded: false,
+                    })
+                }
+            }
+        })
+        .collect();
+    (files, collisions)
 }
 
 /// Safe to exclude globally — can never be valid JVM package names.
@@ -190,49 +246,17 @@ pub fn execute(matches: &ArgMatches) -> Result<()> {
         .respect_ignores(true)
         .collect_files()?;
 
-    // Android build variants commonly contribute the same FQCN from
-    // different source sets (e.g. `src/main/` and `src/debug/` both
-    // defining `com.example.Foo`). After stripping, both map to the same
-    // URL — drop all but the first and tell the user how to scope the bundle.
-    let mut seen_urls: HashMap<String, PathBuf> = HashMap::new();
-    let files: Vec<SourceFile> = sources
-        .into_iter()
-        .filter_map(|source| {
-            let local_path = source.path.strip_prefix(&source.base_path).unwrap();
-            if is_in_ambiguous_build_dir(local_path) {
-                debug!("excluding (build output): {}", source.path.display());
-                return None;
-            }
-            let url = build_source_url(local_path);
-
-            match seen_urls.entry(url) {
-                Entry::Occupied(existing) => {
-                    warn!(
-                        "URL collision on {}: skipping '{}' (already bundled from '{}'). \
-                         Use --exclude to drop the unwanted source set \
-                         (e.g. --exclude='**src/debug/**').",
-                        existing.key(),
-                        source.path.display(),
-                        existing.get().display(),
-                    );
-                    None
-                }
-                Entry::Vacant(slot) => {
-                    let url = slot.key().clone();
-                    slot.insert(source.path.clone());
-                    Some(SourceFile {
-                        url,
-                        path: source.path,
-                        contents: Arc::new(source.contents),
-                        ty: SourceFileType::Source,
-                        headers: BTreeMap::new(),
-                        messages: vec![],
-                        already_uploaded: false,
-                    })
-                }
-            }
-        })
-        .collect();
+    let (files, collisions) = build_source_files(sources);
+    for c in &collisions {
+        warn!(
+            "URL collision on {}: skipping '{}' (already bundled from '{}'). \
+             Use --exclude to drop the unwanted source set \
+             (e.g. --exclude='**src/debug/**').",
+            c.url,
+            c.skipped_path.display(),
+            c.kept_path.display(),
+        );
+    }
 
     let tempfile = source_bundle::build(context, files, Some(*debug_id))
         .context("Unable to create source bundle")?;
@@ -404,5 +428,51 @@ mod tests {
         assert!(!is_in_ambiguous_build_dir(Path::new(
             "app/src/main/java/Foo.java"
         )));
+    }
+
+    fn fake_source(base: &str, relative: &str) -> ReleaseFileMatch {
+        ReleaseFileMatch {
+            base_path: PathBuf::from(base),
+            path: PathBuf::from(base).join(relative),
+            contents: Vec::new(),
+        }
+    }
+
+    #[test]
+    fn test_build_source_files_records_collision_for_android_variants() {
+        let sources = vec![
+            fake_source("/app", "src/main/java/com/example/Config.java"),
+            fake_source("/app", "src/debug/java/com/example/Config.java"),
+        ];
+        let (files, collisions) = build_source_files(sources);
+
+        assert_eq!(files.len(), 1);
+        assert_eq!(files[0].url, "~/com/example/Config.jvm");
+        assert_eq!(
+            files[0].path,
+            Path::new("/app/src/main/java/com/example/Config.java")
+        );
+
+        assert_eq!(collisions.len(), 1);
+        assert_eq!(collisions[0].url, "~/com/example/Config.jvm");
+        assert_eq!(
+            collisions[0].skipped_path,
+            Path::new("/app/src/debug/java/com/example/Config.java")
+        );
+        assert_eq!(
+            collisions[0].kept_path,
+            Path::new("/app/src/main/java/com/example/Config.java")
+        );
+    }
+
+    #[test]
+    fn test_build_source_files_keeps_distinct_urls() {
+        let sources = vec![
+            fake_source("/app", "src/main/java/com/example/Foo.java"),
+            fake_source("/app", "src/main/java/com/example/Bar.java"),
+        ];
+        let (files, collisions) = build_source_files(sources);
+        assert_eq!(files.len(), 2);
+        assert!(collisions.is_empty());
     }
 }

--- a/src/commands/debug_files/bundle_jvm.rs
+++ b/src/commands/debug_files/bundle_jvm.rs
@@ -9,6 +9,7 @@ use crate::utils::source_bundle::{self, BundleContext};
 use anyhow::{bail, Context as _, Result};
 use clap::{Arg, ArgAction, ArgMatches, Command};
 use log::{debug, warn};
+use regex::Regex;
 use sentry::types::DebugId;
 use std::collections::hash_map::Entry;
 use std::collections::{BTreeMap, HashMap};
@@ -16,7 +17,7 @@ use std::ffi::OsStr;
 use std::fs;
 use std::path::{Path, PathBuf};
 use std::str::FromStr as _;
-use std::sync::Arc;
+use std::sync::{Arc, LazyLock};
 use symbolic::debuginfo::sourcebundle::SourceFileType;
 
 const JVM_EXTENSIONS: &[&str] = &[
@@ -28,6 +29,14 @@ const JVM_EXTENSIONS: &[&str] = &[
 /// `src/<sourceset>/<lang>/<package>/...`.
 const SOURCE_SET_LANGS: &[&str] = &["java", "kotlin", "scala", "groovy", "clojure"];
 
+static SOURCE_SET_PREFIX_RE: LazyLock<Regex> = LazyLock::new(|| {
+    let langs = SOURCE_SET_LANGS.join("|");
+    Regex::new(&format!(
+        r"(?:^|[/\\])src[/\\][^/\\]+[/\\](?:{langs})[/\\](.+)$"
+    ))
+    .expect("valid regex")
+});
+
 /// Strips the `[<module>/]src/<sourceset>/<lang>/` prefix from a relative source
 /// path so the remaining portion matches what Symbolicator looks up by URL
 /// (e.g. `io/sentry/android/core/ANRWatchDog.java`). This is needed because
@@ -36,21 +45,11 @@ const SOURCE_SET_LANGS: &[&str] = &["java", "kotlin", "scala", "groovy", "clojur
 ///
 /// Returns the path unchanged if no `src/<sourceset>/<lang>/` segment is found.
 fn strip_source_set_prefix(relative_path: &Path) -> PathBuf {
-    let mut iter = relative_path.components();
-    let mut src_two_back = false;
-    let mut src_one_back = false;
-    while let Some(curr) = iter.next() {
-        let curr_is_lang = curr
-            .as_os_str()
-            .to_str()
-            .is_some_and(|s| SOURCE_SET_LANGS.contains(&s));
-        if src_two_back && curr_is_lang {
-            return iter.collect();
-        }
-        src_two_back = src_one_back;
-        src_one_back = curr.as_os_str() == "src";
-    }
-    relative_path.to_path_buf()
+    relative_path
+        .to_str()
+        .and_then(|s| SOURCE_SET_PREFIX_RE.captures(s))
+        .map(|caps| PathBuf::from(&caps[1]))
+        .unwrap_or_else(|| relative_path.to_path_buf())
 }
 
 /// Builds the Symbolicator-compatible URL for a relative source path
@@ -77,43 +76,44 @@ struct UrlCollision {
 /// After stripping, both map to the same URL — this keeps the first-seen
 /// entry and records the rest as collisions so the caller can warn the user.
 fn build_source_files(sources: Vec<ReleaseFileMatch>) -> (Vec<SourceFile>, Vec<UrlCollision>) {
-    let mut seen_urls: HashMap<String, PathBuf> = HashMap::new();
-    let mut collisions: Vec<UrlCollision> = Vec::new();
-    let files = sources
-        .into_iter()
-        .filter_map(|source| {
-            let local_path = source.path.strip_prefix(&source.base_path).unwrap();
-            if is_in_ambiguous_build_dir(local_path) {
-                debug!("excluding (build output): {}", source.path.display());
-                return None;
-            }
-            let url = build_source_url(local_path);
+    let candidates = sources.into_iter().filter_map(|source| {
+        let local_path = source.path.strip_prefix(&source.base_path).unwrap();
+        if is_in_ambiguous_build_dir(local_path) {
+            debug!("excluding (build output): {}", source.path.display());
+            return None;
+        }
+        let url = build_source_url(local_path);
+        Some((url, source))
+    });
 
-            match seen_urls.entry(url) {
-                Entry::Occupied(existing) => {
-                    collisions.push(UrlCollision {
-                        url: existing.key().clone(),
-                        skipped_path: source.path,
-                        kept_path: existing.get().clone(),
-                    });
-                    None
-                }
-                Entry::Vacant(slot) => {
-                    let url = slot.key().clone();
-                    slot.insert(source.path.clone());
-                    Some(SourceFile {
-                        url,
-                        path: source.path,
-                        contents: Arc::new(source.contents),
-                        ty: SourceFileType::Source,
-                        headers: BTreeMap::new(),
-                        messages: vec![],
-                        already_uploaded: false,
-                    })
-                }
+    let mut seen_urls: HashMap<String, usize> = HashMap::new();
+    let mut files: Vec<SourceFile> = Vec::new();
+    let mut collisions: Vec<UrlCollision> = Vec::new();
+
+    for (url, source) in candidates {
+        match seen_urls.entry(url) {
+            Entry::Occupied(existing) => {
+                collisions.push(UrlCollision {
+                    url: existing.key().clone(),
+                    skipped_path: source.path,
+                    kept_path: files[*existing.get()].path.clone(),
+                });
             }
-        })
-        .collect();
+            Entry::Vacant(slot) => {
+                let url = slot.key().clone();
+                slot.insert(files.len());
+                files.push(SourceFile {
+                    url,
+                    path: source.path,
+                    contents: Arc::new(source.contents),
+                    ty: SourceFileType::Source,
+                    headers: BTreeMap::new(),
+                    messages: vec![],
+                    already_uploaded: false,
+                });
+            }
+        }
+    }
     (files, collisions)
 }
 

--- a/src/commands/debug_files/bundle_jvm.rs
+++ b/src/commands/debug_files/bundle_jvm.rs
@@ -60,22 +60,14 @@ fn build_source_url(relative_path: &Path) -> String {
     format!("~/{}", path_as_url(&package_path_jvm_ext))
 }
 
-/// Records a dropped duplicate file whose URL was already seen.
-#[derive(Debug, PartialEq, Eq)]
-struct UrlCollision {
-    url: String,
-    skipped_path: PathBuf,
-    kept_path: PathBuf,
-}
-
 /// Turns walked source files into `SourceFile`s for bundling, filtering out
 /// build-output directories and deduplicating by URL.
 ///
 /// Android build variants can contribute the same FQCN from different source
 /// sets (e.g. `src/main/` and `src/debug/` both defining `com.example.Foo`).
 /// After stripping, both map to the same URL — this keeps the first-seen
-/// entry and records the rest as collisions so the caller can warn the user.
-fn build_source_files(sources: Vec<ReleaseFileMatch>) -> (Vec<SourceFile>, Vec<UrlCollision>) {
+/// entry and warns the user about the rest.
+fn build_source_files(sources: Vec<ReleaseFileMatch>) -> Vec<SourceFile> {
     let candidates = sources.into_iter().filter_map(|source| {
         let local_path = source.path.strip_prefix(&source.base_path).unwrap();
         if is_in_ambiguous_build_dir(local_path) {
@@ -88,16 +80,18 @@ fn build_source_files(sources: Vec<ReleaseFileMatch>) -> (Vec<SourceFile>, Vec<U
 
     let mut seen_urls: HashMap<String, usize> = HashMap::new();
     let mut files: Vec<SourceFile> = Vec::new();
-    let mut collisions: Vec<UrlCollision> = Vec::new();
 
     for (url, source) in candidates {
         match seen_urls.entry(url) {
             Entry::Occupied(existing) => {
-                collisions.push(UrlCollision {
-                    url: existing.key().clone(),
-                    skipped_path: source.path,
-                    kept_path: files[*existing.get()].path.clone(),
-                });
+                warn!(
+                    "URL collision on {}: skipping '{}' (already bundled from '{}'). \
+                     Use --exclude to drop the unwanted source set \
+                     (e.g. --exclude='**/src/debug/**').",
+                    existing.key(),
+                    source.path.display(),
+                    files[*existing.get()].path.display(),
+                );
             }
             Entry::Vacant(slot) => {
                 let url = slot.key().clone();
@@ -114,7 +108,7 @@ fn build_source_files(sources: Vec<ReleaseFileMatch>) -> (Vec<SourceFile>, Vec<U
             }
         }
     }
-    (files, collisions)
+    files
 }
 
 /// Safe to exclude globally — can never be valid JVM package names.
@@ -247,17 +241,7 @@ pub fn execute(matches: &ArgMatches) -> Result<()> {
         .sort_entries(true)
         .collect_files()?;
 
-    let (files, collisions) = build_source_files(sources);
-    for c in &collisions {
-        warn!(
-            "URL collision on {}: skipping '{}' (already bundled from '{}'). \
-             Use --exclude to drop the unwanted source set \
-             (e.g. --exclude='**/src/debug/**').",
-            c.url,
-            c.skipped_path.display(),
-            c.kept_path.display(),
-        );
-    }
+    let files = build_source_files(sources);
 
     let tempfile = source_bundle::build(context, files, Some(*debug_id))
         .context("Unable to create source bundle")?;
@@ -266,6 +250,57 @@ pub fn execute(matches: &ArgMatches) -> Result<()> {
     println!("Created {}", out.display());
 
     Ok(())
+}
+
+#[cfg(test)]
+mod log_capture {
+    use log::{Level, LevelFilter, Log, Metadata, Record};
+    use std::cell::RefCell;
+    use std::sync::Once;
+
+    thread_local! {
+        static BUFFER: RefCell<Vec<(Level, String)>> = const { RefCell::new(Vec::new()) };
+    }
+
+    struct CaptureLogger;
+
+    impl Log for CaptureLogger {
+        fn enabled(&self, _: &Metadata) -> bool {
+            true
+        }
+
+        fn log(&self, record: &Record) {
+            BUFFER.with(|b| {
+                b.borrow_mut()
+                    .push((record.level(), record.args().to_string()))
+            });
+        }
+
+        fn flush(&self) {}
+    }
+
+    static LOGGER: CaptureLogger = CaptureLogger;
+
+    /// Installs the capture logger (once per process) and clears this
+    /// thread's buffer so a test starts from a clean slate.
+    pub fn setup() {
+        static ONCE: Once = Once::new();
+        ONCE.call_once(|| {
+            let _ = log::set_logger(&LOGGER);
+            log::set_max_level(LevelFilter::Trace);
+        });
+        BUFFER.with(|b| b.borrow_mut().clear());
+    }
+
+    pub fn warnings() -> Vec<String> {
+        BUFFER.with(|b| {
+            b.borrow()
+                .iter()
+                .filter(|(lvl, _)| *lvl == Level::Warn)
+                .map(|(_, msg)| msg.clone())
+                .collect()
+        })
+    }
 }
 
 #[cfg(test)]
@@ -452,14 +487,16 @@ mod tests {
     }
 
     #[test]
-    fn test_build_source_files_records_collision_for_android_variants() {
+    fn test_build_source_files_warns_on_collision_for_android_variants() {
         // Sources arrive pre-sorted from `ReleaseFileSearch` (which configures
         // `WalkBuilder::sort_by_file_name`); the first-seen wins in the dedup.
+        log_capture::setup();
+
         let sources = vec![
             fake_source("/app", "src/debug/java/com/example/Config.java"),
             fake_source("/app", "src/main/java/com/example/Config.java"),
         ];
-        let (files, collisions) = build_source_files(sources);
+        let files = build_source_files(sources);
 
         assert_eq!(files.len(), 1);
         assert_eq!(files[0].url, "~/com/example/Config.jvm");
@@ -468,26 +505,33 @@ mod tests {
             Path::new("/app/src/debug/java/com/example/Config.java")
         );
 
-        assert_eq!(collisions.len(), 1);
-        assert_eq!(collisions[0].url, "~/com/example/Config.jvm");
-        assert_eq!(
-            collisions[0].skipped_path,
-            Path::new("/app/src/main/java/com/example/Config.java")
+        let warnings = log_capture::warnings();
+        assert_eq!(warnings.len(), 1);
+        let msg = &warnings[0];
+        assert!(
+            msg.contains("URL collision on ~/com/example/Config.jvm"),
+            "{msg}"
         );
-        assert_eq!(
-            collisions[0].kept_path,
-            Path::new("/app/src/debug/java/com/example/Config.java")
+        assert!(
+            msg.contains("/app/src/main/java/com/example/Config.java"),
+            "missing skipped path in: {msg}"
+        );
+        assert!(
+            msg.contains("/app/src/debug/java/com/example/Config.java"),
+            "missing kept path in: {msg}"
         );
     }
 
     #[test]
     fn test_build_source_files_keeps_distinct_urls() {
+        log_capture::setup();
+
         let sources = vec![
             fake_source("/app", "src/main/java/com/example/Foo.java"),
             fake_source("/app", "src/main/java/com/example/Bar.java"),
         ];
-        let (files, collisions) = build_source_files(sources);
+        let files = build_source_files(sources);
         assert_eq!(files.len(), 2);
-        assert!(collisions.is_empty());
+        assert!(log_capture::warnings().is_empty());
     }
 }

--- a/src/commands/debug_files/bundle_jvm.rs
+++ b/src/commands/debug_files/bundle_jvm.rs
@@ -252,7 +252,7 @@ pub fn execute(matches: &ArgMatches) -> Result<()> {
         warn!(
             "URL collision on {}: skipping '{}' (already bundled from '{}'). \
              Use --exclude to drop the unwanted source set \
-             (e.g. --exclude='**src/debug/**').",
+             (e.g. --exclude='**/src/debug/**').",
             c.url,
             c.skipped_path.display(),
             c.kept_path.display(),

--- a/src/commands/debug_files/bundle_jvm.rs
+++ b/src/commands/debug_files/bundle_jvm.rs
@@ -26,7 +26,7 @@ const JVM_EXTENSIONS: &[&str] = &[
 /// Directory names that mark the root of a JVM source set (i.e. the parent of
 /// the package hierarchy). Matches the Gradle/Maven convention
 /// `src/<sourceset>/<lang>/<package>/...`.
-const SOURCE_SET_LANGS: &[&str] = &["java", "kotlin", "scala", "groovy"];
+const SOURCE_SET_LANGS: &[&str] = &["java", "kotlin", "scala", "groovy", "clojure"];
 
 /// Strips the `[<module>/]src/<sourceset>/<lang>/` prefix from a relative source
 /// path so the remaining portion matches what Symbolicator looks up by URL
@@ -385,6 +385,18 @@ mod tests {
         assert_eq!(
             strip_source_set_prefix(Path::new("mod/src/main/groovy/com/example/Foo.groovy")),
             Path::new("com/example/Foo.groovy")
+        );
+    }
+
+    #[test]
+    fn test_strip_source_set_prefix_supports_clojure() {
+        assert_eq!(
+            strip_source_set_prefix(Path::new("mod/src/main/clojure/com/example/foo.clj")),
+            Path::new("com/example/foo.clj")
+        );
+        assert_eq!(
+            strip_source_set_prefix(Path::new("mod/src/main/clojure/com/example/foo.cljc")),
+            Path::new("com/example/foo.cljc")
         );
     }
 

--- a/src/utils/file_search.rs
+++ b/src/utils/file_search.rs
@@ -21,6 +21,7 @@ pub struct ReleaseFileSearch {
     ignore_file: Option<String>,
     decompress: bool,
     respect_ignores: bool,
+    sort_entries: bool,
 }
 
 #[derive(Eq, PartialEq, Hash)]
@@ -39,6 +40,7 @@ impl ReleaseFileSearch {
             ignores: BTreeSet::new(),
             decompress: false,
             respect_ignores: false,
+            sort_entries: false,
         }
     }
 
@@ -85,6 +87,14 @@ impl ReleaseFileSearch {
         self
     }
 
+    /// When enabled, directory entries are yielded in sorted order, making
+    /// the walk deterministic across filesystems. Opt-in because callers that
+    /// don't care about order pay no sort cost.
+    pub fn sort_entries(&mut self, sort: bool) -> &mut Self {
+        self.sort_entries = sort;
+        self
+    }
+
     pub fn collect_file(path: PathBuf) -> Result<ReleaseFileMatch> {
         // NOTE: `collect_file` currently do not handle gzip decompression,
         // as its mostly used for 3rd tools like xcode or gradle.
@@ -113,6 +123,10 @@ impl ReleaseFileSearch {
 
         let mut builder = WalkBuilder::new(&self.path);
         builder.follow_links(true);
+
+        if self.sort_entries {
+            builder.sort_by_file_name(|a, b| a.cmp(b));
+        }
 
         if !self.respect_ignores {
             builder.git_exclude(false).git_ignore(false).ignore(false);


### PR DESCRIPTION
Strip the `[<module>/]src/<sourceset>/<lang>/` prefix from bundle URLs so Symbolicator can resolve source context from JVM stack traces.

JVM stack traces reference classes by fully qualified name (e.g. `io.sentry.android.core.ANRWatchDog`) with no knowledge of which Gradle module or source-set directory on disk produced them. The previous URL format included the full on-disk prefix (e.g. `~/sentry-android-core/src/main/java/io/sentry/android/core/ANRWatchDog.jvm`), so Symbolicator's URL-based lookup against the bundle manifest could never match a stack frame. Stripping the prefix produces URLs that match the package layout Symbolicator expects (`~/io/sentry/android/core/ANRWatchDog.jvm`).

Because stripping collapses different source sets into the same URL (e.g. `src/main/` and `src/debug/` both contributing `com.example.Foo` in an Android build variant), the command now tracks seen URLs and emits a `warn!` on collision, skipping all but the first-seen file. The warning points users at `--exclude` so they can scope the bundle to a single variant rather than bundling sources that would otherwise silently overwrite each other in the zip.

Follow-up to #3260, which enabled running `bundle-jvm` directly on a multi-module project root.