### PR TITLE
docs(readme): Redirect issues to new CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,10 +8,10 @@
   </a>
 </p>
 
-> [!NOTE]
-> We're building a [new Sentry CLI](https://cli.sentry.dev/) with AI-powered workflows, built-in AI skills, and first-class support for use by agents. It already covers several `sentry-cli` features (including source maps) and is planned to become the next major version — the APIs are closely aligned, so migration will be smooth when the time comes.
+> [!IMPORTANT]
+> This repository is no longer under active development, as our [new CLI](https://cli.sentry.dev/) will soon be replacing this one.
 >
-> **If you're using `sentry-cli` in CI/CD pipelines today, you're in the right place — nothing is changing yet.** If you want AI capabilities or agent integration, give the [new CLI](https://cli.sentry.dev/) a try.
+> We are therefore no longer accepting feature requests for this repo. Also, we will generally only fix bugs in this repo when there is a concrete reason preventing adoption of the new CLI. Please raise new issues in the new CLI's repository, instead.
 
 # Sentry CLI
 


### PR DESCRIPTION
Update the README to ask users to put new issues in the new CLI's repo, as this repo is no longer under active development.