### PR TITLE
test(update): Avoid network access in integration test

### DIFF
--- a/src/commands/update.rs
+++ b/src/commands/update.rs
@@ -28,6 +28,13 @@ pub fn execute(matches: &ArgMatches) -> Result<()> {
     // Aborts with an error if this installation is not updatable.
     assert_updatable()?;
 
+    // It's not currently possible to easily mock I/O with `trycmd`,
+    // but verifying that `execute` is not panicking, is good enough for now.
+    if env::var("SENTRY_INTEGRATION_TEST").is_ok() {
+        println!("Running in integration tests mode. Skipping execution.");
+        return Ok(());
+    }
+
     let exe = env::current_exe()?;
     let update = get_latest_sentrycli_release()
         .with_context(|| "Error getting latest Sentry CLI version.")?;
@@ -36,13 +43,6 @@ pub fn execute(matches: &ArgMatches) -> Result<()> {
     }
 
     println!("Latest release is {}", update.latest_version());
-
-    // It's not currently possible to easily mock I/O with `trycmd`,
-    // but verifying that `execute` is not panicking, is good enough for now.
-    if env::var("SENTRY_INTEGRATION_TEST").is_ok() {
-        println!("Running in integration tests mode. Skipping execution.");
-        return Ok(());
-    }
 
     if update.is_latest_version() {
         if matches.get_flag("force") {

--- a/tests/integration/_cases/update/update.trycmd
+++ b/tests/integration/_cases/update/update.trycmd
@@ -1,7 +1,6 @@
 ```
 $ sentry-cli update
 ? success
-Latest release is [..]
 Running in integration tests mode. Skipping execution.
 
 ```


### PR DESCRIPTION
### Description

Prevent the `sentry-cli update` integration test from contacting the public release registry.

The command already skips executable replacement when `SENTRY_INTEGRATION_TEST` is set. This moves that existing guard before the latest-release lookup, so integration tests return before external I/O while normal update behavior remains unchanged.

### Issues

- Resolves #2262

### Testing

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --tests`
- Forced-offline focused test with external traffic routed to an unused loopback proxy:
  - `cargo test --test mod integration::update::command_update -- --exact --nocapture`
- Forced-offline full suite:
  - `cargo test --workspace`
  - 194 unit tests and 183 integration tests passed

### Legal Boilerplate
Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
