### PR TITLE
fix(js): Prevent argument injection via type coercion in serializeOptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixes
 
 - (snapshots) Stop sending Sentry auth token to Objectstore ([#3286](https://github.com/getsentry/sentry-cli/pull/3286))
+- (js) Fix argument injection in JavaScript API's `serializeOptions`. String/number options now validate input types and prevent `Array.prototype.concat()` from flattening array values into separate CLI arguments. ([#3287](https://github.com/getsentry/sentry-cli/pull/3287))
 
 ## 3.4.1
 

--- a/lib/__tests__/helper.test.js
+++ b/lib/__tests__/helper.test.js
@@ -203,6 +203,38 @@ describe('SentryCli helper', () => {
         '--ignore-file',
         '/js.ignore',
       ]);
+
+      // Should throw when array is passed to string option (argument injection prevention)
+      expect(() => {
+        helper.prepareCommand(command, SOURCEMAPS_OPTIONS, {
+          urlPrefix: ['~/', '--auth-token', 'malicious-token'],
+        });
+      }).toThrow('urlPrefix should be a string or number');
+
+      expect(() => {
+        helper.prepareCommand(command, SOURCEMAPS_OPTIONS, {
+          urlSuffix: ['?hash=1', '--url', 'https://evil.com'],
+        });
+      }).toThrow('urlSuffix should be a string or number');
+
+      expect(() => {
+        helper.prepareCommand(command, SOURCEMAPS_OPTIONS, { ignoreFile: { path: '/evil' } });
+      }).toThrow('ignoreFile should be a string or number');
+    });
+
+    test('call prepare command with number option', () => {
+      const command = ['sourcemaps', 'upload', '--release', 'release', '/dev/null'];
+
+      // Numbers should be converted to strings
+      expect(helper.prepareCommand(command, SOURCEMAPS_OPTIONS, { urlPrefix: 123 })).toEqual([
+        'sourcemaps',
+        'upload',
+        '--release',
+        'release',
+        '/dev/null',
+        '--url-prefix',
+        '123',
+      ]);
     });
   });
 });

--- a/lib/helper.ts
+++ b/lib/helper.ts
@@ -234,7 +234,11 @@ function serializeOptions(schema: OptionsSchema, options: Record<string, unknown
       return newOptions;
     }
 
-    return newOptions.concat(paramName, paramValue);
+    if (typeof paramValue !== 'string' && typeof paramValue !== 'number') {
+      throw new Error(`${option} should be a string or number`);
+    }
+
+    return newOptions.concat([paramName, String(paramValue)]);
   }, []);
 }
 


### PR DESCRIPTION
### Description

Add runtime type validation for string/number options to match existing validation for array and boolean types. Wrap arguments in array literal to prevent concat() from flattening array inputs.

(there is no ticket for it)

### Legal Boilerplate
Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
