### PR TITLE
fix(ssl): Pass CA bundle env vars to curl on macOS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Fixes
+
+- Respect `CURL_CA_BUNDLE` and `SSL_CERT_FILE` when configuring TLS certificate authorities ([#3301](https://github.com/getsentry/sentry-cli/pull/3301)).
+
 ## 3.4.3
 
 ### Security Fixes

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -242,6 +242,12 @@ impl Api {
         handle.ssl_verify_host(self.config.should_verify_ssl())?;
         handle.ssl_verify_peer(self.config.should_verify_ssl())?;
 
+        if let Ok(ca_bundle) = std::env::var("SSL_CERT_FILE") {
+            handle.cainfo(&ca_bundle)?;
+        } else if let Ok(ca_bundle) = std::env::var("CURL_CA_BUNDLE") {
+            handle.cainfo(&ca_bundle)?;
+        }
+
         let env = self.config.get_pipeline_env();
         let headers = self.config.get_headers();
 

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -242,9 +242,9 @@ impl Api {
         handle.ssl_verify_host(self.config.should_verify_ssl())?;
         handle.ssl_verify_peer(self.config.should_verify_ssl())?;
 
-        if let Ok(ca_bundle) = std::env::var("SSL_CERT_FILE") {
+        if let Ok(ca_bundle) = std::env::var("CURL_CA_BUNDLE") {
             handle.cainfo(&ca_bundle)?;
-        } else if let Ok(ca_bundle) = std::env::var("CURL_CA_BUNDLE") {
+        } else if let Ok(ca_bundle) = std::env::var("SSL_CERT_FILE") {
             handle.cainfo(&ca_bundle)?;
         }
 


### PR DESCRIPTION
On macOS, sentry-cli links system libcurl which uses SecureTransport as its TLS backend. SecureTransport ignores SSL_CERT_FILE, so custom CA bundles (e.g. corporate MITM proxies) don't work even though openssl_probe sets the env var. This reads SSL_CERT_FILE (or CURL_CA_BUNDLE) back and passes it via CURLOPT_CAINFO, which SecureTransport does honor.

Previously we would get a TLS validation when running through our https proxy, like this

```
 error: API request failed

  Caused by:
      0: API request failed
      1: [60] SSL peer certificate or SSH remote key was not OK (SSL certificate problem: unable to get local issuer certificate)
```


Let me know if I should approach this differently or open an issue first to discuss this