### PR TITLE
build(deps): Bump objectstore-client to 0.1.12

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2503,9 +2503,9 @@ dependencies = [
 
 [[package]]
 name = "objectstore-client"
-version = "0.1.9"
+version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "754d0120cf9036efad549de3d65223998b5b7ab00943686dd96acdb926a0cfe6"
+checksum = "2713028097b2f0f00696d7d389a877f7370c02813548124c4422941f669732f3"
 dependencies = [
  "async-compression",
  "bytes",
@@ -2522,16 +2522,18 @@ dependencies = [
  "tokio",
  "tokio-util",
  "url",
+ "zstd-safe",
 ]
 
 [[package]]
 name = "objectstore-types"
-version = "0.1.9"
+version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75d2e3c60712032c880ec7fc56cd01856eb438968957b4c136acd4e6d66f3580"
+checksum = "c83aedfcc050322caefbfdba0372518f316624995f04f97a1f00cafb08ce1d0c"
 dependencies = [
  "http",
  "humantime",
+ "humantime-serde",
  "mediatype",
  "serde",
  "thiserror 2.0.18",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,7 +45,7 @@ java-properties = "2.0.0"
 lazy_static = "1.4.0"
 libc = "0.2.139"
 log = { version = "0.4.17", features = ["std"] }
-objectstore-client = { version = "0.1.9" , default-features = false, features = ["native-tls"] }
+objectstore-client = { version = "0.1.12" , default-features = false, features = ["native-tls"] }
 open = "3.2.0"
 parking_lot = "0.12.1"
 percent-encoding = "2.2.0"


### PR DESCRIPTION
## Summary

Bumps `objectstore-client` from 0.1.9 to 0.1.12 in `Cargo.toml`, and updates `Cargo.lock` accordingly (which also moves the companion `objectstore-types` crate to 0.1.12).

## Motivation

Keep the object store client dependency current with upstream releases.

## Verification

- `cargo check` passes cleanly with the updated dependency.