### PR TITLE
ref: Remove experimental flag from snapshots and build commands

### DIFF
--- a/src/commands/build/download.rs
+++ b/src/commands/build/download.rs
@@ -10,16 +10,10 @@ use crate::config::Config;
 use crate::utils::args::ArgExt as _;
 use crate::utils::fs::TempFile;
 
-const EXPERIMENTAL_WARNING: &str =
-    "[EXPERIMENTAL] The \"build download\" command is experimental. \
-    The command is subject to breaking changes, including removal, in any Sentry CLI release.";
-
 pub fn make_command(command: Command) -> Command {
     command
-        .about("[EXPERIMENTAL] Download a build artifact.")
-        .long_about(format!(
-            "Download a build artifact.\n\n{EXPERIMENTAL_WARNING}"
-        ))
+        .about("Download a build artifact.")
+        .long_about("Download a build artifact.")
         .org_arg()
         .arg(
             Arg::new("build_id")
@@ -53,7 +47,6 @@ fn extension_from_url(url: &str) -> Result<&str> {
 }
 
 pub fn execute(matches: &ArgMatches) -> Result<()> {
-    eprintln!("{EXPERIMENTAL_WARNING}");
     let config = Config::current();
     let org = config.get_org(matches)?;
     let build_id = matches

--- a/src/commands/snapshots/diff.rs
+++ b/src/commands/snapshots/diff.rs
@@ -11,10 +11,6 @@ use crate::utils::fs::{path_as_url, IMAGE_EXTENSIONS};
 use crate::utils::odiff::binary::ensure_binary;
 use crate::utils::odiff::server::{OdiffOptions, OdiffResponse, OdiffServer};
 
-const EXPERIMENTAL_WARNING: &str =
-    "[EXPERIMENTAL] The \"snapshots diff\" command is experimental. \
-    The command is subject to breaking changes, including removal, in any Sentry CLI release.";
-
 #[derive(Serialize)]
 struct DiffReport {
     base_dir: String,
@@ -111,11 +107,8 @@ struct CategorizedImages {
 
 pub fn make_command(command: Command) -> Command {
     command
-        .about("[EXPERIMENTAL] Compare two directories of snapshot images locally using odiff.")
-        .long_about(format!(
-            "Compare two directories of snapshot images locally using odiff.\n\n\
-            {EXPERIMENTAL_WARNING}"
-        ))
+        .about("Compare two directories of snapshot images locally using odiff.")
+        .long_about("Compare two directories of snapshot images locally using odiff.")
         .arg(
             Arg::new("base_dir")
                 .value_name("BASE_DIR")
@@ -171,8 +164,6 @@ pub fn make_command(command: Command) -> Command {
 }
 
 pub fn execute(matches: &ArgMatches) -> Result<()> {
-    eprintln!("{EXPERIMENTAL_WARNING}");
-
     let base_dir = PathBuf::from(
         matches
             .get_one::<String>("base_dir")

--- a/src/commands/snapshots/download.rs
+++ b/src/commands/snapshots/download.rs
@@ -10,19 +10,14 @@ use crate::config::Config;
 use crate::utils::args::ArgExt as _;
 use crate::utils::fs::{path_as_url, TempFile};
 
-const EXPERIMENTAL_WARNING: &str =
-    "[EXPERIMENTAL] The \"snapshots download\" command is experimental. \
-    The command is subject to breaking changes, including removal, in any Sentry CLI release.";
-
 pub fn make_command(command: Command) -> Command {
     command
-        .about("[EXPERIMENTAL] Download baseline snapshot images from Sentry.")
-        .long_about(format!(
+        .about("Download baseline snapshot images from Sentry.")
+        .long_about(
             "Download baseline snapshot images from Sentry's preprod system to a local directory.\n\n\
             Use --snapshot-id to download a specific snapshot, or --app-id to resolve the latest \
-            baseline (org auth tokens require --project with a numeric project ID for --app-id).\n\n\
-            {EXPERIMENTAL_WARNING}"
-        ))
+            baseline (org auth tokens require --project with a numeric project ID for --app-id).",
+        )
         .org_arg()
         .project_arg(false)
         .arg(
@@ -56,8 +51,6 @@ pub fn make_command(command: Command) -> Command {
 }
 
 pub fn execute(matches: &ArgMatches) -> Result<()> {
-    eprintln!("{EXPERIMENTAL_WARNING}");
-
     let config = Config::current();
     let org = config.get_org(matches)?;
     let api_ref = Api::current();

--- a/src/commands/snapshots/mod.rs
+++ b/src/commands/snapshots/mod.rs
@@ -23,7 +23,7 @@ pub fn make_command(mut command: Command) -> Command {
     }
 
     command = command
-        .about("[EXPERIMENTAL] Manage and compare snapshots.")
+        .about("Manage and compare snapshots.")
         .subcommand_required(true)
         .arg_required_else_help(true);
     each_subcommand!(add_subcommand);

--- a/src/commands/snapshots/upload.rs
+++ b/src/commands/snapshots/upload.rs
@@ -25,17 +25,12 @@ use crate::utils::build_vcs::collect_git_metadata;
 use crate::utils::ci::is_ci;
 use crate::utils::fs::IMAGE_EXTENSIONS;
 
-const EXPERIMENTAL_WARNING: &str =
-    "[EXPERIMENTAL] The \"snapshots upload\" command is experimental. \
-    The command is subject to breaking changes, including removal, in any Sentry CLI release.";
 const MAX_PIXELS_PER_IMAGE: u64 = 40_000_000;
 
 pub fn make_command(command: Command) -> Command {
     command
-        .about("[EXPERIMENTAL] Upload snapshots to a project.")
-        .long_about(format!(
-            "Upload snapshots to a project.\n\n{EXPERIMENTAL_WARNING}"
-        ))
+        .about("Upload snapshots to a project.")
+        .long_about("Upload snapshots to a project.")
         .org_arg()
         .project_arg(false)
         .arg(
@@ -118,8 +113,6 @@ impl ImageInfo {
 }
 
 pub fn execute(matches: &ArgMatches) -> Result<()> {
-    eprintln!("{EXPERIMENTAL_WARNING}");
-
     let config = Config::current();
     let org = config.get_org(matches)?;
     let project = config.get_project(matches)?;

--- a/tests/integration/_cases/build/build-download-help.trycmd
+++ b/tests/integration/_cases/build/build-download-help.trycmd
@@ -3,9 +3,6 @@ $ sentry-cli build download --help
 ? success
 Download a build artifact.
 
-[EXPERIMENTAL] The "build download" command is experimental. The command is subject to breaking
-changes, including removal, in any Sentry CLI release.
-
 Usage: sentry-cli[EXE] build download [OPTIONS] --build-id <build_id>
 
 Options:

--- a/tests/integration/_cases/build/build-help.trycmd
+++ b/tests/integration/_cases/build/build-help.trycmd
@@ -6,7 +6,7 @@ Manage builds.
 Usage: sentry-cli[EXE] build [OPTIONS] <COMMAND>
 
 Commands:
-  download  [EXPERIMENTAL] Download a build artifact.
+  download  Download a build artifact.
   upload    Upload builds to a project.
   help      Print this message or the help of the given subcommand(s)
 

--- a/tests/integration/_cases/help/help-windows.trycmd
+++ b/tests/integration/_cases/help/help-windows.trycmd
@@ -31,7 +31,7 @@ Commands:
   repos            Manage repositories on Sentry.
   send-event       Send a manual event to Sentry.
   send-envelope    Send a stored envelope to Sentry.
-  snapshots        [EXPERIMENTAL] Manage and compare snapshots.
+  snapshots        Manage and compare snapshots.
   sourcemaps       Manage sourcemaps for Sentry releases.
   dart-symbol-map  Manage Dart/Flutter symbol maps for Sentry.
   upload-proguard  Upload ProGuard mapping files to a project.

--- a/tests/integration/_cases/help/help.trycmd
+++ b/tests/integration/_cases/help/help.trycmd
@@ -31,7 +31,7 @@ Commands:
   repos            Manage repositories on Sentry.
   send-event       Send a manual event to Sentry.
   send-envelope    Send a stored envelope to Sentry.
-  snapshots        [EXPERIMENTAL] Manage and compare snapshots.
+  snapshots        Manage and compare snapshots.
   sourcemaps       Manage sourcemaps for Sentry releases.
   dart-symbol-map  Manage Dart/Flutter symbol maps for Sentry.
   uninstall        Uninstall the sentry-cli executable.

--- a/tests/integration/_cases/snapshots/snapshots-diff-help.trycmd
+++ b/tests/integration/_cases/snapshots/snapshots-diff-help.trycmd
@@ -3,9 +3,6 @@ $ sentry-cli snapshots diff --help
 ? success
 Compare two directories of snapshot images locally using odiff.
 
-[EXPERIMENTAL] The "snapshots diff" command is experimental. The command is subject to breaking
-changes, including removal, in any Sentry CLI release.
-
 Usage: sentry-cli[EXE] snapshots diff [OPTIONS] <BASE_DIR> <HEAD_DIR>
 
 Arguments:

--- a/tests/integration/_cases/snapshots/snapshots-download-help.trycmd
+++ b/tests/integration/_cases/snapshots/snapshots-download-help.trycmd
@@ -6,9 +6,6 @@ Download baseline snapshot images from Sentry's preprod system to a local direct
 Use --snapshot-id to download a specific snapshot, or --app-id to resolve the latest baseline (org
 auth tokens require --project with a numeric project ID for --app-id).
 
-[EXPERIMENTAL] The "snapshots download" command is experimental. The command is subject to breaking
-changes, including removal, in any Sentry CLI release.
-
 Usage: sentry-cli[EXE] snapshots download [OPTIONS]
 
 Options:

--- a/tests/integration/_cases/snapshots/snapshots-upload-help.trycmd
+++ b/tests/integration/_cases/snapshots/snapshots-upload-help.trycmd
@@ -3,9 +3,6 @@ $ sentry-cli snapshots upload --help
 ? success
 Upload snapshots to a project.
 
-[EXPERIMENTAL] The "snapshots upload" command is experimental. The command is subject to breaking
-changes, including removal, in any Sentry CLI release.
-
 Usage: sentry-cli[EXE] snapshots upload [OPTIONS] --app-id <APP_ID> <PATH>
 
 Arguments:


### PR DESCRIPTION
## Summary

The `snapshots` commands (`upload`, `download`, `diff`) and the `build download` command were marked experimental. Each printed an `[EXPERIMENTAL] ... subject to breaking changes` warning to stderr on every invocation and prefixed its `--help` text with `[EXPERIMENTAL]`.

These commands are now stable, so this removes:
- The per-command `EXPERIMENTAL_WARNING` constants and their `eprintln!` runtime warnings.
- The `[EXPERIMENTAL]` prefixes from `about(...)` strings (including the `snapshots` parent command) and the `{EXPERIMENTAL_WARNING}` interpolation in `long_about` text.

## Motivation

The experimental warnings added noise to every run and signaled instability that no longer applies now that these commands are supported.

## Changes

- `src/commands/snapshots/{mod,upload,download,diff}.rs` — remove warnings and experimental help markers.
- `src/commands/build/download.rs` — same for `build download`.
- Updated the affected `trycmd` help fixtures (snapshots/build help, top-level help, Windows help). Fixtures were edited by hand rather than via `TRYCMD=overwrite` to preserve the `[EXE]` Windows-suffix placeholders.

## Testing

- `cargo build`, `cargo clippy` (clean)
- `cargo test --test mod` — 190 passed, 0 failed