### PR TITLE
fix(snapshots): Remove Sentry auth token from objectstore client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,9 @@
 
 ## Unreleased
 
-### Security
+### Fixes
 
-- (snapshots) Stop sending Sentry auth token to external objectstore hosts during build snapshot uploads ([#3286](https://github.com/getsentry/sentry-cli/pull/3286))
+- (snapshots) Stop sending Sentry auth token to Objectstore ([#3286](https://github.com/getsentry/sentry-cli/pull/3286))
 
 ## 3.4.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Security
+
+- (snapshots) Stop sending Sentry auth token to external objectstore hosts during build snapshot uploads ([#3286](https://github.com/getsentry/sentry-cli/pull/3286))
+
 ## 3.4.1
 
 ### Improvements

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -450,14 +450,6 @@ impl AuthenticatedApi<'_> {
         self.api.request(method, url, None)
     }
 
-    /// Returns the auth info for use in external service authorization.
-    pub fn auth(&self) -> &Auth {
-        self.api
-            .config
-            .get_auth()
-            .expect("AuthenticatedApi can only be constructed when auth exists")
-    }
-
     // High-level method implementations
 
     /// Performs an API request to verify the authentication status of the

--- a/src/commands/build/snapshots.rs
+++ b/src/commands/build/snapshots.rs
@@ -18,7 +18,7 @@ use sha2::{Digest as _, Sha256};
 use walkdir::WalkDir;
 
 use crate::api::{Api, CreateSnapshotResponse, ImageMetadata, SnapshotsManifest};
-use crate::config::{Auth, Config};
+use crate::config::Config;
 use crate::utils::args::ArgExt as _;
 use crate::utils::build_vcs::collect_git_metadata;
 use crate::utils::ci::is_ci;
@@ -336,22 +336,8 @@ fn upload_images(
     if let Some(token) = options.objectstore.auth_token {
         builder = builder.token(token.expose_secret().to_owned());
     }
-    let builder = builder;
-
-    let sentry_token = match authenticated_api.auth() {
-        Auth::Token(token) => token.raw().expose_secret().to_owned(),
-    };
-    let sentry_token = format!("Bearer {sentry_token}")
-        .parse()
-        // Ignore original error to avoid leaking the token (even though it's invalid)
-        .map_err(|_| anyhow::anyhow!("Invalid auth token"))?;
     let client = builder
-        .configure_reqwest(|r| {
-            let mut headers = http::HeaderMap::new();
-            headers.insert(http::header::AUTHORIZATION, sentry_token);
-            r.connect_timeout(Duration::from_secs(10))
-                .default_headers(headers)
-        })
+        .configure_reqwest(|r| r.connect_timeout(Duration::from_secs(10)))
         .build()?;
 
     let scopes = options.objectstore.scopes;


### PR DESCRIPTION
Attaching the Sentry auth token to Objectstore requests is no longer needed after https://github.com/getsentry/sentry/pull/114288, as authentication will be performed by Objectstore through its auth mechanism and its own header, which we already pass.

Part of FS-344