### PR TITLE
docs(readme): add notice pointing to the new Sentry CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,9 +9,9 @@
 </p>
 
 > [!NOTE]
-> **A new Sentry CLI is in active development** and is planned to take over from this one.
-> It already supports several features from `sentry-cli` (including source maps), and is built from the ground up for AI-powered workflows — with built-in AI skills and first-class support for use by agents.
-> If that sounds like what you need, check it out: [cli.sentry.dev](https://cli.sentry.dev/).
+> We're building a [new Sentry CLI](https://cli.sentry.dev/) with AI-powered workflows, built-in AI skills, and first-class support for use by agents. It already covers several `sentry-cli` features (including source maps) and is planned to become the next major version — the APIs are closely aligned, so migration will be smooth when the time comes.
+>
+> **If you're using `sentry-cli` in CI/CD pipelines today, you're in the right place — nothing is changing yet.** If you want AI capabilities or agent integration, give the new CLI a try.
 
 # Sentry CLI
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 > [!NOTE]
 > We're building a [new Sentry CLI](https://cli.sentry.dev/) with AI-powered workflows, built-in AI skills, and first-class support for use by agents. It already covers several `sentry-cli` features (including source maps) and is planned to become the next major version — the APIs are closely aligned, so migration will be smooth when the time comes.
 >
-> **If you're using `sentry-cli` in CI/CD pipelines today, you're in the right place — nothing is changing yet.** If you want AI capabilities or agent integration, give the new CLI a try.
+> **If you're using `sentry-cli` in CI/CD pipelines today, you're in the right place — nothing is changing yet.** If you want AI capabilities or agent integration, give the [new CLI](https://cli.sentry.dev/) a try.
 
 # Sentry CLI
 

--- a/README.md
+++ b/README.md
@@ -8,6 +8,11 @@
   </a>
 </p>
 
+> [!NOTE]
+> **A new Sentry CLI is in active development** and is planned to take over from this one.
+> It already supports several features from `sentry-cli` (including source maps), and is built from the ground up for AI-powered workflows — with built-in AI skills and first-class support for use by agents.
+> If that sounds like what you need, check it out: [cli.sentry.dev](https://cli.sentry.dev/).
+
 # Sentry CLI
 
 This is the repository for Sentry CLI, the official command line interface for Sentry.


### PR DESCRIPTION
### Description
Adds a note at the top of the README pointing users toward the new Sentry CLI ([cli.sentry.dev](https://cli.sentry.dev/)).

We've been getting confused users in this repo who are looking for the newer, AI-capable CLI. We already added a similar disclaimer to the docs site and it worked well. This brings the same treatment to the GitHub README, where a lot of users land first.

The notice is intentionally forward-looking: the new CLI is where things are headed, already supports some of what `sentry-cli` does (including source maps), and is designed for AI-powered workflows and agent use cases.

### Issues
<!-- N/A -->

### Legal Boilerplate
Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.