### PR TITLE
docs(sourcemaps): Clarify prefix stripping behavior

### DIFF
--- a/src/commands/sourcemaps/upload.rs
+++ b/src/commands/sourcemaps/upload.rs
@@ -149,8 +149,10 @@ pub fn make_command(command: Command) -> Command {
                 .long("strip-common-prefix")
                 .action(ArgAction::SetTrue)
                 .help(
-                    "Similar to --strip-prefix but strips the most common \
-                    prefix on all sources references.",
+                    "Strips the common prefix from source references in each sourcemap. \
+                    When uploading multiple sourcemaps, the prefix is computed independently \
+                    for each one. To strip the same explicit prefix from every sourcemap, use \
+                    --strip-prefix.",
                 )
                 .conflicts_with("no_rewrite"),
         )

--- a/tests/integration/_cases/sourcemaps/sourcemaps-upload-help.trycmd
+++ b/tests/integration/_cases/sourcemaps/sourcemaps-upload-help.trycmd
@@ -65,7 +65,9 @@ Options:
           This will not modify the uploaded sources paths. To do that, point the upload or
           upload-sourcemaps command to a more precise directory instead.
       --strip-common-prefix
-          Similar to --strip-prefix but strips the most common prefix on all sources references.
+          Strips the common prefix from source references in each sourcemap. When uploading multiple
+          sourcemaps, the prefix is computed independently for each one. To strip the same explicit
+          prefix from every sourcemap, use --strip-prefix.
   -i, --ignore <IGNORE>
           Ignores all files and folders matching the given glob
   -I, --ignore-file <IGNORE_FILE>


### PR DESCRIPTION
Documents that `--strip-common-prefix` computes a prefix independently for each sourcemap, and points users to repeatable `--strip-prefix` when they need one explicit prefix applied across maps.

Updates the CLI help snapshot to cover the wording.

Fixes #2409

Validation:
- `cargo fmt --all --check`
- `cargo test --test mod sourcemaps -- --nocapture` (32 passed)