### PR TITLE
fix(config): Improve error message for missing organization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixes
 
+- Improve error message when organization slug is missing from config ([#3311](https://github.com/getsentry/sentry-cli/pull/3311))
 - Respect `CURL_CA_BUNDLE` and `SSL_CERT_FILE` when configuring TLS certificate authorities ([#3301](https://github.com/getsentry/sentry-cli/pull/3301)).
 
 ## 3.4.3

--- a/src/config.rs
+++ b/src/config.rs
@@ -355,7 +355,7 @@ impl Config {
                 .get_from(Some("defaults"), "org")
                 .map(str::to_owned)
                 .ok_or_else(|| {
-                    format_err!("An organization ID or slug is required (provide with --org)")
+                    format_err!("An organization ID or slug is required (provide with --org, set SENTRY_ORG, or use an org-scoped auth token)")
                 }),
             (None, Some(cli_org)) => Ok(cli_org),
             (Some(token_org), None) => Ok(token_org.clone()),


### PR DESCRIPTION
When no organization is provided, the error message previously only
mentioned the `--org` flag. This can be confusing for users who may
not know about other ways to configure the organization.

The updated error message now lists all three options:
- `--org` flag
- `SENTRY_ORG` environment variable
- Org-scoped auth token

This helps users resolve the issue faster, especially in CI
environments where env vars or scoped tokens are the preferred
approach.