### PR TITLE
perf(snapshots): Skip uploading images that already exist in objectstore

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Performance
+
+- (snapshots) Skip uploading images that already exist in objectstore by batch-checking with HEAD requests first ([#3305](https://github.com/getsentry/sentry-cli/pull/3305))
+
 ### Fixes
 
 - (snapshots) Reject snapshot uploads that have a PR number but no base SHA, since comparisons cannot work without a base reference ([#3300](https://github.com/getsentry/sentry-cli/pull/3300))

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2300,9 +2300,9 @@ dependencies = [
 
 [[package]]
 name = "objectstore-client"
-version = "0.1.6"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f99caa869461b61decd1985c029d7e1462d1bde8e2448040db27d567165fcc1e"
+checksum = "754d0120cf9036efad549de3d65223998b5b7ab00943686dd96acdb926a0cfe6"
 dependencies = [
  "async-compression",
  "bytes",
@@ -2323,9 +2323,9 @@ dependencies = [
 
 [[package]]
 name = "objectstore-types"
-version = "0.1.6"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c375bccef8773d1739eabb7e2b1bbd7e9a9071c8f9557e3b50dce7220e8c8736"
+checksum = "75d2e3c60712032c880ec7fc56cd01856eb438968957b4c136acd4e6d66f3580"
 dependencies = [
  "http",
  "humantime",
@@ -3410,6 +3410,7 @@ dependencies = [
  "dotenvy",
  "elementtree",
  "flate2",
+ "futures-util",
  "git2",
  "glob",
  "http",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,7 @@ elementtree = "1.2.3"
 flate2 = { version = "1.0.25", default-features = false, features = [
   "rust_backend",
 ] }
+futures-util = "0.3"
 git2 = { version = "0.20.4", default-features = false }
 glob = "0.3.1"
 http = "1.4.0"
@@ -44,7 +45,7 @@ java-properties = "2.0.0"
 lazy_static = "1.4.0"
 libc = "0.2.139"
 log = { version = "0.4.17", features = ["std"] }
-objectstore-client = { version = "0.1.6" , default-features = false, features = ["native-tls"] }
+objectstore-client = { version = "0.1.9" , default-features = false, features = ["native-tls"] }
 open = "3.2.0"
 parking_lot = "0.12.1"
 percent-encoding = "2.2.0"

--- a/src/commands/build/snapshots.rs
+++ b/src/commands/build/snapshots.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::fs::File;
 use std::io::BufReader;
 use std::path::{Path, PathBuf};
@@ -8,9 +8,10 @@ use std::time::Duration;
 use anyhow::{Context as _, Result};
 use clap::{Arg, ArgMatches, Command};
 use console::style;
+use futures_util::StreamExt as _;
 use itertools::Itertools as _;
 use log::{debug, warn};
-use objectstore_client::{ClientBuilder, ExpirationPolicy, Usecase};
+use objectstore_client::{ClientBuilder, ExpirationPolicy, OperationResult, Usecase};
 use rayon::prelude::*;
 use secrecy::ExposeSecret as _;
 use serde_json::Value;
@@ -146,9 +147,8 @@ pub fn execute(matches: &ArgMatches) -> Result<()> {
 
     validate_image_sizes(&images)?;
 
-    // Upload image files to objectstore
     println!(
-        "{} Uploading {} image {}",
+        "{} Processing {} image {}",
         style(">").dim(),
         style(images.len()).yellow(),
         if images.len() == 1 { "file" } else { "files" }
@@ -416,33 +416,69 @@ fn upload_images(
 
     let total_count = uploads.len();
 
-    let mut many_builder = session.many();
-    for prepared in uploads {
-        many_builder = many_builder.push(
-            session
-                .put_path(prepared.path.clone())
-                .key(&prepared.key)
-                .expiration_policy(expiration),
+    let existing_keys: HashSet<String> = runtime.block_on(async {
+        let mut head_builder = session.many();
+        for prepared in &uploads {
+            head_builder = head_builder.push(session.head(&prepared.key));
+        }
+
+        let mut results = head_builder.send().await;
+        let mut existing = HashSet::new();
+        while let Some(result) = results.next().await {
+            if let OperationResult::Head(key, Ok(Some(_))) = result {
+                existing.insert(key);
+            }
+        }
+        existing
+    });
+
+    let missing_uploads: Vec<_> = uploads
+        .into_iter()
+        .filter(|p| !existing_keys.contains(&p.key))
+        .collect();
+    let skipped = total_count - missing_uploads.len();
+    let upload_count = missing_uploads.len();
+
+    if skipped > 0 {
+        println!(
+            "{} {} of {total_count} {} already uploaded, uploading {} new",
+            style(">").dim(),
+            style(skipped).yellow(),
+            if total_count == 1 { "image" } else { "images" },
+            style(upload_count).yellow(),
         );
     }
 
-    let result = runtime.block_on(async { many_builder.send().await.error_for_failures().await });
-    if let Err(errors) = result {
-        let errors: Vec<_> = errors.collect();
-        let error_count = errors.len();
-        eprintln!("There were errors uploading images:");
-        for error in errors {
-            let error = anyhow::Error::new(error);
-            eprintln!("  {}", style(format!("{error:#}")).red());
+    if upload_count > 0 {
+        let mut many_builder = session.many();
+        for prepared in missing_uploads {
+            many_builder = many_builder.push(
+                session
+                    .put_path(prepared.path.clone())
+                    .key(&prepared.key)
+                    .expiration_policy(expiration),
+            );
         }
-        anyhow::bail!("Failed to upload {error_count} images");
+
+        let result =
+            runtime.block_on(async { many_builder.send().await.error_for_failures().await });
+        if let Err(errors) = result {
+            let errors: Vec<_> = errors.collect();
+            let error_count = errors.len();
+            eprintln!("There were errors uploading images:");
+            for error in errors {
+                let error = anyhow::Error::new(error);
+                eprintln!("  {}", style(format!("{error:#}")).red());
+            }
+            anyhow::bail!("Failed to upload {error_count} images");
+        }
     }
 
     println!(
-        "{} Uploaded {} image {}",
+        "{} Uploaded {} new image {}",
         style(">").dim(),
-        style(total_count).yellow(),
-        if total_count == 1 { "file" } else { "files" }
+        style(upload_count).yellow(),
+        if upload_count == 1 { "file" } else { "files" }
     );
     Ok(manifest_entries)
 }


### PR DESCRIPTION
Uses the new batch HEAD operation added in [objectstore#478](https://github.com/getsentry/objectstore/pull/478) to check which images already exist before uploading. Since image keys are content-addressed (SHA-256 hash), unchanged images between runs produce the same key and don't need re-uploading.

**How it works:**
- After hashing all images, batch HEAD all keys via `session.many()` to check existence
- Only batch PUT images where HEAD returned 404 (not found)
- HEAD errors are treated as "doesn't exist" — safe fallback that just re-uploads

**Performance with 40k images:**
- First upload (all new): ~33 minutes
- Second upload (all cached): ~4.5 minutes (~7.5x faster)

Bumps `objectstore-client` from 0.1.6 to 0.1.9 and adds `futures-util` for `StreamExt::next()` on the HEAD results stream.

Note: the objectstore expiration policy is still TTL. Once it's changed to TTI, the HEAD requests will also bump expiration timers, preventing frequently-used images from expiring.