### PR TITLE
docs(snapshots): Correct ImageMetadata CLI-managed fields list

### DIFF
--- a/src/api/data_types/snapshots.rs
+++ b/src/api/data_types/snapshots.rs
@@ -40,8 +40,8 @@ pub struct SnapshotsManifest<'a> {
 // Keep in sync with https://github.com/getsentry/sentry/blob/master/src/sentry/preprod/snapshots/manifest.py
 /// Metadata for a single image in a snapshot manifest.
 ///
-/// CLI-managed fields (`image_file_name`, `width`, `height`) override any
-/// identically named fields provided by user sidecar metadata.
+/// CLI-managed fields (`width`, `height`) override any identically named
+/// fields provided by user sidecar metadata.
 #[derive(Debug, Serialize)]
 pub struct ImageMetadata {
     #[serde(flatten)]


### PR DESCRIPTION
## Summary
- The doc comment on `ImageMetadata` listed `image_file_name` as a CLI-managed override, but no such field is written by the CLI.
- `ImageMetadata::new` only sets `width` and `height`; the Sentry backend derives `image_file_name` from the manifest map key, not from a metadata field.
- Updates the comment to match reality.

🤖 Generated with [Claude Code](https://claude.com/claude-code)