### PR TITLE
fix(snapshots): Reject uploads with pr_number but no base_sha

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Fixes
+
+- (snapshots) Reject snapshot uploads that have a PR number but no base SHA, since comparisons cannot work without a base reference ([#3300](https://github.com/getsentry/sentry-cli/pull/3300))
+
 ## 3.4.2
 
 ### Fixes

--- a/src/commands/build/snapshots.rs
+++ b/src/commands/build/snapshots.rs
@@ -118,6 +118,14 @@ pub fn execute(matches: &ArgMatches) -> Result<()> {
     // Always collect git metadata, but only perform automatic inference when enabled
     let vcs_info = collect_git_metadata(matches, &config, should_collect_git_metadata);
 
+    if vcs_info.pr_number.is_some() && vcs_info.base_sha.is_none() {
+        anyhow::bail!(
+            "A PR number was provided but no base SHA could be determined. \
+             Snapshot comparisons require a base SHA to identify the base build. \
+             Pass --base-sha explicitly or ensure your CI environment exposes the merge base."
+        );
+    }
+
     debug!("Scanning for images in: {}", dir_path.display());
     debug!("Organization: {org}");
     debug!("Project: {project}");


### PR DESCRIPTION
There is no valid scenario where a snapshot uploaded as part of a PR should lack a base SHA — without it, the server cannot identify which base build to compare against. Previously this was silently accepted, leading to orphaned "solo" snapshots that could never produce diffs.

This adds client-side validation that bails early with an actionable error message before any images are uploaded or API calls are made. The error points users to either pass `--base-sha` explicitly or ensure their CI environment exposes the merge base.

Companion to getsentry/sentry#115446, getsentry/sentry#115448, and getsentry/sentry#115460 which handle the server/UI side of base-build edge cases.