### PR TITLE
fix(sourcemaps): Guess appended .map before replaced extension

### DIFF
--- a/src/utils/sourcemaps.rs
+++ b/src/utils/sourcemaps.rs
@@ -109,6 +109,20 @@ fn guess_sourcemap_reference(
     let map_ext = "map";
     let (path, basename, ext) = split_url(min_url);
 
+    if let Some(ext) = ext.as_ref() {
+        // foo.min.js -> foo.min.js.map
+        // Per the source map spec, a reference is formed by appending `.map` to
+        // the file name, so prefer this over replacing the extension (gh-2802).
+        let new_ext = format!("{ext}.{map_ext}");
+        let url_with_path = unsplit_url(path, basename, Some(&new_ext));
+        if sourcemaps.contains(&url_with_path) {
+            return Ok(
+                SourceMapReference::from_url(unsplit_url(None, basename, Some(&new_ext)))
+                    .with_original_url(url_with_path),
+            );
+        }
+    }
+
     // foo.min.js -> foo.map
     let url_with_path = unsplit_url(path, basename, Some("map"));
     if sourcemaps.contains(&url_with_path) {
@@ -119,16 +133,6 @@ fn guess_sourcemap_reference(
     }
 
     if let Some(ext) = ext.as_ref() {
-        // foo.min.js -> foo.min.js.map
-        let new_ext = format!("{ext}.{map_ext}");
-        let url_with_path = unsplit_url(path, basename, Some(&new_ext));
-        if sourcemaps.contains(&url_with_path) {
-            return Ok(
-                SourceMapReference::from_url(unsplit_url(None, basename, Some(&new_ext)))
-                    .with_original_url(url_with_path),
-            );
-        }
-
         // foo.min.js -> foo.js.map
         if let Some(rest) = ext.strip_prefix("min.") {
             let new_ext = format!("{rest}.{map_ext}");
@@ -1286,6 +1290,37 @@ mod tests {
         assert_eq!(&unsplit_url(None, "foo", Some("js")), "foo.js");
         assert_eq!(&unsplit_url(None, "foo", None), "foo");
         assert_eq!(&unsplit_url(Some(""), "foo", None), "/foo");
+    }
+
+    #[test]
+    fn test_guess_sourcemap_reference() {
+        fn set(urls: &[&str]) -> HashSet<String> {
+            urls.iter().map(|s| (*s).to_owned()).collect()
+        }
+
+        // With both candidates present, the appended `foo.min.js.map` wins over
+        // the replaced `foo.map` (gh-2802, per the source map spec).
+        assert_eq!(
+            guess_sourcemap_reference(&set(&["foo.map", "foo.min.js.map"]), "foo.min.js")
+                .unwrap()
+                .url,
+            "foo.min.js.map"
+        );
+
+        // Each form still resolves when it is the only candidate present.
+        for (candidate, expected) in [
+            ("foo.map", "foo.map"),
+            ("foo.min.js.map", "foo.min.js.map"),
+            ("foo.js.map", "foo.js.map"),
+            ("foo.min.map", "foo.min.map"),
+        ] {
+            assert_eq!(
+                guess_sourcemap_reference(&set(&[candidate]), "foo.min.js")
+                    .unwrap()
+                    .url,
+                expected
+            );
+        }
     }
 
     #[test]


### PR DESCRIPTION
### Description

`guess_sourcemap_reference` guessed `foo.min.js` → `foo.map` (replacing the extension) *before* `foo.min.js` → `foo.min.js.map` (appending `.map`). Per the source map naming convention, appending `.map` to the file name is the default reference form, so when both a `<name>.map` and a `<name>.min.js.map` are present the appended one should win.

This reorders the guesses so the appended reference is tried first, and adds a unit test covering the ordering and each individual form.

### Issues

* resolves: getsentry/sentry-cli#2802

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.