### PR TITLE
ref(organizations): Use control silo endpoint for org listing

### DIFF
--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -744,21 +744,18 @@ impl AuthenticatedApi<'_> {
             .send_into(dst)
     }
 
-    /// List all organizations associated with the authenticated token
-    /// in the given `Region`. If no `Region` is provided, we assume
-    /// we're issuing a request to a monolith deployment.
-    pub fn list_organizations(&self, region: Option<&Region>) -> ApiResult<Vec<Organization>> {
+    /// List all organizations associated with the authenticated token.
+    ///
+    /// This hits the control silo organization listing, which returns every
+    /// organization the authenticated user belongs to across all regions in a
+    /// single (paginated) response. Self-hosted/monolith deployments serve the
+    /// same endpoint and return all organizations as well.
+    pub fn list_organizations(&self) -> ApiResult<Vec<Organization>> {
         let mut rv = vec![];
         let mut cursor = "".to_owned();
         loop {
             let current_path = &format!("/organizations/?cursor={}", QueryArg(&cursor));
-            let resp = if let Some(rg) = region {
-                self.api
-                    .request(Method::Get, current_path, Some(&rg.url))?
-                    .send()?
-            } else {
-                self.get(current_path)?
-            };
+            let resp = self.get(current_path)?;
 
             if resp.status() == 404 || (resp.status() == 400 && !cursor.is_empty()) {
                 if rv.is_empty() {
@@ -776,22 +773,6 @@ impl AuthenticatedApi<'_> {
             }
         }
         Ok(rv)
-    }
-
-    pub fn list_available_regions(&self) -> ApiResult<Vec<Region>> {
-        let resp = self.get("/users/me/regions/")?;
-        if resp.status() == 404 {
-            // This endpoint may not exist for self-hosted users, so
-            // returning a default of [] seems appropriate.
-            return Ok(vec![]);
-        }
-
-        if resp.status() == 400 {
-            return Err(ApiErrorKind::ResourceNotFound.into());
-        }
-
-        let region_response = resp.convert::<RegionResponse>()?;
-        Ok(region_response.regions)
     }
 
     /// List all monitors associated with an organization
@@ -1960,9 +1941,9 @@ pub struct Organization {
     pub is_early_adopter: bool,
     #[serde(rename = "require2FA")]
     pub require_2fa: bool,
-    #[serde(rename = "requireEmailVerification")]
-    #[expect(dead_code)]
-    pub require_email_verification: bool,
+    // features was removed from the org listing endpoint; this could be removed too
+    // Same with the get-organizations.json test fixture, the features fields could be removed
+    #[serde(default)]
     #[expect(dead_code)]
     pub features: Vec<String>,
 }
@@ -2109,18 +2090,6 @@ impl fmt::Display for ProcessedEventTag {
         write!(f, "{}: {}", &self.key, &self.value)?;
         Ok(())
     }
-}
-
-#[derive(Clone, Debug, Deserialize)]
-pub struct Region {
-    #[expect(dead_code)]
-    pub name: String,
-    pub url: String,
-}
-
-#[derive(Clone, Debug, Deserialize)]
-pub struct RegionResponse {
-    pub regions: Vec<Region>,
 }
 
 /// Response structure for logs API

--- a/src/commands/organizations/list.rs
+++ b/src/commands/organizations/list.rs
@@ -1,6 +1,5 @@
 use anyhow::Result;
 use clap::{ArgMatches, Command};
-use log::debug;
 
 use crate::api::{Api, Organization};
 use crate::utils::formatting::Table;
@@ -13,21 +12,7 @@ pub fn execute(_matches: &ArgMatches) -> Result<()> {
     let api = Api::current();
     let authenticated_api = api.authenticated()?;
 
-    // Query regions available to the current CLI user
-    let regions = authenticated_api.list_available_regions()?;
-
-    let mut organizations: Vec<Organization> = vec![];
-    debug!("Available regions: {regions:?}");
-
-    // Self-hosted instances won't have a region instance or prefix, so we
-    // need to check before fanning out.
-    if !regions.is_empty() {
-        for region in regions {
-            organizations.append(&mut authenticated_api.list_organizations(Some(&region))?)
-        }
-    } else {
-        organizations.append(&mut authenticated_api.list_organizations(None)?)
-    }
+    let mut organizations: Vec<Organization> = authenticated_api.list_organizations()?;
 
     organizations.sort_by_key(|o| o.name.clone().to_lowercase());
 

--- a/tests/integration/_responses/organizations/get-organizations.json
+++ b/tests/integration/_responses/organizations/get-organizations.json
@@ -10,7 +10,6 @@
     "dateCreated": "2020-09-14T17:28:14.933511Z",
     "isEarlyAdopter": true,
     "require2FA": false,
-    "requireEmailVerification": false,
     "avatar": {
       "avatarType": "upload",
       "avatarUuid": "9fe0ee23944145b49c64924dfbca40fe"
@@ -98,7 +97,6 @@
     "dateCreated": "2019-12-18T13:20:09.250550Z",
     "isEarlyAdopter": false,
     "require2FA": false,
-    "requireEmailVerification": false,
     "avatar": {
       "avatarType": "letter_avatar",
       "avatarUuid": null
@@ -147,7 +145,6 @@
     "dateCreated": "2018-04-03T17:51:37.660710Z",
     "isEarlyAdopter": false,
     "require2FA": false,
-    "requireEmailVerification": false,
     "avatar": {
       "avatarType": "letter_avatar",
       "avatarUuid": null
@@ -198,7 +195,6 @@
     "dateCreated": "2015-03-02T23:55:20Z",
     "isEarlyAdopter": true,
     "require2FA": false,
-    "requireEmailVerification": false,
     "avatar": {
       "avatarType": "upload",
       "avatarUuid": "24e94751da694e0fa57947e289048d7e"
@@ -292,7 +288,6 @@
     "dateCreated": "2014-12-15T04:06:24.263571Z",
     "isEarlyAdopter": true,
     "require2FA": false,
-    "requireEmailVerification": false,
     "avatar": {
       "avatarType": "upload",
       "avatarUuid": "24f6f762f7a7473888b259c566da5adb"

--- a/tests/integration/organizations.rs
+++ b/tests/integration/organizations.rs
@@ -3,9 +3,6 @@ use crate::integration::{MockEndpointBuilder, TestManager};
 #[test]
 fn command_organizations() {
     TestManager::new()
-        // Mock is for the organizations list command. The listing is served
-        // from a single (control silo) endpoint, so there is no per-region
-        // fan-out and no `/users/me/regions/` call to mock.
         .mock_endpoint(
             MockEndpointBuilder::new("GET", "/api/0/organizations/?cursor=")
                 .with_response_file("organizations/get-organizations.json"),

--- a/tests/integration/organizations.rs
+++ b/tests/integration/organizations.rs
@@ -2,26 +2,13 @@ use crate::integration::{MockEndpointBuilder, TestManager};
 
 #[test]
 fn command_organizations() {
-    let manager = TestManager::new();
-    let region_response = format!(
-        r#"{{
-            "regions": [{{
-                "name": "monolith",
-                "url": "{}"
-            }}]
-        }}"#,
-        manager.server_url(),
-    );
-
-    manager
-        // Mocks are for the organizations list command.
+    TestManager::new()
+        // Mock is for the organizations list command. The listing is served
+        // from a single (control silo) endpoint, so there is no per-region
+        // fan-out and no `/users/me/regions/` call to mock.
         .mock_endpoint(
             MockEndpointBuilder::new("GET", "/api/0/organizations/?cursor=")
                 .with_response_file("organizations/get-organizations.json"),
-        )
-        .mock_endpoint(
-            MockEndpointBuilder::new("GET", "/api/0/users/me/regions/")
-                .with_response_body(region_response),
         )
         .register_trycmd_test("organizations/*.trycmd")
         .with_default_token();


### PR DESCRIPTION
### Description
The organization listing endpoint (GET /organizations/) is now served from the control silo and returns every organization the authenticated user belongs to across all regions in a single paginated response. This replaces the previous per-region fan-out (which called /users/me/regions/ and then queried each region) with one call.

Also aligns the Organization model with the current API response: drops requireEmailVerification (removed in getsentry/sentry#115003) and makes features optional (removed from the listing endpoint in #115007), so no longer fails to deserialize the live response.

### Issues
* resolves: INFRENG-199

### Legal Boilerplate
Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
