### PR TITLE
feat: Add Linux riscv64 support

### DIFF
--- a/.craft.yml
+++ b/.craft.yml
@@ -27,6 +27,9 @@ targets:
     id: '@sentry/cli-linux-i686'
     includeNames: /^sentry-cli-linux-i686-\d.*\.tgz$/
   - name: npm
+    id: '@sentry/cli-linux-riscv64'
+    includeNames: /^sentry-cli-linux-riscv64-\d.*\.tgz$/
+  - name: npm
     id: '@sentry/cli-linux-x64'
     includeNames: /^sentry-cli-linux-x64-\d.*\.tgz$/
   - name: npm
@@ -64,7 +67,7 @@ targets:
               url "https://downloads.sentry-cdn.com/sentry-cli/{{version}}/sentry-cli-Linux-armv7"
               sha256 "{{checksums.sentry-cli-Linux-armv7}}"
             end
-          elseif Hardware::CPU.intel?
+          elsif Hardware::CPU.intel?
             if Hardware::CPU.is_64_bit?
               url "https://downloads.sentry-cdn.com/sentry-cli/{{version}}/sentry-cli-Linux-x86_64"
               sha256 "{{checksums.sentry-cli-Linux-x86_64}}"
@@ -72,6 +75,9 @@ targets:
               url "https://downloads.sentry-cdn.com/sentry-cli/{{version}}/sentry-cli-Linux-i686"
               sha256 "{{checksums.sentry-cli-Linux-i686}}"
             end
+          elsif RUBY_PLATFORM.include?("riscv64")
+            url "https://downloads.sentry-cdn.com/sentry-cli/{{version}}/sentry-cli-Linux-riscv64"
+            sha256 "{{checksums.sentry-cli-Linux-riscv64}}"
           else
             raise "Unsupported architecture"
           end
@@ -115,6 +121,7 @@ requireNames:
   - /^sentry-cli-Linux-x86_64$/
   - /^sentry-cli-Linux-armv7$/
   - /^sentry-cli-Linux-aarch64$/
+  - /^sentry-cli-Linux-riscv64$/
   - /^sentry-cli-Windows-i686.exe$/
   - /^sentry-cli-Windows-x86_64.exe$/
   - /^sentry-cli-Windows-aarch64.exe$/

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,6 +31,9 @@ jobs:
           - arch: aarch64
             target: aarch64-unknown-linux-musl
             container: aarch64-musl
+          - arch: riscv64
+            target: riscv64gc-unknown-linux-musl
+            container: riscv64gc-musl
 
     name: Linux ${{ matrix.arch }}
     runs-on: ubuntu-24.04
@@ -368,6 +371,7 @@ jobs:
           mv binary-artifacts/sentry-cli-Linux-armv7 npm-binary-distributions/linux-arm/bin/sentry-cli
           mv binary-artifacts/sentry-cli-Linux-aarch64 npm-binary-distributions/linux-arm64/bin/sentry-cli
           mv binary-artifacts/sentry-cli-Linux-i686 npm-binary-distributions/linux-i686/bin/sentry-cli
+          mv binary-artifacts/sentry-cli-Linux-riscv64 npm-binary-distributions/linux-riscv64/bin/sentry-cli
           mv binary-artifacts/sentry-cli-Linux-x86_64 npm-binary-distributions/linux-x64/bin/sentry-cli
           mv binary-artifacts/sentry-cli-Windows-i686.exe npm-binary-distributions/win32-i686/bin/sentry-cli.exe
           mv binary-artifacts/sentry-cli-Windows-x86_64.exe npm-binary-distributions/win32-x64/bin/sentry-cli.exe

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,7 +9,7 @@ This is **sentry-cli**, a command-line utility for working with Sentry. It's pri
 - **Primary language**: Rust (core functionality)
 - **Secondary language**: JavaScript/TypeScript (npm wrapper, installation scripts)
 - **Build system**: Cargo for Rust, npm/yarn for JavaScript
-- **Cross-platform**: Supports multiple architectures (darwin, linux, windows, ARM variants)
+- **Cross-platform**: Supports multiple architectures (darwin, linux, windows, ARM and RISC-V variants)
 - **Binary distributions**: Located in `npm-binary-distributions/` for different platforms
 
 ## Project Structure

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,13 @@
 
 ## Unreleased
 
+### Features
+
+- Add Linux riscv64 release binaries, npm package, and Python wheel
+
 ### Fixes
 
+- Use `elsif` in the Homebrew formula so Linux Intel and RISC-V bottles resolve correctly
 - (logs) Correct the severity query example ([#3387](https://github.com/getsentry/sentry-cli/pull/3387))
 
 ## 3.6.2

--- a/build.rs
+++ b/build.rs
@@ -21,6 +21,10 @@ fn main() -> Result<(), Box<dyn Error>> {
         arch = "arm64"; // enforce Darwin naming conventions
     }
 
+    if arch == "riscv64gc" {
+        arch = "riscv64"; // match uname -m / Node os.arch()
+    }
+
     writeln!(f, "/// The platform identifier")?;
     writeln!(f, "pub const PLATFORM: &str = \"{platform}\";")?;
     writeln!(f, "/// The CPU architecture identifier")?;

--- a/lib/helper.ts
+++ b/lib/helper.ts
@@ -12,6 +12,7 @@ const BINARY_DISTRIBUTIONS = [
   { packageName: '@sentry/cli-linux-i686', subpath: 'bin/sentry-cli' },
   { packageName: '@sentry/cli-linux-arm64', subpath: 'bin/sentry-cli' },
   { packageName: '@sentry/cli-linux-arm', subpath: 'bin/sentry-cli' },
+  { packageName: '@sentry/cli-linux-riscv64', subpath: 'bin/sentry-cli' },
   { packageName: '@sentry/cli-win32-x64', subpath: 'bin/sentry-cli.exe' },
   { packageName: '@sentry/cli-win32-i686', subpath: 'bin/sentry-cli.exe' },
   { packageName: '@sentry/cli-win32-arm64', subpath: 'bin/sentry-cli.exe' },
@@ -55,6 +56,9 @@ function getDistributionForThisPlatform() {
         break;
       case 'arm':
         packageName = '@sentry/cli-linux-arm';
+        break;
+      case 'riscv64':
+        packageName = '@sentry/cli-linux-riscv64';
         break;
     }
   } else if (platform === 'win32') {
@@ -102,7 +106,7 @@ function throwUnsupportedPlatformError(): void {
 
 Sentry CLI supports:
 - Darwin (macOS)
-- Linux and FreeBSD on x64, x86, ia32, arm64, and arm architectures
+- Linux and FreeBSD on x64, x86, ia32, arm64, arm, and riscv64 architectures
 - Windows x64, x86, and ia32 architectures`
   );
 }

--- a/npm-binary-distributions/linux-riscv64/README.md
+++ b/npm-binary-distributions/linux-riscv64/README.md
@@ -1,0 +1,11 @@
+<p align="center">
+  <a href="https://sentry.io/?utm_source=github&utm_medium=logo" target="_blank">
+    <img src="https://sentry-brand.storage.googleapis.com/sentry-wordmark-dark-280x84.png" alt="Sentry" width="280" height="84">
+  </a>
+</p>
+
+# Sentry CLI Linux RISC-V 64-bit Binary
+
+This package contains the Sentry CLI binary for Linux riscv64.
+
+See https://github.com/getsentry/sentry-cli for more information.

--- a/npm-binary-distributions/linux-riscv64/package.json
+++ b/npm-binary-distributions/linux-riscv64/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "@sentry/cli-linux-riscv64",
+  "version": "3.6.2",
+  "description": "The linux riscv64 distribution of the Sentry CLI binary.",
+  "repository": "https://github.com/getsentry/sentry-cli",
+  "license": "FSL-1.1-MIT",
+  "publishConfig": {
+    "access": "public"
+  },
+  "engines": {
+    "node": ">=18"
+  },
+  "os": [
+    "linux",
+    "freebsd",
+    "android"
+  ],
+  "cpu": [
+    "riscv64"
+  ]
+}

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "@sentry/cli-linux-arm": "3.6.2",
     "@sentry/cli-linux-arm64": "3.6.2",
     "@sentry/cli-linux-i686": "3.6.2",
+    "@sentry/cli-linux-riscv64": "3.6.2",
     "@sentry/cli-linux-x64": "3.6.2",
     "@sentry/cli-win32-i686": "3.6.2",
     "@sentry/cli-win32-x64": "3.6.2",

--- a/scripts/install.js
+++ b/scripts/install.js
@@ -69,6 +69,9 @@ function getDownloadUrl(platform, arch) {
     case 'arm':
       archString = 'armv7';
       break;
+    case 'riscv64':
+      archString = 'riscv64';
+      break;
     default:
       archString = arch;
   }

--- a/scripts/wheels
+++ b/scripts/wheels
@@ -41,6 +41,10 @@ WHEELS = (
         plat='manylinux_2_17_i686.manylinux2014_i686.musllinux_1_2_i686',
     ),
     Wheel(
+        src='sentry-cli-Linux-riscv64',
+        plat='manylinux_2_31_riscv64.musllinux_1_2_riscv64',
+    ),
+    Wheel(
         src='sentry-cli-Linux-x86_64',
         plat='manylinux_2_17_x86_64.manylinux2014_x86_64.musllinux_1_2_x86_64',
     ),


### PR DESCRIPTION
### Description
<!-- What changed and why? -->

Build and distribute sentry-cli for Linux riscv64 across GitHub releases, npm, PyPI, and Homebrew. Leave package-lock.json unchanged because @sentry/cli-linux-riscv64 is not published yet.

### Issues
<!--
* resolves: #1234
* resolves: LIN-1234
-->

<!--
#### Reminders
- Add GH Issue ID _&_ Linear ID (if applicable)
- PR title should use [conventional commit](https://develop.sentry.dev/engineering-practices/commit-messages/#type) style (`feat:`, `fix:`, `ref:`, `meta:`)
- For external contributors: [CONTRIBUTING.md](https://github.com/getsentry/sentry-cli/blob/master/CONTRIBUTING.md), [Sentry SDK development docs](https://develop.sentry.dev/sdk/), [Discord community](https://discord.gg/Ww9hbqr)
-->

### Legal Boilerplate
Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
