### PR TITLE
fix: Fix compile error in Docker build

### DIFF
--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -1374,7 +1374,6 @@ impl ApiRequest {
     }
 
     /// enables or disables redirects.  The default is off.
-    #[cfg(any(target_os = "macos", not(feature = "managed")))]
     pub fn follow_location(mut self, val: bool) -> ApiResult<Self> {
         debug!("follow redirects: {val}");
         self.handle.follow_location(val)?;


### PR DESCRIPTION
We were failing to compile in our Docker release build step due to this function being called when not compiled in.
