### PR TITLE
ci(workflow): Update runner images

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -74,7 +74,7 @@ jobs:
             target: aarch64-apple-darwin
 
     name: macOS ${{ matrix.arch }}
-    runs-on: macos-14
+    runs-on: macos-26
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # 6.0.2
@@ -108,9 +108,9 @@ jobs:
       - name: Download x86_64 OpenSSL
         if: matrix.arch == 'x86_64' && steps.cache-openssl-x86.outputs.cache-hit != 'true'
         run: |
-          brew fetch --bottle-tag=sonoma openssl@3
+          arch -x86_64 brew fetch --bottle-tag=tahoe openssl@3
           mkdir -p $X86_64_APPLE_DARWIN_OPENSSL_DIR
-          tar xzf $(brew --cache --bottle-tag=sonoma openssl@3) -C $X86_64_APPLE_DARWIN_OPENSSL_DIR --strip-components=2
+          tar xzf $(arch -x86_64 brew --cache --bottle-tag=tahoe openssl@3) -C $X86_64_APPLE_DARWIN_OPENSSL_DIR --strip-components=2
 
       - name: Cache Dependencies
         uses: swatinem/rust-cache@779680da715d629ac1d338a641029a2f4372abb5 # 2.8.2
@@ -130,7 +130,7 @@ jobs:
   macos_universal:
     needs: macos
     name: macOS universal
-    runs-on: macos-14
+    runs-on: macos-26
 
     steps:
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # 8.0.1
@@ -229,7 +229,7 @@ jobs:
       TARGET: ${{ matrix.arch }}-pc-windows-msvc
 
     name: Windows ${{ matrix.arch }}
-    runs-on: windows-2022
+    runs-on: windows-2025
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # 6.0.2

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -25,13 +25,13 @@ jobs:
             os: ubuntu-24.04
             display-os: Linux
           - target: x86_64-pc-windows-msvc
-            os: windows-2022
+            os: windows-2025
             display-os: Windows
           - target: aarch64-apple-darwin
-            os: macos-14
+            os: macos-26
             display-os: macOS – aarch64
           - target: x86_64-apple-darwin
-            os: macos-14
+            os: macos-26
             display-os: macOS – x86_64
 
     name: ${{ matrix.display-os }}
@@ -77,9 +77,9 @@ jobs:
       - name: Download x86_64 OpenSSL
         if: matrix.target == 'x86_64-apple-darwin' && steps.cache-openssl-x86.outputs.cache-hit != 'true'
         run: |
-          brew fetch --bottle-tag=sonoma openssl@3
+          arch -x86_64 brew fetch --bottle-tag=tahoe openssl@3
           mkdir -p $X86_64_APPLE_DARWIN_OPENSSL_DIR
-          tar xzf $(brew --cache --bottle-tag=sonoma openssl@3) -C $X86_64_APPLE_DARWIN_OPENSSL_DIR --strip-components=2
+          tar xzf $(arch -x86_64 brew --cache --bottle-tag=tahoe openssl@3) -C $X86_64_APPLE_DARWIN_OPENSSL_DIR --strip-components=2
 
       - name: Cache Dependencies
         uses: swatinem/rust-cache@779680da715d629ac1d338a641029a2f4372abb5 # 2.8.2

--- a/.github/workflows/swift-test.yml
+++ b/.github/workflows/swift-test.yml
@@ -10,7 +10,7 @@ on:
 jobs:
   run-tests:
     name: Run tests
-    runs-on: macos-15
+    runs-on: macos-26
     steps:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # 6.0.2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,13 +25,13 @@ jobs:
             os: ubuntu-24.04
             display-os: Linux
           - target: x86_64-pc-windows-msvc
-            os: windows-2022
+            os: windows-2025
             display-os: Windows
           - target: aarch64-apple-darwin
-            os: macos-14
+            os: macos-26
             display-os: macOS – aarch64
           - target: x86_64-apple-darwin
-            os: macos-14
+            os: macos-26
             display-os: macOS – x86_64
 
     name: ${{ matrix.display-os }}
@@ -76,9 +76,9 @@ jobs:
       - name: Download x86_64 OpenSSL
         if: matrix.target == 'x86_64-apple-darwin' && steps.cache-openssl-x86.outputs.cache-hit != 'true'
         run: |
-          brew fetch --bottle-tag=sonoma openssl@3
+          arch -x86_64 brew fetch --bottle-tag=tahoe openssl@3
           mkdir -p $X86_64_APPLE_DARWIN_OPENSSL_DIR
-          tar xzf $(brew --cache --bottle-tag=sonoma openssl@3) -C $X86_64_APPLE_DARWIN_OPENSSL_DIR --strip-components=2
+          tar xzf $(arch -x86_64 brew --cache --bottle-tag=tahoe openssl@3) -C $X86_64_APPLE_DARWIN_OPENSSL_DIR --strip-components=2
 
       - name: Cache Dependencies
         uses: swatinem/rust-cache@779680da715d629ac1d338a641029a2f4372abb5 # 2.8.2


### PR DESCRIPTION
Bump pinned GitHub-hosted runner labels to the newest GA images from actions/runner-images.

This updates Windows jobs to windows-2025 and macOS jobs to macos-26 while keeping Ubuntu on 24.04, which is still the newest GA Ubuntu label.

Ref #3356
