### PR TITLE
fix(logs): Correct severity query example

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Fixes
+
+- (logs) Correct the severity query example ([#3387](https://github.com/getsentry/sentry-cli/pull/3387))
+
 ## 3.6.2
 
 ### Fixes

--- a/src/commands/logs/list.rs
+++ b/src/commands/logs/list.rs
@@ -66,7 +66,7 @@ pub(super) struct ListLogsArgs {
     max_rows: NonZeroUsize,
 
     #[arg(long = "query", default_value = "", hide_default_value = true)]
-    #[arg(help = "Query to filter logs. Example: \"level:error\". \
+    #[arg(help = "Query to filter logs. Example: \"severity:error\". \
         If omitted, no filtering is applied. \
         See https://docs.sentry.io/concepts/search/ for syntax.")]
     query: String,

--- a/tests/integration/_cases/logs/logs-list-help.trycmd
+++ b/tests/integration/_cases/logs/logs-list-help.trycmd
@@ -32,7 +32,7 @@ Options:
           Set the log output verbosity. [possible values: trace, debug, info, warn, error]
 
       --query <QUERY>
-          Query to filter logs. Example: "level:error". If omitted, no filtering is applied. See
+          Query to filter logs. Example: "severity:error". If omitted, no filtering is applied. See
           https://docs.sentry.io/concepts/search/ for syntax.
 
       --live


### PR DESCRIPTION
## Summary

- replace the misleading `level:error` Logs query example with `severity:error`
- update the CLI help snapshot

## Why

The Logs API uses `severity` for the canonical log severity. `level` is treated as an independent custom attribute, not an alias, so the existing example commonly returns no matches.
